### PR TITLE
Improve run insights UX with baseline detection and empty states

### DIFF
--- a/application/app/components/run/RunInsights.vue
+++ b/application/app/components/run/RunInsights.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 }>();
 
 interface RunInsightsData {
+  hasBaseline: boolean;
   newRegressions: Array<{ testRunsCaseId: number; title: string; filePath: string; duration: number | null }>;
   recurrences: Array<{ testRunsCaseId: number; title: string; filePath: string; duration: number | null }>;
   recovered: Array<{ testRunsCaseId: number; title: string; filePath: string; duration: number | null }>;
@@ -37,13 +38,13 @@ const data = ref<RunInsightsData | null>(null);
 const loading = ref(false);
 const error = ref<string | null>(null);
 
+const isRunActive = computed(
+  () =>
+    props.runStatus === 'running' || props.runStatus === 'initialising' || props.runStatus === 'finalizing',
+);
+
 async function load() {
-  if (
-    !props.testRunId ||
-    props.runStatus === 'running' ||
-    props.runStatus === 'initialising' ||
-    props.runStatus === 'finalizing'
-  ) {
+  if (!props.testRunId || isRunActive.value) {
     data.value = null;
     return;
   }
@@ -69,6 +70,23 @@ watch(
   },
 );
 
+const hasAnyInsights = computed(() => {
+  if (!data.value) return false;
+  const d = data.value;
+  return (
+    d.newRegressions.length > 0 ||
+    d.recurrences.length > 0 ||
+    d.recovered.length > 0 ||
+    d.newFlaky.length > 0 ||
+    d.flakyOnRetry.length > 0 ||
+    d.mostRegressed.length > 0 ||
+    d.mostImproved.length > 0 ||
+    d.slowestTests.length > 0 ||
+    d.workerImbalance.length > 1 ||
+    d.clusterNew.length > 0
+  );
+});
+
 function formatMs(ms: number | null | undefined): string {
   if (ms == null) return '—';
   if (ms < 1000) return `${ms}ms`;
@@ -85,8 +103,34 @@ function formatMs(ms: number | null | undefined): string {
 
   <LoadingState v-else-if="loading" padded />
 
+  <div v-else-if="isRunActive" class="p-4">
+    <EmptyState icon="i-lucide-loader-circle" text="Run in progress">
+      <p class="text-sm text-muted max-w-sm text-center">
+        Insights are computed once the run finishes. Switch back here when the run completes.
+      </p>
+    </EmptyState>
+  </div>
+
   <div v-else-if="!data" class="p-4">
-    <EmptyState text="All clear" />
+    <EmptyState text="No insights yet" />
+  </div>
+
+  <div v-else-if="!data.hasBaseline" class="p-4">
+    <EmptyState icon="i-lucide-git-compare-arrows" text="No baseline run found">
+      <p class="text-sm text-muted max-w-sm text-center">
+        Insights compare this run against the most recent passing run in the same project. No previous passing run
+        exists yet — once you have at least two completed runs, comparisons will appear here automatically.
+      </p>
+    </EmptyState>
+  </div>
+
+  <div v-else-if="!hasAnyInsights" class="p-4">
+    <EmptyState icon="i-lucide-check-circle" text="Everything looks consistent">
+      <p class="text-sm text-muted max-w-sm text-center">
+        No regressions, performance changes, or newly flaky tests detected compared to the baseline run. Insights
+        appear when something changes — keep running your tests to build history.
+      </p>
+    </EmptyState>
   </div>
 
   <div v-else class="space-y-6 p-4">

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -54,6 +54,7 @@ import {
   getFailureGroups,
   computeRegressionContextForRun,
 } from '~~/shared/handlers/test-runs';
+import { computeRunInsights } from '~~/shared/handlers/run-insights';
 import {
   listUsers,
   createUserRecord,
@@ -264,6 +265,13 @@ const routes: RouteEntry[] = [
     method: 'GET',
     pattern: /^\/api\/test-runs\/(\d+)\/regression-context$/,
     handler: async (m) => computeRegressionContextForRun(await getDemoDb(), +m[1]!),
+  },
+
+  // Run insights
+  {
+    method: 'GET',
+    pattern: /^\/api\/test-runs\/(\d+)\/insights$/,
+    handler: async (m) => computeRunInsights(await getDemoDb(), +m[1]!),
   },
 
   // Failure clusters

--- a/application/shared/handlers/run-insights.ts
+++ b/application/shared/handlers/run-insights.ts
@@ -19,6 +19,7 @@ interface PerfChangeEntry {
 }
 
 interface RunInsightsResult {
+  hasBaseline: boolean;
   newRegressions: TestCaseEntry[];
   recurrences: TestCaseEntry[];
   recovered: TestCaseEntry[];
@@ -80,6 +81,7 @@ export async function computeRunInsights(db: DrizzleDB, runId: number): Promise<
 
   const baselineRun = baselineResults[0];
   const empty = {
+    hasBaseline: false,
     newRegressions: [],
     recurrences: [],
     recovered: [],
@@ -198,6 +200,7 @@ export async function computeRunInsights(db: DrizzleDB, runId: number): Promise<
     .limit(20);
 
   return {
+    hasBaseline: true,
     newRegressions,
     recurrences,
     recovered,


### PR DESCRIPTION
## Summary
Enhanced the run insights feature with better handling of edge cases and improved user feedback. Added baseline run detection, computed insights availability checking, and contextual empty states to guide users through different scenarios.

## Key Changes
- **Baseline detection**: Added `hasBaseline` field to `RunInsightsData` interface to track whether a baseline run exists for comparison
- **Active run state**: Extracted run status check into a computed property `isRunActive` for cleaner logic and reusability
- **Insights availability**: Added `hasAnyInsights` computed property to determine if there are any insights to display across all categories
- **Enhanced empty states**: Replaced generic empty state with four contextual states:
  - Run in progress: Informs users insights are computed after completion
  - No data: Generic fallback when data fails to load
  - No baseline: Explains that comparisons require a previous passing run
  - No insights: Confirms everything is consistent when no changes detected
- **Demo API route**: Added `/api/test-runs/:id/insights` endpoint to the demo router

## Implementation Details
- The `hasBaseline` flag is set based on whether a baseline run is found during computation
- Empty states use appropriate icons and descriptive messages to help users understand why insights aren't available
- The `hasAnyInsights` check covers all insight categories including regressions, flakiness, performance changes, and worker imbalance

https://claude.ai/code/session_01EQszbV3LPJAtRr9CwrBWfo