### PR TITLE
fix(ai): provider correctness + token-efficiency for model calls

### DIFF
--- a/application/.env.example
+++ b/application/.env.example
@@ -91,12 +91,23 @@ PIWI_AI_EMBEDDING_API_KEY=
 # Cap how much evidence is packed into each diagnosis (and therefore token cost).
 # Defaults shown below; these are also editable in Settings → AI. When set, an
 # env var takes precedence over the stored setting and the field becomes read-only in the UI.
-# PIWI_AI_MAX_SAMPLE_ERROR_CHARS=3000     # characters of raw error text per error block
-# PIWI_AI_MAX_SCM_PATCH_BUDGET=4000       # total characters of diff patches across files
-# PIWI_AI_MAX_AFFECTED_TESTS=15           # affected tests listed
-# PIWI_AI_MAX_STEPS=30                     # recent test steps included
-# PIWI_AI_MAX_CONSOLE_ENTRIES=15          # console error/warning entries
-# PIWI_AI_MAX_CONSOLE_ENTRY_CHARS=400     # characters per console entry
-# PIWI_AI_MAX_NETWORK_REQUESTS=15         # failed network requests included
-# PIWI_AI_MAX_ARIA_SNAPSHOT_CHARS=4000    # characters of the page ARIA snapshot
-# PIWI_AI_MAX_TEST_SOURCE_CHARS=3000      # characters of the test source snippet
+# PIWI_AI_MAX_SAMPLE_ERROR_CHARS=10000    # characters of raw error text per error block
+# PIWI_AI_MAX_SCM_PATCH_BUDGET=15000      # total characters of diff patches across files
+# PIWI_AI_MAX_AFFECTED_TESTS=30           # affected tests listed
+# PIWI_AI_MAX_STEPS=50                    # recent test steps included
+# PIWI_AI_MAX_CONSOLE_ENTRIES=30          # console error/warning entries
+# PIWI_AI_MAX_CONSOLE_ENTRY_CHARS=1000    # characters per console entry
+# PIWI_AI_MAX_NETWORK_REQUESTS=25         # failed network requests included
+# PIWI_AI_MAX_ARIA_SNAPSHOT_CHARS=12000   # characters of the page ARIA snapshot
+# PIWI_AI_MAX_TEST_SOURCE_CHARS=8000      # characters of the test source snippet
+# PIWI_AI_MAX_SOURCE_FILES=4              # full source files fetched from SCM to ground patches (0 disables)
+# PIWI_AI_MAX_SOURCE_FILE_CHARS=12000     # characters per fetched full source file
+# PIWI_AI_MAX_SERVER_LOG_ENTRIES=50       # backend server log entries (X-Piwi-Logs header)
+# PIWI_AI_MAX_SERVER_LOG_ENTRY_CHARS=1000 # characters per backend server log entry
+# PIWI_AI_MAX_IMAGES=5                    # screenshots auto-included in the context
+# PIWI_AI_MAX_PASSED_PEERS=20             # passing peer tests in the same file listed
+# PIWI_AI_MAX_CONSOLE_WINDOW=50           # console entries of any type in the window before failure
+# PIWI_AI_SLOW_REQUEST_MS=1500            # duration (ms) above which a network request is flagged as slow
+# PIWI_AI_MAX_TRACE_ACTIONS=10            # actions extracted from the trace ZIP for failing-action context (0 disables)
+# PIWI_AI_TRACE_DOM_CHARS=6000            # characters of the trace-derived DOM/ARIA excerpt
+# PIWI_AI_IMAGE_MAX_EDGE=1920             # screenshots are downscaled so their long edge is at most this many pixels

