### PR TITLE
docs: fix remaining invalid npm commands, document project access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,8 +262,8 @@ node scripts/db-query.mjs "SELECT id, name FROM projects" --json
 | `npm run reporter:format`| Format source code with oxfmt |
 | `npm run reporter:test`  | Run unit tests with Vitest |
 | `npm run reporter:test:watch` | Watch mode — re-run tests on changes |
-| `npm run lint`           | Lint with oxlint               |
-| `npm run lint:fix`       | Lint with auto-fix             |
+| `npm run reporter:lint`     | Lint with oxlint               |
+| `npm run reporter:lint:fix` | Lint with auto-fix             |
 
 ## Making Changes
 
@@ -558,7 +558,7 @@ curl -X POST http://localhost:3000/api/test-runs/submit \
 The app can be built as a fully client-side SPA (no server needed) by setting `PIWI_DEMO_MODE=true`. The demo build:
 
 1. **`npm run app:seed:demo`** — Generates `public/demo/seed.sql` (SQLite dump with 4 projects, 43 test cases, 61 test runs, 698 test-run-case rows, 8 failure clusters) and `public/demo/seed.version.json` (SHA-256 hash of the SQL content + timestamp). **`public/demo/seed.sql` is NOT committed** — it is gitignored and regenerated on demand (and in CI, `docs.yml` runs `app:seed:demo` before the demo build), so don't commit or stage it. Only `seed.version.json` is tracked. After editing `scripts/generate-demo-seed.mjs`, re-run `npm run app:seed:demo` and commit the generator + the updated `seed.version.json` (the regenerated `seed.sql` stays local).
-2. **`npm run generate:demo`** — Builds the SPA with `ssr: false` and PWA service worker that intercepts `/api/` calls, serving them from in-browser sql.js (WASM SQLite) via Drizzle ORM.
+2. **`npm run app:generate:demo`** — Builds the SPA with `ssr: false` and PWA service worker that intercepts `/api/` calls, serving them from in-browser sql.js (WASM SQLite) via Drizzle ORM.
 3. The SQLite database is persisted in IndexedDB across page loads and re-seeded only when no persisted data exists.
 4. **Staleness detection**: The build injects `demoDataVersion` (the SHA-256 hash from `seed.version.json`) into `runtimeConfig.public`. At runtime, the layout compares it against the version stored in IndexedDB and shows a "New demo data available" button in the sidebar footer. Clicking it wipes IndexedDB and reloads the page.
 5. The service worker (`app/service-worker/demo-sw.ts`) handles API fetches via `app/demo/api/router.ts`. Both SW and main thread share `app/demo/db.client.ts` for DB initialization.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,9 +11,11 @@ The dashboard supports optional user authentication with role-based access contr
 
 | Role | Description |
 |------|-------------|
