### PR TITLE
Add reporter heartbeat for fast interrupted-run detection

### DIFF
--- a/application/server/api/test-runs/[id]/events.post.ts
+++ b/application/server/api/test-runs/[id]/events.post.ts
@@ -4,7 +4,7 @@ import { eq, sql } from 'drizzle-orm';
 import { runEventBus } from '../../../utils/run-events';
 import { parseLocation } from '../../../utils/parse-location';
 import { persistRunCases, type RunCaseInput } from '../../../utils/persist-run-cases';
-import { validateAndReviveRun } from '../../../utils/revive-run';
+import { authorizeStreamToken } from '../../../utils/stream-auth';
 import type { StreamEventPayload } from '../../../../shared/types';
 import { Role } from '../../../../shared/types';
 import { countFailedFromTally } from '../../../../shared/utils/test-counts';
@@ -66,34 +66,7 @@ export default eventHandler(async (event) => {
 
   const db = await getDatabase();
 
-  // Fast path: skip the DB SELECT when the run is cached in memory.
-  // Falls back to a full DB lookup for cache misses (e.g. after server restart
-  // or for interrupted-run revival) and populates the cache on success.
-  let projectId: number;
-  const cachedState = runEventBus.getRunState(id);
-
-  if (cachedState) {
-    const valid = cachedState.streamToken === body.streamToken || cachedState.shardTokens?.has(body.streamToken);
-    if (!valid) {
-      throw createError({ statusCode: 403, message: 'Invalid stream token' });
-    }
-    projectId = cachedState.projectId;
-  } else {
-    const testRunResults = await db.select().from(testRuns).where(eq(testRuns.id, id));
-    const testRun = testRunResults[0];
-
-    if (!testRun) {
-      throw createError({ statusCode: 404, message: 'Test run not found' });
-    }
-
-    const isSharded = !!(testRun.shardTotal && testRun.shardTotal > 1);
-    const shardTokens = isSharded ? readShardTokensFromMeta(testRun.metadata) : undefined;
-    const isShardToken = shardTokens ? (token: string) => shardTokens.has(token) : undefined;
-    await validateAndReviveRun(db, id, testRun, body.streamToken, isShardToken);
-    projectId = testRun.projectId;
-    // Warm the cache so subsequent batches skip this SELECT
-    runEventBus.cacheRunState(id, { streamToken: body.streamToken as string, projectId, shardTokens });
-  }
+  const { projectId } = await authorizeStreamToken(db, id, body.streamToken);
 
   // Process test cases (supports single or batch)
   const testCaseEvents = Array.isArray(body.testCases) ? body.testCases : [body.testCase];

--- a/application/server/api/test-runs/[id]/heartbeat.post.ts
+++ b/application/server/api/test-runs/[id]/heartbeat.post.ts
@@ -1,0 +1,53 @@
+import { eq } from 'drizzle-orm';
+import { getDatabase } from '../../../database';
+import { testRuns } from '../../../database/schema';
+import { authorizeStreamToken } from '../../../utils/stream-auth';
+import { Role } from '../../../../shared/types';
+
+const REQUIRED_ROLES: Role[] = [];
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Runs'],
+    summary: 'Keep a streaming test run alive',
+    description:
+      'Lightweight liveness ping for an active streaming run. The reporter sends this during idle gaps (when no test events are flowing) so the server can tell a still-running run apart from a crashed one. Bumps the run\'s activity timestamp; the stale-run reaper marks runs with no recent activity as "interrupted". Requires the stream token.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': REQUIRED_ROLES,
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: { streamToken: { type: 'string' } },
+            required: ['streamToken'],
+          },
+        },
+      },
+    },
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = parseInt(getRouterParam(event, 'id') || '0');
+
+  if (!id) {
+    throw createError({ statusCode: 400, message: 'Invalid test run ID' });
+  }
+
+  const body = await readBody(event);
+
+  if (!body.streamToken) {
+    throw createError({ statusCode: 401, message: 'Missing stream token' });
+  }
+
+  const db = await getDatabase();
+
+  // Validates the token (and revives an interrupted run if it was prematurely reaped).
+  await authorizeStreamToken(db, id, body.streamToken);
+
+  // Advance the activity timestamp so the stale-run reaper leaves this run alone.
+  await db.update(testRuns).set({ updatedAt: new Date() }).where(eq(testRuns.id, id));
+
+  return { success: true };
+});

