### PR TITLE
Allow users to manage display names and optional passwords

### DIFF
--- a/application/app/pages/settings/account.vue
+++ b/application/app/pages/settings/account.vue
@@ -17,6 +17,10 @@ const { data: me, refresh } = await useFetch<{ authenticated: boolean; user: MeU
 
 const isOAuth = computed(() => Boolean(me.value?.user?.oauthProvider));
 
+// Display name form
+const nameField = ref('');
+const savingName = ref(false);
+
 // Email form
 const emailField = ref('');
 const savingEmail = ref(false);
@@ -31,7 +35,10 @@ const changingPassword = ref(false);
 watch(
   () => me.value?.user,
   (u) => {
-    if (u) emailField.value = u.email || '';
+    if (u) {
+      nameField.value = u.name || '';
+      emailField.value = u.email || '';
+    }
   },
   { immediate: true },
 );
@@ -41,6 +48,19 @@ onMounted(() => {
     toast.add({ title: 'Email verified', color: 'success' });
   }
 });
+
+async function saveName() {
+  savingName.value = true;
+  try {
+    await $fetch(`/api/users/${me.value?.user?.id}`, { method: 'PATCH', body: { name: nameField.value || null } });
+    await refresh();
+    toast.add({ title: 'Display name updated', color: 'success' });
+  } catch (e) {
+    toast.add({ title: 'Failed to update display name', description: String((e as Error)?.message ?? e), color: 'error' });
+  } finally {
+    savingName.value = false;
+  }
+}
 
 async function saveEmail() {
   savingEmail.value = true;
@@ -111,6 +131,21 @@ const authEnabled = computed(() => config.public.authEnabled);
     />
 
     <template v-else-if="me?.user">
+      <!-- Display name section -->
+      <SectionCard icon="i-lucide-user" title="Display name">
+        <UFormField label="Display name" name="name">
+          <UInput v-model="nameField" placeholder="Your display name (optional)" class="w-full" />
+        </UFormField>
+
+        <template #footer>
+          <div class="flex justify-end">
+            <UButton color="primary" :loading="savingName" icon="i-lucide-save" @click="saveName">
+              Save name
+            </UButton>
+          </div>
+        </template>
+      </SectionCard>
+
       <!-- Email section -->
       <SectionCard icon="i-lucide-mail" title="Email address" help="account.email">
         <div class="space-y-3">

--- a/application/app/pages/settings/users.vue
+++ b/application/app/pages/settings/users.vue
@@ -43,7 +43,7 @@ const columns: TableColumn<UserDetails>[] = [
 const isAddUserModalOpen = ref(false);
 const addUserSchema = z.object({
   username: z.string().min(3, 'Username must be at least 3 characters'),
-  password: z.string().min(6, 'Password must be at least 6 characters'),
+  password: z.string().min(6, 'Password must be at least 6 characters').optional().or(z.literal('')),
   role: z.enum(['administrator', 'reporter', 'user']),
   name: z.string().optional(),
   email: z.string().email().optional().or(z.literal('')),
@@ -489,8 +489,13 @@ async function handleInviteUser(user: UserDetails) {
             <UInput v-model="newUser.username" placeholder="Enter username" />
           </UFormField>
 
-          <UFormField label="Password" name="password" required class="mb-4">
-            <UInput v-model="newUser.password" type="password" placeholder="Enter password" />
+          <UFormField
+            label="Password"
+            name="password"
+            class="mb-4"
+            description="Leave blank to let the user set their own password via invite email"
+          >
+            <UInput v-model="newUser.password" type="password" placeholder="Leave blank to send invite" />
           </UFormField>
 
           <UFormField label="Display name" name="name" class="mb-4">

--- a/application/server/api/auth/reset-password.post.ts
+++ b/application/server/api/auth/reset-password.post.ts
@@ -46,7 +46,8 @@ export default eventHandler(async (event) => {
   if (!user) throw createError({ statusCode: 400, message: 'Invalid or expired token' });
 
   const hashedPassword = await hashPassword(password);
-  await db.update(users).set({ password: hashedPassword, updatedAt: new Date() }).where(eq(users.id, user.id));
+  const extraFields = validated.purpose === 'invite' ? { emailVerified: true } : {};
+  await db.update(users).set({ password: hashedPassword, updatedAt: new Date(), ...extraFields }).where(eq(users.id, user.id));
 
   await consumeAccountToken(db, validated.tokenId);
 

--- a/application/server/api/users/[id].patch.ts
+++ b/application/server/api/users/[id].patch.ts
@@ -10,8 +10,7 @@ defineRouteMeta({
   openAPI: {
     tags: ['Users'],
     summary: 'Update a user',
-    description: "Updates a user's name, email, or role. Requires administrator role.",
-    'x-required-roles': REQUIRED_ROLES,
+    description: "Updates a user's name, email, or role. Admins can update any user; non-admins can only update their own name and email.",
     parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
   },
 });
@@ -23,15 +22,27 @@ const schema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event, REQUIRED_ROLES);
+  const currentUser = await requireAuth(event, []);
 
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) throw createError({ statusCode: 400, message: 'Invalid user ID' });
+
+  const isAdmin = currentUser.role === Role.ADMINISTRATOR;
+  const isSelf = currentUser.id === id;
+
+  if (!isAdmin && !isSelf) {
+    throw createError({ statusCode: 403, message: 'Insufficient permissions' });
+  }
 
   const body = await readBody(event);
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
     throw createError({ statusCode: 400, message: 'Invalid request body', data: parsed.error.issues });
+  }
+
+  // Non-admins can only update their own name and email, not role
+  if (!isAdmin && parsed.data.role !== undefined) {
+    throw createError({ statusCode: 403, message: 'Only administrators can change roles' });
   }
 
   try {

--- a/application/server/api/users/index.post.ts
+++ b/application/server/api/users/index.post.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { getDatabase } from '../../database';
 import { createUserRecord } from '~~/shared/handlers/users';
 import { Role } from '../../../shared/types';
@@ -18,7 +19,7 @@ defineRouteMeta({
 
 const createUserSchema = z.object({
   username: z.string().min(3),
-  password: z.string().min(6),
+  password: z.string().min(6).optional(),
   role: z.nativeEnum(Role),
   name: z.string().optional(),
   email: z.string().email().optional().or(z.literal('')),
@@ -41,7 +42,8 @@ export default eventHandler(async (event) => {
   const { username, password, role, name, email } = validation.data;
 
   try {
-    const hashedPassword = await hashPassword(password);
+    // If no password provided, generate a random one — the user will set their own via invite email
+    const hashedPassword = await hashPassword(password ?? randomBytes(32).toString('hex'));
     const user = await createUserRecord(await getDatabase(), {
       username,
       password: hashedPassword,


### PR DESCRIPTION
## Summary
This PR enhances user account management by allowing users to update their own display names and making passwords optional when creating new users via admin invite flow.

## Key Changes

- **Display Name Management**: Added a new "Display name" section in account settings that allows users to update their own display name
  - New form field and save functionality in the account settings page
  - Backend endpoint updated to allow non-admins to update their own name and email
  - Display name is synced from user data on page load

- **Optional Passwords for User Creation**: Made password optional when admins create new users
  - When no password is provided, a random password is generated and the user receives an invite email to set their own password
  - Updated user creation schema and form UI with helpful guidance text
  - Password reset endpoint now marks email as verified when completing an invite flow

- **Permission Model Refinement**: Updated the PATCH `/api/users/[id]` endpoint to support granular permissions
  - Admins can update any user's name, email, or role
  - Non-admins can only update their own name and email (not role)
  - Removed the blanket admin-only requirement to enable self-service updates

## Implementation Details

- The display name form uses the same pattern as the existing email form with loading state and toast notifications
- User creation now generates a cryptographically secure random password when none is provided
- The invite flow automatically verifies email addresses when users set their password
- All changes maintain backward compatibility with existing admin workflows

https://claude.ai/code/session_016MLFU8ygd6dnVqJanx9qif