### PR TITLE
fix(ci): use a PAT for release-please so tags trigger publish workflows

### DIFF
--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -3,6 +3,9 @@ name: Publish Instrumentation (npm)
 on:
   push:
     tags: ['v*']
+  # Manual escape hatch: run against an existing tag (e.g. one release-please
+  # created that didn't auto-trigger this workflow — see release-please.yml).
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -3,6 +3,9 @@ name: Publish NuGet Package
 on:
   push:
     tags: ['v*']
+  # Manual escape hatch: run against an existing tag (e.g. one release-please
+  # created that didn't auto-trigger this workflow — see release-please.yml).
+  workflow_dispatch:
 
 jobs:
   publish-nuget:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
     branches:
       - main
+  # Manual escape hatch: run against an existing tag (e.g. one release-please
+  # created that didn't auto-trigger this workflow — see release-please.yml).
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,11 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # A tag/commit/PR made with the default GITHUB_TOKEN does not trigger
+          # other workflows (GitHub's anti-recursion protection) — the release
+          # tag this step creates would silently never fire publish.yml /
+          # publish-instrumentation.yml / publish-nuget.yml. A PAT or GitHub App
+          # token isn't subject to that restriction. See CONTRIBUTING.md.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,12 @@ BREAKING CHANGE: unverified accounts can no longer sign in.
 1. **Local `commit-msg` hook** (husky + commitlint) — runs on every `git commit` after `npm install`. Bypassable with `--no-verify`; treat it as convenience, not a gate.
 2. **`Lint commits` CI check** — lints every commit in a PR's range on push.
 3. **`Lint PR title` CI check** — lints the PR title itself, since that's what becomes the squash-merge commit subject. This is the check that actually gates `main`.
+
+## Releases
+
+Merging a release-please PR (titled `chore(main): release X.Y.Z`) tags the release and publishes it, but this requires one-time repo setup — without it, releases silently stop at the tag and the npm/NuGet publish workflows never fire:
+
+1. **`Settings → Actions → General → Workflow permissions`** — check **"Allow GitHub Actions to create and approve pull requests"** (org-level setting too, if the repo checkbox is greyed out). Without this, `release-please.yml` fails with `GitHub Actions is not permitted to create or approve pull requests`.
+2. **A `RELEASE_PLEASE_TOKEN` repo secret** — a Personal Access Token (classic `repo` scope, or fine-grained with `Contents: read/write` + `Pull requests: read/write`) or a GitHub App installation token, added at `Settings → Secrets and variables → Actions`. This is required because GitHub's anti-recursion protection means a tag created with the default `GITHUB_TOKEN` does **not** trigger other `on: push: tags` workflows — `publish.yml`, `publish-instrumentation.yml`, and `publish-nuget.yml` would never run even though the tag exists. A PAT/App token isn't subject to that restriction.
+
+If a release's tag already exists but the packages never published (e.g. because this wasn't set up yet), re-run the affected workflow manually against that tag — `publish.yml` / `publish-instrumentation.yml` / `publish-nuget.yml` all have a `workflow_dispatch` trigger for exactly this.


### PR DESCRIPTION
GitHub's anti-recursion protection means a tag pushed with the default GITHUB_TOKEN doesn't trigger other on:push workflows — v0.8.0 and v0.9.0 were both created by release-please but never fired publish.yml, publish-instrumentation.yml, or publish-nuget.yml. Point release-please at a RELEASE_PLEASE_TOKEN secret (PAT or GitHub App token) instead, which isn't subject to that restriction, and add workflow_dispatch to the three publish workflows as a manual escape hatch for tags that already exist.


Claude-Session: https://claude.ai/code/session_0112w3xCSkVDQhX5uS4Vy8Pq