--- a/application/server/plugins/stale-run-cleanup.ts
+++ b/application/server/plugins/stale-run-cleanup.ts
@@ -3,8 +3,13 @@ import { testRuns } from '../database/schema';
 import { eq, and, lt, or, isNull } from 'drizzle-orm';
 import { runEventBus } from '../utils/run-events';
 
-const STALE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour without activity → mark interrupted
-const CHECK_INTERVAL_MS = 5 * 60 * 1000; // check every 5 minutes
+// A live reporter sends a heartbeat (~every 15s) during idle gaps, so an active
+// run's `updatedAt` never goes quiet for long. This timeout must stay comfortably
+// above the heartbeat interval to tolerate transient network blips and the long
+// idle gaps of pre-heartbeat reporters (a single slow test with no events). If a
+// run is reaped early, the next event or heartbeat revives it (see revive-run.ts).
+const STALE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes without activity → mark interrupted
+const CHECK_INTERVAL_MS = 30 * 1000; // check every 30 seconds
 
 async function cleanupStaleRuns() {
   try {
@@ -27,24 +32,34 @@ async function cleanupStaleRuns() {
           ),
         ),
       )
-      .returning({ id: testRuns.id });
+      .returning({
+        id: testRuns.id,
+        duration: testRuns.duration,
+        totalTests: testRuns.totalTests,
+        passedTests: testRuns.passedTests,
+        failedTests: testRuns.failedTests,
+        skippedTests: testRuns.skippedTests,
+        didNotRunTests: testRuns.didNotRunTests,
+      });
 
     if (staleRuns.length > 0) {
       console.log(
         `[StaleRunCleanup] Marked ${staleRuns.length} stale run(s) as interrupted: ${staleRuns.map((r) => r.id).join(', ')}`,
       );
-      // Signal SSE subscribers so their connections close, then free event bus memory
+      // Signal SSE subscribers so their connections close, then free event bus memory.
+      // Echo the run's real accumulated counts so live viewers keep the partial
+      // results already streamed instead of snapping back to zeros.
       for (const run of staleRuns) {
         runEventBus.publish(run.id, {
           type: 'run-finished',
           data: {
             status: 'interrupted',
-            duration: null,
-            totalTests: 0,
-            passedTests: 0,
-            failedTests: 0,
-            skippedTests: 0,
-            didNotRunTests: 0,
+            duration: run.duration,
+            totalTests: run.totalTests,
+            passedTests: run.passedTests,
+            failedTests: run.failedTests,
+            skippedTests: run.skippedTests,
+            didNotRunTests: run.didNotRunTests,
           },
         });
         runEventBus.cleanup(run.id);

--- a/application/server/utils/stream-auth.ts
+++ b/application/server/utils/stream-auth.ts
@@ -1,0 +1,43 @@
+import { eq } from 'drizzle-orm';
+import { testRuns } from '../database/schema';
+import { runEventBus } from './run-events';
+import { validateAndReviveRun } from './revive-run';
+import { readShardTokensFromMeta } from './shard-tokens';
+import type { getDatabase } from '../database';
+
+type DB = Awaited<ReturnType<typeof getDatabase>>;
+
+/**
+ * Authorize a streaming request by its stream token and return the run's `projectId`.
+ *
+ * Fast path: when the run is cached in memory (warm), validate the token against
+ * the cached main/shard tokens with no DB round-trip. On a cache miss — server
+ * restart, or an interrupted run being revived — it falls back to a full DB
+ * lookup + `validateAndReviveRun`, then warms the cache so subsequent requests
+ * skip the SELECT.
+ *
+ * Shared by the `events` and `heartbeat` endpoints, which need identical token
+ * validation. Throws 404 if the run doesn't exist, 403 on an invalid token.
+ */
+export async function authorizeStreamToken(db: DB, runId: number, streamToken: string): Promise<{ projectId: number }> {
+  const cachedState = runEventBus.getRunState(runId);
+  if (cachedState) {
+    const valid = cachedState.streamToken === streamToken || cachedState.shardTokens?.has(streamToken);
+    if (!valid) throw createError({ statusCode: 403, message: 'Invalid stream token' });
+    return { projectId: cachedState.projectId };
+  }
+
+  const testRunResults = await db.select().from(testRuns).where(eq(testRuns.id, runId));
+  const testRun = testRunResults[0];
+
+  if (!testRun) throw createError({ statusCode: 404, message: 'Test run not found' });
+
+  const isSharded = !!(testRun.shardTotal && testRun.shardTotal > 1);
+  const shardTokens = isSharded ? readShardTokensFromMeta(testRun.metadata) : undefined;
+  const isShardToken = shardTokens ? (token: string) => shardTokens.has(token) : undefined;
+  await validateAndReviveRun(db, runId, testRun, streamToken, isShardToken);
+
+  // Warm the cache so subsequent requests skip this SELECT
+  runEventBus.cacheRunState(runId, { streamToken, projectId: testRun.projectId, shardTokens });
+  return { projectId: testRun.projectId };
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -272,6 +272,28 @@ Stream test case results as they complete. Supports single or batch submission.
 
 ---
 
+### POST `/api/test-runs/[id]/heartbeat`
+
+Liveness ping for an active streaming run. The reporter sends this automatically during idle gaps (when no test events are flowing — e.g. a single long-running test or `beforeAll` setup) so the server can distinguish a still-running run from a crashed one. It bumps the run's activity timestamp; the stale-run reaper marks runs with no recent activity as `interrupted`. No configuration is required.
+
+**Request body**
+
+```json
+{
+  "streamToken": "abc123..."
+}
+```
+
+**Response**
+
+```json
+{
+  "success": true
+}
+```
+
+---
+
 ### POST `/api/test-runs/[id]/case-files`
 
 Upload one test case's trace and attachments while the run is still streaming, so files are viewable in the dashboard as soon as the test finishes. The test case must already have been sent to `/events` — the files are linked to that row.

--- a/reporter/src/stream-manager.ts
+++ b/reporter/src/stream-manager.ts
@@ -24,6 +24,16 @@ export class StreamManager {
   private retryCount = 0;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly maxRetryDelay = 30000;
+  /**
+   * Idle heartbeat: while the run is open but no events are flowing (e.g. a single
+   * long test, or `beforeAll` setup), a periodic ping keeps the server's activity
+   * timestamp fresh so the stale-run reaper can tell a live run from a crashed one.
+   * The interval must stay well below the server's stale timeout.
+   */
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatStopped = false;
+  private lastActivityAt = 0;
+  private readonly heartbeatInterval = 15000;
   /** Tracks cases whose files have already been uploaded live, so `uploadRemaining` can skip them. */
   private readonly uploadedCaseFiles = new WeakSet<CollectedTestCase>();
 
@@ -179,6 +189,8 @@ export class StreamManager {
         this._token = response.streamToken;
         this._enabled = true;
         this.logger.info(`Streaming enabled. Run ID: ${response.runId}`);
+        this.lastActivityAt = Date.now();
+        this.scheduleHeartbeat();
 
         if (this.pendingBeginEvents.length > 0) {
           this.pendingEvents = [...this.pendingBeginEvents, ...this.pendingEvents];
@@ -230,6 +242,7 @@ export class StreamManager {
       .then(
         () => {
           this.retryCount = 0;
+          this.lastActivityAt = Date.now();
           return true;
         },
         () => {
@@ -260,8 +273,48 @@ export class StreamManager {
     }, delay);
   }
 
+  // Schedule the next idle heartbeat. Self-rescheduling; cleared by stopHeartbeat.
+  private scheduleHeartbeat(): void {
+    if (this.heartbeatStopped || this.heartbeatTimer) return;
+    this.heartbeatTimer = setTimeout(() => {
+      this.heartbeatTimer = null;
+      void this.sendHeartbeat();
+    }, this.heartbeatInterval);
+  }
+
+  // Ping the server only when the run has actually been idle. Real event traffic
+  // already bumps the server's activity timestamp, so a recent flush (or pending
+  // events about to flush) makes the ping redundant — skip it and reschedule.
+  private async sendHeartbeat(): Promise<void> {
+    if (this.heartbeatStopped || !this._enabled || !this._runId || !this._token) return;
+
+    const idleFor = Date.now() - this.lastActivityAt;
+    if (idleFor < this.heartbeatInterval || this.pendingEvents.length > 0) {
+      this.scheduleHeartbeat();
+      return;
+    }
+
+    try {
+      await this.httpClient.postJSON(`/api/test-runs/${this._runId}/heartbeat`, { streamToken: this._token }, this._auth);
+      this.lastActivityAt = Date.now();
+    } catch (error: any) {
+      this.logger.debug(`Heartbeat failed: ${error.message}`);
+    }
+    this.scheduleHeartbeat();
+  }
+
+  /** Stop the idle heartbeat permanently (called when the run is wrapping up). */
+  private stopHeartbeat(): void {
+    this.heartbeatStopped = true;
+    if (this.heartbeatTimer) {
+      clearTimeout(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
   /** Drain all pending and buffered events before the run finishes. Retries up to 10 times with exponential back-off. */
   async drain(): Promise<void> {
+    this.stopHeartbeat();
     if (!this._enabled) {
       this.pendingEvents = [];
       this.flushPromises = [];

--- a/reporter/tests/stream-manager.spec.ts
+++ b/reporter/tests/stream-manager.spec.ts
@@ -204,3 +204,77 @@ describe('StreamManager batching & drain', () => {
     expect(seen.some((e: any) => e.title === 'buffered-1'), `seen: ${JSON.stringify(seen)}`).toBeTruthy();
   });
 });
+
+describe('StreamManager idle heartbeat', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  function makeEnabledManager(postJSON: (url: string, body: any) => Promise<any>): StreamManager {
+    const http = {
+      postJSON,
+      async resolveAuth() {
+        return null;
+      },
+    };
+    const sm = new StreamManager(
+      http as any,
+      new StreamBuffer(projectName),
+      new CrashRecovery(projectName),
+      {} as any,
+      new FileHandler(),
+      makeOptions(),
+    );
+    (sm as any)._enabled = true;
+    (sm as any)._runId = 1;
+    (sm as any)._token = 'tok';
+    (sm as any).heartbeatInterval = 20;
+    return sm;
+  }
+
+  const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  it('pings the heartbeat endpoint after an idle gap', async () => {
+    const calls: string[] = [];
+    const sm = makeEnabledManager(async (url) => {
+      calls.push(url);
+      return {};
+    });
+    (sm as any).lastActivityAt = Date.now() - 1000; // already idle
+    (sm as any).scheduleHeartbeat();
+    await wait(70);
+    (sm as any).stopHeartbeat();
+    expect(calls.some((u) => u.includes('/heartbeat'))).toBe(true);
+  });
+
+  it('skips the heartbeat when activity arrives before it fires', async () => {
+    const calls: string[] = [];
+    const sm = makeEnabledManager(async (url) => {
+      calls.push(url);
+      return {};
+    });
+    (sm as any).heartbeatInterval = 30;
+    (sm as any).lastActivityAt = Date.now();
+    (sm as any).scheduleHeartbeat();
+    // Activity lands before the timer fires → idle gap resets, ping is redundant.
+    setTimeout(() => {
+      (sm as any).lastActivityAt = Date.now();
+    }, 20);
+    await wait(45);
+    (sm as any).stopHeartbeat();
+    expect(calls.length).toBe(0);
+  });
+
+  it('drain stops the heartbeat', async () => {
+    const calls: string[] = [];
+    const sm = makeEnabledManager(async (url) => {
+      calls.push(url);
+      return {};
+    });
+    (sm as any).lastActivityAt = Date.now() - 1000;
+    (sm as any).scheduleHeartbeat();
+    await sm.drain();
+    const afterDrain = calls.length;
+    await wait(70);
+    expect(calls.length, 'no heartbeats fire after drain').toBe(afterDrain);
+  });
+});


### PR DESCRIPTION
The reporter→server streaming protocol is stateless HTTP, so an
interrupted run (CI box killed, OOM, lost machine) was only detected by
the stale-run reaper after a full hour of inactivity. This adds a
lightweight liveness signal so interruptions surface in ~2 minutes.

Reporter:
- StreamManager now sends a heartbeat POST during idle gaps (a single
  long test, beforeAll setup) when no events are flowing. It tracks last
  activity and skips the ping whenever real traffic already kept the run
  fresh, so active streaming adds zero extra requests. Starts when the
  stream opens, stops on drain.

Server:
- New POST /api/test-runs/[id]/heartbeat bumps the run's activity
  timestamp (and revives a prematurely reaped run via the existing path).
- Extracted the events endpoint's stream-token validation into a shared
  authorizeStreamToken helper, reused by the heartbeat endpoint.
- Lowered the stale-run timeout from 1h to 2m and the check interval from
  5m to 30s. The timeout stays well above the 15s heartbeat to tolerate
  network blips and pre-heartbeat reporters; an early reap self-heals on
  the next event or heartbeat.
- Fixed the reaper publishing zeroed counters on interrupt — it now
  echoes the run's real accumulated counts so live viewers keep the
  partial results already streamed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ALdybcsLf3A3HD9Z98maQc