### PR TITLE
Improve AI diagnosis with locator-literal matching and prompt caching

### DIFF
--- a/application/server/utils/ai-context.ts
+++ b/application/server/utils/ai-context.ts
@@ -751,11 +751,31 @@ async function artifactsSection(db: DbClient, rep: RepresentativeRow): Promise<s
 }
 
 /**
- * When Playwright attaches an `error-context.md` (automatically for failed
- * tests), it contains a ref-annotated ARIA snapshot under `## Page snapshot`
- * that carries the full DOM hierarchy with `[ref=eXX]` / `[cursor=pointer]` /
- * `[active]` annotations. This is richer than the stored flat snapshot and
- * works retroactively — the file is already uploaded, it just wasn't read.
+ * Extract the "Page snapshot" section from a Playwright `error-context.md`
+ * body. Playwright (1.53 through at least 1.61) writes it as an h1 —
+ * `# Page snapshot` — followed by a ```yaml fence; h2 is tolerated for other
+ * generators. Returns the snapshot YAML (fence contents when fenced), or null
+ * when no section is found. Exported for unit testing.
+ */
+export function extractPageSnapshotSection(text: string): string | null {
+  const snapshotMatch = text.match(
+    /(?:^|\n)#{1,2} Page snapshot\s*\n(```(?:ya?ml)?\s*\n[\s\S]*?\n```|[\s\S]*?)(?=\n#{1,2} |\n---\n|$)/,
+  );
+  if (!snapshotMatch) return null;
+  let snapshot = snapshotMatch[1]!.trim();
+  const fenceMatch = snapshot.match(/^```(?:ya?ml)?\s*\n([\s\S]*?)\n```$/);
+  if (fenceMatch) snapshot = fenceMatch[1]!;
+  return snapshot || null;
+}
+
+/**
+ * When Playwright attaches an error context (automatically for failed tests
+ * since ~1.53), it contains a ref-annotated ARIA snapshot under `# Page
+ * snapshot` that carries the full DOM hierarchy with `[ref=eXX]` /
+ * `[cursor=pointer]` / `[active]` annotations. This is richer than the stored
+ * flat snapshot and works retroactively — the file is already uploaded, it
+ * just wasn't read. The attachment is stored under Playwright's attachment
+ * *name* (`error-context`), not its on-disk file name (`error-context.md`).
  *
  * Returns the extracted snapshot YAML block (without the heading), or null
  * when no error-context attachment exists or parsing fails.
@@ -764,7 +784,7 @@ async function resolveErrorContextAria(db: DbClient, rep: RepresentativeRow): Pr
   const row = await db
     .select({ path: files.path })
     .from(files)
-    .where(and(eq(files.testRunsCaseId, rep.id), eq(files.type, 'attachment'), eq(files.subtype, 'error-context.md')))
+    .where(and(eq(files.testRunsCaseId, rep.id), eq(files.type, 'attachment'), eq(files.subtype, 'error-context')))
     .limit(1)
     .then((r) => r[0] ?? null);
 
@@ -773,15 +793,7 @@ async function resolveErrorContextAria(db: DbClient, rep: RepresentativeRow): Pr
   try {
     const storage = getStorage();
     const buf = await storage.readFile(row.path);
-    const text = buf.toString('utf8');
-    const snapshotMatch = text.match(
-      /## Page snapshot\s*\n(```(?:ya?ml)?\s*\n[\s\S]*?\n```|[\s\S]*?)(?=\n## |\n---\n|$)/,
-    );
-    if (!snapshotMatch) return null;
-    let snapshot = snapshotMatch[1]!.trim();
-    const fenceMatch = snapshot.match(/^```(?:ya?ml)?\s*\n([\s\S]*?)\n```$/);
-    if (fenceMatch) snapshot = fenceMatch[1]!;
-    return snapshot || null;
+    return extractPageSnapshotSection(buf.toString('utf8'));
   } catch {
     return null;
   }
@@ -1436,15 +1448,17 @@ export function representativeExecutionSections(
   // D9: Network — correlate with the failure when timing data allows
   const nrItems = (rep as any).nrItems ?? [];
   const networkLines: string[] = [];
-  // Find the failure time anchor: from the last failed network request, endTime or startedAt
+  // Time anchor: the case's startedAt and the request's startTime are both
+  // Unix epoch milliseconds, so their difference is already the ms offset
+  // from test start.
   const failureAnchor = rep.startedAt ?? 0;
   const failedReqs = nrItems.filter((r: any) => r.status >= 400 || r.status === 0).slice(0, limits.networkRequests);
   const slowReqs = nrItems
     .filter((r: any) => r.status >= 200 && r.status < 400 && r.duration != null && r.duration > limits.slowRequestMs)
     .slice(0, limits.networkRequests);
   for (const r of failedReqs) {
-    const timing =
-      r.startTime != null && failureAnchor ? ` (t+${Math.round((r.startTime - failureAnchor) * 1000)}ms)` : '';
+    const offsetMs = r.startTime != null && failureAnchor ? Math.round(r.startTime - failureAnchor) : null;
+    const timing = offsetMs != null && offsetMs >= 0 ? ` (t+${offsetMs}ms)` : '';
     networkLines.push(
       `- [failed] ${r.method} ${r.url} → ${r.status}${r.duration != null ? ` (${r.duration}ms)` : ''}${timing}`,
     );
@@ -1547,6 +1561,8 @@ export interface RelevanceSignals {
   ariaSnapshot?: string | null;
   /** Failing test source, when in context — enables import-based scoring. */
   testSource?: string | null;
+  /** Raw failing error text — enables locator-literal matching against patch contents. */
+  errorText?: string | null;
 }
 
 /** Split a string into lowercase alphanumeric tokens of length ≥ 3. */
