### PR TITLE
Update tag colors to use hex values instead of color names

### DIFF
--- a/application/public/demo/seed.sql
+++ b/application/public/demo/seed.sql
@@ -613,10 +613,10 @@ ALTER TABLE `test_runs_cases` ADD `wasted_time_ms` integer;
 BEGIN TRANSACTION;
 
 -- Tags
-INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (1, 'smoke', 'green', 1740787200, 1740787200);
-INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (2, 'regression', 'blue', 1740787200, 1740787200);
-INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (3, 'critical', 'red', 1741996800, 1741996800);
-INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (4, 'performance', 'yellow', 1743465600, 1743465600);
+INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (1, 'smoke', '#34d399', 1740787200, 1740787200);
+INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (2, 'regression', '#818cf8', 1740787200, 1740787200);
+INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (3, 'critical', '#fb7185', 1741996800, 1741996800);
+INSERT INTO tags (id, text, color, created_at, updated_at) VALUES (4, 'performance', '#fbbf24', 1743465600, 1743465600);
 
 -- Projects
 INSERT INTO projects (id, name, label, description, created_at, updated_at) VALUES (1, 'e2e-checkout', 'E2E Checkout', 'End-to-end tests for the checkout flow', 1740787200, 1745562600);

--- a/application/public/demo/seed.version.json
+++ b/application/public/demo/seed.version.json
@@ -1,4 +1,4 @@
 {
-  "hash": "3ab5183fdcb8a543e55efb94a2ef84851e9babab8c7e9f4af67aec57e25407ad",
-  "generatedAt": "2026-06-24T20:12:05.496Z"
+  "hash": "d7a3f05bffc9cefda140806b07d624ceda37a0191f992b26ed337c3b3c68742b",
+  "generatedAt": "2026-06-25T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary
Updated the seed data to use hex color codes instead of named colors for tags, improving consistency and visual accuracy in the demo dataset.

## Changes
- Replaced color names with hex color codes in the tags table:
  - `smoke`: 'green' → '#34d399' (emerald green)
  - `regression`: 'blue' → '#818cf8' (indigo)
  - `critical`: 'red' → '#fb7185' (rose red)
  - `performance`: 'yellow' → '#fbbf24' (amber)
- Updated seed version hash and timestamp to reflect the data changes

## Details
The hex color values appear to be from the Tailwind CSS color palette, providing more precise color definitions than generic color names. This ensures consistent rendering across different systems and UI components that may interpret named colors differently.

https://claude.ai/code/session_013uhMzSghgXDRTiZsw43xrG