### PR TITLE
fix: make password truly optional in add user form

### DIFF
--- a/application/app/pages/settings/users.vue
+++ b/application/app/pages/settings/users.vue
@@ -43,7 +43,7 @@ const columns: TableColumn<UserDetails>[] = [
 const isAddUserModalOpen = ref(false);
 const addUserSchema = z.object({
   username: z.string().min(3, 'Username must be at least 3 characters'),
-  password: z.string().min(6, 'Password must be at least 6 characters').optional().or(z.literal('')),
+  password: z.union([z.string().min(6, 'Password must be at least 6 characters'), z.literal('').transform(() => undefined)]).optional(),
   role: z.enum(['administrator', 'reporter', 'user']),
   name: z.string().optional(),
   email: z.string().email().optional().or(z.literal('')),
@@ -67,9 +67,10 @@ const roleOptions = [
 
 async function handleAddUser() {
   try {
+    const body = { ...newUser, password: newUser.password || undefined };
     await $fetch('/api/users', {
       method: 'POST',
-      body: newUser,
+      body,
     });
 
     toast.add({


### PR DESCRIPTION
Empty password field is stripped before sending to API so the min-length validation is not triggered. Frontend schema also updated to accept empty string without error.


Claude-Session: https://claude.ai/code/session_016MLFU8ygd6dnVqJanx9qif