### PR TITLE
refactor: move grid count into TestCaseSummary to guarantee accuracy

### DIFF
--- a/application/app/components/test-case/TestCaseSummary.vue
+++ b/application/app/components/test-case/TestCaseSummary.vue
@@ -24,7 +24,7 @@ interface HistoricalTiming {
   pct: number;
 }
 
-defineProps<{
+const props = defineProps<{
   testCase: TestCaseResult | null;
   scmInfo: ScmInfo | null;
   ciInfo: CiInfo | null;
@@ -32,8 +32,6 @@ defineProps<{
   environment: string | null | undefined;
   stepsCount: number;
   historicalTiming: HistoricalTiming | null;
-  summaryColSpanClass: string;
-  blockColSpanClass: string;
   traces?: TraceInfo[];
   attachments?: AttachmentInfo[];
   stableLinks?: EntityLinkInfo[] | null;
@@ -42,6 +40,16 @@ defineProps<{
 defineEmits<{
   refresh: [];
 }>();
+
+const { summaryColSpanClass, blockColSpanClass } = useDetailGrid(() => {
+  let count = 0;
+  if (props.scmInfo) count++;
+  if (props.ciInfo || props.environment) count++;
+  if (props.browser) count++;
+  if ((props.traces?.length ?? 0) > 0 || (props.attachments?.length ?? 0) > 0) count++;
+  count++; // Links card always visible
+  return count;
+});
 
 const origin = computed(() => {
   if (import.meta.client) {

--- a/application/app/pages/test-run-cases/[id].vue
+++ b/application/app/pages/test-run-cases/[id].vue
@@ -93,20 +93,6 @@ const failureCluster = computed(() => {
 
 const activeTab = ref('steps');
 
-const { summaryColSpanClass, blockColSpanClass } = useDetailGrid(() => {
-  let count = 0;
-  if (scmInfo.value) count++;
-  if (ciInfo.value || testCase.value?.testRun?.environment) count++;
-  if (testCase.value?.browser) count++;
-  if (
-    (traceData.value?.length ?? 0) > 0 ||
-    ((testCase.value as { attachments?: { length: number } } | null)?.attachments?.length ?? 0) > 0
-  )
-    count++;
-  count++; // Links card is always visible
-  return count;
-});
-
 const tabItems = computed(() => [
   { label: `Steps (${steps.value.length})`, icon: 'i-lucide-list-checks', value: 'steps', slot: 'steps' },
   { label: 'Traces & Console', icon: 'i-lucide-terminal', value: 'traces', slot: 'traces' },
@@ -325,8 +311,6 @@ function copyFailure() {
             :environment="environment"
             :steps-count="steps.length"
             :historical-timing="historicalTiming"
-            :summary-col-span-class="summaryColSpanClass"
-            :block-col-span-class="blockColSpanClass"
             :traces="traceData ?? []"
             :attachments="(testCase as any)?.attachments ?? []"
             :stable-links="(testCase as any)?.stableLinks ?? null"


### PR DESCRIPTION
The parent page was computing the block count separately from the component that actually renders the blocks, creating a mismatch risk. Move useDetailGrid into TestCaseSummary so the count is derived directly from the same props that drive v-if on each block.


Claude-Session: https://claude.ai/code/session_01V3D8DLvTyjnasWevRn1KR2