### PR TITLE
Fix totalTests count in simulator to match real reporter

### DIFF
--- a/application/app/demo/simulator.ts
+++ b/application/app/demo/simulator.ts
@@ -922,7 +922,12 @@ async function runSingleSimulation(
     method: 'POST',
     body: {
       setupToken: setup.setupToken,
-      totalTests: tests.length,
+      // Matches the real reporter (stream-manager.ts), which always sends 0
+      // here — `totalTests` is built up from `events.post`/`reporter.ts` as
+      // each test completes, then finalized by `finish`. Sending the real
+      // count upfront would double it, since those insert counts land on
+      // top of an already-correct total instead of starting from zero.
+      totalTests: 0,
       metadata,
       playwrightVersion: '1.51.0',
       shardIndex: shardOverride?.shardIndex,


### PR DESCRIPTION
## Summary
Corrects the `totalTests` value sent by the simulator during test initialization to match the behavior of the real reporter implementation.

## Changes
- Changed `totalTests` from `tests.length` to `0` in the simulator's initial POST request
- Added detailed comment explaining the rationale: the real reporter (stream-manager.ts) always sends 0 initially, then builds up the count from individual test completion events. Sending the actual count upfront would result in double-counting since those event-based increments are added on top of the initial value rather than starting from zero.

## Details
This ensures the simulator accurately reflects how the real reporter works, preventing test count discrepancies during simulation runs. The total is properly accumulated through the `events.post`/`reporter.ts` flow as each test completes, then finalized by the `finish` event.

https://claude.ai/code/session_01VoXyzAJtkzmbpzqskyyup2