### PR TITLE
Add filtering UI for home dashboard by environment and run type

### DIFF
--- a/application/app/components/home/HomeFilters.vue
+++ b/application/app/components/home/HomeFilters.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+export interface HomeFilterState {
+  environments: string[];
+  fullRunsOnly: boolean;
+}
+
+const props = defineProps<{
+  modelValue: HomeFilterState;
+  availableEnvironments: string[];
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: HomeFilterState];
+}>();
+
+const selectedEnvironments = computed({
+  get: () => props.modelValue.environments,
+  set: (val) => emit('update:modelValue', { ...props.modelValue, environments: val }),
+});
+
+const fullRunsOnly = computed({
+  get: () => props.modelValue.fullRunsOnly,
+  set: (val) => emit('update:modelValue', { ...props.modelValue, fullRunsOnly: val }),
+});
+
+const hasActiveFilters = computed(
+  () => props.modelValue.environments.length > 0 || !props.modelValue.fullRunsOnly,
+);
+
+function clearFilters() {
+  emit('update:modelValue', { environments: [], fullRunsOnly: true });
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-3 flex-wrap">
+    <!-- Environment filter -->
+    <USelectMenu
+      v-if="availableEnvironments.length > 0"
+      v-model="selectedEnvironments"
+      :items="availableEnvironments"
+      multiple
+      placeholder="All environments"
+      size="sm"
+      class="min-w-[160px]"
+    >
+      <template #default="{ modelValue: selected }">
+        <div class="flex items-center gap-1.5">
+          <UIcon name="i-lucide-server" class="size-3.5 shrink-0" :class="(selected as string[]).length ? 'text-primary' : 'text-gray-400'" />
+          <span v-if="!(selected as string[]).length" class="text-gray-500">All environments</span>
+          <span v-else-if="(selected as string[]).length === 1">{{ (selected as string[])[0] }}</span>
+          <span v-else>{{ (selected as string[]).length }} environments</span>
+        </div>
+      </template>
+    </USelectMenu>
+
+    <!-- Full runs only toggle -->
+    <label class="flex items-center gap-1.5 cursor-pointer select-none text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">
+      <UCheckbox v-model="fullRunsOnly" size="sm" />
+      Full runs only
+    </label>
+
+    <!-- Clear filters -->
+    <UButton
+      v-if="hasActiveFilters"
+      variant="ghost"
+      size="sm"
+      color="neutral"
+      icon="i-lucide-x"
+      @click="clearFilters"
+    >
+      Reset
+    </UButton>
+  </div>
+</template>

--- a/application/app/pages/index.vue
+++ b/application/app/pages/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useLocalStorage } from '@vueuse/core';
+import type { HomeFilterState } from '~/components/home/HomeFilters.vue';
 import type { ProjectOverview, TestRunForChart } from '~~/types/api';
 
 useHead({ title: 'Piwi Dashboard' });
@@ -10,10 +12,57 @@ const { data: recentTestRuns, refresh: refreshRecentRuns } = await useFetch<Test
 
 useRunStream(() => Promise.all([refreshOverview(), refreshRecentRuns()]));
 
