### PR TITLE
Block demo run simulator when acting user lacks project access

### DIFF
--- a/application/app/composables/useAuth.ts
+++ b/application/app/composables/useAuth.ts
@@ -46,6 +46,19 @@ export const useAuth = () => {
     window.location.reload();
   };
 
+  /**
+   * Whether the active demo identity has access to a project (its affectations).
+   * Mirrors the server's project-scope rules: admins and globally-assigned users
+   * see everything; others only their assigned projects. Always true outside the
+   * demo (real access control is enforced server-side there).
+   */
+  const canAccessDemoProject = (projectId: number): boolean => {
+    if (!config.public.demoMode) return true;
+    const u = findDemoUser(currentDemoUserId.value);
+    if (u.role === Role.ADMINISTRATOR || u.assignment.global) return true;
+    return u.assignment.projectIds.includes(projectId);
+  };
+
   const fetchUser = async (): Promise<AuthState> => {
     if (config.public.demoMode) {
       const state = demoStateFor(readSelectedDemoUserId());
@@ -118,5 +131,6 @@ export const useAuth = () => {
     demoUsers,
     currentDemoUserId,
     setDemoUser,
+    canAccessDemoProject,
   };
 };

--- a/application/app/composables/useDemoSimulator.ts
+++ b/application/app/composables/useDemoSimulator.ts
@@ -2,6 +2,7 @@ import { reactive } from 'vue';
 import {
   DEMO_SCENARIOS,
   DEMO_SIMULATOR_INSTANCE_ID,
+  DEMO_PROJECT_ID,
   runSimulation,
   type DemoScenario,
   type SimulationController,
@@ -40,6 +41,7 @@ let staleRunsCancelled = false;
 
 export function useDemoSimulator() {
   const toast = useToast();
+  const { canAccessDemoProject } = useAuth();
 
   /**
    * Cancel runs orphaned by a page reload mid-simulation (their reporter
@@ -60,6 +62,20 @@ export function useDemoSimulator() {
 
   async function start(scenario: DemoScenario): Promise<void> {
     if (state.status !== 'idle') return;
+
+    // Simulated runs land in the demo's e2e-checkout project. If the active
+    // "act as" identity isn't assigned to it, refuse rather than dropping the
+    // visitor into a project they shouldn't see — and explain why.
+    if (!canAccessDemoProject(DEMO_PROJECT_ID)) {
+      toast.add({
+        title: 'No access to this project',
+        description:
+          'Simulated runs target the “e2e-checkout” project, which the current user isn’t assigned to. Switch to a user with access (e.g. the admin) to run a simulation.',
+        color: 'warning',
+        icon: 'i-lucide-lock',
+      });
+      return;
+    }
 
     state.status = 'running';
     state.scenario = scenario;

--- a/application/app/demo/simulator.ts
+++ b/application/app/demo/simulator.ts
@@ -21,6 +21,14 @@ export const DEMO_SIMULATOR_INSTANCE_ID = 'demo-simulator';
 /** Project from the demo seed (scripts/generate-demo-seed.mjs) */
 const DEMO_PROJECT_NAME = 'e2e-checkout';
 
+/**
+ * Id of {@link DEMO_PROJECT_NAME} in the demo seed — the project every scenario
+ * targets. Used to gate the simulator on the acting demo user's project access
+ * (affectations). Must match the `e2e-checkout` row id in
+ * scripts/generate-demo-seed.mjs.
+ */
+export const DEMO_PROJECT_ID = 1;
+
 // ── Simulated data types ───────────────────────────────────────────────────
 
 interface SimStep {


### PR DESCRIPTION
Simulated runs always target the seeded e2e-checkout project. When the active "act as" identity isn't assigned to that project, the simulator used to create the run and navigate the visitor straight into it — contradicting the project affectation the demo is meant to showcase.

This is not a security boundary (the demo DB is entirely client-side), only a consistency issue. Gate start() on the acting user's affectations via a new useAuth().canAccessDemoProject() helper and show a "no access" toast instead of running, pointing the visitor to switch to a user with access.


Claude-Session: https://claude.ai/code/session_01EW2RjAT9SaizfAM4Tv7baA