-| **Administrator** | Full access to all features including editing projects, managing users, and deleting runs |
-| **Reporter** | Can only call submission API endpoints (`/api/test-runs/submit` and `/api/test-runs/upload`) |
-| **User** | Read-only access to all dashboard pages and data |
+| **Administrator** | Full access to every project and feature — editing projects, managing users, and deleting runs. Never restricted by project access. |
+| **Reporter** | Submits results (`/api/test-runs/submit`, `/api/test-runs/upload`) and can triage, but only for the **projects it's assigned to**. |
+| **User** | Read-only access to the **projects it's assigned to**. |
+
+Administrators always see everything. **Reporter** and **User** accounts are additionally scoped by [project access](#project-access) — they only see and act on the projects assigned to them.
 
 ## Enabling authentication
 
@@ -170,9 +172,33 @@ To create additional users:
 2. Click **Add user**
 3. Set username, password, role, and optional display name
 
-Each non-admin user's **project access (affectations)** is managed from the **Project access** action on this page (per user), or from a project's **Members** tab (per project). A user can be granted global access (all projects) or scoped to specific ones.
+## Project access
 
-> **Try it in the demo:** the [live demo](https://piwitests.github.io/demo/) ships with several pre-seeded identities. Use the **Acting as** picker in the demo banner to switch between them and watch how each user's project affectations change what they can see. See [UI overview → Demo user switcher](./ui-overview.md#demo-user-switcher-act-as).
+Administrators see every project. **Reporter** and **User** accounts see only the projects they are **assigned** to — so you can give each team its own slice of the dashboard.
+
+An assignment is one of two kinds:
+
+- **Global** — access to *all* projects, including ones created later. Good for a shared CI reporter or a team lead.
+- **Per-project** — access to a specific set of projects only.
+
+What scoping affects for a non-admin user:
+
+- The project list, sidebar menu, home dashboard, recent runs, and search only include assigned projects.
+- Runs, test cases, and clusters that belong to an unassigned project return **403**.
+- A reporter can submit results to an assigned project. Creating a **new** project on first submission requires **global** access — a per-project reporter can't invent projects.
+
+> **Default is no access.** A freshly created Reporter/User has no assignments and sees an empty dashboard until you grant some. (When authentication is first enabled, existing accounts are automatically backfilled with global access so nothing breaks on upgrade.)
+
+### Managing assignments
+
+Assignments are administrator-only and can be edited from either direction:
+
+- **Per user** — **Settings → Users → Project access** (the action next to a user). Choose global access or tick specific projects.
+- **Per project** — a project's **Members** tab (`/projects/:id`, admins only). Add or remove users for that one project.
+
+Both edit the same underlying assignments, so use whichever is more convenient.
+
+> **Try it in the demo:** the [live demo](https://piwitests.github.io/demo/) ships with several pre-seeded identities — an admin, a global CI reporter, and users scoped to one or two projects (plus one with none). Use the **Acting as** picker in the demo banner to switch between them and watch the project list, sidebar, and search change to match each user's access. Acting as the admin, change the assignments live and switch back to see the effect. See [UI overview → Live demo](./ui-overview.md#live-demo).
 
 ## API authentication
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -203,8 +203,8 @@ spec:
 ```bash
 cd application
 npm install
-npm run build
-npm run preview  # preview the production build locally
+npm run app:build
+npm run app:preview  # preview the production build locally
 ```
 
 ## Security

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -119,11 +119,11 @@ To customize the path, set the variable in `application/.env` (recommended, cros
 ::: code-group
 
 ```bash [Linux / macOS]
-PIWI_DATABASE_PATH=/custom/path/database.db npm run dev
+PIWI_DATABASE_PATH=/custom/path/database.db npm run app:dev
 ```
 
 ```powershell [Windows (PowerShell)]
-$env:PIWI_DATABASE_PATH = '/custom/path/database.db'; npm run dev
+$env:PIWI_DATABASE_PATH = '/custom/path/database.db'; npm run app:dev
 ```
 
 :::
@@ -135,11 +135,11 @@ Set the `PIWI_DATABASE_URL` environment variable to switch to PostgreSQL (in `ap
 ::: code-group
 
 ```bash [Linux / macOS]
-PIWI_DATABASE_URL=postgresql://user:password@localhost:5432/piwi_dashboard npm run dev
+PIWI_DATABASE_URL=postgresql://user:password@localhost:5432/piwi_dashboard npm run app:dev
 ```
 
 ```powershell [Windows (PowerShell)]
-$env:PIWI_DATABASE_URL = 'postgresql://user:password@localhost:5432/piwi_dashboard'; npm run dev
+$env:PIWI_DATABASE_URL = 'postgresql://user:password@localhost:5432/piwi_dashboard'; npm run app:dev
 ```
 
 :::
@@ -157,11 +157,11 @@ Then start the dashboard:
 ::: code-group
 
 ```bash [Linux / macOS]
-PIWI_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/piwi_dashboard npm run dev
+PIWI_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/piwi_dashboard npm run app:dev
 ```
 
 ```powershell [Windows (PowerShell)]
-$env:PIWI_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/piwi_dashboard'; npm run dev
+$env:PIWI_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/piwi_dashboard'; npm run app:dev
 ```
 
 :::
@@ -204,7 +204,7 @@ If you modify the database schema:
 npm run db:generate
 
 # 3. Restart the application — migrations apply automatically on startup
-npm run dev
+npm run app:dev
 ```
 
 ::: warning

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -54,7 +54,7 @@ The complete history for one project, organized into tabs:
 - **Test cases** — every unique test with pass rate, result breakdown, average duration, and last-run date.
 - **Compare** — side-by-side delta between two runs (new failures, recovered, duration changes).
 - **Spec health** — a heatmap grouping test cases by spec file and coloring each by pass rate, so an unhealthy area of the suite jumps out. See [Spec health heatmap](./flaky-tests#spec-health-heatmap).
-- **Members** *(admins, when auth is enabled)* — grant or scope project access per user. See [Authentication](./authentication#user-management).
+- **Members** *(admins, when auth is enabled)* — grant or scope project access per user. See [Project access](./authentication#project-access).
 
 Project **edit** (`/projects/:id/edit`) sets the label, description, tags, per-project SCM token, and **AI diagnosis instructions** (project-specific context combined with the global instructions for every diagnosis).
 
@@ -112,7 +112,7 @@ The [live demo](https://piwitests.github.io/demo/) runs entirely in your browser
 
 **Simulate a test run** — the demo banner replays the exact streaming protocol a Piwi reporter speaks during a real run, so you can watch one arrive live. Scenarios: a passing run, a run with failures (joining a known cluster plus a brand-new one), flaky retries, a performance regression, an interrupted run, and a cross-browser run. Each creates a real run in the in-browser database, so worker timeline, failure groups, and history comparisons all behave exactly as they would against a server.
 
-**Acting as** — the demo runs with authentication conceptually enabled. Switch between pre-seeded identities (an admin, a CI reporter, and several project-scoped users) to see how [project access](./authentication#user-management) changes what each user sees. Acting as the admin, you can change affectations live and then switch users to see the effect.
+**Acting as** — the demo runs with authentication conceptually enabled. Switch between pre-seeded identities (an admin, a CI reporter, and several project-scoped users) to see how [project access](./authentication#project-access) changes what each user sees. Acting as the admin, you can change affectations live and then switch users to see the effect.
 
 ## Responsive & dark mode
 


### PR DESCRIPTION
- Replace the remaining bare workspace scripts with their `app:`/ `reporter:` prefixed names: `npm run dev` -> `app:dev` (storage), `build`/`preview` -> `app:build`/`app:preview` (deployment), the reporter lint commands -> `reporter:lint`(`:fix`), and `generate:demo` -> `app:generate:demo` (AGENTS).
- Document project access (assignments) in authentication.md: how Reporter/User accounts are scoped to assigned projects (global vs per-project), what scoping affects, the no-access default with upgrade backfill, and managing it per-user (Settings -> Users) or per-project (Members tab). Sharpen the roles table accordingly and cross-link from the UI overview.


Claude-Session: https://claude.ai/code/session_013zY6LZyivyrbazbSihiEC2