### PR TITLE
Update Docker Hub image repository to phenx/piwitests-server

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v5
         with:
-          images: docker.io/piwitests/dashboard
+          images: docker.io/phenx/piwitests-server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -143,7 +143,7 @@ jobs:
           echo "### Registries" >> $GITHUB_STEP_SUMMARY
           echo "- **GitHub Container Registry**: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
           if [[ "$IS_RELEASE" == "true" ]]; then
-            echo "- **Docker Hub**: \`piwitests/dashboard\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **Docker Hub**: \`phenx/piwitests-server\`" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Tags" >> $GITHUB_STEP_SUMMARY
@@ -161,7 +161,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Pull from Docker Hub" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo "docker pull piwitests/dashboard:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "docker pull phenx/piwitests-server:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Updates the Docker Hub image repository reference from `piwitests/dashboard` to `phenx/piwitests-server` in the publish workflow.

## Changes
- Updated Docker metadata action to use the new Docker Hub image name `phenx/piwitests-server`
- Updated release notes summary to reference the correct Docker Hub repository
- Updated pull command example in release notes to use the new image name

## Details
This change updates all references to the Docker Hub image in the CI/CD publish workflow to reflect the new repository ownership and naming convention. The changes affect:
1. The image metadata configuration for Docker builds
2. The release summary output that documents where images are published
3. The example pull command shown in release notes

https://claude.ai/code/session_01GHEuLnyKKkH2WKs6WiLebj