### PR TITLE
refactor(run-summary): compute grid layout dynamically

### DIFF
--- a/application/app/components/run/RunSummary.vue
+++ b/application/app/components/run/RunSummary.vue
@@ -8,8 +8,6 @@ const props = defineProps<{
   displayProgress: { totalTests: number; passedTests: number; failedTests: number; skippedTests: number } | null;
   allReports: ReportInfo[];
   showCustomData: boolean;
-  summaryColSpanClass: string;
-  blockColSpanClass: string;
   finalizing?: boolean;
   activeFilter?: string;
   totalWastedTime?: number;
@@ -23,6 +21,35 @@ const emit = defineEmits<{
 
 const toast = useToast();
 const storageStats = computed(() => props.testRun?.storageStats);
+
+// Visibility of each metadata block, defined once and referenced by both the
+// block count (below) and the template `v-if`, so the two can never drift and
+// leave the grid spanning more than 12 columns (which would wrap a block).
+const showCiEnv = computed(
+  () =>
+    !!(
+      props.testRun?.metadata?.ci ||
+      props.testRun?.environment ||
+      props.testRun?.playwrightVersion ||
+      props.testRun?.reporterVersion
+    ),
+);
+const showSource = computed(() => !!props.testRun?.metadata?.scm);
+const showStorage = computed(() => !!(storageStats.value?.totalFiles || props.finalizing));
+const showOther = computed(
+  () =>
+    !!(
+      props.testRun?.metadata?.tags?.length ||
+      props.testRun?.metadata?.projectDescription ||
+      props.testRun?.metadata?.relatedIssue ||
+      props.testRun?.metadata?.customData ||
+      props.testRun?.links?.length
+    ),
+);
+
+const { summaryColSpanClass, blockColSpanClass } = useDetailGrid(
+  () => [showCiEnv, showSource, showStorage, showOther].filter((b) => b.value).length,
+);
 
 const { copy, copied } = useCopy();
 const retryMode = ref<RetryMode>('file-line');
@@ -461,7 +488,7 @@ function onLabelKeydown(e: KeyboardEvent) {
 
       <!-- Block 1: CI + Environment + Tooling versions -->
       <CiEnvCard
-        v-if="testRun?.metadata?.ci || testRun?.environment || testRun?.playwrightVersion || testRun?.reporterVersion"
+        v-if="showCiEnv"
         :ci="testRun?.metadata?.ci"
         :environment="testRun?.environment"
         :playwright-version="testRun?.playwrightVersion"
@@ -470,11 +497,11 @@ function onLabelKeydown(e: KeyboardEvent) {
       />
 
       <!-- Block 2: Source control -->
-      <SourceInfoCard v-if="testRun?.metadata?.scm" :scm="testRun.metadata.scm" :class="blockColSpanClass" />
+      <SourceInfoCard v-if="showSource" :scm="testRun.metadata.scm" :class="blockColSpanClass" />
 
       <!-- Block 3: Storage stats -->
       <BlockCard
-        v-if="storageStats?.totalFiles || finalizing"
+        v-if="showStorage"
         :class="blockColSpanClass"
         title="Storage"
         icon="i-lucide-database"
@@ -522,19 +549,7 @@ function onLabelKeydown(e: KeyboardEvent) {
       </BlockCard>
 
       <!-- Block 4: Tags / Details / Custom data -->
-      <BlockCard
-        v-if="
-          testRun?.metadata?.tags?.length ||
-          testRun?.metadata?.projectDescription ||
-          testRun?.metadata?.relatedIssue ||
-          testRun?.metadata?.customData ||
-          testRun?.links?.length
-        "
-        :class="blockColSpanClass"
-        title="Other"
-        icon="i-lucide-tags"
-        help="run.metadata"
-      >
+      <BlockCard v-if="showOther" :class="blockColSpanClass" title="Other" icon="i-lucide-tags" help="run.metadata">
         <div class="space-y-3 text-sm">
           <div v-if="testRun.metadata.tags && testRun.metadata.tags.length > 0">
             <div class="flex flex-wrap gap-1.5">

--- a/application/app/components/shared/CiEnvCard.vue
+++ b/application/app/components/shared/CiEnvCard.vue
@@ -18,38 +18,36 @@ defineProps<{
 
 <template>
   <BlockCard :class="$props.class" title="CI / Env" icon="i-lucide-cloud" help="run.ci-env">
-    <div class="space-y-2 text-sm">
-      <div v-if="environment" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-server" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span class="rounded-full border px-2 py-0.5 text-xs bg-gray-50 dark:bg-gray-800">{{ environment }}</span>
-      </div>
-      <div v-if="ci?.provider" class="flex items-center gap-1.5">
+    <div class="space-y-1.5 text-sm">
+      <!-- Environment + CI provider -->
+      <div v-if="environment || ci?.provider" class="flex items-center gap-x-2 gap-y-1 flex-wrap">
         <UIcon name="i-lucide-cloud" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span>{{ ci.provider }}</span>
+        <span v-if="environment" class="rounded-full border px-2 py-0.5 text-xs bg-gray-50 dark:bg-gray-800">{{
+          environment
+        }}</span>
+        <span v-if="ci?.provider">{{ ci.provider }}</span>
       </div>
-      <div v-if="ci?.buildNumber" class="flex items-center gap-1.5">
+      <!-- Build (links to the CI build when a URL is available) -->
+      <div v-if="ci?.buildNumber || ci?.buildUrl" class="flex items-center gap-1.5">
         <UIcon name="i-lucide-hash" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span>Build #{{ ci.buildNumber }}</span>
+        <a v-if="ci?.buildUrl" :href="ci.buildUrl" target="_blank" class="text-primary hover:underline">{{
+          ci?.buildNumber ? `Build #${ci.buildNumber}` : 'View build'
+        }}</a>
+        <span v-else>Build #{{ ci.buildNumber }}</span>
       </div>
-      <div v-if="ci?.jobName" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-notebook-pen" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span>{{ ci.jobName }}</span>
-      </div>
-      <div v-if="ci?.workflow" class="flex items-center gap-1.5">
+      <!-- Workflow · job -->
+      <div v-if="ci?.workflow || ci?.jobName" class="flex items-center gap-x-1.5 gap-y-1 flex-wrap">
         <UIcon name="i-lucide-workflow" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span>{{ ci.workflow }}</span>
+        <span v-if="ci?.workflow">{{ ci.workflow }}</span>
+        <span v-if="ci?.workflow && ci?.jobName" class="text-gray-300 dark:text-gray-600">·</span>
+        <span v-if="ci?.jobName">{{ ci.jobName }}</span>
       </div>
-      <div v-if="ci?.buildUrl" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-external-link" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <a :href="ci.buildUrl" target="_blank" class="text-primary hover:underline text-xs">View build</a>
-      </div>
-      <div v-if="playwrightVersion" class="flex items-center gap-1.5">
+      <!-- Tooling versions -->
+      <div v-if="playwrightVersion || reporterVersion" class="flex items-center gap-x-1.5 gap-y-1 flex-wrap">
         <UIcon name="i-lucide-tag" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span>Playwright v{{ playwrightVersion }}</span>
-      </div>
-      <div v-if="reporterVersion" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-tag" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span>Piwi reporter v{{ reporterVersion }}</span>
+        <span v-if="playwrightVersion">Playwright v{{ playwrightVersion }}</span>
+        <span v-if="playwrightVersion && reporterVersion" class="text-gray-300 dark:text-gray-600">·</span>
+        <span v-if="reporterVersion">Piwi v{{ reporterVersion }}</span>
       </div>
     </div>
   </BlockCard>

--- a/application/app/components/shared/SourceInfoCard.vue
+++ b/application/app/components/shared/SourceInfoCard.vue
@@ -15,21 +15,23 @@ defineProps<{
 <template>
   <BlockCard :class="$props.class" title="Source" icon="i-lucide-git-branch">
     <div class="space-y-1.5 text-sm">
-      <div v-if="scm.branch" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-git-branch" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span class="font-medium">{{ scm.branch }}</span>
+      <div v-if="scm.branch || scm.commit || scm.author" class="flex items-center gap-x-3 gap-y-1 flex-wrap">
+        <span v-if="scm.branch" class="flex items-center gap-1.5">
+          <UIcon name="i-lucide-git-branch" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
+          <span class="font-medium">{{ scm.branch }}</span>
+        </span>
+        <span v-if="scm.commit" class="flex items-center gap-1.5">
+          <UIcon name="i-lucide-git-commit-horizontal" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
+          <code class="text-xs font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">{{
+            scm.commit.length >= 8 ? scm.commit.substring(0, 8) : scm.commit
+          }}</code>
+        </span>
+        <span v-if="scm.author" class="flex items-center gap-1.5">
+          <UIcon name="i-lucide-user" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
+          <span class="text-gray-600 dark:text-gray-400">{{ scm.author }}</span>
+        </span>
       </div>
-      <div v-if="scm.commit" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-git-commit-horizontal" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <code class="text-xs font-mono bg-gray-100 dark:bg-gray-800 px-1 rounded">{{
-          scm.commit.length >= 8 ? scm.commit.substring(0, 8) : scm.commit
-        }}</code>
-      </div>
-      <div v-if="scm.author" class="flex items-center gap-1.5">
-        <UIcon name="i-lucide-user" class="w-3.5 h-3.5 text-gray-400 shrink-0" />
-        <span class="text-gray-600 dark:text-gray-400">{{ scm.author }}</span>
-      </div>
-      <p v-if="scm.commitMessage" class="text-gray-400 text-xs break-words pl-1">
+      <p v-if="scm.commitMessage" class="text-gray-400 text-xs break-words">
         {{ scm.commitMessage }}
       </p>
     </div>

--- a/application/app/pages/test-runs/[id].vue
+++ b/application/app/pages/test-runs/[id].vue
@@ -385,21 +385,6 @@ async function handleDeleteRun() {
 
 const showCustomData = ref(false);
 
-const { summaryColSpanClass, blockColSpanClass } = useDetailGrid(() => {
-  let count = 0;
-  if (testRun.value?.metadata?.ci || testRun.value?.environment) count++;
-  if (testRun.value?.metadata?.scm) count++;
-  if ((testRun.value?.storageStats && testRun.value.storageStats.totalFiles > 0) || isFinalizing.value) count++;
-  if (
-    testRun.value?.metadata?.tags?.length ||
-    testRun.value?.metadata?.projectDescription ||
-    testRun.value?.metadata?.relatedIssue ||
-    testRun.value?.metadata?.customData
-  )
-    count++;
-  return count;
-});
-
 // Test-cases filter state — lifted here so it survives tab switches
 const testCaseSearch = ref('');
 const testCaseActiveStatuses = ref<string[]>([]);
@@ -601,8 +586,6 @@ function handleSelectCluster(clusterId: number) {
             :display-progress="displayProgress"
             :all-reports="allReports"
             :show-custom-data="showCustomData"
-            :summary-col-span-class="summaryColSpanClass"
-            :block-col-span-class="blockColSpanClass"
             :finalizing="isFinalizing"
             :active-filter="statusFilterForSummary"
             :total-wasted-time="totalWastedTime"

--- a/application/shared/test-project-names.ts
+++ b/application/shared/test-project-names.ts
@@ -19,6 +19,7 @@ export const PROJECT = {
   AUTH_TEST: 'auth-test-project',
   BLOB_GZ: 'blob-gz-test-project',
   BLOCK_LAYOUT: 'block-layout-test',
+  BLOCK_LAYOUT_VERSIONS: 'block-layout-versions-test',
   CASE_FILES_LIVE: 'case-files-live-test',
   CLUSTER_MERGE: 'cluster-merge-test',
   CLUSTER_NAMING: 'cluster-naming-test',

--- a/application/tests/dashboard-ui.spec.ts
+++ b/application/tests/dashboard-ui.spec.ts
@@ -293,6 +293,54 @@ test.describe('Dashboard UI Tests', () => {
     // All metadata blocks should be in a single row (not wrapped)
     expect(rows.size).toBe(1);
   });
+
+  test('metadata blocks stay on one row when CI/Env shows only tooling versions', async ({ page, request }) => {
+    // A run with no ci/environment but with Playwright/reporter versions still
+    // renders the CI/Env block. The block count must include it — a regression
+    // guard: the count once ignored the versions, so it widened the spans past
+    // 12 columns and wrapped a block onto a second row.
+    const submitRes = await retryPost(request, '/api/test-runs/submit', {
+      data: {
+        projectName: PROJECT.BLOCK_LAYOUT_VERSIONS,
+        status: 'passed',
+        startTime: new Date().toISOString(),
+        duration: 30000,
+        totalTests: 1,
+        passedTests: 1,
+        failedTests: 0,
+        skippedTests: 0,
+        playwrightVersion: '1.51.0',
+        reporterVersion: '0.7.0',
+        testCases: [{ title: 'versions-only-case', status: 'passed', duration: 500, location: 'tests/v.spec.ts:1:1' }],
+        metadata: {
+          scm: { commit: 'abc123def456', branch: 'main', author: 'test' },
+          tags: ['smoke'],
+        },
+      },
+    });
+    const { testRunId } = await submitRes.json();
+
+    await page.goto(`/test-runs/${testRunId}`);
+    await waitForHydration(page);
+
+    const runSummary = page.locator('[class*="grid"][class*="lg:grid-cols-12"]').first();
+    await expect(runSummary).toBeVisible();
+
+    // The CI/Env block rendered from the tooling versions alone
+    await expect(page.getByText('Playwright v1.51.0')).toBeVisible();
+
+    // CI/Env (versions), Source (scm) and Other (tags) — three blocks
+    const blocks = runSummary.locator('> [class*="lg:col-span"]');
+    expect(await blocks.count()).toBeGreaterThanOrEqual(3);
+
+    const positions = await blocks.evaluateAll((els) => els.map((el) => ({ y: el.getBoundingClientRect().top })));
+    const rows = new Map<number, number>();
+    for (const p of positions) {
+      const key = Math.round(p.y / 5) * 5;
+      rows.set(key, (rows.get(key) || 0) + 1);
+    }
+    expect(rows.size).toBe(1);
+  });
 });
 
 test.describe('Foldable Summary', () => {


### PR DESCRIPTION
## What & why

Moves grid layout computation from the page level into the `RunSummary` component where the metadata block visibility logic lives. This eliminates prop drilling (`summaryColSpanClass` and `blockColSpanClass`) and, more importantly, fixes a bug where the block count calculation didn't account for all conditions that determine visibility.

Previously, the CI/Env block count ignored `playwrightVersion` and `reporterVersion`, causing the grid to miscalculate when only tooling versions were present (no CI provider or environment). This could cause blocks to wrap onto a second row.

The fix:
- Extracts visibility logic into computed properties (`showCiEnv`, `showSource`, `showStorage`, `showOther`)
- Uses these same properties in both the block count calculation and template `v-if` directives, ensuring they never drift
- Removes prop drilling by computing `summaryColSpanClass` and `blockColSpanClass` locally via `useDetailGrid()`

Also improves the UI layout of metadata cards:
- **CiEnvCard**: Groups related fields (environment + CI provider, workflow + job, tooling versions) on single lines with flex wrapping and separators
- **SourceInfoCard**: Consolidates branch/commit/author into a single flex row with wrapping

## How was it tested?

- Added regression test `metadata blocks stay on one row when CI/Env shows only tooling versions` to verify the block count includes tooling versions
- Existing test `metadata blocks stay on one row` continues to pass
- All metadata block visibility conditions are now centralized and tested together

https://claude.ai/code/session_01G69Y7Kx3LjpLAy63HZ6ydP