+// ── Filters (persisted to localStorage) ──────────────────────────────────────
+
+const filters = useLocalStorage<HomeFilterState>('piwi-home-filters', {
+  environments: [],
+  fullRunsOnly: true,
+});
+
+const availableEnvironments = computed(() => {
+  const envSet = new Set<string>();
+  for (const run of recentTestRuns.value ?? []) {
+    if (run.environment) envSet.add(run.environment);
+  }
+  for (const project of overview.value ?? []) {
+    for (const run of project.recentRuns) {
+      if (run.environment) envSet.add(run.environment);
+    }
+  }
+  return [...envSet].sort();
+});
+
+// ── Filtered data ─────────────────────────────────────────────────────────────
+
+function matchesEnv(env: string | null | undefined): boolean {
+  if (filters.value.environments.length === 0) return true;
+  return !!env && filters.value.environments.includes(env);
+}
+
+const filteredRecentRuns = computed(() => {
+  let runs = recentTestRuns.value ?? [];
+  if (filters.value.fullRunsOnly) runs = runs.filter((r) => r.isFullRun);
+  if (filters.value.environments.length > 0) runs = runs.filter((r) => matchesEnv(r.environment));
+  return runs;
+});
+
+const filteredOverview = computed(() => {
+  let projects = overview.value ?? [];
+  if (filters.value.environments.length > 0) {
+    projects = projects
+      .map((p) => ({
+        ...p,
+        recentRuns: p.recentRuns.filter((r) => matchesEnv(r.environment)),
+      }))
+      .filter((p) => p.recentRuns.length > 0);
+  }
+  return projects;
+});
+
 // ── Stat strip ────────────────────────────────────────────────────────────────
 
 const overviewStats = computed(() => {
-  const projects = overview.value ?? [];
+  const projects = filteredOverview.value;
   const totalProjects = projects.length;
   const failingNow = projects.filter((p) => p.tendency === 'failing').length;
   const flakyNow = projects.filter((p) => p.tendency === 'flaky').length;
@@ -29,9 +78,7 @@ const overviewStats = computed(() => {
   const avgPassRate = totalTests > 0 ? Math.round((totalPassed / totalTests) * 100) : null;
 
   const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
-  const runs24h = projects.reduce((sum, p) => {
-    return sum + p.recentRuns.filter((r) => new Date(r.startTime).getTime() > oneDayAgo).length;
-  }, 0);
+  const runs24h = filteredRecentRuns.value.filter((r) => new Date(r.startTime).getTime() > oneDayAgo).length;
 
   return { totalProjects, failingNow, flakyNow, avgPassRate, runs24h };
 });
@@ -43,11 +90,8 @@ const ACTIVITY_PREVIEW_LIMIT = 6;
 
 const activityExpanded = ref(false);
 
-const today = new Date();
-today.setHours(0, 0, 0, 0);
-
 const allActivity = computed(() => {
-  const runs = [...(recentTestRuns.value ?? [])];
+  const runs = [...filteredRecentRuns.value];
   // Running runs first, then by start time desc
   return runs.sort((a, b) => {
     const aR = RUNNING_STATUSES.has(a.status) ? 0 : 1;
@@ -63,7 +107,7 @@ const visibleActivity = computed(() =>
 
 const hasMoreActivity = computed(() => allActivity.value.length > ACTIVITY_PREVIEW_LIMIT);
 
-const hasActivity = computed(() => (recentTestRuns.value?.length ?? 0) > 0);
+const hasActivity = computed(() => filteredRecentRuns.value.length > 0);
 const hasProjects = computed(() => (overview.value?.length ?? 0) > 0);
 
 // ── Pass rate helper (for activity list) ─────────────────────────────────────
@@ -128,6 +172,9 @@ const featureHighlights = [
           <UDashboardSidebarCollapse />
           <UBreadcrumb :items="[{ label: 'Home', icon: 'i-lucide-house', to: '/' }]" />
         </template>
+        <template v-if="hasProjects" #trailing>
+          <HomeFilters v-model="filters" :available-environments="availableEnvironments" />
+        </template>
       </UDashboardNavbar>
     </template>
 
@@ -186,7 +233,7 @@ const featureHighlights = [
         <!-- Per-project trend table + Recent activity side by side on wide screens -->
         <div v-if="hasProjects || hasActivity" class="grid grid-cols-1 xl:grid-cols-3 gap-6 items-start">
           <div class="xl:col-span-2">
-            <ProjectTrendTable v-if="hasProjects" :projects="overview ?? []" />
+            <ProjectTrendTable v-if="hasProjects" :projects="filteredOverview" />
           </div>
 
           <!-- Recent activity -->
@@ -232,6 +279,15 @@ const featureHighlights = [
               </NuxtLink>
             </div>
           </SectionCard>
+        </div>
+
+        <!-- Empty state when projects exist but all filtered out -->
+        <div
+          v-if="hasProjects && !hasActivity && filteredOverview.length === 0"
+          class="text-center py-12 text-gray-500 dark:text-gray-400"
+        >
+          <UIcon name="i-lucide-filter-x" class="size-8 mx-auto mb-2 opacity-40" />
+          <p>No runs match the current filters.</p>
         </div>
 
         <!-- Empty state: feature highlights + setup wizard -->

--- a/application/app/pages/index.vue
+++ b/application/app/pages/index.vue
@@ -18,7 +18,7 @@ const filters = useCookie<HomeFilterState>('piwi-home-filters', {
   encode: (v) => JSON.stringify(v),
   decode: (v) => {
     try {
-      return JSON.parse(v) as HomeFilterState;
+      return v ? (JSON.parse(v) as HomeFilterState) : { environments: [], fullRunsOnly: true };
     } catch {
       return { environments: [], fullRunsOnly: true };
     }

--- a/application/app/pages/index.vue
+++ b/application/app/pages/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useLocalStorage } from '@vueuse/core';
 import type { HomeFilterState } from '~/components/home/HomeFilters.vue';
 import type { ProjectOverview, TestRunForChart } from '~~/types/api';
 
@@ -12,11 +11,18 @@ const { data: recentTestRuns, refresh: refreshRecentRuns } = await useFetch<Test
 
 useRunStream(() => Promise.all([refreshOverview(), refreshRecentRuns()]));
 
-// ── Filters (persisted to localStorage) ──────────────────────────────────────
+// ── Filters (persisted to cookie, SSR-safe — no hydration flicker) ───────────
 
-const filters = useLocalStorage<HomeFilterState>('piwi-home-filters', {
-  environments: [],
-  fullRunsOnly: true,
+const filters = useCookie<HomeFilterState>('piwi-home-filters', {
+  default: () => ({ environments: [], fullRunsOnly: true }),
+  encode: (v) => JSON.stringify(v),
+  decode: (v) => {
+    try {
+      return JSON.parse(v) as HomeFilterState;
+    } catch {
+      return { environments: [], fullRunsOnly: true };
+    }
+  },
 });
 
 const availableEnvironments = computed(() => {

--- a/application/shared/handlers/projects.ts
+++ b/application/shared/handlers/projects.ts
@@ -1006,6 +1006,7 @@ export async function getProjectsOverview(db: DrizzleDB, scope: ProjectScope = '
           totalTests: testRuns.totalTests,
           startTime: testRuns.startTime,
           duration: testRuns.duration,
+          environment: testRuns.environment,
           rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${testRuns.projectId} ORDER BY ${testRuns.startTime} DESC)`.as(
             'rn',
           ),
@@ -1026,6 +1027,7 @@ export async function getProjectsOverview(db: DrizzleDB, scope: ProjectScope = '
         totalTests: rankedCte.totalTests,
         startTime: rankedCte.startTime,
         duration: rankedCte.duration,
+        environment: rankedCte.environment,
       })
       .from(rankedCte)
       .where(lte(rankedCte.rn, 20))
@@ -1069,6 +1071,7 @@ export async function getProjectsOverview(db: DrizzleDB, scope: ProjectScope = '
         flakyTests: r.flakyTests ?? 0,
         totalTests: r.totalTests ?? 0,
         startTime: r.startTime,
+        environment: r.environment ?? null,
       })),
       tendency: deriveTendency(runs),
     };

--- a/application/shared/handlers/test-runs.ts
+++ b/application/shared/handlers/test-runs.ts
@@ -205,6 +205,8 @@ const RECENT_FIELDS = {
   avgTestDuration: testRuns.avgTestDuration,
   p90TestDuration: testRuns.p90TestDuration,
   playwrightVersion: testRuns.playwrightVersion,
+  isFullRun: testRuns.isFullRun,
+  environment: testRuns.environment,
 };
 
 export async function getRecentTestRuns(db: DrizzleDB, scope: ProjectScope = 'all') {

--- a/application/types/api.ts
+++ b/application/types/api.ts
@@ -172,6 +172,7 @@ export interface ProjectOverviewRun {
   flakyTests: number;
   totalTests: number;
   startTime: string | Date;
+  environment?: string | null;
 }
 
 /**
@@ -343,6 +344,7 @@ export interface TestRunForChart {
   avgTestDuration?: number | null;
   p90TestDuration?: number | null;
   isFullRun?: boolean;
+  environment?: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Adds a new filtering system to the home dashboard that allows users to filter test runs and projects by environment and run type (full runs only). Filters are persisted to cookies for a seamless user experience across sessions.

## Key Changes
- **New HomeFilters component** (`components/home/HomeFilters.vue`): Provides UI controls for filtering by environment and toggling "full runs only" mode, with a reset button when filters are active
- **Filter state management**: Implemented cookie-based persistence of filter state (`piwi-home-filters`) with SSR-safe encoding/decoding to prevent hydration flicker
- **Computed filter logic**: Added `filteredRecentRuns` and `filteredOverview` computed properties that apply environment and full-run filters to the data
- **Dynamic environment discovery**: `availableEnvironments` computed property extracts all unique environments from both recent runs and project data
- **Updated statistics**: Modified `overviewStats` and activity calculations to use filtered data instead of raw data
- **Empty state handling**: Added UI message when projects exist but all are filtered out
- **Database schema updates**: Added `environment` field to `ProjectOverviewRun` and `TestRunForChart` types, and updated queries to include environment data in results

## Implementation Details
- Filter state uses a `HomeFilterState` interface with `environments: string[]` and `fullRunsOnly: boolean`
- Cookie encoding/decoding includes error handling to gracefully fall back to defaults on parse failures
- Environment filtering is applied at multiple levels: recent runs list, project overview, and statistics calculations
- The filter UI is conditionally rendered only when projects exist, keeping the interface clean when there's no data

https://claude.ai/code/session_019fe6dedfhB4MTvVd9VUpAn