### PR TITLE
docs: align UI/MCP/getting-started with current product

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ reporter/               — Custom Playwright reporter package (TypeScript → c
 ```bash
 cd application
 npm install
-npm run dev          # http://localhost:3000
+npm run app:dev      # http://localhost:3000
 ```
 
 SQLite database auto-initializes on first API call.
@@ -538,12 +538,12 @@ Always regenerate the seed SQL after changes: `cd application && npm run app:see
 
 ## Troubleshooting
 - DB locked? Stop other processes accessing `.data/piwi.db`
-- Port 3000 in use? Use `PORT=3001 npm run dev` (Linux/macOS) or `$env:PORT=3001; npm run dev` (Windows PowerShell)
+- Port 3000 in use? Use `PORT=3001 npm run app:dev` (Linux/macOS) or `$env:PORT=3001; npm run app:dev` (Windows PowerShell)
 - Tests failing? Ensure no dev server on port 3000 (tests start their own)
 - Reporter not found? `npm link` in `reporter/` then in target project
 - Migration not applying? If a migration file or `_journal.json` was created by hand (not via `npm run db:generate`), the Drizzle migrator may silently skip it — delete the hand-written migration, revert the journal entry, run `npm run db:generate` (or `db:generate:pg` for PostgreSQL), and manually run `ALTER TABLE ... ADD COLUMN` on the existing database if needed.
 - Command appears frozen / no output? It probably launched an interactive pager. Use `git --no-pager <cmd>` for `diff`/`log`/`show`, and avoid commands that open an editor or wait for input (non-interactive shells hang on them).
-- **Don't start the dev server interactively** — `npm run dev` / `nuxt dev` runs as a foreground process and blocks all subsequent commands. The tests handle server startup automatically via `webServer` in `playwright.config.ts`. If you need to start the server manually, do it as a background PowerShell job or use `Start-Process`. Starting it directly in a bash tool call will leave you stuck until the tool times out.
+- **Don't start the dev server interactively** — `npm run app:dev` / `nuxt dev` runs as a foreground process and blocks all subsequent commands. The tests handle server startup automatically via `webServer` in `playwright.config.ts`. If you need to start the server manually, do it as a background PowerShell job or use `Start-Process`. Starting it directly in a bash tool call will leave you stuck until the tool times out.
 
 ## Testing API
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,17 +51,19 @@ See [Deployment](./deployment) for detailed Docker, Docker Compose, PostgreSQL, 
 ```bash
 # Clone the repository
 git clone https://github.com/piwitests/platform.git
-cd piwi-dashboard/application
+cd platform/application
 
 # Install dependencies
 npm install
 
 # Start the development server
-npm run dev
+npm run app:dev
 ```
 
 The dashboard will be available at `http://localhost:3000`.  
 The SQLite database is automatically created on the first API call.
+
+> The repository is an npm-workspaces monorepo, so the application scripts are prefixed `app:` (e.g. `app:dev`, `app:build`). Run them from the `application/` directory.
 
 ## Submitting your first test result
 
@@ -170,12 +172,13 @@ After submitting results, the dashboard provides:
 |------|---------|
 | **Home** (`/`) | Overview stats, test trend chart, and quick access to recent projects |
 | **Projects** (`/projects`) | Searchable table of all projects with status, duration, and tag filters |
-| **Project detail** (`/projects/:id`) | Run history for a single project with breakdown charts |
-| **Performance** (`/projects/:id/performance`) | Duration trends, slowest tests ranking, side-by-side run comparison |
-| **Test run** (`/test-runs/:id`) | Individual test cases with status, errors, traces, failure groups, and reports |
+| **Project detail** (`/projects/:id`) | Run history for a project, with tabs for failure clusters, flaky tests, performance, spec health, and run comparison |
+| **Test run** (`/test-runs/:id`) | Individual test cases with status, errors, traces, insights, failure groups, worker timeline, and reports |
 | **Test case** (`/test-cases/:id`) | Detailed view of a single test including steps, web vitals, and network data |
 | **API Docs** (`/docs`) | Interactive API reference with endpoint documentation, schemas, and try-it console (auto-generated) |
-| **Settings** (`/settings`) | User management, storage stats, tag management, and cleanup tools |
+| **Settings** (`/settings`) | Account, users, storage, tags, wasted-time patterns, AI diagnosis, and notifications |
+
+See the [UI overview](./ui-overview) for a full map of every page and tab.
 
 ## Development commands
 
@@ -183,16 +186,18 @@ Run these from the `application/` directory:
 
 | Command | Description |
 |---------|-------------|
-| `npm run dev` | Start development server with hot reload |
-| `npm run build` | Build for production |
-| `npm run preview` | Preview the production build locally |
-| `npm run typecheck` | TypeScript type checking |
-| `npm run lint` | Run ESLint |
-| `npm test` | Run Playwright functional tests |
+| `npm run app:dev` | Start development server with hot reload |
+| `npm run app:build` | Build for production |
+| `npm run app:preview` | Preview the production build locally |
+| `npm run app:typecheck` | TypeScript type checking |
+| `npm run app:lint` | Run oxlint (`app:lint:fix` to auto-fix) |
+| `npm run app:test:unit` | Run unit tests (Vitest) |
+| `npm run app:test` | Run Playwright end-to-end tests |
+| `npm test` | Run both unit and end-to-end tests |
 | `npm run db:generate` | Generate SQLite migration from schema changes |
 | `npm run db:generate:pg` | Generate PostgreSQL migration from schema changes |
 | `npm run db:studio` | Open Drizzle Studio to browse the SQLite database |
 | `npm run db:studio:pg` | Open Drizzle Studio to browse the PostgreSQL database |
-| `npm run seed:demo` | Regenerate demo seed data for the live demo |
+| `npm run app:seed:demo` | Regenerate demo seed data for the live demo |
 
-> **Migration workflow:** edit `server/database/schema.ts` → run `npm run db:generate` (SQLite) or `npm run db:generate:pg` (PostgreSQL) → review the generated `.sql` file → restart the app. Never create migration files or edit `meta/_journal.json` by hand — the Drizzle migrator depends on the journal to track which migrations have been applied, and manual entries cause it to silently skip the migration.
+> **Migration workflow:** edit `server/database/schema.sqlite.ts` (and `schema.pg.ts` for the PostgreSQL equivalent — `schema.ts` is just a dialect-selecting re-export, don't edit it) → run `npm run db:generate` (SQLite) or `npm run db:generate:pg` (PostgreSQL) → review the generated `.sql` file → restart the app. Never create migration files or edit `meta/_journal.json` by hand — the Drizzle migrator depends on the journal to track which migrations have been applied, and manual entries cause it to silently skip the migration.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -15,21 +15,45 @@ The MCP server is served from the same Nitro process as the dashboard. There is 
 
 ## What it provides
 
-The server exposes 11 read-only tools that cover the full diagnostic workflow:
+The server exposes 18 read-only tools that cover the full diagnostic workflow, from browsing projects to inspecting the exact evidence behind a failure.
+
+**Projects & activity**
 
 | Tool | Description |
 |------|-------------|
 | `list_projects` | All projects with run stats and latest run status |
 | `get_project` | Project details and recent test runs |
+| `list_recent_activity` | Most recent runs across *all* projects — a cross-project CI feed (no project ID needed) |
+
+**Runs & test cases**
+
+| Tool | Description |
+|------|-------------|
 | `list_runs` | Filter runs by project, branch, or status |
 | `get_run` | Run summary and test cases filtered by status |
 | `list_failed_cases` | Failed/timed-out cases across runs for a project |
 | `list_flaky_tests` | Flaky test analysis with flakiness scores and retry patterns |
+| `search_test_cases` | Find a test case by title or file path within a project |
 | `get_test_case` | Test case stats and recent execution history |
+| `get_test_run_case` | One execution record with full (untruncated) error, steps, console, network, web vitals, and ARIA snapshot |
+| `get_test_case_context` | Execution-scoped AI evidence for a single failure (steps, console, network, SCM diff) |
+| `get_case_screenshots` | Screenshots for an execution — metadata by default, or base64 image data on request |
+
+**Failure clusters**
+
+| Tool | Description |
+|------|-------------|
 | `list_clusters` | Failure clusters grouped by error fingerprint |
 | `get_cluster` | Cluster detail with affected tests and diagnosis summary |
 | `get_cluster_diagnosis` | Full AI diagnosis: root cause, evidence, suggested fix |
-| `get_cluster_context` | Raw AI evidence context (errors, steps, console logs, SCM diff) — the same data the built-in diagnosis AI receives |
+| `get_cluster_context` | Full AI evidence context (errors, steps, console logs, SCM diff) — the same data the built-in diagnosis AI receives |
+
+**Source control** *(requires an SCM token — per-project or global)*
+
+| Tool | Description |
+|------|-------------|
+| `get_repo_commits` | Recent commits for a project's repository (SHA, message, author, date) |
+| `get_repo_diff` | Changed files with patches for a single commit — inspect what a suspect commit changed |
 
 All tools return **token-optimized** compact JSON: null fields are omitted, errors are truncated, and large blobs (browser configs, metadata) are flattened to short strings.
 

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -5,207 +5,115 @@ lang: en-US
 
 # UI overview
 
-The Piwi Dashboard is a single-page application built with [Nuxt UI](https://ui.nuxt.com). It uses a sidebar navigation layout with real-time updates via Server-Sent Events — pages refresh automatically when test runs start or finish, without requiring manual reload.
+This page is a **map of the dashboard** — where each view lives and what it's for. For the concepts behind a feature, follow the links to the dedicated pages ([Flaky tests & analytics](./flaky-tests), [AI diagnosis & clustering](./ai-diagnosis), [Reporter](./reporter)).
+
+The dashboard is a single-page app built with [Nuxt UI](https://ui.nuxt.com). It updates itself in real time over Server-Sent Events — pages refresh automatically when runs start or finish, so you never reload manually.
 
 ## Inline help
 
-Throughout the dashboard, blocks that aren't self-explanatory carry a small muted help icon (a circled question mark) next to their title. Click it for a short explanation of the feature and, where available, a **Learn more** link to the relevant documentation page. The icon is keyboard-focusable and the popover closes with `Esc`. Self-explanatory blocks (counters, search boxes, basic forms) intentionally have no icon, keeping the interface uncluttered.
+Blocks that aren't self-explanatory carry a small muted help icon (a circled question mark) next to their title. Click it for a short explanation and, where relevant, a **Learn more** link into these docs. The icon is keyboard-focusable and closes with `Esc`. Self-explanatory blocks (counters, search boxes) have no icon, keeping the UI uncluttered.
 
-## Navigation structure
+## Navigation
 
-The dashboard sidebar provides access to the main sections:
+The sidebar gives access to the top-level sections:
 
-| Section | Path | Description |
-|---------|------|-------------|
-| Home | `/` | Landing page with aggregate statistics and activity overview |
-| Projects | `/projects` | Full project listing with search, filters, and actions |
-| Settings | `/settings` | Application configuration (general, users, storage, tags) |
-| API Docs | `/docs` | Interactive API reference auto-generated from the OpenAPI 3.1 spec — browse all endpoints, request/response schemas, and run live requests |
+| Section | Path | Purpose |
+|---------|------|---------|
+| Home | `/` | Aggregate stats and activity across all projects |
+| Projects | `/projects` | Full project listing with search and tag filters |
+| Settings | `/settings` | Configuration — general, account, users, storage, tags, wasted time, AI, notifications |
+| API docs | `/docs` | Interactive OpenAPI 3.1 reference (Scalar) — browse schemas and run live requests |
+| MCP server | `/mcp` | Setup guide for connecting AI clients (see [MCP server](./mcp)) |
 
-Project-level pages are accessed by clicking into a specific project:
+Everything else is reached by drilling into a project, run, or test case:
 
-| Page | Path | Description |
-|------|------|-------------|
-| Project detail | `/projects/:id` | Run history, failure clusters, flaky tests, trends, test cases, run comparison |
-| Project edit | `/projects/:id/edit` | Edit project label, description, tags, and AI diagnosis instructions |
-| Performance | `/projects/:id/performance` | Duration trends, slowest tests, run comparison |
-| Test cases | `/projects/:id/test-cases` | All unique test cases with per-case history |
-| Failure cluster | `/failure-clusters/:id` | Cluster details, affected tests, AI diagnosis, and triage |
+| Page | Path |
+|------|------|
+| Project detail | `/projects/:id` |
+| Project edit | `/projects/:id/edit` |
+| Test cases (project) | `/projects/:id/test-cases` |
+| Failure cluster | `/failure-clusters/:id` |
+| Test run | `/test-runs/:id` |
+| Test case | `/test-cases/:id` |
 
-Individual run and test case pages:
+## Home
 
-| Page | Path | Description |
-|------|------|-------------|
-| Test run | `/test-runs/:id` | Full detail of a single run — test list, errors, reports, traces |
-| Test case | `/test-cases/:id` | Single test details — steps, web vitals, network requests |
+A quick health check across all projects: **stats cards** (projects, runs, active/passing projects, flaky count, slowest project), a **test-results trend chart** (pass/fail/skip/flaky over time), **recent projects**, and a getting-started snippet for teams that haven't wired up the reporter yet.
 
-## Home page
+## Projects
 
-The home page provides a quick health check across all projects:
-
-- **Stats cards** — total projects, total runs, active projects, passing projects, flaky test count, and slowest project
-- **Test results trend chart** — stacked area chart showing pass/fail/skip/flaky distribution over time
-- **Recent projects** — quick links to the most recently active projects with their current status
-- **Getting started** — API usage example for teams that haven't configured the reporter yet
-
-## Projects page
-
-The projects page is the primary navigation hub:
-
-- **Search** — filter projects by name with an instant text search
-- **Tag filters** — click tag badges to show only projects with specific tags
-- **Table columns** — project name (with tags), run count, last run date, duration, status badge, test status bar, report links, and action buttons
-- **New project** — create a project manually with name, label, description, and tags
-- **Refresh** — manually trigger a data refresh (also happens automatically via SSE)
+The primary hub: instant **text search**, **tag filters**, and a table showing each project's run count, last-run date, duration, status, test pass/fail bar, report links, and actions. Create a project manually with **New project** (it's also created automatically on first result submission).
 
 ## Project detail
 
-Shows the complete run history for a single project, with six tabs:
+The complete history for one project, organized into tabs:
 
-- **Test runs** — each row shows run status, start time, duration, test counts, browser badges, and links to reports/traces; select two runs to compare them
-- **Failure clusters** — all unique failure signatures across all runs, with status, error type, occurrence count, AI diagnosis badge, and a link to the cluster detail page
-- **Flaky tests** — tests that fail intermittently, scored by a composite flakiness metric; shows failure rate, retry passes, status alternation count, root cause classification, and impact score (wasted CI minutes); sortable and filterable by root cause
-- **Trends** — duration trend chart with date filter, and a slowest-tests table
-- **Test cases** — all unique test cases with status, pass rate, result breakdown (with icons), average duration, and last run date
-- **Compare** — side-by-side delta view between two selected runs (new failures, recovered, duration changes)
+- **Test runs** — every run with status, start time, duration, test counts, and browser badges; select two runs to compare. Runs with a shared failure signature roll up into **Failure clusters** here (see [AI diagnosis & clustering](./ai-diagnosis)).
+- **Flaky tests** — intermittent tests scored by a composite flakiness metric, with root-cause classification and impact ranking. See [Flaky tests & analytics](./flaky-tests#flaky-test-detection).
+- **Performance** — average/P90 duration trends and a slowest-tests table. See [Performance](./flaky-tests#performance).
+- **Test cases** — every unique test with pass rate, result breakdown, average duration, and last-run date.
+- **Compare** — side-by-side delta between two runs (new failures, recovered, duration changes).
+- **Spec health** — a heatmap grouping test cases by spec file and coloring each by pass rate, so an unhealthy area of the suite jumps out. See [Spec health heatmap](./flaky-tests#spec-health-heatmap).
+- **Members** *(admins, when auth is enabled)* — grant or scope project access per user. See [Authentication](./authentication#user-management).
 
-## Performance page
-
-Provides insights into test execution speed:
-
-- **Duration trend chart** — line chart showing average and P90 run durations over time
-- **Slowest tests table** — top 20 test cases ranked by average duration, with min/max and occurrence count
-- **Run comparison** — select two runs to see a side-by-side delta view showing which tests improved, regressed, or stayed unchanged
+Project **edit** (`/projects/:id/edit`) sets the label, description, tags, per-project SCM token, and **AI diagnosis instructions** (project-specific context combined with the global instructions for every diagnosis).
 
 ## Test run detail
 
-Deep dive into a single test execution:
+A deep dive into a single run. The **summary header** shows status, duration, test counts, duration metrics (avg/P90), and metadata cards (CI/environment, source control, tags). While a run is still `running`, a **live progress bar** and streaming results appear in real time. **Reports** buttons open or download the attached HTML reports (Playwright, Monocart).
 
-- **Summary header** — status, duration, start time, test counts, duration metrics (Avg P90), and metadata blocks (CI/Environment, Source control, Tags/Other) in a responsive card grid
-- **Live progress** — if the run is still in progress (`running` status), a live progress bar and streaming test results appear in real time
-- **Reports** — buttons to open attached HTML reports (Playwright, Monocart) in a new tab or download blob archives
-- **Tabbed right panel** with five tabs:
-  - **Test cases** — every test with browser icon (first column), status, duration, file location, error messages, annotation badges, traces; scrollable table with sticky header, searchable, filterable by status and browser, and paginated
-- **Tree** — tests grouped by suite hierarchy (describe blocks), with expandable/collapsible nodes that show suite mode badges, annotation counts, and per-suite aggregate statistics
-  - **Workers** — horizontal timeline showing worker assignment per test case; click a bar to jump to that test case in the table
-  - **Compare** — select a baseline run for side-by-side delta view showing new failures, recovered tests, and duration changes (improved/regressed/unchanged)
-  - **Slow endpoints** — aggregated network request table showing slow API calls grouped by method + normalized route, with avg/p90/max duration and error rate
-  - **Failure groups** — failures grouped by root cause via error fingerprinting; each group shows signature, error type, count, flaky/worker-correlation signals, known-since run, and actions: filter the test list, trigger AI diagnosis (opens a modal), or navigate to the cluster detail page
-- **Delete** — administrators can delete the entire run and associated files
+The right panel is tabbed:
+
+- **Test cases** — every test with browser icon, status, duration, location, errors, annotations, and traces; searchable, filterable by status/browser, and grouped by suite hierarchy (describe blocks).
+- **Insights** — what changed versus the last passing baseline: new regressions, recurring failures, fixed tests, new flaky tests, performance changes, worker imbalance, and new clusters. See [Run insights](./flaky-tests#run-insights).
+- **Failure groups** — failures grouped by error fingerprint, each with flaky/worker-correlation signals and actions to filter the list, trigger AI diagnosis, or open the cluster. See [AI diagnosis & clustering](./ai-diagnosis).
+- **Regression** *(shown when a baseline exists)* — the regression delta for this run at a glance.
+- **Timeline** — a horizontal per-worker timeline of test execution, with a span-type filter to isolate test phases (setup, actual test, wasted waits, teardown); click a bar to jump to that test case.
+- **Compare** — pick a baseline run for a side-by-side delta (improved / regressed / unchanged).
+- **Slow endpoints** — network requests grouped by method + normalized route, with avg/p90/max duration and error rate.
+
+Administrators can **delete** the entire run and its files from the header.
 
 ## Test case detail
 
-Shows everything about a single test execution:
+Everything about a single test execution: a **status card** (id, title, copyable location, duration, worker, retries, slowest step, duration-vs-average), **run context** (environment, CI, branch, commit, author, browser), a link into the specific test in the HTML report, and attached **traces** (open in the Playwright viewer or download; they stream in live while the parent run is in progress).
 
-- **Status card** — test ID, title, location (copyable), duration, worker index, retries, slowest step, and duration vs historical average comparison
-- **Run context** — environment, CI provider, build number, branch, commit, author, browser, viewport — all from the parent test run's metadata
-- **HTML report** — direct link to the specific test in the full HTML report (with screenshots, video, and interactive trace viewer)
-- **Traces** — attached trace files with "View trace" buttons that open them in the Playwright trace viewer (trace.playwright.dev), plus download buttons; while the parent run is still in progress, traces and attachments appear live as soon as each test uploads them
-- **Error details** — full error message with copy button and expandable view for long errors; if the test belongs to a failure cluster, a context row shows how many other tests in the same run share the same root cause
-- **Alternative locators** — when the failure is a broken locator, ranked replacement locators with stability scores and a highlighted recommended fix (see [locator healing](./reporter#locator-healing)); shown only when prior-run or ARIA-snapshot data is available
-- **Performance hints** — actionable suggestions for slow navigations, flaky tests, slow assertions, and long step sequences
-- **Steps** — execution steps with category badges and individual timing
-- **Web Vitals** — TTFB, FCP, DOMContentLoaded, etc. with color-coded thresholds (green/amber/red)
-- **Network requests** — all HTTP requests grouped by method + normalized route with count and avg duration; backend server logs (captured via the `X-Piwi-Logs` header by ASP.NET Core or Nitro integrations) are shown inline under each request
-- **History** — line chart and table showing this test case's status and duration across all previous runs
-
-## Settings pages
-
-### General settings
-
-Basic application configuration. In demo mode, includes a "Reset Demo" button to restore seed data.
-
-### Users (`/settings/users`)
-
-Available when authentication is enabled (or shown with an informational message when disabled):
-
-- **User table** — username, display name, role, and creation date
-- **Add user** — create accounts with username, password, role (administrator/reporter/user), and display name
-- **API keys** — generate and manage API keys for CI authentication; keys are shown once at creation and stored hashed
-
-### Storage (`/settings/storage`)
-
-Storage statistics and maintenance tools:
-
-- **Stats** — total projects, test runs, test cases, traces, stored reports, aggregate report size, and on-disk storage size
-- **Cleanup** — bulk-delete test runs older than a configurable period (7 to 365 days) with a confirmation dialog
-
-### Tags (`/settings/tags`)
-
-Manage tags used to organize projects:
-
-- **Tag table** — tag text, color, and creation date
-- **Add tag** — create new tags with custom names and colors
-- **Edit/Delete** — modify or remove existing tags (administrator only)
-
-### AI diagnosis (`/settings/ai`)
-
-Configure LLM-based failure analysis:
-
-- **Provider** — choose Anthropic API or an OpenAI-compatible endpoint (Ollama, LM Studio, OpenRouter, Groq, Together AI, Mistral AI, or any custom URL)
-- **API key / model / base URL** — provider credentials and model selection; keys are stored in the database (admin-only) or via `PIWI_AI_*` environment variables
-- **Auto-diagnose** — automatically run AI diagnosis on new failure clusters when a run finishes (max 3 per run)
-- **Global analysis instructions** — persistent text appended to the system prompt for every diagnosis across all projects; use this for general preferences, output format requirements, or team conventions (e.g. "always recommend checking retry counts before concluding flakiness")
-- **Diagnosis context limits** — caps on how much evidence is packed into each diagnosis (error text, SCM patch budget, affected tests, steps, console entries, network requests, ARIA snapshot, test source), letting you trade detail against token cost. Leave a field empty to use its default. Any limit can instead be pinned via a `PIWI_AI_MAX_*` environment variable, in which case it takes precedence and shows read-only.
-- **Environment variables** — copy-to-clipboard snippet for `PIWI_AI_*` env vars when credentials should not be stored in the database
+Also here: full **error details** with cluster context; **alternative locators** when a locator broke, with ranked replacements and a recommended fix (see [locator healing](./reporter#locator-healing)); **performance hints**; execution **steps**; **Web Vitals** with color-coded thresholds; **network requests** with inline backend server logs (see [Backend logs](./backend-logs)); and a **history** chart of this test's status and duration over time.
 
 ## Failure cluster detail
 
-Each failure cluster has a dedicated page (`/failure-clusters/:id`) with three tabs:
+Each cluster (`/failure-clusters/:id`) has three tabs — **Overview** (signature, affected tests, and an alternative-locators panel for broken locators), **Triage** (set status open/resolved/ignored and write a note), and **AI diagnosis** (run an SCM-grounded LLM analysis with a baseline-commit picker and commit browser). Full detail: [AI diagnosis & clustering](./ai-diagnosis).
 
-- **Overview** — signature, error type, selector, occurrence count, first/last seen runs, sample raw error, list of affected test cases with their latest run status, and — for broken-locator failures — an **Alternative locators** panel with ranked replacements and a recommended fix (see [locator healing](./reporter#locator-healing))
-- **Triage** — set cluster status (open / resolved / ignored) and write an internal triage note
-- **AI diagnosis** — run an LLM diagnosis of the cluster with full control over the context sent to the LLM:
-  - **Baseline commit picker** — select the commit to compare against so the diagnosis includes the relevant SCM diff; pin a commit to persist it for all future diagnoses of this cluster
-  - **Commit browser** — "Browse commits" opens a split modal where you can check specific commits to include their full diffs in the LLM context, regardless of the baseline; useful when the relevant change isn't the most recent one; the modal shows file-level diffs with syntax-colored patch lines and aggregates stats (files changed, lines added/removed) for your selection
-  - **Diagnosis result** — category, confidence, summary, root cause, evidence list, suggested fix, and prevention tips; re-run at any time to refresh after new occurrences
+## Settings
 
-### Per-project AI instructions
+| Page | Path | What it does |
+|------|------|--------------|
+| General | `/settings` | Basic app configuration; a **Reset Demo** button in demo mode |
+| Account | `/settings/account` | Your display name, email, password, and **connected accounts** (link/unlink Google or GitHub — see [OAuth](./authentication#oauth-google-github)) |
+| Users | `/settings/users` | User accounts, roles, project access, and API keys (shown once, stored hashed) — see [Authentication](./authentication) |
+| Storage | `/settings/storage` | Storage stats and cleanup (bulk-delete runs older than N days) — see [Storage](./storage#storage-management) |
+| Tags | `/settings/tags` | Create, color, edit, and delete the tags used to organize projects |
+| Wasted time | `/settings/wasted-time` | Patterns that classify which Playwright waits count as "wasted time" on the timeline — see [Configuration](./configuration#wasted-time) |
+| AI | `/settings/ai` | Provider/model roles, auto-diagnose, global instructions, and context limits — see [AI diagnosis](./ai-diagnosis#enabling-ai-diagnosis) |
+| Notifications | `/settings/notifications` | Channels, subscriptions, and SMTP — see [Notifications & alerts](./notifications) |
 
-In the project edit page (`/projects/:id/edit`), an **AI diagnosis instructions** field lets you provide project-specific context that is combined with the global instructions for every diagnosis of that project's clusters. Use this to describe the system under test, known failure patterns, or domain-specific remediation guidance.
+Where an environment variable backs a setting, the field is shown read-only with a lock badge and the env var name (see [Configuration](./configuration)).
 
 ## Real-time updates
 
-The dashboard uses Server-Sent Events (SSE) for live updates:
+The dashboard uses Server-Sent Events so it never needs a manual refresh:
 
-1. **Global stream** (`/api/stream`) — notifies all connected clients when a run starts, finishes, or is submitted. Pages automatically refresh their data.
-2. **Per-run stream** (`/api/test-runs/:id/stream`) — used on the test run detail page to show live progress as tests complete during a streaming run.
+- **Global stream** (`/api/stream`) — tells every connected client when a run starts, finishes, or is submitted; pages re-fetch their data.
+- **Per-run stream** (`/api/test-runs/:id/stream`) — drives the live progress on the run detail page during a streaming run.
 
-This means you never need to manually refresh the dashboard — it updates itself whenever CI submits new results.
+## Live demo
 
-## Demo run simulator
+The [live demo](https://piwitests.github.io/demo/) runs entirely in your browser (in-memory SQLite) and adds two things the real app doesn't need:
 
-The [live demo](https://piwitests.github.io/demo/) includes a **Simulate a test run** menu in the demo banner. It replays the exact streaming protocol a Piwi reporter speaks during a real Playwright run — entirely in your browser — so you can watch a run arrive live. Available scenarios:
+**Simulate a test run** — the demo banner replays the exact streaming protocol a Piwi reporter speaks during a real run, so you can watch one arrive live. Scenarios: a passing run, a run with failures (joining a known cluster plus a brand-new one), flaky retries, a performance regression, an interrupted run, and a cross-browser run. Each creates a real run in the in-browser database, so worker timeline, failure groups, and history comparisons all behave exactly as they would against a server.
 
-- **Passing run** — all tests pass across 4 parallel workers
-- **Run with failures** — failures joining a known failure cluster, plus a brand-new cluster
-- **Flaky retries** — tests that fail and then pass on retry
-- **Performance regression** — a green run that is ~2× slower, with degraded endpoints
-- **Interrupted run** — a CI job killed partway through the suite
-- **Cross-browser run** — tests distributed across Chromium, Firefox, and WebKit to showcase the browser column and filter
+**Acting as** — the demo runs with authentication conceptually enabled. Switch between pre-seeded identities (an admin, a CI reporter, and several project-scoped users) to see how [project access](./authentication#user-management) changes what each user sees. Acting as the admin, you can change affectations live and then switch users to see the effect.
 
-Each simulation creates a real run in the in-browser database: initialization status, live per-test updates, worker timeline, failure groups, regression context, and history-based comparisons all behave exactly as they would against a real server.
+## Responsive & dark mode
 
-## Demo user switcher (act as)
-
-The demo runs with authentication conceptually **enabled** so the role-based and project-affectation features are fully explorable. Use the **Acting as** picker in the demo banner to switch between several pre-seeded identities:
-
-- **Avery (Admin)** — full access to every project; sees the user management and project members screens
-- **Robin (CI Reporter)** — global access; can submit/triage but not manage users
-- **Sam (Checkout team)** — a `user` scoped to a single project
-- **Priya (API & UI team)** — a `user` scoped to two projects
-- **Noah (No projects yet)** — a `user` with no affectations (sees an empty dashboard until assigned)
-
-Switching identity reloads the dashboard under the new user, so the project list, sidebar menu, dashboard overview, recent runs, and search all reflect that user's **project affectations**. Acting as the admin, you can change affectations live — from **Settings → User management → Project access** (per user) or a project's **Members** tab (per project) — then switch to that user to see the effect. All of this happens entirely in your browser.
-
-## Responsive design
-
-The dashboard is fully responsive:
-
-- **Desktop** — sidebar navigation with full table views
-- **Tablet** — collapsible sidebar, tables scroll horizontally
-- **Mobile** — compact layout with stacked cards and hamburger menu
-
-## Dark mode
-
-The dashboard supports light and dark themes, following the system preference by default. Toggle manually via the theme switcher in the sidebar.
+The dashboard is fully responsive — sidebar navigation on desktop, collapsible sidebar and horizontally scrolling tables on tablet, and a stacked/hamburger layout on mobile. It supports light and dark themes, following the system preference by default, with a manual toggle in the sidebar.


### PR DESCRIPTION
The docs had drifted from the shipped product. This corrects the
stale parts and trims duplication:

- ui-overview: lean rewrite as a "where things live" map. Fix the
  project-detail tabs (Trends -> Performance, add Spec health and
  Members, Failure clusters nested under runs), the run-detail tabs
  (add Insights and Regression, Workers -> Timeline with span filter,
  drop the removed Tree tab), and add the Notifications, Wasted time,
  and Account settings pages. Defer feature depth to the dedicated
  pages instead of re-explaining it.
- mcp: list all 18 tools (was 11), grouped by area, adding the
  test-case-context, screenshots, search, run-case, recent-activity,
  and repo commit/diff tools.
- getting-started: fix contributor commands to the app:-prefixed
  workspace scripts (app:dev, app:build, app:seed:demo, ...), the
  clone path, the schema-edit note (edit schema.sqlite.ts/pg, not the
  re-export), and the navigation table (Performance is a tab now).
- AGENTS: fix stray `npm run dev` references to `npm run app:dev`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013zY6LZyivyrbazbSihiEC2