### PR TITLE
Add animated latest-run button to breadcrumb on test run page

### DIFF
--- a/application/app/pages/test-runs/[id].vue
+++ b/application/app/pages/test-runs/[id].vue
@@ -10,7 +10,17 @@ const isDemoMode = Boolean(useRuntimeConfig().public.demoMode);
 
 const { data: testRun, refresh } = await useFetch<TestRunDetails>(`/api/test-runs/${runId}`);
 
-useRunStream(refresh);
+// Lightweight poll for latest run info — avoids reloading full page data on run events
+const projectId = computed(() => testRun.value?.projectId);
+const { data: latestRunInfo, refresh: refreshLatestRun } = await useFetch<{ id: number; status: string } | null>(
+  () => projectId.value ? `/api/projects/${projectId.value}/latest-run` : null,
+  { key: `latest-run-${projectId.value}` },
+);
+useRunStream(refreshLatestRun);
+
+const latestRunId = computed(() => latestRunInfo.value?.id ?? testRun.value?.project?.latestRunId ?? null);
+const latestRunStatus = computed(() => latestRunInfo.value?.status ?? testRun.value?.project?.latestRunStatus ?? null);
+const isLatestRunActive = computed(() => latestRunStatus.value === 'running' || latestRunStatus.value === 'finalizing');
 
 useHead(
   computed(() => ({
@@ -533,12 +543,12 @@ function handleSelectCluster(clusterId: number) {
                 {{ item.label }}
               </NuxtLink>
               <UTooltip
-                v-if="testRun?.project?.latestRunId && testRun.project.latestRunId !== Number(runId)"
-                text="Go to latest run"
+                v-if="latestRunId && latestRunId !== Number(runId)"
+                :text="isLatestRunActive ? 'Go to running run' : 'Go to latest run'"
               >
-                <NuxtLink :to="`/test-runs/${testRun.project.latestRunId}`">
+                <NuxtLink :to="`/test-runs/${latestRunId}`">
                   <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-blue-500/10 hover:bg-blue-500/20 transition-colors ml-1">
-                    <UIcon name="i-lucide-circle-play" class="w-3.5 h-3.5 text-blue-500 animate-pulse" />
+                    <UIcon name="i-lucide-circle-play" class="w-3.5 h-3.5 text-blue-500" :class="{ 'animate-pulse': isLatestRunActive }" />
                   </span>
                 </NuxtLink>
               </UTooltip>

--- a/application/app/pages/test-runs/[id].vue
+++ b/application/app/pages/test-runs/[id].vue
@@ -2,12 +2,15 @@
 import { computed, nextTick, watch, onUnmounted } from 'vue';
 import type { TestRunDetails, TestCaseResult, ReportInfo, TestStepEvent } from '~~/types/api';
 import { subscribeDemoEvents } from '~/demo/run-events';
+import { useRunStream } from '~/composables/useRunStream';
 
 const route = useRoute();
 const runId = route.params.id;
 const isDemoMode = Boolean(useRuntimeConfig().public.demoMode);
 
 const { data: testRun, refresh } = await useFetch<TestRunDetails>(`/api/test-runs/${runId}`);
+
+useRunStream(refresh);
 
 useHead(
   computed(() => ({

--- a/application/app/pages/test-runs/[id].vue
+++ b/application/app/pages/test-runs/[id].vue
@@ -11,11 +11,11 @@ const isDemoMode = Boolean(useRuntimeConfig().public.demoMode);
 const { data: testRun, refresh } = await useFetch<TestRunDetails>(`/api/test-runs/${runId}`);
 
 // Lightweight poll for latest run info — avoids reloading full page data on run events
-const projectId = computed(() => testRun.value?.projectId);
-const { data: latestRunInfo, refresh: refreshLatestRun } = await useFetch<{ id: number; status: string } | null>(
-  () => projectId.value ? `/api/projects/${projectId.value}/latest-run` : null,
-  { key: `latest-run-${projectId.value}` },
-);
+const projectId = testRun.value?.projectId;
+type LatestRunInfo = { id: number; status: string } | null;
+const { data: latestRunInfo, refresh: refreshLatestRun } = projectId
+  ? await useFetch<LatestRunInfo>(`/api/projects/${projectId}/latest-run`, { key: `latest-run-${projectId}` })
+  : { data: ref<LatestRunInfo>(null), refresh: async () => {} };
 useRunStream(refreshLatestRun);
 
 const latestRunId = computed(() => latestRunInfo.value?.id ?? testRun.value?.project?.latestRunId ?? null);

--- a/application/app/pages/test-runs/[id].vue
+++ b/application/app/pages/test-runs/[id].vue
@@ -518,12 +518,29 @@ function handleSelectCluster(clusterId: number) {
                     {
                       label: testRun.project.label || testRun.project.name || 'Project',
                       to: `/projects/${testRun.project.id}`,
+                      slot: 'project',
                     },
                   ]
                 : [{ label: 'Project' }]),
               { label: `Run #${runId}` + (testRun?.label ? ` — ${testRun.label}` : '') },
             ]"
-          />
+          >
+            <template #project="{ item }">
+              <NuxtLink :to="item.to" class="text-sm font-medium text-[var(--ui-text-muted)] hover:text-[var(--ui-text)] transition-colors">
+                {{ item.label }}
+              </NuxtLink>
+              <UTooltip
+                v-if="testRun?.project?.latestRunId && testRun.project.latestRunId !== Number(runId)"
+                text="Go to latest run"
+              >
+                <NuxtLink :to="`/test-runs/${testRun.project.latestRunId}`">
+                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-blue-500/10 hover:bg-blue-500/20 transition-colors ml-1">
+                    <UIcon name="i-lucide-circle-play" class="w-3.5 h-3.5 text-blue-500 animate-pulse" />
+                  </span>
+                </NuxtLink>
+              </UTooltip>
+            </template>
+          </UBreadcrumb>
         </template>
         <template #right>
           <UButton icon="i-lucide-refresh-cw" size="md" label="Refresh" @click="() => refresh()" />

--- a/application/server/api/projects/[id]/latest-run.get.ts
+++ b/application/server/api/projects/[id]/latest-run.get.ts
@@ -1,0 +1,34 @@
+import { eq, desc } from 'drizzle-orm';
+import { getDatabase } from '../../../database';
+import { testRuns } from '../../../database/schema';
+import { Role } from '../../../../shared/types';
+import { requireProjectAccess } from '../../../utils/project-access';
+
+const REQUIRED_ROLES: Role[] = [Role.ADMINISTRATOR, Role.REPORTER, Role.USER];
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Projects'],
+    summary: 'Get latest run info for a project',
+    description: 'Returns the id and status of the most recent test run for the project',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': REQUIRED_ROLES,
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = parseInt(getRouterParam(event, 'id') || '0');
+  if (!id) throw createError({ statusCode: 400, message: 'Invalid project ID' });
+
+  await requireProjectAccess(event, id);
+
+  const db = await getDatabase();
+  const result = await db
+    .select({ id: testRuns.id, status: testRuns.status })
+    .from(testRuns)
+    .where(eq(testRuns.projectId, id))
+    .orderBy(desc(testRuns.id))
+    .limit(1);
+
+  return result[0] ?? null;
+});

--- a/application/shared/handlers/test-runs.ts
+++ b/application/shared/handlers/test-runs.ts
@@ -36,10 +36,13 @@ export async function getTestRun(
   const project = projectResults[0];
 
   const latestRunResult = await db
-    .select({ latestRunId: sql<number>`MAX(${testRuns.id})` })
+    .select({ id: testRuns.id, status: testRuns.status })
     .from(testRuns)
-    .where(eq(testRuns.projectId, testRun.projectId));
-  const latestRunId = latestRunResult[0]?.latestRunId ?? null;
+    .where(eq(testRuns.projectId, testRun.projectId))
+    .orderBy(desc(testRuns.id))
+    .limit(1);
+  const latestRunId = latestRunResult[0]?.id ?? null;
+  const latestRunStatus = latestRunResult[0]?.status ?? null;
 
   const reportResults = await db
     .select()
@@ -162,7 +165,7 @@ export async function getTestRun(
   return {
     ...testRunPublic,
     isFullRun: testRun.isFullRun === 1,
-    project: project ? { ...project, latestRunId } : project,
+    project: project ? { ...project, latestRunId, latestRunStatus } : project,
     reports: reportResults.map((r: any) => ({
       id: r.id,
       type: r.subtype || r.type,

--- a/application/shared/handlers/test-runs.ts
+++ b/application/shared/handlers/test-runs.ts
@@ -35,6 +35,12 @@ export async function getTestRun(
   const projectResults = await db.select().from(projects).where(eq(projects.id, testRun.projectId));
   const project = projectResults[0];
 
+  const latestRunResult = await db
+    .select({ latestRunId: sql<number>`MAX(${testRuns.id})` })
+    .from(testRuns)
+    .where(eq(testRuns.projectId, testRun.projectId));
+  const latestRunId = latestRunResult[0]?.latestRunId ?? null;
+
   const reportResults = await db
     .select()
     .from(files)
@@ -156,7 +162,7 @@ export async function getTestRun(
   return {
     ...testRunPublic,
     isFullRun: testRun.isFullRun === 1,
-    project,
+    project: project ? { ...project, latestRunId } : project,
     reports: reportResults.map((r: any) => ({
       id: r.id,
       type: r.subtype || r.type,

--- a/application/types/api.ts
+++ b/application/types/api.ts
@@ -254,6 +254,7 @@ export interface TestRunDetails {
     name: string;
     label?: string | null;
     latestRunId?: number | null;
+    latestRunStatus?: string | null;
   };
   reports?: ReportInfo[];
   testCases?: TestCaseResult[];

--- a/application/types/api.ts
+++ b/application/types/api.ts
@@ -253,6 +253,7 @@ export interface TestRunDetails {
     id: number;
     name: string;
     label?: string | null;
+    latestRunId?: number | null;
   };
   reports?: ReportInfo[];
   testCases?: TestCaseResult[];


### PR DESCRIPTION
When viewing a test run that is not the project's latest run, shows an
animated blue icon button next to the project name in the breadcrumb
that links to the latest run. The button pulses to indicate activity.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016KiCyiRorLtNr4CYqL7RLx