--- a/application/app/components/diagnosis/DiagnosisResult.vue
+++ b/application/app/components/diagnosis/DiagnosisResult.vue
@@ -404,10 +404,15 @@ const alternateHypotheses = computed<Array<{ category?: string; rootCause?: stri
 const showAlternates = ref(false);
 
 /** Pipeline stages (two-stage research → diagnosis), when present. */
-const pipeline = computed<Array<{ role: string; model: string }>>(() => {
+const pipeline = computed<
+  Array<{ role: string; model: string; inputTokens?: number | null; cacheReadInputTokens?: number | null }>
+>(() => {
   const p = details.value?.pipeline;
   return Array.isArray(p) ? p : [];
 });
+
+/** Tokens served from the provider prompt cache across stages (0 when unknown/none). */
+const cachedTokens = computed<number>(() => pipeline.value.reduce((acc, s) => acc + (s.cacheReadInputTokens ?? 0), 0));
 </script>
 
 <template>
@@ -760,7 +765,8 @@ const pipeline = computed<Array<{ role: string; model: string }>>(() => {
             2-stage
           </UBadge>
           <span>
-            {{ diagnosis.model }} · {{ formatTokens(diagnosis.inputTokens, diagnosis.outputTokens) }} ·
+            {{ diagnosis.model }} · {{ formatTokens(diagnosis.inputTokens, diagnosis.outputTokens)
+            }}<template v-if="cachedTokens > 0"> ({{ cachedTokens }} cached)</template> ·
             {{ formatRelativeTime(diagnosis.updatedAt) }}
           </span>
         </div>

--- a/application/app/components/settings/AiRoleConfigForm.vue
+++ b/application/app/components/settings/AiRoleConfigForm.vue
@@ -43,9 +43,10 @@ const props = defineProps<{
   models: ModelInfo[];
   loadingModels: boolean;
   providerResolved: string;
+  testing: boolean;
 }>();
 
-const emit = defineEmits<{ applyPreset: [label: string]; loadModels: [] }>();
+const emit = defineEmits<{ applyPreset: [label: string]; loadModels: []; test: [] }>();
 
 const model = defineModel<RoleForm>({ required: true });
 
@@ -174,6 +175,12 @@ const roleEnvVars = computed<PiwiEnvVarName[]>(() => helpEnvVars(props.meta.help
           @load-models="emit('loadModels')"
         />
       </UFormField>
+
+      <div v-if="providerResolved" class="flex justify-end">
+        <UButton size="xs" color="neutral" variant="soft" icon="i-lucide-plug" :loading="testing" @click="emit('test')">
+          Test connection
+        </UButton>
+      </div>
     </template>
   </div>
 </template>

--- a/application/app/components/settings/AiUsagePanel.vue
+++ b/application/app/components/settings/AiUsagePanel.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { AiUsageSummary } from '~~/types/api';
+
+const days = ref(30);
+
+const periodOptions = [
+  { label: 'Last 7 days', value: 7 },
+  { label: 'Last 30 days', value: 30 },
+  { label: 'Last 90 days', value: 90 },
+];
+
+const { data: usage, pending } = await useFetch<AiUsageSummary>('/api/settings/ai/usage', {
+  query: { days },
+});
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+</script>
+
+<template>
+  <SectionCard icon="i-lucide-activity" title="AI usage">
+    <template #actions>
+      <USelect v-model="days" :items="periodOptions" size="sm" class="w-36" />
+    </template>
+
+    <div v-if="usage" class="space-y-3">
+      <p class="text-sm text-gray-500">
+        {{ formatCount(usage.totals.diagnoses) }} diagnoses · {{ formatCount(usage.totals.inputTokens) }} input tokens ·
+        {{ formatCount(usage.totals.outputTokens) }} output tokens
+      </p>
+
+      <p v-if="usage.byModel.length === 0" class="text-sm text-gray-500">No AI calls recorded in this period.</p>
+
+      <div v-else class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="text-xs text-gray-500 uppercase tracking-wider border-b border-default">
+              <th class="text-left px-2 py-2 font-medium">Model</th>
+              <th class="text-right px-2 py-2 font-medium">Diagnoses</th>
+              <th class="text-right px-2 py-2 font-medium">Failed</th>
+              <th class="text-right px-2 py-2 font-medium">Input tokens</th>
+              <th class="text-right px-2 py-2 font-medium">Output tokens</th>
+              <th class="text-right px-2 py-2 font-medium">Avg duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="row in usage.byModel"
+              :key="`${row.provider ?? 'unknown'}/${row.model}`"
+              class="border-b last:border-b-0 border-default"
+            >
+              <td class="px-2 py-2">
+                <span class="font-mono text-xs">{{ row.model }}</span>
+                <span class="text-xs text-gray-400"> · {{ row.provider ?? 'unknown' }}</span>
+              </td>
+              <td class="text-right px-2 py-2">{{ row.diagnoses }}</td>
+              <td class="text-right px-2 py-2" :class="row.failed > 0 ? 'text-red-600 dark:text-red-400' : ''">
+                {{ row.failed }}
+              </td>
+              <td class="text-right px-2 py-2" :title="row.inputTokens.toLocaleString()">
+                {{ formatCount(row.inputTokens) }}
+              </td>
+              <td class="text-right px-2 py-2" :title="row.outputTokens.toLocaleString()">
+                {{ formatCount(row.outputTokens) }}
+              </td>
+              <td class="text-right px-2 py-2">
+                {{ row.avgDurationMs === null ? '—' : formatDuration(row.avgDurationMs) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div v-else-if="pending" class="flex items-center gap-2 py-4 text-muted">
+      <UIcon name="i-lucide-loader-circle" class="size-4 animate-spin" />
+      <span class="text-sm">Loading usage…</span>
+    </div>
+  </SectionCard>
+</template>

--- a/application/app/demo/api/ai.ts
+++ b/application/app/demo/api/ai.ts
@@ -265,3 +265,12 @@ export async function apiGetAiLimits() {
 export async function apiPutAiLimits(_body: unknown) {
   return { success: true };
 }
+
+/** GET /api/settings/ai/usage — no live AI calls in demo mode */
+export async function apiGetAiUsage() {
+  return {
+    days: 30,
+    totals: { diagnoses: 0, inputTokens: 0, outputTokens: 0 },
+    byModel: [],
+  };
+}

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -83,6 +83,7 @@ import {
   apiTestAiSettings,
   apiGetAiLimits,
   apiPutAiLimits,
+  apiGetAiUsage,
 } from './ai';
 import { apiGetAdminStats } from './admin';
 import { apiDeleteTestRun } from './test-runs';
@@ -362,6 +363,7 @@ const routes: RouteEntry[] = [
   { method: 'GET', pattern: /^\/api\/settings\/ai$/, handler: () => apiGetAiSettings() },
   { method: 'PUT', pattern: /^\/api\/settings\/ai$/, handler: (_, body) => apiPutAiSettings(body) },
   { method: 'POST', pattern: /^\/api\/settings\/ai\/test$/, handler: () => apiTestAiSettings() },
+  { method: 'GET', pattern: /^\/api\/settings\/ai\/usage$/, handler: () => apiGetAiUsage() },
   {
     method: 'GET',
     pattern: /^\/api\/settings\/ai\/limits$/,

--- a/application/app/pages/settings/ai.vue
+++ b/application/app/pages/settings/ai.vue
@@ -30,7 +30,11 @@ const saving = ref(false);
 const savingInstructions = ref(false);
 const savingScmToken = ref(false);
 
-const testing = ref(false);
+const testingRoles = reactive<Record<RoleKey, boolean>>({
+  diagnosis: false,
+  research: false,
+  embedding: false,
+});
 
 const modelsRecord = reactive<Record<RoleKey, ModelInfo[]>>({
   diagnosis: [],
@@ -58,7 +62,8 @@ async function loadModels(role: RoleKey) {
   try {
     const res = await $fetch<{ models: ModelInfo[] }>('/api/settings/ai/models', {
       method: 'POST',
-      body: { provider, baseUrl: source.baseUrl || undefined, apiKey },
+      // role lets the server fall back to the stored key when the form key is blank
+      body: { role, provider, baseUrl: source.baseUrl || undefined, apiKey },
     });
     modelsRecord[role] = res.models;
   } catch {
@@ -88,7 +93,8 @@ const ROLE_META = [
     help: 'settings.ai-research',
     optional: true,
     enableLabel: 'Two-stage diagnosis',
-    blurb: 'A cheaper/faster model that pre-analyzes the failure before the diagnosis model writes the final answer.',
+    blurb:
+      'A cheaper/faster model that pre-analyzes the failure before the diagnosis model writes the final answer. Also used for cluster naming and merge adjudication.',
     reuseTargets: ['diagnosis'],
     modelPlaceholderAnthropic: 'e.g. claude-haiku-4-5',
     modelPlaceholderOpenai: 'e.g. llama-3.1-8b-instant',
@@ -97,7 +103,7 @@ const ROLE_META = [
     key: 'embedding',
     title: 'Embedding model',
     icon: 'i-lucide-vector-square',
-    help: 'settings.ai-provider',
+    help: 'settings.embedding-model',
     optional: true,
     enableLabel: 'Semantic clustering',
     blurb: 'Embeds failures so semantically-similar errors group together (used by failure clustering).',
@@ -111,6 +117,8 @@ const providerOptions = [
   { label: 'Anthropic API', value: 'anthropic' },
   { label: 'OpenAI-compatible', value: 'openai' },
 ];
+// Anthropic has no embeddings API — the embedding role must be OpenAI-compatible.
+const embeddingProviderOptions = providerOptions.filter((p) => p.value !== 'anthropic');
 
 // Stable per-role reuse options (recomputed only when role-enable state changes),
 // so the child <USelect>'s `items` keep a stable reference and the listbox doesn't
@@ -122,6 +130,8 @@ const reuseOptionsByRole = computed<Record<RoleKey, Array<{ label: string; value
       { label: 'Configure its own provider', value: 'own' },
       ...meta.reuseTargets
         .filter((t) => roles[t].enabled || t === 'diagnosis')
+        // Embeddings can only reuse OpenAI-compatible roles.
+        .filter((t) => meta.key !== 'embedding' || roles[t].provider === 'openai')
         .map((t) => ({ label: `Reuse ${ROLE_META.find((m) => m.key === t)!.title.toLowerCase()}`, value: t })),
     ];
   }
@@ -251,17 +261,21 @@ async function saveInstructions() {
   }
 }
 
-async function testConnection() {
-  testing.value = true;
+async function testRole(role: RoleKey) {
+  testingRoles[role] = true;
   try {
-    const d = roles.diagnosis;
+    const r = roles[role];
+    // Reused roles source provider/key/baseUrl from the reused role's form
+    // state; the server falls back to saved keys when the form key is blank.
+    const src = r.reuse ? roles[r.reuse] : r;
     const res = await $fetch<{ success: boolean; model?: string; error?: string }>('/api/settings/ai/test', {
       method: 'POST',
       body: {
-        provider: d.provider,
-        apiKey: d.apiKey || undefined,
-        model: d.model || undefined,
-        baseUrl: d.baseUrl || undefined,
+        role,
+        provider: src.provider || undefined,
+        apiKey: src.apiKey || undefined,
+        model: r.model || (r.reuse ? src.model : '') || undefined,
+        baseUrl: src.baseUrl || undefined,
       },
     });
     if (res.success)
@@ -270,7 +284,7 @@ async function testConnection() {
   } catch (err) {
     toast.add({ title: 'Connection failed', description: String((err as Error)?.message ?? err), color: 'error' });
   } finally {
-    testing.value = false;
+    testingRoles[role] = false;
   }
 }
 
@@ -343,23 +357,25 @@ function resetLimits() {
           :meta="meta"
           :has-api-key="hasStoredKey(meta.key)"
           :reuse-options="reuseOptionsByRole[meta.key]"
-          :provider-options="providerOptions"
+          :provider-options="meta.key === 'embedding' ? embeddingProviderOptions : providerOptions"
           :preset-options="presetOptions"
           :disabled="envManaged"
           :env-managed="envManaged"
           :provider-resolved="resolvedProvider(meta.key)"
           :models="modelsRecord[meta.key]"
           :loading-models="loadingModels[meta.key]"
+          :testing="testingRoles[meta.key]"
           @apply-preset="(label: string) => applyPreset(meta.key, label)"
           @load-models="loadModels(meta.key)"
+          @test="testRole(meta.key)"
         />
 
         <SettingsField label="Auto-diagnose" help="settings.auto-diagnose" :env-managed="envManaged">
           <div class="flex items-center gap-3">
             <USwitch v-model="autoDiagnose" :disabled="envManaged || !roles.diagnosis.enabled" />
             <span class="text-sm text-gray-500">
-              Automatically diagnose new failure clusters when a run finishes — one LLM call per new cluster, max 3 per
-              run
+              Automatically diagnose new failure clusters when a run finishes — up to 3 clusters per run (research +
+              diagnosis call each), plus one batched call to title new clusters
             </span>
           </div>
         </SettingsField>
@@ -367,20 +383,12 @@ function resetLimits() {
 
       <template #footer>
         <div class="flex items-center gap-2 justify-end">
-          <UButton
-            color="neutral"
-            variant="soft"
-            :loading="testing"
-            :disabled="!roles.diagnosis.provider"
-            icon="i-lucide-plug"
-            @click="testConnection"
-          >
-            Test diagnosis connection
-          </UButton>
           <UButton color="primary" :loading="saving" icon="i-lucide-save" @click="save"> Save </UButton>
         </div>
       </template>
     </SectionCard>
+
+    <AiUsagePanel />
 
     <SectionCard title="Repository access" help="project.scm-token">
       <template #subtitle> Optional — required for private repositories. Per-project tokens override this. </template>

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -356,7 +356,7 @@ export const HELP_TOPICS = {
   },
   'settings.ai-provider': {
     title: 'AI provider',
-    text: 'Choose the model provider and key used for failure diagnosis. The key is stored encrypted and never returned by the API.',
+    text: 'Configure the model providers behind the three AI roles — diagnosis, research and embedding. Each role has its own provider config, or reuses another role’s provider and credentials. Keys are stored encrypted and never returned by the API.',
     doc: 'ai-diagnosis#enabling-ai-diagnosis',
     envVars: ['PIWI_AI_PROVIDER', 'PIWI_AI_MODEL', 'PIWI_AI_API_KEY', 'PIWI_AI_BASE_URL'],
   },
@@ -367,7 +367,7 @@ export const HELP_TOPICS = {
   },
   'settings.ai-research': {
     title: 'Research model',
-    text: 'An optional cheaper/faster model that pre-analyzes the failure (on a lean view) before the main model writes the final diagnosis. It can use its own provider, and the costly SCM diff is only fetched when it flags a likely regression.',
+    text: 'An optional cheaper/faster model that pre-analyzes the failure (on a lean view) before the main model writes the final diagnosis. It can use its own provider, and the costly SCM diff is only fetched when it flags a likely regression. It also handles cluster naming and merge adjudication, so configuring a cheap research model routes those utility calls away from the expensive diagnosis model.',
     doc: 'ai-diagnosis#enabling-ai-diagnosis',
     envVars: [
       'PIWI_AI_RESEARCH_PROVIDER',
@@ -419,7 +419,7 @@ export const HELP_TOPICS = {
   },
   'settings.auto-diagnose': {
     title: 'Auto-diagnose',
-    text: 'Automatically diagnose new failure clusters when a run finishes — one LLM call per new cluster, max 3 per run. Requires the diagnosis model to be configured.',
+    text: 'When a run finishes, up to 3 new failure clusters are diagnosed automatically — each diagnosis is one research call (when a research model is configured) plus one diagnosis call — and new clusters get human-readable titles in one batched call. Requires the diagnosis model to be configured.',
     doc: 'ai-diagnosis#enabling-ai-diagnosis',
     envVars: ['PIWI_AI_AUTO_DIAGNOSE'],
   },

--- a/application/server/api/settings/ai.put.ts
+++ b/application/server/api/settings/ai.put.ts
@@ -126,6 +126,19 @@ export default eventHandler(async (event) => {
       throw createError({ statusCode: 400, message: 'A diagnosis role with its own provider is required' });
     }
 
+    // Embeddings need an OpenAI-compatible endpoint — Anthropic has no
+    // embeddings API, so reject configs that would only fail at run time.
+    if (out.embedding) {
+      let cfg: RawStoredRole | undefined = out.embedding;
+      for (let hops = 0; cfg?.reuse && hops < AI_ROLES.length; hops++) cfg = out[cfg.reuse];
+      if (cfg?.provider !== 'openai') {
+        throw createError({
+          statusCode: 400,
+          message: 'The embedding role requires an OpenAI-compatible provider (Anthropic has no embeddings API)',
+        });
+      }
+    }
+
     const autoDiagnose = 'autoDiagnose' in body ? Boolean(body.autoDiagnose) : Boolean(existing.autoDiagnose);
     await setAppSetting(db, 'ai', { autoDiagnose, roles: out });
   }

--- a/application/server/api/settings/ai/models.post.ts
+++ b/application/server/api/settings/ai/models.post.ts
@@ -1,6 +1,8 @@
+import { getDatabase } from '../../../database';
 import { requireAuth } from '../../../utils/auth';
 import { Role } from '#shared/types';
-import type { ModelInfo } from '~~/types/api';
+import { resolveAiConfig } from '../../../utils/ai-provider';
+import type { AiModelRole, ModelInfo } from '~~/types/api';
 
 /** Convert per-token pricing string to per-million-tokens, keeping larger values as-is. */
 function normalizePricing(v: string | undefined): string | undefined {
@@ -35,7 +37,7 @@ defineRouteMeta({
     tags: ['Settings'],
     summary: 'List available models from an AI provider',
     description:
-      "Calls the provider's models endpoint to return available models with metadata. Accepts provider, baseUrl, and apiKey in the request body. Requires administrator role.",
+      "Calls the provider's models endpoint to return available models with metadata. Accepts provider, baseUrl, apiKey, and role in the request body; when apiKey is omitted, the saved key for that role (then the diagnosis role) is used. Requires administrator role.",
     'x-required-roles': [Role.ADMINISTRATOR],
   },
 });
@@ -47,9 +49,19 @@ export default eventHandler(async (event) => {
     provider?: string;
     baseUrl?: string;
     apiKey?: string;
+    role?: string;
   }>(event).catch(() => null);
 
-  const { provider, baseUrl, apiKey } = body || {};
+  const { provider, baseUrl } = body || {};
+
+  // The form clears key fields after save, so listing models for a saved
+  // config must fall back to the stored (decrypted) or env-managed key.
+  let apiKey = body?.apiKey;
+  if (!apiKey) {
+    const role: AiModelRole = body?.role === 'research' || body?.role === 'embedding' ? body.role : 'diagnosis';
+    const resolved = await resolveAiConfig(await getDatabase());
+    apiKey = resolved?.roles[role]?.apiKey || resolved?.roles.diagnosis?.apiKey || undefined;
+  }
 
   if (provider === 'openai') {
     if (!baseUrl) return { models: [] };
@@ -102,8 +114,10 @@ export default eventHandler(async (event) => {
 
   if (provider === 'anthropic') {
     if (!apiKey) return { models: [] };
+    // Honour a configured baseUrl (proxy override) like the diagnosis calls do.
+    const root = (baseUrl || 'https://api.anthropic.com').replace(/\/+$/, '');
     try {
-      const res = await fetch('https://api.anthropic.com/v1/models', {
+      const res = await fetch(`${root}/v1/models`, {
         headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
         signal: AbortSignal.timeout(10000),
       });

--- a/application/server/api/settings/ai/test.post.ts
+++ b/application/server/api/settings/ai/test.post.ts
@@ -2,8 +2,8 @@ import { getDatabase } from '../../../database';
 import { requireAuth } from '../../../utils/auth';
 import { Role } from '#shared/types';
 import { resolveAiConfig, callAiProvider } from '../../../utils/ai-provider';
-import { getAppSetting } from '../../../utils/app-settings';
-import type { AiProvider, ResolvedAiRole } from '~~/types/api';
+import { embedTexts } from '../../../utils/ai-embeddings';
+import type { AiModelRole, AiProvider, ResolvedAiRole } from '~~/types/api';
 
 const REQUIRED_ROLES: Role[] = [Role.ADMINISTRATOR];
 
@@ -12,7 +12,7 @@ defineRouteMeta({
     tags: ['Settings'],
     summary: 'Test AI provider connection',
     description:
-      'Sends a connectivity test to the configured AI provider. Accepts optional provider, apiKey, model, and baseUrl in the request body. Requires administrator role.',
+      'Sends a connectivity test to the configured AI provider for a given model role (`diagnosis`, `research`, or `embedding` — the embedding role is probed via the embeddings endpoint). Accepts optional role, provider, apiKey, model, and baseUrl in the request body; omitted fields fall back to the saved configuration. Requires administrator role.',
     'x-required-roles': REQUIRED_ROLES,
   },
 });
@@ -21,32 +21,27 @@ export default eventHandler(async (event) => {
   await requireAuth(event, REQUIRED_ROLES);
 
   const body = (await readBody(event).catch(() => null)) as {
+    role?: string;
     provider?: string;
     apiKey?: string;
     model?: string;
     baseUrl?: string;
   } | null;
 
+  const role: AiModelRole = body?.role === 'research' || body?.role === 'embedding' ? body.role : 'diagnosis';
+
   const db = await getDatabase();
+  const resolved = await resolveAiConfig(db);
 
   let config: ResolvedAiRole | null;
 
   if (!body?.provider) {
-    const resolved = await resolveAiConfig(db);
-    config = resolved ? resolved.roles.diagnosis : null;
+    config = resolved ? resolved.roles[role] : null;
   } else {
-    let apiKey = body.apiKey || '';
-    if (!apiKey) {
-      // User didn't type a new key — fall back to whatever is currently active
-      // (env var key via resolveAiConfig, or stored DB key)
-      const existing = await resolveAiConfig(db);
-      apiKey = existing?.apiKey || '';
-      if (!apiKey) {
-        // Last resort: read raw stored value (handles case where existing config is invalid)
-        const stored = await getAppSetting<{ apiKey?: string }>(db, 'ai');
-        apiKey = stored?.apiKey || '';
-      }
-    }
+    // Form values win; a blank key falls back to the saved key for this role
+    // (users leave the field empty to keep the stored secret), then to the
+    // diagnosis role's key (the common "reuse" source).
+    const apiKey = body.apiKey || resolved?.roles[role]?.apiKey || resolved?.roles.diagnosis?.apiKey || '';
     config = {
       provider: body.provider as AiProvider,
       apiKey,
@@ -55,9 +50,14 @@ export default eventHandler(async (event) => {
     };
   }
 
-  if (!config) throw createError({ statusCode: 503, message: 'AI diagnosis is not configured' });
+  if (!config) throw createError({ statusCode: 503, message: `The ${role} role is not configured` });
 
   try {
+    if (role === 'embedding') {
+      const vectors = await embedTexts(config, ['connectivity check']);
+      if (!vectors[0]?.length) throw new Error('embeddings endpoint returned no vector');
+      return { success: true, model: config.model };
+    }
     const result = await callAiProvider(config, {
       system: 'You are a connectivity check.',
       user: 'Reply with the single word OK.',

--- a/application/server/api/settings/ai/usage.get.ts
+++ b/application/server/api/settings/ai/usage.get.ts
@@ -1,0 +1,66 @@
+import { and, avg, count, gte, isNotNull, sql, sum } from 'drizzle-orm';
+import { getDatabase } from '../../../database';
+import { failureDiagnoses } from '../../../database/schema';
+import { requireAuth } from '../../../utils/auth';
+import { Role } from '#shared/types';
+import type { AiUsageSummary } from '~~/types/api';
+
+const REQUIRED_ROLES: Role[] = [Role.ADMINISTRATOR];
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Settings'],
+    summary: 'Get AI token usage',
+    description:
+      'Aggregates AI diagnosis token usage over the requested period, grouped by provider and model. Requires administrator role.',
+    parameters: [{ name: 'days', in: 'query', schema: { type: 'integer', default: 30, minimum: 1, maximum: 365 } }],
+    'x-required-roles': REQUIRED_ROLES,
+  },
+});
+
+export default eventHandler(async (event): Promise<AiUsageSummary> => {
+  await requireAuth(event, REQUIRED_ROLES);
+
+  const parsed = parseInt((getQuery(event).days as string) || '30');
+  const days = Math.min(365, Math.max(1, Number.isFinite(parsed) ? parsed : 30));
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  const db = await getDatabase();
+  const rows = await db
+    .select({
+      provider: failureDiagnoses.provider,
+      model: failureDiagnoses.model,
+      diagnoses: count(),
+      // Plain SQL CASE so the expression works on both SQLite and PostgreSQL.
+      failed: sql<number>`sum(case when ${failureDiagnoses.status} = 'failed' then 1 else 0 end)`,
+      inputTokens: sum(failureDiagnoses.inputTokens),
+      outputTokens: sum(failureDiagnoses.outputTokens),
+      avgDurationMs: avg(failureDiagnoses.durationMs),
+    })
+    .from(failureDiagnoses)
+    .where(and(isNotNull(failureDiagnoses.model), gte(failureDiagnoses.updatedAt, since)))
+    .groupBy(failureDiagnoses.provider, failureDiagnoses.model);
+
+  // sum/avg come back as string | null depending on the driver — normalize to numbers.
+  const byModel = rows
+    .map((r) => ({
+      provider: r.provider,
+      model: r.model ?? '',
+      diagnoses: Number(r.diagnoses ?? 0),
+      failed: Number(r.failed ?? 0),
+      inputTokens: Number(r.inputTokens ?? 0),
+      outputTokens: Number(r.outputTokens ?? 0),
+      avgDurationMs: r.avgDurationMs === null ? null : Math.round(Number(r.avgDurationMs)),
+    }))
+    .sort((a, b) => b.inputTokens - a.inputTokens);
+
+  return {
+    days,
+    totals: {
+      diagnoses: byModel.reduce((acc, r) => acc + r.diagnoses, 0),
+      inputTokens: byModel.reduce((acc, r) => acc + r.inputTokens, 0),
+      outputTokens: byModel.reduce((acc, r) => acc + r.outputTokens, 0),
+    },
+    byModel,
+  };
+});

--- a/application/server/utils/ai-diagnosis.ts
+++ b/application/server/utils/ai-diagnosis.ts
@@ -8,6 +8,8 @@ import type { AiConfig } from '~~/types/api';
 import { callAiProvider, resolveAiConfig, streamAiProvider, DEFAULT_ANTHROPIC_MODEL } from './ai-provider';
 import type { AiAttachedImage, StreamChunk, StreamResult } from './ai-provider';
 import { buildDiagnosisContext } from './ai-context';
+import { resolveContextLimits } from './ai-context-limits';
+import { downscaleImages } from './ai-images';
 import { buildDiagnosisSystemPrompt } from './ai-system-prompt';
 import { reconcileNewClusters } from './cluster-reconcile';
 import { nameNewClusters } from './cluster-naming';
@@ -223,7 +225,14 @@ export async function runClusterDiagnosis(
             skipScm,
           });
 
-    type PipelineStage = { role: string; model: string; inputTokens: number | null; outputTokens: number | null };
+    type PipelineStage = {
+      role: string;
+      model: string;
+      inputTokens: number | null;
+      outputTokens: number | null;
+      cacheCreationInputTokens: number | null;
+      cacheReadInputTokens: number | null;
+    };
     const pipeline: PipelineStage[] = [];
 
     // The research stage runs only when a distinct research role is configured
@@ -254,12 +263,15 @@ export async function runClusterDiagnosis(
           user: buildResearchProjection(ctx),
           jsonSchema: RESEARCH_JSON_SCHEMA,
           maxTokens: 2048,
+          effort: 'low',
         });
         pipeline.push({
           role: 'research',
           model: research.model,
           inputTokens: research.inputTokens,
           outputTokens: research.outputTokens,
+          cacheCreationInputTokens: research.cacheCreationInputTokens,
+          cacheReadInputTokens: research.cacheReadInputTokens,
         });
         const parsed = parseResearchJson(research.text);
         researchBlock = formatResearchBlock(parsed);
@@ -277,14 +289,20 @@ export async function runClusterDiagnosis(
     const baseContent = extra ? `${ctx.text}\n\n## Additional Context Provided by User\n${extra}` : ctx.text;
     const userContent = researchBlock ? `${baseContent}\n\n${researchBlock}` : baseContent;
     // Merge auto-resolved screenshots (D1) with user-provided images
+    // Downscale screenshots (auto-resolved + user-provided) — full-resolution
+    // images cost ~3× more tokens on current models without helping diagnosis.
     const allImages = [...(ctx.images ?? []), ...(opts?.images ?? [])];
-    const images = allImages.length > 0 ? allImages : undefined;
+    const images =
+      allImages.length > 0
+        ? await downscaleImages(allImages, (await resolveContextLimits(db)).imageMaxEdge)
+        : undefined;
 
     const result = await callAiProvider(config, {
       system: systemPrompt,
       user: userContent,
       jsonSchema: DIAGNOSIS_JSON_SCHEMA,
       images,
+      adaptiveThinking: true,
       cacheControl: true,
       // The built context is the cache-stable prefix; additional context and
       // the research block vary between re-runs and sit after the breakpoint.
@@ -295,6 +313,8 @@ export async function runClusterDiagnosis(
       model: result.model,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,
+      cacheCreationInputTokens: result.cacheCreationInputTokens,
+      cacheReadInputTokens: result.cacheReadInputTokens,
     });
     const diagnosis = parseDiagnosisJson(result.text);
 
@@ -322,7 +342,8 @@ export async function runClusterDiagnosis(
           affectedArea: diagnosis.affectedArea,
           hypotheses: diagnosis.hypotheses,
           investigationSteps: diagnosis.investigationSteps,
-          ...(pipeline.length > 1 ? { pipeline } : {}),
+          // Always stored (even single-stage) so per-stage token + cache stats are inspectable.
+          pipeline,
           selectedCommitShas: opts?.selectedCommitShas ?? null,
           additionalContext: opts?.additionalContext ?? null,
           autoSelectedCommits: ctx.scmChanges?.commits?.slice(0, 3).map((c) => c.sha) ?? null,
@@ -499,7 +520,14 @@ export async function streamClusterDiagnosis(
             skipScm,
           });
 
-    type PipelineStage = { role: string; model: string; inputTokens: number | null; outputTokens: number | null };
+    type PipelineStage = {
+      role: string;
+      model: string;
+      inputTokens: number | null;
+      outputTokens: number | null;
+      cacheCreationInputTokens: number | null;
+      cacheReadInputTokens: number | null;
+    };
     const pipeline: PipelineStage[] = [];
 
     // Research stage (synchronous, not streamed)
@@ -523,12 +551,15 @@ export async function streamClusterDiagnosis(
           user: buildResearchProjection(ctx),
           jsonSchema: RESEARCH_JSON_SCHEMA,
           maxTokens: 2048,
+          effort: 'low',
         });
         pipeline.push({
           role: 'research',
           model: research.model,
           inputTokens: research.inputTokens,
           outputTokens: research.outputTokens,
+          cacheCreationInputTokens: research.cacheCreationInputTokens,
+          cacheReadInputTokens: research.cacheReadInputTokens,
         });
         const parsed = parseResearchJson(research.text);
         researchBlock = formatResearchBlock(parsed);
@@ -544,20 +575,28 @@ export async function streamClusterDiagnosis(
     const extra = opts?.additionalContext?.trim();
     const baseContent = extra ? `${ctx.text}\n\n## Additional Context Provided by User\n${extra}` : ctx.text;
     const userContent = researchBlock ? `${baseContent}\n\n${researchBlock}` : baseContent;
+    // Downscale screenshots (auto-resolved + user-provided) — full-resolution
+    // images cost ~3× more tokens on current models without helping diagnosis.
     const allImages = [...(ctx.images ?? []), ...(opts?.images ?? [])];
-    const images = allImages.length > 0 ? allImages : undefined;
+    const images =
+      allImages.length > 0
+        ? await downscaleImages(allImages, (await resolveContextLimits(db)).imageMaxEdge)
+        : undefined;
 
     // Stream the diagnosis stage
     let accumulatedText = '';
     let streamModel = config.model;
     let streamInputTokens: number | null = null;
     let streamOutputTokens: number | null = null;
+    let streamCacheCreation: number | null = null;
+    let streamCacheRead: number | null = null;
 
     for await (const chunk of streamAiProvider(config, {
       system: systemPrompt,
       user: userContent,
       jsonSchema: DIAGNOSIS_JSON_SCHEMA,
       images,
+      adaptiveThinking: true,
       cacheControl: true,
       // The built context is the cache-stable prefix; additional context and
       // the research block vary between re-runs and sit after the breakpoint.
@@ -571,6 +610,8 @@ export async function streamClusterDiagnosis(
         streamModel = result.model;
         streamInputTokens = result.inputTokens;
         streamOutputTokens = result.outputTokens;
+        streamCacheCreation = result.cacheCreationInputTokens;
+        streamCacheRead = result.cacheReadInputTokens;
       } else if (chunk.type === 'error') {
         throw new Error(chunk.data as string);
       }
@@ -581,6 +622,8 @@ export async function streamClusterDiagnosis(
       model: streamModel,
       inputTokens: streamInputTokens,
       outputTokens: streamOutputTokens,
+      cacheCreationInputTokens: streamCacheCreation,
+      cacheReadInputTokens: streamCacheRead,
     });
 
     const diagnosis = parseDiagnosisJson(accumulatedText);
@@ -609,7 +652,8 @@ export async function streamClusterDiagnosis(
           affectedArea: diagnosis.affectedArea,
           hypotheses: diagnosis.hypotheses,
           investigationSteps: diagnosis.investigationSteps,
-          ...(pipeline.length > 1 ? { pipeline } : {}),
+          // Always stored (even single-stage) so per-stage token + cache stats are inspectable.
+          pipeline,
           selectedCommitShas: opts?.selectedCommitShas ?? null,
           additionalContext: opts?.additionalContext ?? null,
           autoSelectedCommits: ctx.scmChanges?.commits?.slice(0, 3).map((c) => c.sha) ?? null,

--- a/application/server/utils/ai-images.ts
+++ b/application/server/utils/ai-images.ts
@@ -1,0 +1,31 @@
+/**
+ * Screenshot downscaling for the AI diagnosis context. Current Claude models
+ * accept high-resolution images but bill up to ~3× more tokens for them, and
+ * failure screenshots rarely need more than ~1080p to be readable. Images are
+ * resized (long edge ≤ `maxEdge`, aspect ratio kept, format preserved) before
+ * being base64-attached; any failure falls back to the original image.
+ */
+
+import sharp from 'sharp';
+import type { AiAttachedImage } from './ai-provider';
+
+export async function downscaleImages(images: AiAttachedImage[], maxEdge: number): Promise<AiAttachedImage[]> {
+  if (images.length === 0 || !Number.isFinite(maxEdge) || maxEdge <= 0) return images;
+
+  return Promise.all(
+    images.map(async (img) => {
+      try {
+        const input = Buffer.from(img.data, 'base64');
+        const meta = await sharp(input).metadata();
+        const edge = Math.max(meta.width ?? 0, meta.height ?? 0);
+        if (edge <= maxEdge) return img;
+        const resized = await sharp(input)
+          .resize({ width: maxEdge, height: maxEdge, fit: 'inside', withoutEnlargement: true })
+          .toBuffer();
+        return { ...img, data: resized.toString('base64') };
+      } catch {
+        return img;
+      }
+    }),
+  );
+}

--- a/application/server/utils/ai-provider.ts
+++ b/application/server/utils/ai-provider.ts
@@ -35,7 +35,11 @@ interface StoredAi {
   researchApiKey?: string;
 }
 
-function isValidRole(role: ResolvedAiRole): boolean {
+/** What a role is used for: embeddings need an OpenAI-compatible endpoint (Anthropic has no embeddings API). */
+type RoleKind = 'chat' | 'embedding';
+
+function isValidRole(role: ResolvedAiRole, kind: RoleKind): boolean {
+  if (kind === 'embedding') return role.provider === 'openai' && Boolean(role.baseUrl && role.model);
   if (role.provider === 'anthropic') return Boolean(role.apiKey);
   if (role.provider === 'openai') return Boolean(role.baseUrl && role.model);
   return false;
@@ -47,11 +51,12 @@ function makeRole(
   apiKey?: string | null,
   model?: string | null,
   baseUrl?: string | null,
+  kind: RoleKind = 'chat',
 ): ResolvedAiRole | null {
   const p = (provider || '') as AiProvider;
   if (p !== 'anthropic' && p !== 'openai') return null;
   const role: ResolvedAiRole = { provider: p, apiKey: apiKey || '', model: model || '', baseUrl: baseUrl || null };
-  return isValidRole(role) ? role : null;
+  return isValidRole(role, kind) ? role : null;
 }
 
 const ROLE_ORDER: AiModelRole[] = ['diagnosis', 'research', 'embedding'];
@@ -62,13 +67,14 @@ function resolveStoredRoles(roles: Partial<Record<AiModelRole, StoredRole>>): Ai
   const out: Record<AiModelRole, ResolvedAiRole | null> = { diagnosis: null, research: null, embedding: null };
 
   for (const role of ROLE_ORDER) {
+    const kind: RoleKind = role === 'embedding' ? 'embedding' : 'chat';
     const cfg = roles[role];
     if (!cfg) continue;
     if (cfg.reuse && out[cfg.reuse]) {
       const base = out[cfg.reuse]!;
-      out[role] = makeRole(base.provider, base.apiKey, cfg.model || base.model, base.baseUrl);
+      out[role] = makeRole(base.provider, base.apiKey, cfg.model || base.model, base.baseUrl, kind);
     } else {
-      out[role] = makeRole(cfg.provider, decrypt(cfg.apiKey), cfg.model, cfg.baseUrl);
+      out[role] = makeRole(cfg.provider, decrypt(cfg.apiKey), cfg.model, cfg.baseUrl, kind);
     }
   }
 
@@ -129,12 +135,18 @@ export async function resolveAiConfig(db: DbClient): Promise<AiConfig | null> {
           envAi.researchBaseUrl || envAi.baseUrl,
         )
       : null;
-    const embedding = makeRole(
-      envAi.embeddingProvider,
-      envAi.embeddingApiKey,
-      envAi.embeddingModel,
-      envAi.embeddingBaseUrl,
-    );
+    // Embedding defaults its provider/key/baseUrl to the main role when not
+    // overridden (same convention as research). Only useful when the main
+    // provider is OpenAI-compatible — embeddings require one.
+    const embedding = envAi.embeddingModel
+      ? makeRole(
+          envAi.embeddingProvider || envAi.provider,
+          envAi.embeddingApiKey || envAi.apiKey,
+          envAi.embeddingModel,
+          envAi.embeddingBaseUrl || envAi.baseUrl,
+          'embedding',
+        )
+      : null;
     return assembleConfig(diagnosis, research, embedding, String(envAi.autoDiagnose) === 'true', 'env');
   }
 
@@ -181,6 +193,18 @@ export interface AiCallOptions {
   jsonSchema?: object;
   maxTokens?: number;
   images?: AiAttachedImage[];
+  /**
+   * Anthropic only: enable adaptive thinking (better diagnosis quality on
+   * current Claude models). Ignored for OpenAI-compat providers; if the
+   * configured model rejects it, the call is retried once without it.
+   */
+  adaptiveThinking?: boolean;
+  /**
+   * Anthropic only: output effort hint — 'low' keeps utility calls (research,
+   * naming, adjudication) cheap. Same reject-then-retry behavior as
+   * adaptiveThinking on models that don't support it.
+   */
+  effort?: 'low' | 'medium' | 'high';
   /** When true, mark the system prompt and stable context prefix for Anthropic cache_control. Re-runs become ~90 % cached input. */
   cacheControl?: boolean;
   /**
@@ -239,6 +263,10 @@ export interface AiCallResult {
   model: string;
   inputTokens: number | null;
   outputTokens: number | null;
+  /** Tokens written to the provider prompt cache (Anthropic), null when unknown. */
+  cacheCreationInputTokens: number | null;
+  /** Tokens served from the provider prompt cache (Anthropic `cache_read_input_tokens`, OpenAI `cached_tokens`). */
+  cacheReadInputTokens: number | null;
 }
 
 export interface StreamChunk {
@@ -250,6 +278,8 @@ export interface StreamResult {
   model: string;
   inputTokens: number | null;
   outputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
 }
 
 export async function callAiProvider(config: ResolvedAiRole, opts: AiCallOptions): Promise<AiCallResult> {
@@ -264,36 +294,77 @@ export async function callAiProvider(config: ResolvedAiRole, opts: AiCallOptions
   }
 }
 
-async function callAnthropic(config: ResolvedAiRole, opts: AiCallOptions): Promise<AiCallResult> {
-  const client = new Anthropic({
+function anthropicClient(config: ResolvedAiRole): Anthropic {
+  return new Anthropic({
     apiKey: config.apiKey,
     baseURL: config.baseUrl || undefined,
     timeout: 120_000,
     maxRetries: 1,
   });
+}
 
-  // Prompt caching (when opts.cacheControl): two breakpoints — the system
-  // prompt and the stable user prefix (images + built context). With 1.6's
-  // stable section ordering the prefix is cache-friendly; the volatile tail
-  // (user additional context, research block) is a separate uncached block.
-  const res = await client.messages.create({
+/**
+ * Request params for an Anthropic call. Prompt caching (when opts.cacheControl):
+ * two breakpoints — the system prompt and the stable user prefix (images +
+ * built context); the volatile tail (user additional context, research block)
+ * is a separate uncached block. No sampling params: `temperature` & co. are
+ * rejected by current Claude models (Opus 4.7+).
+ *
+ * `tuned` adds adaptive thinking / effort when requested; callers retry once
+ * untuned when the configured model rejects those fields (older models).
+ */
+function buildAnthropicParams(
+  config: ResolvedAiRole,
+  opts: AiCallOptions,
+  tuned: boolean,
+): Anthropic.Messages.MessageCreateParamsNonStreaming {
+  const outputConfig: Record<string, unknown> = {};
+  if (opts.jsonSchema) {
+    outputConfig.format = { type: 'json_schema' as const, schema: opts.jsonSchema as { [key: string]: unknown } };
+  }
+  if (tuned && opts.effort) outputConfig.effort = opts.effort;
+
+  return {
     model: config.model || DEFAULT_ANTHROPIC_MODEL,
     max_tokens: opts.maxTokens ?? 8192,
-    temperature: 0,
     system: anthropicSystem(opts),
     messages: [{ role: 'user', content: anthropicUserContent(opts) as Anthropic.MessageParam['content'] }],
-    ...(opts.jsonSchema
-      ? {
-          output_config: {
-            format: { type: 'json_schema' as const, schema: opts.jsonSchema as { [key: string]: unknown } },
-          },
-        }
-      : {}),
-  });
+    ...(tuned && opts.adaptiveThinking ? { thinking: { type: 'adaptive' } } : {}),
+    ...(Object.keys(outputConfig).length > 0 ? { output_config: outputConfig } : {}),
+  } as Anthropic.Messages.MessageCreateParamsNonStreaming;
+}
 
-  if (res.stop_reason === 'refusal') {
+function wantsTuning(opts: AiCallOptions): boolean {
+  return Boolean(opts.adaptiveThinking || opts.effort);
+}
+
+/** 400 from a model that doesn't support the thinking/effort params — retry untuned. */
+function isTuningRejection(err: unknown): boolean {
+  return err instanceof Anthropic.BadRequestError && /thinking|effort/i.test(err.message);
+}
+
+/** Throw a clear error for terminal stop reasons shared by the sync and streaming paths. */
+function checkAnthropicStopReason(msg: Anthropic.Message, opts: AiCallOptions): void {
+  if (msg.stop_reason === 'refusal') {
     throw new Error('The model declined to analyze this failure');
   }
+  if (msg.stop_reason === 'max_tokens') {
+    throw new Error(`Model output was truncated at ${opts.maxTokens ?? 8192} tokens — raise the max token limit`);
+  }
+}
+
+async function callAnthropic(config: ResolvedAiRole, opts: AiCallOptions): Promise<AiCallResult> {
+  const client = anthropicClient(config);
+
+  let res: Anthropic.Message;
+  try {
+    res = await client.messages.create(buildAnthropicParams(config, opts, true));
+  } catch (err) {
+    if (!wantsTuning(opts) || !isTuningRejection(err)) throw err;
+    res = await client.messages.create(buildAnthropicParams(config, opts, false));
+  }
+
+  checkAnthropicStopReason(res, opts);
 
   const text = res.content.find((b) => b.type === 'text')?.text ?? '';
   return {
@@ -301,23 +372,20 @@ async function callAnthropic(config: ResolvedAiRole, opts: AiCallOptions): Promi
     model: res.model,
     inputTokens: res.usage.input_tokens ?? null,
     outputTokens: res.usage.output_tokens ?? null,
+    cacheCreationInputTokens: res.usage.cache_creation_input_tokens ?? null,
+    cacheReadInputTokens: res.usage.cache_read_input_tokens ?? null,
   };
 }
 
-async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Promise<AiCallResult> {
-  const baseUrl = (config.baseUrl || '').replace(/\/$/, '');
-  const url = `${baseUrl}/chat/completions`;
+type OAIPart = { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } };
+type OAIUsage = {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+};
 
-  const headers: Record<string, string> = { 'content-type': 'application/json' };
-  if (config.apiKey) headers['authorization'] = `Bearer ${config.apiKey}`;
-
-  const systemContent = opts.jsonSchema
-    ? `${opts.system}\n\nRespond ONLY with a JSON object matching this schema:\n${JSON.stringify(opts.jsonSchema)}`
-    : opts.system;
-
-  type OAIPart = { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } };
-
-  const userMessageContent: string | OAIPart[] = opts.images?.length
+function openAiUserContent(opts: AiCallOptions): string | OAIPart[] {
+  return opts.images?.length
     ? [
         ...opts.images.map(
           (img): OAIPart => ({
@@ -328,24 +396,58 @@ async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Pr
         { type: 'text', text: opts.user },
       ]
     : opts.user;
+}
 
-  const body = JSON.stringify({
+/**
+ * Base chat-completions body. The JSON schema is enforced with
+ * `response_format: json_schema` where the server supports it (`strictFormat`);
+ * callers retry with the older `json_object` mode on HTTP 400. The schema also
+ * stays inlined in the system prompt so servers that ignore response_format
+ * still see it.
+ */
+function buildOpenAiBody(config: ResolvedAiRole, opts: AiCallOptions, strictFormat: boolean): Record<string, unknown> {
+  const systemContent = opts.jsonSchema
+    ? `${opts.system}\n\nRespond ONLY with a JSON object matching this schema:\n${JSON.stringify(opts.jsonSchema)}`
+    : opts.system;
+
+  const responseFormat = opts.jsonSchema
+    ? strictFormat
+      ? { type: 'json_schema', json_schema: { name: 'response', schema: opts.jsonSchema } }
+      : { type: 'json_object' }
+    : undefined;
+
+  return {
     model: config.model,
     max_tokens: opts.maxTokens ?? 8192,
     temperature: 0,
-    response_format: { type: 'json_object' },
+    ...(responseFormat ? { response_format: responseFormat } : {}),
     messages: [
       { role: 'system', content: systemContent },
-      { role: 'user', content: userMessageContent },
+      { role: 'user', content: openAiUserContent(opts) },
     ],
-  });
+  };
+}
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers,
-    body,
-    signal: AbortSignal.timeout(120_000),
-  });
+async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Promise<AiCallResult> {
+  const baseUrl = (config.baseUrl || '').replace(/\/$/, '');
+  const url = `${baseUrl}/chat/completions`;
+
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (config.apiKey) headers['authorization'] = `Bearer ${config.apiKey}`;
+
+  const post = (strictFormat: boolean) =>
+    fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildOpenAiBody(config, opts, strictFormat)),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+  let res = await post(true);
+  if (res.status === 400 && opts.jsonSchema) {
+    // Server rejects response_format json_schema (older OpenAI-compat) — fall back to json_object.
+    res = await post(false);
+  }
 
   if (!res.ok) {
     const bodyText = await res.text().catch(() => '');
@@ -353,10 +455,14 @@ async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Pr
   }
 
   const data = (await res.json()) as {
-    choices: Array<{ message: { content: string } }>;
+    choices: Array<{ message: { content: string }; finish_reason?: string }>;
     model?: string;
-    usage?: { prompt_tokens?: number; completion_tokens?: number };
+    usage?: OAIUsage;
   };
+
+  if (data.choices?.[0]?.finish_reason === 'length') {
+    throw new Error(`Model output was truncated at ${opts.maxTokens ?? 8192} tokens — raise the max token limit`);
+  }
 
   const text = data.choices?.[0]?.message?.content ?? '';
   return {
@@ -364,6 +470,8 @@ async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Pr
     model: data.model || config.model,
     inputTokens: data.usage?.prompt_tokens ?? null,
     outputTokens: data.usage?.completion_tokens ?? null,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: data.usage?.prompt_tokens_details?.cached_tokens ?? null,
   };
 }
 
@@ -384,74 +492,45 @@ export async function* streamAiProvider(config: ResolvedAiRole, opts: AiCallOpti
   }
 }
 
-async function* streamAnthropic(config: ResolvedAiRole, opts: AiCallOptions): AsyncGenerator<StreamChunk> {
-  const client = new Anthropic({
-    apiKey: config.apiKey,
-    baseURL: config.baseUrl || undefined,
-    timeout: 120_000,
-    maxRetries: 1,
-  });
-
-  const textChunks: string[] = [];
-  let streamError: Error | null = null;
-  let finalMsg: Anthropic.Message | null = null;
-  let index = 0;
-  let resolveFinal: (() => void) | null = null;
-  const finalDone = new Promise<void>((r) => {
-    resolveFinal = r;
-  });
-
-  // Same caching layout as callAnthropic — see anthropicSystem/anthropicUserContent.
-  const stream = client.messages.stream({
-    model: config.model || DEFAULT_ANTHROPIC_MODEL,
-    max_tokens: opts.maxTokens ?? 8192,
-    temperature: 0,
-    system: anthropicSystem(opts),
-    messages: [{ role: 'user', content: anthropicUserContent(opts) as Anthropic.MessageParam['content'] }],
-    ...(opts.jsonSchema
-      ? {
-          output_config: {
-            format: { type: 'json_schema' as const, schema: opts.jsonSchema as { [key: string]: unknown } },
-          },
-        }
-      : {}),
-  });
-
-  stream.on('text', (text: string) => {
-    textChunks.push(text);
-  });
-
-  stream.finalMessage().then(
-    (msg) => {
-      finalMsg = msg;
-      if (resolveFinal) resolveFinal();
-    },
-    (err) => {
-      streamError = err;
-      if (resolveFinal) resolveFinal();
-    },
-  );
-
-  // Poll for text chunks until the stream completes
-  while (!finalMsg && !streamError) {
-    while (index < textChunks.length) {
-      yield { type: 'text', data: textChunks[index++] };
+/** Yield the text deltas of one Anthropic message stream. */
+async function* anthropicTextDeltas(stream: ReturnType<Anthropic['messages']['stream']>): AsyncGenerator<string> {
+  for await (const event of stream) {
+    if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+      yield event.delta.text;
     }
-    const raceResult = await Promise.race([finalDone, new Promise<undefined>((r) => setTimeout(r, 80))]);
-    if (raceResult !== undefined) break;
+  }
+}
+
+async function* streamAnthropic(config: ResolvedAiRole, opts: AiCallOptions): AsyncGenerator<StreamChunk> {
+  const client = anthropicClient(config);
+
+  // Same params/caching layout as callAnthropic. A tuning rejection surfaces
+  // on the first iteration, before any delta arrives, so the untuned retry
+  // never duplicates already-yielded text.
+  let stream = client.messages.stream(buildAnthropicParams(config, opts, true));
+  try {
+    for await (const text of anthropicTextDeltas(stream)) {
+      yield { type: 'text', data: text };
+    }
+  } catch (err) {
+    if (!wantsTuning(opts) || !isTuningRejection(err)) throw err;
+    stream = client.messages.stream(buildAnthropicParams(config, opts, false));
+    for await (const text of anthropicTextDeltas(stream)) {
+      yield { type: 'text', data: text };
+    }
   }
 
-  // Drain any remaining chunks
-  while (index < textChunks.length) {
-    yield { type: 'text', data: textChunks[index++] };
-  }
-
-  if (streamError) throw streamError;
-
-  const msg = finalMsg!;
+  const msg = await stream.finalMessage();
 
   if (msg.stop_reason === 'refusal') {
     yield { type: 'error', data: 'The model declined to analyze this failure' };
+    return;
+  }
+  if (msg.stop_reason === 'max_tokens') {
+    yield {
+      type: 'error',
+      data: `Model output was truncated at ${opts.maxTokens ?? 8192} tokens — raise the max token limit`,
+    };
     return;
   }
 
@@ -461,6 +540,8 @@ async function* streamAnthropic(config: ResolvedAiRole, opts: AiCallOptions): As
       model: msg.model,
       inputTokens: msg.usage?.input_tokens ?? null,
       outputTokens: msg.usage?.output_tokens ?? null,
+      cacheCreationInputTokens: msg.usage?.cache_creation_input_tokens ?? null,
+      cacheReadInputTokens: msg.usage?.cache_read_input_tokens ?? null,
     } as StreamResult,
   };
 }
@@ -472,46 +553,27 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
   const headers: Record<string, string> = { 'content-type': 'application/json' };
   if (config.apiKey) headers['authorization'] = `Bearer ${config.apiKey}`;
 
-  const systemContent = opts.jsonSchema
-    ? `${opts.system}\n\nRespond ONLY with a JSON object matching this schema:\n${JSON.stringify(opts.jsonSchema)}`
-    : opts.system;
-
-  type OAIPart = { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } };
-
-  const userMessageContent: string | OAIPart[] = opts.images?.length
-    ? [
-        ...opts.images.map(
-          (img): OAIPart => ({
-            type: 'image_url',
-            image_url: { url: `data:${img.mediaType};base64,${img.data}` },
-          }),
-        ),
-        { type: 'text', text: opts.user },
-      ]
-    : opts.user;
-
-  const body = JSON.stringify({
-    model: config.model,
-    max_tokens: opts.maxTokens ?? 8192,
-    temperature: 0,
-    stream: true,
-    stream_options: { include_usage: true },
-    messages: [
-      { role: 'system', content: systemContent },
-      { role: 'user', content: userMessageContent },
-    ],
-  });
-
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 120_000);
 
-  try {
-    const res = await fetch(url, {
+  const post = (strictFormat: boolean) =>
+    fetch(url, {
       method: 'POST',
       headers,
-      body,
+      body: JSON.stringify({
+        ...buildOpenAiBody(config, opts, strictFormat),
+        stream: true,
+        stream_options: { include_usage: true },
+      }),
       signal: controller.signal,
     });
+
+  try {
+    let res = await post(true);
+    if (res.status === 400 && opts.jsonSchema) {
+      // Server rejects response_format json_schema (older OpenAI-compat) — fall back to json_object.
+      res = await post(false);
+    }
 
     if (!res.ok) {
       const bodyText = await res.text().catch(() => '');
@@ -526,6 +588,8 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
     let modelName = config.model;
     let inputTokens: number | null = null;
     let outputTokens: number | null = null;
+    let cachedTokens: number | null = null;
+    let truncated = false;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -546,7 +610,7 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
           const parsed = JSON.parse(data) as {
             choices?: Array<{ delta?: { content?: string }; finish_reason?: string }>;
             model?: string;
-            usage?: { prompt_tokens?: number; completion_tokens?: number };
+            usage?: OAIUsage;
             x_groq?: { usage?: { completion_tokens?: number; prompt_tokens?: number } };
           };
 
@@ -561,9 +625,12 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
           if (usage) {
             if (usage.prompt_tokens != null) inputTokens = usage.prompt_tokens;
             if (usage.completion_tokens != null) outputTokens = usage.completion_tokens;
+            const cached = (usage as OAIUsage).prompt_tokens_details?.cached_tokens;
+            if (cached != null) cachedTokens = cached;
           }
 
           const choice = parsed.choices?.[0];
+          if (choice?.finish_reason === 'length') truncated = true;
           if (choice?.delta?.content) {
             yield { type: 'text', data: choice.delta.content };
           }
@@ -573,7 +640,24 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
       }
     }
 
-    yield { type: 'done', data: { model: modelName, inputTokens, outputTokens } as StreamResult };
+    if (truncated) {
+      yield {
+        type: 'error',
+        data: `Model output was truncated at ${opts.maxTokens ?? 8192} tokens — raise the max token limit`,
+      };
+      return;
+    }
+
+    yield {
+      type: 'done',
+      data: {
+        model: modelName,
+        inputTokens,
+        outputTokens,
+        cacheCreationInputTokens: null,
+        cacheReadInputTokens: cachedTokens,
+      } as StreamResult,
+    };
   } finally {
     clearTimeout(timeoutId);
   }

--- a/application/server/utils/ai-settings.ts
+++ b/application/server/utils/ai-settings.ts
@@ -68,12 +68,13 @@ export function rolesFromLegacy(flat: {
         }
       : { reuse: 'diagnosis', model: flat.researchModel };
   }
-  if (flat.embeddingProvider) {
+  if (flat.embeddingModel) {
+    // Provider/baseUrl/key default to the main role's (mirrors resolveAiConfig).
     roles.embedding = {
-      provider: flat.embeddingProvider,
+      provider: flat.embeddingProvider || flat.provider,
       model: flat.embeddingModel,
-      baseUrl: flat.embeddingBaseUrl,
-      apiKey: flat.embeddingApiKey,
+      baseUrl: flat.embeddingBaseUrl || flat.baseUrl,
+      apiKey: flat.embeddingApiKey || flat.apiKey,
     };
   }
   return roles;

--- a/application/server/utils/cluster-adjudicate.ts
+++ b/application/server/utils/cluster-adjudicate.ts
@@ -54,6 +54,7 @@ export async function adjudicateClusterPair(
     user,
     jsonSchema: ADJUDICATION_JSON_SCHEMA as unknown as object,
     maxTokens: 512,
+    effort: 'low',
   });
   try {
     const j = JSON.parse(res.text) as Partial<AdjudicationResult>;

--- a/application/server/utils/cluster-naming.ts
+++ b/application/server/utils/cluster-naming.ts
@@ -66,6 +66,7 @@ export async function generateClusterTitles(
     user: `Name these ${clusters.length} failure clusters. Return one title per id.\n\n${user}`,
     jsonSchema: NAMING_JSON_SCHEMA as unknown as object,
     maxTokens: 1024,
+    effort: 'low',
   });
 
   try {

--- a/application/shared/ai-context-limits.ts
+++ b/application/shared/ai-context-limits.ts
@@ -43,6 +43,8 @@ export interface ContextLimits {
   maxConsoleWindow: number;
   /** Network request duration (ms) threshold for flagging as slow (D9). */
   slowRequestMs: number;
+  /** Screenshots are downscaled so their long edge is at most this many pixels before being sent. */
+  imageMaxEdge: number;
 }
 
 export const DEFAULT_CONTEXT_LIMITS: ContextLimits = {
@@ -65,6 +67,7 @@ export const DEFAULT_CONTEXT_LIMITS: ContextLimits = {
   slowRequestMs: 1500,
   maxTraceActions: 10,
   traceDomChars: 6000,
+  imageMaxEdge: 1920,
 };
 
 export interface ContextLimitField {
@@ -230,6 +233,14 @@ export const CONTEXT_LIMIT_FIELDS: ContextLimitField[] = [
     description: 'Max characters for the trace-derived DOM/ARIA excerpt in failing-action context.',
     min: 0,
     max: 20000,
+  },
+  {
+    key: 'imageMaxEdge',
+    label: 'Screenshot max edge (px)',
+    envVar: 'PIWI_AI_IMAGE_MAX_EDGE',
+    description: 'Screenshots are downscaled to at most this many pixels on the long edge before being sent.',
+    min: 512,
+    max: 8192,
   },
 ];
 

--- a/application/shared/piwi-env-vars.ts
+++ b/application/shared/piwi-env-vars.ts
@@ -294,6 +294,10 @@ export const PIWI_ENV_VARS = {
     description: 'Max characters for the trace-derived DOM/ARIA excerpt in failing-action context.',
     category: 'ai-limits',
   },
+  PIWI_AI_IMAGE_MAX_EDGE: {
+    description: 'Screenshots are downscaled to at most this many pixels on the long edge before being sent.',
+    category: 'ai-limits',
+  },
 
   PIWI_TEST_LOGS_DISABLED: {
     description:

--- a/application/types/api.ts
+++ b/application/types/api.ts
@@ -1026,6 +1026,28 @@ export interface SaveAiSettingsBody {
   scmToken?: string | null;
 }
 
+/**
+ * Aggregated AI token usage for one provider + model pair.
+ */
+export interface AiUsageModelRow {
+  provider: string | null;
+  model: string;
+  diagnoses: number;
+  failed: number;
+  inputTokens: number;
+  outputTokens: number;
+  avgDurationMs: number | null;
+}
+
+/**
+ * AI usage summary — returned by GET /api/settings/ai/usage
+ */
+export interface AiUsageSummary {
+  days: number;
+  totals: { diagnoses: number; inputTokens: number; outputTokens: number };
+  byModel: AiUsageModelRow[];
+}
+
 // ============================================================================
 // Entity Link types (A.4)
 // ============================================================================

--- a/docs/ai-diagnosis.md
+++ b/docs/ai-diagnosis.md
@@ -27,9 +27,11 @@ Clustering is always on and requires no configuration. When the normalization al
 
 If an **embedding** model role is configured (Settings → AI), Piwi adds a semantic layer on top of the deterministic fingerprint. After a run, the clusters first seen in it are embedded and compared (cosine similarity) against the project's other open clusters; near-duplicates above `PIWI_CLUSTER_SIMILARITY_THRESHOLD` (default `0.92`) are merged into the longest-lived cluster. This catches failures that are the same root cause but phrased differently enough to dodge the fingerprint. Merges record a fingerprint alias so future occurrences attach to the survivor instead of re-forking. With no embedding role configured, clustering stays purely deterministic.
 
-When auto-diagnose is enabled, new clusters are also given a short **human-readable title** (one cheap batched model call per run) shown in place of the raw normalized signature across the lists and the cluster page — the signature stays available on hover and below the title. Clusters fall back to the signature when no title has been generated.
+When auto-diagnose is enabled, new clusters are also given a short **human-readable title** (one cheap batched model call per run, using the research model when one is configured, otherwise the diagnosis model) shown in place of the raw normalized signature across the lists and the cluster page — the signature stays available on hover and below the title. Clusters fall back to the signature when no title has been generated.
 
-Pairs that fall in the **ambiguous band** (similarity between `PIWI_CLUSTER_SUGGEST_THRESHOLD`, default `0.80`, and the merge threshold) aren't merged automatically. If a **research** model is configured it adjudicates the pair ("same root cause?") and merges only on a high-confidence yes; otherwise — or when it's unsure — the pair becomes a **merge suggestion** on the project's Failure clusters tab, where a reporter or admin approves (merge) or dismisses it. Adjudication is budget-capped per run to control cost.
+Pairs that fall in the **ambiguous band** (similarity between `PIWI_CLUSTER_SUGGEST_THRESHOLD`, default `0.80`, and the merge threshold) aren't merged automatically. Whenever AI is configured, a model adjudicates the pair ("same root cause?") — the **research** model when one is configured, the diagnosis model otherwise — and merges only on a high-confidence yes; when it's unsure (or no AI is configured at all), the pair becomes a **merge suggestion** on the project's Failure clusters tab, where a reporter or admin approves (merge) or dismisses it. Adjudication is budget-capped per run to control cost.
+
+Embedding-based reconciliation runs after every finished run whenever an embedding role is configured — it is independent of the auto-diagnose toggle.
 
 ## Enabling AI diagnosis
 
@@ -206,6 +208,9 @@ Every piece of evidence sent to the model costs tokens. Piwi caps each input so 
 | `PIWI_AI_MAX_PASSED_PEERS` | 20 | Passing peer tests in the same file listed |
 | `PIWI_AI_MAX_CONSOLE_WINDOW` | 50 | Console entries (any level) in the window before failure |
 | `PIWI_AI_SLOW_REQUEST_MS` | 1500 | Duration (ms) above which a network request is flagged as slow |
+| `PIWI_AI_MAX_TRACE_ACTIONS` | 10 | Actions extracted from the Playwright trace ZIP for failing-action context (0 disables) |
+| `PIWI_AI_TRACE_DOM_CHARS` | 6000 | Characters of the trace-derived DOM/ARIA excerpt |
+| `PIWI_AI_IMAGE_MAX_EDGE` | 1920 | Screenshots are downscaled so their long edge is at most this many pixels before being sent |
 
 ## Privacy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,10 +90,10 @@ When unset, configure the patterns from **Settings → Wasted time** (administra
 | `PIWI_AI_RESEARCH_MODEL` | — | Cheaper/faster model for the research stage. Empty disables the two-stage pipeline. |
 | `PIWI_AI_RESEARCH_BASE_URL` | — | Base URL for the research-stage provider. Falls back to `PIWI_AI_BASE_URL`. |
 | `PIWI_AI_RESEARCH_API_KEY` | — | API key for the research-stage provider. Falls back to `PIWI_AI_API_KEY`. |
-| `PIWI_AI_EMBEDDING_PROVIDER` | — | Provider for embeddings (semantic clustering). Falls back to `PIWI_AI_PROVIDER`. |
-| `PIWI_AI_EMBEDDING_MODEL` | — | Embedding model name (e.g. `text-embedding-3-small`). |
-| `PIWI_AI_EMBEDDING_BASE_URL` | — | Base URL for the embedding provider. Falls back to `PIWI_AI_BASE_URL`. |
-| `PIWI_AI_EMBEDDING_API_KEY` | — | API key for the embedding provider. Falls back to `PIWI_AI_API_KEY`. |
+| `PIWI_AI_EMBEDDING_PROVIDER` | — | Provider for embeddings (semantic clustering). Falls back to `PIWI_AI_PROVIDER` when `PIWI_AI_EMBEDDING_MODEL` is set. Must be OpenAI-compatible — Anthropic has no embeddings API — so the fallback only helps when the main provider is `openai`. |
+| `PIWI_AI_EMBEDDING_MODEL` | — | Embedding model name (e.g. `text-embedding-3-small`). Empty disables semantic clustering (and the embedding fallbacks). |
+| `PIWI_AI_EMBEDDING_BASE_URL` | — | Base URL for the embedding provider. Falls back to `PIWI_AI_BASE_URL` when `PIWI_AI_EMBEDDING_MODEL` is set. |
+| `PIWI_AI_EMBEDDING_API_KEY` | — | API key for the embedding provider. Falls back to `PIWI_AI_API_KEY` when `PIWI_AI_EMBEDDING_MODEL` is set. |
 
 The `PIWI_AI_MAX_*` and `PIWI_AI_SLOW_REQUEST_MS` context-limit variables are documented in [AI diagnosis → Context limits](./ai-diagnosis#context-limits-and-token-cost).
 


### PR DESCRIPTION
- Drop temperature from Anthropic requests: current Claude models
  (Opus 4.7+) reject sampling params with HTTP 400, so the default
  claude-opus-4-8 setup failed on every diagnosis
- Enable adaptive thinking on the diagnosis stage and effort: low on
  research/naming/adjudication, with a one-shot untuned retry for
  models that reject those params
- Capture prompt-cache usage (creation/read tokens) per pipeline stage
  and store the pipeline on every diagnosis, not just two-stage runs
- Downscale screenshots (sharp, new PIWI_AI_IMAGE_MAX_EDGE limit,
  default 1920px long edge) before attaching — full-res images cost
  ~3x more tokens on current models
- Rewrite streamAnthropic as a plain for-await over the SDK stream
  (removes the 80 ms busy-poll); surface max_tokens truncation as a
  clear error on both providers
- OpenAI-compat: enforce the schema via response_format json_schema
  with a json_object fallback on HTTP 400; only send response_format
  when a schema is requested; capture cached_tokens
- Fix /api/settings/ai/test falling back to the raw encrypted key;
  support testing any role incl. an embeddings probe
- /api/settings/ai/models: fall back to the stored/env key when the
  form key is blank, honour the Anthropic baseUrl override
- Validate the embedding role as OpenAI-compatible at save time and in
  role resolution; embedding env vars now default provider/key/baseUrl
  to the main role like research does

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011toVxFZbpHiU7aLcMtAjY4