@@ -1567,6 +1583,54 @@ function extractImportSpecifiers(source: string): string[] {
   return out;
 }
 
+/**
+ * Extract the string literals the failing test was locating, from the error
+ * text's call log — `getByText('Run trend')`, `locator('.card')`,
+ * `getByRole('button', { name: 'Pay' })`. These are the highest-precision
+ * search keys for the SCM diff: a changed line containing one of them is very
+ * likely the causal change. Deduped, ≥ 3 chars, capped at 10. Exported for
+ * unit testing.
+ */
+export function extractLocatorLiterals(errorText: string): string[] {
+  const clean = stripAnsi(errorText);
+  const out = new Set<string>();
+  const patterns = [
+    /getBy[A-Za-z]+\(\s*['"]([^'"\n]{3,100})['"]/g,
+    /\blocator\(\s*['"]([^'"\n]{3,100})['"]/g,
+    /\bname:\s*['"]([^'"\n]{3,100})['"]/g,
+  ];
+  for (const re of patterns) {
+    for (const m of clean.matchAll(re)) {
+      if (m[1]) out.add(m[1]);
+      if (out.size >= 10) return [...out];
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Find the first locator literal that appears in a changed file's patch.
+ * A hit on a removed (`-`) line is the smoking gun — the text the test expects
+ * was just renamed or deleted — and is preferred over a hit anywhere else in
+ * the patch. Exported for unit testing.
+ */
+export function findLiteralInPatch(
+  patch: string | null | undefined,
+  literals: string[],
+): { literal: string; removed: boolean } | null {
+  if (!patch || literals.length === 0) return null;
+  const removedText = patch
+    .split('\n')
+    .filter((l) => l.startsWith('-') && !l.startsWith('---'))
+    .join('\n');
+  let plainHit: { literal: string; removed: boolean } | null = null;
+  for (const lit of literals) {
+    if (removedText.includes(lit)) return { literal: lit, removed: true };
+    if (!plainHit && patch.includes(lit)) plainHit = { literal: lit, removed: false };
+  }
+  return plainHit;
+}
+
 /** Basename without directory or extension, lowercased. */
 function fileStem(path: string): string {
   return (path.replace(/\\/g, '/').split('/').pop() ?? path).replace(/\.\w+$/, '').toLowerCase();
@@ -1577,10 +1641,20 @@ function fileStem(path: string): string {
  * repo-layout-independent signals. Higher score = more likely to be the cause.
  * Exported for unit testing.
  */
-export function scoreChangedFile(filename: string, signals: RelevanceSignals): number {
+export function scoreChangedFile(
+  filename: string,
+  signals: RelevanceSignals,
+  /** Precomputed locator-literal hit in this file's patch (see `findLiteralInPatch`). */
+  patchMatch?: { literal: string; removed: boolean } | null,
+): number {
   let score = 0;
   const fnLower = filename.toLowerCase().replace(/\\/g, '/');
   const stem = fileStem(filename);
+
+  // Smoking gun: a changed line contains a string literal the failing test was
+  // locating. A removed line is the strongest form — the text the test expects
+  // was just renamed away. Outranks every filename-based signal.
+  if (patchMatch) score += patchMatch.removed ? 8 : 6;
 
   // Strongest signal: the failing test imports this file (by basename match).
   if (signals.testSource) {
@@ -1620,11 +1694,17 @@ export function scoreChangedFile(filename: string, signals: RelevanceSignals): n
 interface ScoredFile {
   file: ChangedFile;
   score: number;
+  /** Locator literal from the failing error found in this file's patch, if any. */
+  literalMatch: { literal: string; removed: boolean } | null;
 }
 
 function scoreFilesByRelevance(files: ChangedFile[], signals: RelevanceSignals): ScoredFile[] {
+  const literals = signals.errorText ? extractLocatorLiterals(signals.errorText) : [];
   return files
-    .map((f) => ({ file: f, score: scoreChangedFile(f.filename, signals) }))
+    .map((f) => {
+      const literalMatch = findLiteralInPatch(f.patch, literals);
+      return { file: f, score: scoreChangedFile(f.filename, signals, literalMatch), literalMatch };
+    })
     .sort((a, b) => b.score - a.score);
 }
 
@@ -1637,7 +1717,12 @@ function scoreFilesByRelevance(files: ChangedFile[], signals: RelevanceSignals):
 function getTopSuspectedChange(
   scored: ScoredFile[],
   commits: Array<{ sha: string; message: string }>,
-): { file: string; score: number; recentCommit: { sha: string; message: string } | null } | null {
+): {
+  file: string;
+  score: number;
+  literalMatch: { literal: string; removed: boolean } | null;
+  recentCommit: { sha: string; message: string } | null;
+} | null {
   const topFile = scored[0];
   // Only show a file as "most relevant" when the signal is genuine — a score
   // of ≤ 2 means the file happened to share a generic path prefix or one common
@@ -1646,6 +1731,7 @@ function getTopSuspectedChange(
   return {
     file: topFile.file.filename,
     score: topFile.score,
+    literalMatch: topFile.literalMatch,
     recentCommit: commits[0] ?? null,
   };
 }
@@ -1656,6 +1742,13 @@ function formatTopSuspectedChange(top: NonNullable<ReturnType<typeof getTopSuspe
     `### Top Suspected Change`,
     `- Most relevant changed file: \`${top.file}\` (relevance score ${top.score})`,
   ];
+  if (top.literalMatch) {
+    lines.push(
+      top.literalMatch.removed
+        ? `- Why: the diff removes a line containing the test's target text "${top.literalMatch.literal}" — likely renamed or deleted`
+        : `- Why: the diff touches a line containing the test's target text "${top.literalMatch.literal}"`,
+    );
+  }
   if (top.recentCommit) {
     lines.push(`- Most recent commit in range: \`${top.recentCommit.sha.slice(0, 7)}\` (${top.recentCommit.message})`);
   }
@@ -2069,6 +2162,7 @@ export async function buildDiagnosisContext(
         testTitle: rep.testTitle,
         ariaSnapshot: rep.ariaSnapshot,
         testSource: rep.testSource,
+        errorText: rep.error ?? cluster.sampleError,
       });
       for (const s of scm.sections) {
         if (s.startsWith('## What Changed')) {
@@ -2104,7 +2198,8 @@ export async function buildDiagnosisContext(
   const absentReasons: Record<string, string> = {};
   const sectionIds = new Set(contextSections.map((s) => s.id));
   if (!sectionIds.has('testSource')) {
-    absentReasons.testSource = 'reporter option collectTestSource may be disabled';
+    absentReasons.testSource =
+      'not captured by the reporter — requires a recent reporter version and the test file to be readable at run time';
   }
   if (!sectionIds.has('failingAction')) {
     absentReasons.failingAction = 'no trace files found — enable trace recording in Playwright config';
@@ -2114,10 +2209,11 @@ export async function buildDiagnosisContext(
       'no SCM diff available — check repository URL in project settings or configure a SCM token';
   }
   if (!sectionIds.has('console')) {
-    absentReasons.console = 'collectPerformanceMetrics or captureConsole may be disabled in reporter options';
+    absentReasons.console = 'no console entries captured — collectPerformanceMetrics may be disabled in reporter options';
   }
   if (!sectionIds.has('networkRequests')) {
-    absentReasons.networkRequests = 'collectPerformanceMetrics or captureNetwork may be disabled in reporter options';
+    absentReasons.networkRequests =
+      'no network data captured — collectPerformanceMetrics may be disabled in reporter options';
   }
 
   const coverageBlock = buildCoverageBlock(contextSections, {

--- a/application/server/utils/ai-diagnosis.ts
+++ b/application/server/utils/ai-diagnosis.ts
@@ -257,6 +257,9 @@ export async function runClusterDiagnosis(
       jsonSchema: DIAGNOSIS_JSON_SCHEMA,
       images,
       cacheControl: true,
+      // The built context is the cache-stable prefix; additional context and
+      // the research block vary between re-runs and sit after the breakpoint.
+      stablePrefixChars: ctx.text.length,
     });
     pipeline.push({
       role: 'diagnosis',
@@ -523,6 +526,9 @@ export async function streamClusterDiagnosis(
       jsonSchema: DIAGNOSIS_JSON_SCHEMA,
       images,
       cacheControl: true,
+      // The built context is the cache-stable prefix; additional context and
+      // the research block vary between re-runs and sit after the breakpoint.
+      stablePrefixChars: ctx.text.length,
     })) {
       if (chunk.type === 'text') {
         accumulatedText += chunk.data as string;

--- a/application/server/utils/ai-provider.ts
+++ b/application/server/utils/ai-provider.ts
@@ -180,6 +180,55 @@ export interface AiCallOptions {
   images?: AiAttachedImage[];
   /** When true, mark the system prompt and stable context prefix for Anthropic cache_control. Re-runs become ~90 % cached input. */
   cacheControl?: boolean;
+  /**
+   * With `cacheControl`: how many characters at the start of `user` are stable
+   * across re-runs (the built diagnosis context). The cache breakpoint sits at
+   * the end of that prefix; the remainder (user-provided additional context,
+   * research block) is sent as a separate uncached block so its variation
+   * cannot invalidate the cached prefix. Defaults to the whole user text,
+   * which only hits the cache on byte-identical re-runs.
+   */
+  stablePrefixChars?: number;
+}
+
+type AnthropicImageBlock = {
+  type: 'image';
+  source: { type: 'base64'; media_type: AiAttachedImage['mediaType']; data: string };
+};
+type AnthropicTextBlock = { type: 'text'; text: string; cache_control?: { type: 'ephemeral' } };
+
+/** System prompt param — one cache breakpoint when caching is on (it is identical across re-runs). */
+function anthropicSystem(opts: AiCallOptions): Anthropic.Messages.MessageCreateParams['system'] {
+  return opts.cacheControl ? [{ type: 'text', text: opts.system, cache_control: { type: 'ephemeral' } }] : opts.system;
+}
+
+/**
+ * User-message content. Without caching: optional image blocks followed by one
+ * text block (or a bare string). With caching: images (stable across re-runs —
+ * same screenshots for the same execution) precede the stable text block that
+ * carries the cache breakpoint, so both are covered by the cached prefix; the
+ * volatile tail of `user` (see `stablePrefixChars`) follows as its own
+ * uncached block.
+ */
+function anthropicUserContent(opts: AiCallOptions): string | Array<AnthropicImageBlock | AnthropicTextBlock> {
+  const imageBlocks: AnthropicImageBlock[] = (opts.images ?? []).map((img) => ({
+    type: 'image',
+    source: { type: 'base64', media_type: img.mediaType, data: img.data },
+  }));
+
+  if (!opts.cacheControl) {
+    return imageBlocks.length > 0 ? [...imageBlocks, { type: 'text', text: opts.user }] : opts.user;
+  }
+
+  const split = Math.max(0, Math.min(opts.stablePrefixChars ?? opts.user.length, opts.user.length));
+  const stable = opts.user.slice(0, split);
+  const volatileTail = opts.user.slice(split);
+
+  const blocks: Array<AnthropicImageBlock | AnthropicTextBlock> = [...imageBlocks];
+  if (stable) blocks.push({ type: 'text', text: stable, cache_control: { type: 'ephemeral' } });
+  if (volatileTail) blocks.push({ type: 'text', text: volatileTail });
+  if (blocks.length === 0) blocks.push({ type: 'text', text: opts.user });
+  return blocks;
 }
 
 export interface AiCallResult {
@@ -220,60 +269,15 @@ async function callAnthropic(config: ResolvedAiRole, opts: AiCallOptions): Promi
     maxRetries: 1,
   });
 
-  type ImageBlock = {
-    type: 'image';
-    source: { type: 'base64'; media_type: AiAttachedImage['mediaType']; data: string };
-  };
-  type TextBlock = { type: 'text'; text: string };
-
-  const userContent: string | Array<ImageBlock | TextBlock> = opts.images?.length
-    ? [
-        ...opts.images.map(
-          (img): ImageBlock => ({
-            type: 'image',
-            source: { type: 'base64', media_type: img.mediaType, data: img.data },
-          }),
-        ),
-        { type: 'text', text: opts.user },
-      ]
-    : opts.user;
-
-  // Prompt caching: mark the system prompt (identical across re-runs) and
-  // the first user-message content block for Anthropic cache_control. With
-  // 1.6's stable section ordering the prefix is cache-friendly; volatile
-  // parts (user additional context, research block) sit at the end where
-  // they cannot invalidate earlier cached blocks.
-  const system: Anthropic.Messages.MessageCreateParams['system'] = opts.cacheControl
-    ? [{ type: 'text', text: opts.system, cache_control: { type: 'ephemeral' } }]
-    : opts.system;
-
-  let messages: Anthropic.Messages.MessageCreateParams['messages'];
-  if (opts.cacheControl) {
-    let contentBlock: Array<ImageBlock | TextBlock>;
-    if (Array.isArray(userContent)) {
-      // Images first, text with cache_control last
-      const textBlocks = userContent.filter((b) => b.type === 'text') as TextBlock[];
-      const imageBlocks = userContent.filter((b) => b.type === 'image') as ImageBlock[];
-      const lastText = textBlocks[textBlocks.length - 1];
-      contentBlock = [
-        ...imageBlocks,
-        ...(lastText
-          ? [{ type: 'text' as const, text: lastText.text, cache_control: { type: 'ephemeral' as const } } as any]
-          : []),
-      ];
-    } else {
-      contentBlock = [{ type: 'text', text: userContent, cache_control: { type: 'ephemeral' } } as any];
-    }
-    messages = [{ role: 'user', content: contentBlock } as any];
-  } else {
-    messages = [{ role: 'user', content: userContent as Anthropic.MessageParam['content'] }];
-  }
-
+  // Prompt caching (when opts.cacheControl): two breakpoints — the system
+  // prompt and the stable user prefix (images + built context). With 1.6's
+  // stable section ordering the prefix is cache-friendly; the volatile tail
+  // (user additional context, research block) is a separate uncached block.
   const res = await client.messages.create({
     model: config.model || 'claude-opus-4-8',
     max_tokens: opts.maxTokens ?? 8192,
-    system: system as any,
-    messages,
+    system: anthropicSystem(opts),
+    messages: [{ role: 'user', content: anthropicUserContent(opts) as Anthropic.MessageParam['content'] }],
     ...(opts.jsonSchema
       ? {
           output_config: {
@@ -384,24 +388,6 @@ async function* streamAnthropic(config: ResolvedAiRole, opts: AiCallOptions): As
     maxRetries: 1,
   });
 
-  type ImageBlock = {
-    type: 'image';
-    source: { type: 'base64'; media_type: AiAttachedImage['mediaType']; data: string };
-  };
-  type TextBlock = { type: 'text'; text: string };
-
-  const userContent: string | Array<ImageBlock | TextBlock> = opts.images?.length
-    ? [
-        ...opts.images.map(
-          (img): ImageBlock => ({
-            type: 'image',
-            source: { type: 'base64', media_type: img.mediaType, data: img.data },
-          }),
-        ),
-        { type: 'text', text: opts.user },
-      ]
-    : opts.user;
-
   const textChunks: string[] = [];
   let streamError: Error | null = null;
   let finalMsg: Anthropic.Message | null = null;
@@ -411,36 +397,12 @@ async function* streamAnthropic(config: ResolvedAiRole, opts: AiCallOptions): As
     resolveFinal = r;
   });
 
-  const systemStream: Anthropic.Messages.MessageCreateParamsStreaming['system'] = opts.cacheControl
-    ? [{ type: 'text', text: opts.system, cache_control: { type: 'ephemeral' } }]
-    : opts.system;
-
-  let messagesStream: Anthropic.Messages.MessageCreateParamsStreaming['messages'];
-  if (opts.cacheControl) {
-    let contentBlock: Array<ImageBlock | TextBlock>;
-    if (Array.isArray(userContent)) {
-      const textBlocks = userContent.filter((b) => b.type === 'text') as TextBlock[];
-      const imageBlocks = userContent.filter((b) => b.type === 'image') as ImageBlock[];
-      const lastText = textBlocks[textBlocks.length - 1];
-      contentBlock = [
-        ...imageBlocks,
-        ...(lastText
-          ? [{ type: 'text' as const, text: lastText.text, cache_control: { type: 'ephemeral' as const } } as any]
-          : []),
-      ];
-    } else {
-      contentBlock = [{ type: 'text', text: userContent, cache_control: { type: 'ephemeral' } } as any];
-    }
-    messagesStream = [{ role: 'user', content: contentBlock } as any];
-  } else {
-    messagesStream = [{ role: 'user', content: userContent as Anthropic.MessageParam['content'] }];
-  }
-
+  // Same caching layout as callAnthropic — see anthropicSystem/anthropicUserContent.
   const stream = client.messages.stream({
     model: config.model || 'claude-opus-4-8',
     max_tokens: opts.maxTokens ?? 8192,
-    system: systemStream as any,
-    messages: messagesStream,
+    system: anthropicSystem(opts),
+    messages: [{ role: 'user', content: anthropicUserContent(opts) as Anthropic.MessageParam['content'] }],
     ...(opts.jsonSchema
       ? {
           output_config: {

--- a/application/server/utils/locator-healing.ts
+++ b/application/server/utils/locator-healing.ts
@@ -15,7 +15,12 @@ import {
   locatorSignature,
   recommendLocatorFix,
 } from '#shared/locator-healing';
-import { elementMatchAlternatives, parseAriaCandidates, type ElementFingerprint } from '#shared/locator-fingerprint';
+import {
+  elementMatchAlternatives,
+  parseAriaCandidates,
+  TEXT_CONTENT_ROLES,
+  type ElementFingerprint,
+} from '#shared/locator-fingerprint';
 import type { RankedLocator, LocatorSnapshot, LocatorFixRecommendation } from '#shared/locator-healing.types';
 import type { DrizzleDB } from '#shared/handlers/db';
 
@@ -195,32 +200,6 @@ function extractErrorLocation(error: string): string | null {
 
   return topFrame; // fallback: just the file
 }
-
-/**
- * TEXTSM_ROLES — roles whose visible text content matches what `getByText`
- * inspects, so a `getByText` alternative is valid when the element bears one
- * of these roles. Mirrors `freshLocatorsFromCandidate` in locator-fingerprint.ts
- * so the ARIA fallback ladder generates the same shape as the element-match path.
- */
-const TEXT_CONTENT_ROLES = new Set([
-  'button',
-  'link',
-  'heading',
-  'menuitem',
-  'option',
-  'tab',
-  'listitem',
-  'cell',
-  'rowheader',
-  'columnheader',
-  'combobox',
-  'alert',
-  'status',
-  'label',
-  'legend',
-  'caption',
-  'term',
-]);
 
 /**
  * Generate alternatives from ARIA snapshot text, filtered and scored by

--- a/application/server/utils/trace-parser.ts
+++ b/application/server/utils/trace-parser.ts
@@ -132,6 +132,11 @@ export interface ParsedTraceData {
   eventCount: number;
   /** True when the failing action was identified by timeout fallback (no action had an error). */
   timeoutFallback: boolean;
+  /**
+   * Largest timestamp observed anywhere in the trace, in the same timebase as
+   * action startTime/endTime. 0 when no timestamp was found.
+   */
+  traceEndTime: number;
 }
 
 /** Parse trace events from a loaded slim ZIP buffer. Returns null on failure. */
@@ -167,8 +172,20 @@ function extractFromEvents(events: Record<string, unknown>[]): ParsedTraceData {
   const beforeSnapshots = new Map<string, string>();
   const afterSnapshots = new Map<string, string>();
 
+  // Largest timestamp seen across all events, in the trace's own timebase.
+  let traceEndTime = 0;
+
   for (const evt of events) {
     const type = evt.type as string;
+
+    // Fold in any timestamp this event carries so traceEndTime tracks the last
+    // moment the trace recorded (used as an upper bound for timed-out actions).
+    for (const key of ['time', 'startTime', 'endTime'] as const) {
+      const ts = evt[key];
+      if (typeof ts === 'number' && Number.isFinite(ts) && ts > traceEndTime) {
+        traceEndTime = ts;
+      }
+    }
 
     if (type === 'before') {
       const callId = evt.callId as string;
@@ -278,6 +295,7 @@ function extractFromEvents(events: Record<string, unknown>[]): ParsedTraceData {
     failingActionIndex: failingAction ? failingIndex : -1,
     eventCount: events.length,
     timeoutFallback,
+    traceEndTime,
   };
 }
 
@@ -309,8 +327,11 @@ export function formatFailingActionSection(
     const duration = action.endTime ? action.endTime - action.startTime : null;
     if (duration != null) {
       lines.push(`- Duration: ${Math.round(duration)}ms`);
-    } else if (data.timeoutFallback) {
-      lines.push(`- Duration: timed out after ${Math.round(Date.now() / 1000 - action.startTime / 1000)}ms+`);
+    } else if (data.timeoutFallback && data.traceEndTime > action.startTime) {
+      // Killed mid-action: no endTime was recorded. Use the last timestamp seen
+      // in the trace (same timebase as startTime) as a lower bound on how long
+      // the action had been running before the process was torn down.
+      lines.push(`- Duration: ran ≥ ${Math.round(data.traceEndTime - action.startTime)}ms before the test was killed`);
     }
   }
   if (action.error) {

--- a/application/shared/locator-fingerprint.ts
+++ b/application/shared/locator-fingerprint.ts
@@ -40,8 +40,15 @@ const PRESENT_SIMILARITY = 0.8;
 /** Minimum name similarity to accept a match when several same-role candidates compete. */
 const MATCH_SIMILARITY = 0.2;
 
-/** Roles whose accessible name comes from their visible text — `getByText` is viable. */
-const TEXT_CONTENT_ROLES = new Set([
+/**
+ * Roles whose accessible name comes from their visible text — `getByText` is
+ * viable. The single source of truth shared by fresh-locator generation
+ * (`freshLocatorsFromCandidate`, below) and the server's ARIA-fallback healing
+ * (`generateFromAriaSnapshot` in server/utils/locator-healing.ts): both emit a
+ * `getByText` alternative for these roles, whose visible text content is exactly
+ * what `getByText` matches.
+ */
+export const TEXT_CONTENT_ROLES = new Set([
   'button',
   'link',
   'heading',

--- a/application/tests/unit/ai-context-sections.test.ts
+++ b/application/tests/unit/ai-context-sections.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'vitest';
-import { scoreChangedFile, representativeExecutionSections } from '../../server/utils/ai-context';
+import {
+  scoreChangedFile,
+  representativeExecutionSections,
+  extractPageSnapshotSection,
+  extractLocatorLiterals,
+  findLiteralInPatch,
+} from '../../server/utils/ai-context';
 import type { ContextLimits } from '#shared/ai-context-limits';
 
 // Minimal limits object — large enough that nothing truncates in these tests.
@@ -103,5 +109,88 @@ describe('scoreChangedFile — generic relevance (Tier 0.5)', () => {
     const lock = scoreChangedFile('package-lock.json', {});
     const src = scoreChangedFile('src/app/main.ts', {});
     expect(src).toBeGreaterThan(lock);
+  });
+});
+
+describe('extractPageSnapshotSection — Playwright error-context parsing (0.5.4a)', () => {
+  test('extracts the yaml fence under the h1 heading Playwright ≥ 1.53 writes', () => {
+    const md = [
+      '# Test info',
+      '',
+      '- Name: pressing Escape cancels label edit',
+      '',
+      '# Error details',
+      '',
+      '```',
+      'TimeoutError: locator.click: Timeout 30000ms exceeded.',
+      '```',
+      '',
+      '# Page snapshot',
+      '',
+      '```yaml',
+      '- banner [ref=e2]:',
+      '  - heading "Run trend" [level=2] [ref=e14]',
+      '```',
+    ].join('\n');
+    expect(extractPageSnapshotSection(md)).toBe('- banner [ref=e2]:\n  - heading "Run trend" [level=2] [ref=e14]');
+  });
+
+  test('tolerates an h2 heading and stops at the next section', () => {
+    const md = '## Page snapshot\n\n```yaml\n- link "Home"\n```\n\n## Next section\ntext';
+    expect(extractPageSnapshotSection(md)).toBe('- link "Home"');
+  });
+
+  test('returns null when there is no snapshot section', () => {
+    expect(extractPageSnapshotSection('# Error details\nboom')).toBeNull();
+  });
+});
+
+describe('locator-literal SCM matching (diff-content relevance)', () => {
+  const timeoutError = [
+    'Test timeout of 30000ms exceeded.',
+    '---',
+    'locator.click: Test timeout of 30000ms exceeded.',
+    'Call log:',
+    "  - waiting for locator('h2').getByTitle('Add a label')",
+    '',
+    '    at tests/labels.spec.ts:42:7',
+  ].join('\n');
+
+  test('pulls the locator string literals out of a call log', () => {
+    const lits = extractLocatorLiterals(timeoutError);
+    expect(lits).toContain('Add a label');
+    // Short CSS selector args (< 3 chars) are noise and filtered out.
+    expect(lits).not.toContain('h2');
+  });
+
+  test('getByRole name option is extracted', () => {
+    const lits = extractLocatorLiterals("expect(page.getByRole('button', { name: 'Pay now' })).toBeVisible()");
+    expect(lits).toContain('Pay now');
+  });
+
+  test('a removed patch line containing the literal beats an added-line hit elsewhere in the patch', () => {
+    const patch = [
+      '--- a/app/pages/index.vue',
+      '+++ b/app/pages/index.vue',
+      '@@ -640,7 +640,7 @@',
+      '-      subtitle="Add a label to organize runs"',
+      '+      subtitle="Tag your runs"',
+    ].join('\n');
+    expect(findLiteralInPatch(patch, ['Add a label'])).toEqual({ literal: 'Add a label', removed: true });
+  });
+
+  test('an added-only hit is reported as non-removed; no hit yields null', () => {
+    expect(findLiteralInPatch('+ <h2 title="Add a label">…</h2>', ['Add a label'])).toEqual({
+      literal: 'Add a label',
+      removed: false,
+    });
+    expect(findLiteralInPatch('+ unrelated', ['Add a label'])).toBeNull();
+  });
+
+  test('a patch hit outranks filename-only signals in scoring', () => {
+    const signals = { testTitle: 'labels can be edited' };
+    const withHit = scoreChangedFile('app/pages/whatever.vue', signals, { literal: 'Add a label', removed: true });
+    const pathOnly = scoreChangedFile('app/pages/labels-editor.vue', signals);
+    expect(withHit).toBeGreaterThan(pathOnly);
   });
 });

--- a/application/tests/unit/trace-parser.test.ts
+++ b/application/tests/unit/trace-parser.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from 'vitest';
+import { formatFailingActionSection } from '../../server/utils/trace-parser';
+import type { ParsedTraceData, TraceAction } from '../../server/utils/trace-parser';
+
+// Large limits so nothing truncates in these tests.
+const MAX_TRACE_ACTIONS = 10;
+const TRACE_DOM_CHARS = 6000;
+
+/** Build a minimal TraceAction with only the fields under test. */
+function makeAction(overrides: Partial<TraceAction> = {}): TraceAction {
+  return {
+    callId: 'call@1',
+    apiName: 'locator.click',
+    startTime: 1000,
+    ...overrides,
+  };
+}
+
+/** Build a ParsedTraceData whose single action is the failing one. */
+function makeData(overrides: Partial<ParsedTraceData> = {}): ParsedTraceData {
+  const failingAction = overrides.failingAction ?? makeAction();
+  return {
+    actions: [failingAction],
+    consoleEntries: [],
+    networkRequests: [],
+    failingAction,
+    failingActionIndex: 0,
+    eventCount: 0,
+    timeoutFallback: false,
+    traceEndTime: 0,
+    ...overrides,
+  };
+}
+
+describe('formatFailingActionSection — timeout-fallback duration', () => {
+  test('renders "ran ≥ Nms" from the trace timebase, with no Date.now artifacts', () => {
+    const action = makeAction({ startTime: 1000, endTime: undefined });
+    const data = makeData({
+      failingAction: action,
+      timeoutFallback: true,
+      // Same timebase as startTime; last timestamp seen in the trace.
+      traceEndTime: 4500,
+    });
+
+    const out = formatFailingActionSection(data, MAX_TRACE_ACTIONS, TRACE_DOM_CHARS);
+    expect(out).not.toBeNull();
+
+    // N = traceEndTime - startTime = 3500.
+    expect(out).toContain('- Duration: ran ≥ 3500ms before the test was killed');
+
+    // Guard against the old Date.now()-based, seconds-vs-ms bug.
+    expect(out).not.toContain('timed out after');
+    expect(out).not.toContain('ms+');
+    // No wall-clock leakage: the buggy code produced a ~1.7e9 second value.
+    expect(out).not.toMatch(/Duration: timed out/);
+    expect(out).not.toMatch(/ran ≥ \d{7,}ms/);
+  });
+
+  test('rounds the trace-timebase delta to whole milliseconds', () => {
+    const action = makeAction({ startTime: 1000.2, endTime: undefined });
+    const data = makeData({
+      failingAction: action,
+      timeoutFallback: true,
+      traceEndTime: 4501.9, // delta 3501.7 → rounds to 3502
+    });
+
+    const out = formatFailingActionSection(data, MAX_TRACE_ACTIONS, TRACE_DOM_CHARS);
+    expect(out).toContain('- Duration: ran ≥ 3502ms before the test was killed');
+  });
+
+  test('renders no duration line when traceEndTime <= startTime', () => {
+    const action = makeAction({ startTime: 5000, endTime: undefined });
+
+    // Equal timestamps (no later event observed).
+    const equal = formatFailingActionSection(
+      makeData({ failingAction: action, timeoutFallback: true, traceEndTime: 5000 }),
+      MAX_TRACE_ACTIONS,
+      TRACE_DOM_CHARS,
+    );
+    expect(equal).not.toBeNull();
+    expect(equal).not.toContain('Duration:');
+
+    // No timestamp found anywhere in the trace (traceEndTime === 0).
+    const none = formatFailingActionSection(
+      makeData({ failingAction: action, timeoutFallback: true, traceEndTime: 0 }),
+      MAX_TRACE_ACTIONS,
+      TRACE_DOM_CHARS,
+    );
+    expect(none).not.toContain('Duration:');
+  });
+});
+
+describe('formatFailingActionSection — non-fallback duration (unchanged)', () => {
+  test('uses endTime - startTime when the action completed', () => {
+    const action = makeAction({ startTime: 1000, endTime: 1250 });
+    const data = makeData({ failingAction: action, timeoutFallback: false, traceEndTime: 9999 });
+
+    const out = formatFailingActionSection(data, MAX_TRACE_ACTIONS, TRACE_DOM_CHARS);
+    // Duration comes from endTime, not traceEndTime.
+    expect(out).toContain('- Duration: 250ms');
+    expect(out).not.toContain('ran ≥');
+  });
+});

--- a/reporter/package.json
+++ b/reporter/package.json
@@ -49,7 +49,7 @@
     "dist/"
   ],
   "peerDependencies": {
-    "@playwright/test": "^1.52.0"
+    "@playwright/test": "^1.40.0"
   },
   "dependencies": {
     "form-data": "^4.0.0"

--- a/reporter/src/internal/capture/capture-fixtures.ts
+++ b/reporter/src/internal/capture/capture-fixtures.ts
@@ -108,6 +108,40 @@ const FORM_FIELD_TAGS = new Set(['input', 'select', 'textarea']);
 // it once instead of spreading a fresh array per call.
 const CAPTURED_ATTRS_ARG: string[] = [...CAPTURED_ATTRIBUTES];
 
+/**
+ * ARIA snapshot that tolerates every Playwright version the reporter supports,
+ * returning null instead of throwing so a capture can never fail the test. The
+ * options validator runs client-side in the user's installed Playwright, so an
+ * unsupported key surfaces as a rejected promise (not a synchronous throw):
+ *   - ≥ 1.59: `mode: 'ai'` yields the ref-annotated AI snapshot (the ideal);
+ *     `ref` is unknown and silently stripped.
+ *   - 1.52: `mode: 'ai'` fails validation (only 'raw'/'regex' are accepted) and
+ *     rejects; the `{ ref: true }` fallback then yields a ref-annotated snapshot.
+ *   - 1.53–1.58: neither `ref` nor `mode` exists — unknown keys are stripped
+ *     server-side, so the first call already returns a plain flat snapshot.
+ *   - < 1.49: `locator.ariaSnapshot` does not exist — returns null up front.
+ */
+async function ariaSnapshotBestEffort(target: Locator, timeout?: number): Promise<string | null> {
+  // Playwright < 1.49 predates locator.ariaSnapshot entirely.
+  if (typeof target.ariaSnapshot !== 'function') return null;
+  try {
+    return await target.ariaSnapshot({
+      ...(timeout != null ? { timeout } : {}),
+      mode: 'ai',
+    } as Parameters<Locator['ariaSnapshot']>[0]);
+  } catch {
+    // 1.52 rejects `mode: 'ai'`; retry with the `ref` flag that release accepts.
+    try {
+      return await target.ariaSnapshot({
+        ...(timeout != null ? { timeout } : {}),
+        ref: true,
+      } as Parameters<Locator['ariaSnapshot']>[0]);
+    } catch {
+      return null;
+    }
+  }
+}
+
 // Chain methods that take args and define a new locator scope (not just narrow).
 // Origin method/args update to the chain call, e.g. .locator('.item') → locator('.item').
 // Positional/filter chains that narrow but don't change locator identity.
@@ -207,10 +241,9 @@ function wrapLocator(page: Page, locator: Locator, originMethod: string, originA
             // Bound with a timeout: without it, ariaSnapshot waits up to the
             // test timeout when the page is mid-navigation, which hangs the
             // teardown that drains these capture promises.
-            // The `ref` and `mode: 'ai'` flags require Playwright ≥ 1.52 and
-            // are typed only in newer @playwright/test versions — cast the opts.
-            const ariaOpts = { ref: true, mode: 'ai' as const, timeout: 500 } as Parameters<Locator['ariaSnapshot']>[0];
-            const aria = role || isFormField ? await target.ariaSnapshot(ariaOpts).catch(() => null) : null;
+            // ariaSnapshotBestEffort adapts the options to the installed
+            // Playwright version and never throws (see its doc comment).
+            const aria = role || isFormField ? await ariaSnapshotBestEffort(target, 500) : null;
 
             const accessibleName =
               extractAccessibleName(aria) || approximateAccessibleName({ ...attrs, accessibleName: null });
@@ -402,9 +435,7 @@ async function flushSink(sink: CaptureSink, testInfo: TestInfo): Promise<void> {
 
   if (page && testInfo.status !== 'passed' && testInfo.status !== 'skipped') {
     try {
-      const snapshot = await page
-        .locator(':root')
-        .ariaSnapshot({ ref: true, mode: 'ai' as const } as Parameters<Locator['ariaSnapshot']>[0]);
+      const snapshot = await ariaSnapshotBestEffort(page.locator(':root'));
       if (snapshot) {
         await testInfo.attach(ATTACHMENT_NAMES.ariaSnapshot, {
           contentType: 'text/plain',


### PR DESCRIPTION
## Summary

This PR enhances the AI diagnosis system with two major improvements: (1) locator-literal extraction and SCM diff matching to identify causal code changes with higher precision, and (2) refined prompt caching configuration to optimize token usage during re-runs. It also refactors Playwright error-context parsing and fixes timeout-duration calculation in trace analysis.

## Key Changes

### Locator-Literal Matching for SCM Relevance
- **Extract locator literals from error text** (`extractLocatorLiterals`): Parses failing test error logs to pull out string literals from `getByText()`, `locator()`, and `getByRole()` calls — the exact text the test was searching for.
- **Match literals against patch diffs** (`findLiteralInPatch`): Searches changed files' patches for these literals, with special weight given to removed lines (smoking gun: the text was just renamed or deleted).
- **Boost scoring for literal hits** (`scoreChangedFile`): A removed-line match adds 8 points (outranking all filename-based signals); an added-line hit adds 6 points. This dramatically improves precision when multiple files are candidates.
- **Surface the match in diagnosis output** (`formatTopSuspectedChange`): Explains *why* a file is suspected — e.g., "the diff removes a line containing the test's target text 'Add a label'".
- **Pass error text to scoring** (`RelevanceSignals.errorText`): The failing error is now included in relevance signals so literal extraction can run.

### Prompt Caching Refinement
- **Add `stablePrefixChars` option** (`AiCallOptions`): Allows callers to specify how many characters at the start of the user message are stable across re-runs (the built diagnosis context). The cache breakpoint sits at the end of this prefix; the remainder (additional context, research block) is sent as a separate uncached block so its variation cannot invalidate the cached prefix.
- **Refactor Anthropic message building** (`anthropicSystem`, `anthropicUserContent`): Extract message construction into reusable helpers that handle both cached and non-cached paths, reducing duplication between `callAnthropic` and `streamAnthropic`.
- **Set stable prefix in diagnosis** (`ai-diagnosis.ts`): When calling the AI, mark the built context as the stable prefix so re-runs benefit from caching without byte-identical requirements.

### Error-Context Parsing Improvements
- **Extract `extractPageSnapshotSection`** as a standalone, testable function: Parses Playwright's `error-context` attachment (since ~1.53) to extract the ARIA snapshot from the `# Page snapshot` section. Tolerates both h1 and h2 headings, fenced and unfenced YAML.
- **Fix attachment subtype lookup**: Change from `'error-context.md'` (on-disk filename) to `'error-context'` (Playwright's attachment name) so the query actually finds the file.
- **Update docstring**: Clarify that the attachment is stored under Playwright's attachment *name*, not its file name.

### Trace Analysis Fixes
- **Track `traceEndTime`** in `ParsedTraceData`: Record the largest timestamp observed anywhere in the trace (in the trace's own timebase) so timeout-fallback duration calculation has a proper upper bound.
- **Fix timeout-duration calculation** (`formatFailingActionSection`): When the failing action has no `endTime` and `timeoutFallback` is true, compute duration as `traceEndTime - startTime` (both in the same timebase, so the delta is already in milliseconds). This fixes a bug where the old code mixed `Date.now()` (wall-clock seconds) with trace timestamps, producing nonsensical values like 1.7e9 seconds.
- **Add unit tests** (`trace-parser.test.ts`): Verify timeout-fallback duration rendering, rounding, and edge cases (equal timestamps, no timestamps).

### Shared Exports
- **Export `TEXT_CONTENT_ROLES`** from `locator-fingerprint.ts`: Move this constant to the shared module so the server's ARIA-fallback healing (`locator-healing

https://claude.ai/code/session_01GmmNDEtf9TAaEips4S9vdE