### PR TITLE
Fix demo-sw.js crash: move storage-touching deleteProject out of the …

### DIFF
--- a/application/server/api/projects/[id].delete.ts
+++ b/application/server/api/projects/[id].delete.ts
@@ -3,7 +3,7 @@ import { projects } from '../../database/schema';
 import { eq } from 'drizzle-orm';
 import { requireProjectAccess, requireRouteId } from '../../utils/project-access';
 import { Role } from '#shared/types';
-import { deleteProject } from '#shared/handlers/projects';
+import { deleteProject } from '../../utils/delete-project';
 
 const REQUIRED_ROLES: Role[] = [Role.ADMINISTRATOR];
 

--- a/application/server/api/tests/cleanup.delete.ts
+++ b/application/server/api/tests/cleanup.delete.ts
@@ -4,7 +4,7 @@ import { eq, inArray, like } from 'drizzle-orm';
 import { requireAuth } from '../../utils/auth';
 import { Role } from '#shared/types';
 import { TEST_PROJECT_NAMES } from '#shared/test-project-names';
-import { deleteProject } from '#shared/handlers/projects';
+import { deleteProject } from '../../utils/delete-project';
 
 const REQUIRED_ROLES: Role[] = [Role.ADMINISTRATOR];
 

--- a/application/server/utils/delete-project.ts
+++ b/application/server/utils/delete-project.ts
@@ -1,0 +1,24 @@
+import { getDatabase } from '../database';
+import { getStorage } from '../storage';
+import { deleteProjectData } from '#shared/handlers/projects';
+import { testCaseCache } from './test-case-cache';
+
+/**
+ * Permanently delete a project and all its associated data.
+ *
+ * Deletes storage first (entire project-{id}/ directory), then clears DB rows
+ * in FK order via `deleteProjectData`. Server-only: touches the real
+ * filesystem/S3 storage adapter, so it must not be imported by shared/demo
+ * code (demo calls `deleteProjectData` directly against its in-browser DB).
+ */
+export async function deleteProject(projectId: number): Promise<void> {
+  const db = await getDatabase();
+  const storage = getStorage();
+
+  // Delete all project files in one shot — covers reports, blobs, trace-resources
+  await storage.deleteDirectory(`project-${projectId}`);
+
+  await deleteProjectData(db, projectId);
+
+  testCaseCache.invalidate(projectId);
+}

--- a/application/shared/handlers/projects.ts
+++ b/application/shared/handlers/projects.ts
@@ -13,9 +13,6 @@ import { desc, eq, sql, and, inArray, gte, lte, isNotNull, count } from 'drizzle
 import type { BrowserConfig } from '../types';
 
 import type { DrizzleDB } from './db';
-import { getDatabase } from '../../server/database';
-import { getStorage } from '../../server/storage';
-import { testCaseCache } from '../../server/utils/test-case-cache';
 
 type ProjectScope = 'all' | Set<number>;
 
@@ -323,7 +320,14 @@ export async function updateProject(
 }
 
 // ─── deleteProjectData ───────────────────────────────────────────
-// Cascading delete — no storage operations (server-only concern)
+// Cascading DB-only delete — no storage operations, so it's safe to call from
+// both the server (via server/utils/delete-project.ts, which also clears
+// storage) and demo mode (directly, against the in-browser DB). The
+// storage-touching `deleteProject` wrapper lives in server/utils/ instead of
+// here so this shared module never imports server/storage — that module's
+// LocalStorageAdapter does synchronous fs/util promisify() calls at import
+// time, which crashes when bundled into the demo service worker (no Node
+// fs/util in a Worker global scope).
 
 export async function deleteProjectData(db: DrizzleDB, projectId: number) {
   // Get all run IDs to cascade-delete dependent rows that lack DB-level cascade
@@ -351,26 +355,6 @@ export async function deleteProjectData(db: DrizzleDB, projectId: number) {
   // Deleting the project row cascades to: projectTags, failureClusters,
   // failureDiagnoses, traceBlobs, traceResources
   await db.delete(projects).where(eq(projects.id, projectId));
-}
-
-/**
- * Permanently delete a project and all its associated data.
- *
- * Deletes storage first (entire project-{id}/ directory), then clears DB rows
- * in FK order. Tables with onDelete: cascade (projectTags, failureClusters,
- * failureDiagnoses, traceBlobs, traceResources) are handled automatically when
- * the project row is removed.
- */
-export async function deleteProject(projectId: number): Promise<void> {
-  const db = await getDatabase();
-  const storage = getStorage();
-
-  // Delete all project files in one shot — covers reports, blobs, trace-resources
-  await storage.deleteDirectory(`project-${projectId}`);
-
-  await deleteProjectData(db, projectId);
-
-  testCaseCache.invalidate(projectId);
 }
 
 // ─── getProjectMenu ──────────────────────────────────────────────


### PR DESCRIPTION
…shared handler

The demo service worker was crashing on load with:
  Uncaught TypeError: (0, Ts.promisify) is not a function
at a top-level `promisify(fs.readFile)` call.

Root cause: shared/handlers/projects.ts (imported by both the real server and the demo build) had a runtime import of server/storage — specifically getStorage() for deleteProject()'s cascade delete. server/storage/local.ts's LocalStorageAdapter calls promisify(fs.readFile/writeFile/mkdir) eagerly at module scope, which crashes immediately when that module gets pulled into the demo service worker's bundle (no Node fs/util in a Worker global scope). demo/api/router.ts imports other (portable) exports from the same file, which drags in the whole module including its side-effecting imports.

Fix: extract the storage-touching deleteProject() into a new server-only server/utils/delete-project.ts (matching the existing delete-run-files.ts convention), importing the still-shared, DB-only deleteProjectData() from shared/handlers/projects.ts. Demo mode already called deleteProjectData() directly against its own in-browser DB and is unaffected. Updated the two server API routes that called the old export.

Verified: rebuilt the demo bundle — the crash and the storage code are both gone from the compiled demo-sw.js; loaded it in a browser and confirmed the service worker activates and the app renders normally. Re-ran the mobile regression suite, including its teardown (which calls the now-relocated deleteProject via DELETE /api/tests/cleanup) — all 12 tests pass and cleanup succeeds.


Claude-Session: https://claude.ai/code/session_01F4osgBMdQTrAVe8Gj2uvQt