### PR TITLE
fix(app): trace viewer base-path, blob caching, dedup, and Fault0 positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Native Playwright HTML reports are great for local debugging — but they're eph
 - 🔗 **Failure clustering** — failures sharing a root cause are auto-grouped by error fingerprint.
 - 📈 **Performance & flaky tracking** — P90 duration trends, slowest tests, composite flakiness scores.
 - 🩹 **Locator healing** — when a locator breaks, ranked replacement locators captured from prior passing runs, with a recommended fix.
+- 🎬 **Self-hosted trace viewer** — open the full Playwright trace viewer from any failure; the trace stays on your server.
+- 🔔 **Notifications** — email, Slack, webhook, and in-browser alerts for failed runs and new failure clusters.
 - 🔌 **Built for automation** — drop-in reporter, REST API, OpenAPI docs, and an MCP server for agent integrations.
 - ☁️ **Zero lock-in** — self-hosted with Docker; your data in SQLite/PostgreSQL and local/S3 storage.
 - 🔒 **Private by design** — zero telemetry, no phone-home. The only outbound calls are the ones you configure (your AI provider, SMTP, S3).

--- a/application/app/components/shared/TraceListItem.vue
+++ b/application/app/components/shared/TraceListItem.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { TraceInfo } from '~~/types/api';
+
+const props = withDefaults(
+  defineProps<{
+    trace: TraceInfo;
+    showTime?: boolean;
+  }>(),
+  {
+    showTime: true,
+  },
+);
+
+const name = computed(() => props.trace.filePath.split('/').pop() || props.trace.filePath);
+
+function downloadUrl(path: string): string {
+  return `/api/files/${getFileApiPath(path)}`;
+}
+</script>
+
+<template>
+  <div class="flex items-center justify-between gap-2">
+    <div class="flex items-center gap-2 min-w-0">
+      <UIcon name="i-lucide-file-archive" class="size-4 text-gray-400 shrink-0" />
+      <span class="text-sm truncate">{{ name }}</span>
+      <span v-if="trace.size" class="text-xs text-gray-400 shrink-0">{{ formatBytes(trace.size) }}</span>
+      <span v-if="showTime" class="text-xs text-gray-400 shrink-0">{{ formatRelativeTime(trace.createdAt) }}</span>
+    </div>
+    <div class="flex items-center gap-1.5 shrink-0">
+      <UButton
+        :to="getTraceViewerUrl(trace.filePath)"
+        target="_blank"
+        icon="i-lucide-bug-play"
+        size="xs"
+        label="View trace"
+      />
+      <UButton
+        :to="downloadUrl(trace.filePath)"
+        target="_blank"
+        icon="i-lucide-download"
+        size="xs"
+        color="neutral"
+        variant="soft"
+        label="Download"
+      />
+    </div>
+  </div>
+</template>

--- a/application/app/components/shared/TraceListItem.vue
+++ b/application/app/components/shared/TraceListItem.vue
@@ -11,11 +11,12 @@ const props = withDefaults(
   },
 );
 
-const name = computed(() => props.trace.filePath.split('/').pop() || props.trace.filePath);
+const config = useRuntimeConfig();
+const base = computed(() => (config.app?.baseURL ?? '/').replace(/\/$/, ''));
 
-function downloadUrl(path: string): string {
-  return `/api/files/${getFileApiPath(path)}`;
-}
+const name = computed(() => props.trace.filePath.split('/').pop() || props.trace.filePath);
+const viewUrl = computed(() => getTraceViewerUrl(props.trace.filePath, config.app?.baseURL));
+const downloadUrl = computed(() => `${base.value}/api/files/${getFileApiPath(props.trace.filePath)}`);
 </script>
 
 <template>
@@ -27,15 +28,9 @@ function downloadUrl(path: string): string {
       <span v-if="showTime" class="text-xs text-gray-400 shrink-0">{{ formatRelativeTime(trace.createdAt) }}</span>
     </div>
     <div class="flex items-center gap-1.5 shrink-0">
+      <UButton :to="viewUrl" target="_blank" icon="i-lucide-bug-play" size="xs" label="View trace" />
       <UButton
-        :to="getTraceViewerUrl(trace.filePath)"
-        target="_blank"
-        icon="i-lucide-bug-play"
-        size="xs"
-        label="View trace"
-      />
-      <UButton
-        :to="downloadUrl(trace.filePath)"
+        :to="downloadUrl"
         target="_blank"
         icon="i-lucide-download"
         size="xs"

--- a/application/app/components/test-case/TestCaseSummary.vue
+++ b/application/app/components/test-case/TestCaseSummary.vue
@@ -51,10 +51,6 @@ const { summaryColSpanClass, blockColSpanClass } = useDetailGrid(() => {
   return count;
 });
 
-function downloadUrl(path: string): string {
-  return `/api/files/${getFileApiPath(path)}`;
-}
-
 function attFileUrl(path: string, contentType?: string | null): string {
   let url = `/api/files/${getFileApiPath(path)}`;
   const ext = path.toLowerCase().split('.').pop() || '';
@@ -75,10 +71,7 @@ function isImage(path: string, contentType?: string | null): boolean {
 
 function totalStorageSize(traces?: TraceInfo[], attachments?: AttachmentInfo[]): number {
   let total = 0;
-  if (traces)
-    for (const t of traces)
-      if ((t as unknown as Record<string, unknown>).size as number)
-        total += (t as unknown as Record<string, unknown>).size as number;
+  if (traces) for (const t of traces) if (t.size) total += t.size;
   if (attachments) for (const a of attachments) if (a.size) total += a.size;
   return total;
 }
@@ -257,30 +250,7 @@ function fileName(path: string): string {
       >
         <div class="space-y-2">
           <!-- Traces -->
-          <div v-for="trace in traces" :key="trace.id" class="flex items-center justify-between gap-2 py-1.5">
-            <div class="flex items-center gap-2 min-w-0">
-              <UIcon name="i-lucide-file-archive" class="size-4 text-gray-400 shrink-0" />
-              <span class="text-xs truncate">{{ trace.filePath.split('/').pop() }}</span>
-            </div>
-            <div class="flex items-center gap-1 shrink-0">
-              <UButton
-                :to="getTraceViewerUrl(trace.filePath)"
-                target="_blank"
-                icon="i-lucide-bug-play"
-                size="xs"
-                label="View trace"
-              />
-              <UButton
-                :to="downloadUrl(trace.filePath)"
-                target="_blank"
-                icon="i-lucide-download"
-                size="xs"
-                color="neutral"
-                variant="soft"
-                label="Download"
-              />
-            </div>
-          </div>
+          <TraceListItem v-for="trace in traces" :key="trace.id" :trace="trace" :show-time="false" class="py-1.5" />
 
           <!-- Attachments summary -->
           <div v-if="(attachments?.length ?? 0) > 0" class="space-y-1">

--- a/application/app/components/test-case/TestCaseTracesCard.vue
+++ b/application/app/components/test-case/TestCaseTracesCard.vue
@@ -4,10 +4,6 @@ import type { TraceInfo } from '~~/types/api';
 defineProps<{
   traces: TraceInfo[];
 }>();
-
-function downloadUrl(path: string): string {
-  return `/api/files/${getFileApiPath(path)}`;
-}
 </script>
 
 <template>
@@ -19,35 +15,7 @@ function downloadUrl(path: string): string {
     help="case.traces"
   >
     <div class="space-y-2">
-      <div
-        v-for="trace in traces"
-        :key="trace.id"
-        class="flex items-center justify-between py-2 px-3 rounded-lg border"
-      >
-        <div class="flex items-center gap-2 min-w-0">
-          <UIcon name="i-lucide-file-archive" class="size-4 text-gray-400 shrink-0" />
-          <span class="text-sm truncate">{{ trace.filePath.split('/').pop() || trace.filePath }}</span>
-          <span class="text-xs text-gray-400">{{ formatRelativeTime(trace.createdAt) }}</span>
-        </div>
-        <div class="flex items-center gap-1.5 shrink-0">
-          <UButton
-            :to="getTraceViewerUrl(trace.filePath)"
-            target="_blank"
-            icon="i-lucide-bug-play"
-            size="xs"
-            label="View trace"
-          />
-          <UButton
-            :to="downloadUrl(trace.filePath)"
-            target="_blank"
-            icon="i-lucide-download"
-            size="xs"
-            color="neutral"
-            variant="soft"
-            label="Download"
-          />
-        </div>
-      </div>
+      <TraceListItem v-for="trace in traces" :key="trace.id" :trace="trace" class="py-2 px-3 rounded-lg border" />
     </div>
   </SectionCard>
 </template>

--- a/application/app/components/test-case/TestEvidenceTraces.vue
+++ b/application/app/components/test-case/TestEvidenceTraces.vue
@@ -5,14 +5,6 @@ defineProps<{
   traces: TraceInfo[];
   loading?: boolean;
 }>();
-
-function downloadUrl(path: string): string {
-  return `/api/files/${getFileApiPath(path)}`;
-}
-
-function fileName(path: string): string {
-  return path.split('/').pop() || path;
-}
 </script>
 
 <template>
@@ -28,30 +20,7 @@ function fileName(path: string): string {
         <UIcon name="i-lucide-loader-circle" class="size-4 animate-spin text-gray-400" />
       </div>
       <div v-else class="divide-y divide-default">
-        <div v-for="trace in traces" :key="trace.id" class="flex items-center justify-between px-3 py-2 gap-2">
-          <div class="flex items-center gap-1.5 min-w-0">
-            <UIcon name="i-lucide-file-archive" class="size-3.5 text-gray-400 shrink-0" />
-            <span class="text-xs truncate">{{ fileName(trace.filePath) }}</span>
-            <span class="text-xs text-gray-400 shrink-0">{{ formatRelativeTime(trace.createdAt) }}</span>
-          </div>
-          <div class="flex items-center gap-1 shrink-0">
-            <UButton
-              :to="getTraceViewerUrl(trace.filePath)"
-              target="_blank"
-              icon="i-lucide-play"
-              size="xs"
-              label="View"
-            />
-            <UButton
-              :to="downloadUrl(trace.filePath)"
-              target="_blank"
-              icon="i-lucide-download"
-              size="xs"
-              color="neutral"
-              variant="soft"
-            />
-          </div>
-        </div>
+        <TraceListItem v-for="trace in traces" :key="trace.id" :trace="trace" class="px-3 py-2" />
       </div>
     </template>
   </TestEvidenceSection>

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -187,8 +187,8 @@ export const HELP_TOPICS = {
   },
   'case.traces': {
     title: 'Traces',
-    text: 'Playwright trace files for this execution. Open one in the trace viewer to step through actions, snapshots and network.',
-    doc: 'ui-overview#test-case-detail',
+    text: 'Playwright trace files for this execution. "View trace" opens them in the dashboard\'s own trace viewer — the trace stays on your server, it is never sent to a third party.',
+    doc: 'ui-overview#trace-viewer',
   },
   'case.console': {
     title: 'Console output',

--- a/application/app/utils/index.ts
+++ b/application/app/utils/index.ts
@@ -244,8 +244,17 @@ export function getFileApiPath(filePath: string): string {
   return filePath.replace(storagePath, '');
 }
 
-export function getTraceViewerUrl(filePath: string): string {
-  return `/trace-viewer/?trace=${encodeURIComponent(`${location.origin}/api/files/${getFileApiPath(filePath)}`)}`;
+/**
+ * Build a URL that opens a stored trace in the bundled Playwright trace viewer.
+ *
+ * `baseURL` is the app's base path (`useRuntimeConfig().app.baseURL`). It must be
+ * applied to both the viewer path and the trace file URL so links keep working
+ * when the app is served from a sub-path (e.g. the demo at `/demo/`).
+ */
+export function getTraceViewerUrl(filePath: string, baseURL: string = '/'): string {
+  const base = (baseURL || '/').replace(/\/$/, '');
+  const traceUrl = `${location.origin}${base}/api/files/${getFileApiPath(filePath)}`;
+  return `${base}/trace-viewer/?trace=${encodeURIComponent(traceUrl)}`;
 }
 
 /**

--- a/application/server/api/files/[...path].get.ts
+++ b/application/server/api/files/[...path].get.ts
@@ -73,10 +73,16 @@ async function reconstructTraceZip(
     // Parse slim ZIP to recover event entries
     const slimEntries = await parseZip(slimZipData);
 
-    // Fetch all shared resources in parallel; skip any that are missing
-    const resourceEntries = (
-      await Promise.all(
-        resourceNames.map(async (name) => {
+    // Fetch shared resources in bounded batches rather than all at once, so a
+    // trace with hundreds of resources doesn't open hundreds of simultaneous
+    // storage reads (which pressures S3 connection/rate limits); missing
+    // resources are skipped.
+    const resourceEntries: { name: string; data: Buffer }[] = [];
+    const RESOURCE_FETCH_CONCURRENCY = 16;
+    for (let i = 0; i < resourceNames.length; i += RESOURCE_FETCH_CONCURRENCY) {
+      const batch = resourceNames.slice(i, i + RESOURCE_FETCH_CONCURRENCY);
+      const settled = await Promise.all(
+        batch.map(async (name) => {
           const resourcePath = `${projectPrefix}trace-resources/${name}`;
           try {
             const data = await storage.readFile(resourcePath);
@@ -86,8 +92,9 @@ async function reconstructTraceZip(
             return null;
           }
         }),
-      )
-    ).filter((e): e is NonNullable<typeof e> => e !== null);
+      );
+      for (const entry of settled) if (entry) resourceEntries.push(entry);
+    }
 
     return buildZip([...slimEntries, ...resourceEntries]);
   } catch (err) {
@@ -137,10 +144,30 @@ export default eventHandler(async (event) => {
 
   // Security headers applied to all file responses
   setResponseHeader(event, 'X-Content-Type-Options', 'nosniff');
-  setResponseHeader(event, 'Cache-Control', 'no-store');
 
-  // Trace archives are fetched cross-origin by the Playwright trace viewer
-  // (local /trace-viewer/ or hosted trace.playwright.dev) from the user's browser
+  // Trace blobs live under /blobs/ and are content-addressed by hash, so their
+  // bytes never change — cache them aggressively and answer conditional requests
+  // with 304 instead of re-downloading and re-reconstructing the full ZIP on
+  // every trace-viewer open. Every other path (reports, attachments) is
+  // path-stable but content-mutable, so it keeps no-store.
+  const isBlobPath = path.includes('/blobs/');
+  if (isBlobPath) {
+    const etag = `"${path.split('/blobs/')[1]}"`;
+    setResponseHeader(event, 'ETag', etag);
+    setResponseHeader(event, 'Cache-Control', 'private, max-age=31536000, immutable');
+    if (getRequestHeader(event, 'if-none-match') === etag) {
+      setResponseStatus(event, 304);
+      return null;
+    }
+  } else {
+    setResponseHeader(event, 'Cache-Control', 'no-store');
+  }
+
+  // Trace archives are fetched by the Playwright trace viewer from the user's
+  // browser. The bundled local viewer (/trace-viewer/) is same-origin, so it
+  // works with auth on; the hosted trace.playwright.dev viewer is cross-origin
+  // and cannot send the session cookie, so it only works when auth is disabled.
+  // The wildcard is safe because responses carry no credentials cross-origin.
   if (path.endsWith('.zip')) {
     setResponseHeader(event, 'Access-Control-Allow-Origin', '*');
   }

--- a/application/shared/handlers/test-cases.ts
+++ b/application/shared/handlers/test-cases.ts
@@ -295,6 +295,7 @@ export async function getTestRunCaseTraces(db: DrizzleDB, id: number) {
     id: t.id,
     filePath: t.path,
     createdAt: t.createdAt,
+    size: t.size ?? null,
   }));
 }
 

--- a/application/tests/unit/app-utils.test.ts
+++ b/application/tests/unit/app-utils.test.ts
@@ -124,6 +124,13 @@ describe('file path helpers', () => {
     expect(url).toBe(`/trace-viewer/?trace=${encodeURIComponent('http://localhost:3000/api/files/t.zip')}`);
     vi.unstubAllGlobals();
   });
+
+  test('getTraceViewerUrl prefixes the base path for both the viewer and the trace URL', () => {
+    vi.stubGlobal('location', { origin: 'http://localhost:3000' });
+    const url = getTraceViewerUrl('.data/storage/t.zip', '/demo/');
+    expect(url).toBe(`/demo/trace-viewer/?trace=${encodeURIComponent('http://localhost:3000/demo/api/files/t.zip')}`);
+    vi.unstubAllGlobals();
+  });
 });
 
 describe('errorMessage (fetch error unwrapping)', () => {

--- a/application/types/api.ts
+++ b/application/types/api.ts
@@ -757,6 +757,7 @@ export interface TraceInfo {
   id: number;
   filePath: string;
   createdAt: Date;
+  size?: number | null;
 }
 
 /**

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,23 +15,26 @@ Every tool below is good at what it targets. The honest differences:
 - **Allure Report** — a mature, multi-framework report generator producing a rich static report. History across builds requires wiring previous results into each build, and there's no server, live view, or cross-run analytics in the open-source generator (that's the commercial TestOps product).
 - **ReportPortal** — a mature, framework-agnostic, self-hosted test-ops platform with ML-based failure triage. It's built for organizations aggregating many frameworks, and its self-hosted footprint matches that ambition: a multi-service stack (API services, PostgreSQL, RabbitMQ, OpenSearch). Piwi trades that breadth for Playwright-native depth in a single container.
 - **Currents** — a polished commercial SaaS for Playwright and Cypress: run history, flake detection, CI orchestration. It's managed and maintained for you; in exchange it's paid and your test data lives on their infrastructure.
+- **Fault0** — the closest peer to Piwi: a newer, free, self-hosted, Playwright-only results dashboard with a one-line reporter, centralized run history, trace/screenshot/video debugging, notifications, and flaky-test trends. It targets the same "give your Playwright results a home" job. Where Piwi differs today is the depth of the analysis layer on top of that shared core — failure clustering, flaky **scoring** with CI-cost impact, locator healing, an MCP server for AI agents, and optional git-grounded AI diagnosis — so the honest split is *seeing* failures (both) versus *resolving* them (Piwi's focus). We've based this on Fault0's public docs and homepage; corrections welcome.
 
 ## Feature comparison
 
-| | **Piwi** | Playwright HTML report | Allure Report | ReportPortal | Currents |
-|---|---|---|---|---|---|
-| Run history across builds | ✅ | ❌ per-run | ➖ manual wiring | ✅ | ✅ |
-| Self-hosted | ✅ single container | — | ➖ static files | ✅ multi-service stack | ❌ SaaS |
-| Live run streaming | ✅ SSE, per-test | ❌ | ❌ | ➖ | ✅ |
-| Playwright traces, first-class | ✅ stored + viewer links | ✅ | ➖ attachments | ➖ attachments | ✅ |
-| Flaky detection & scoring | ✅ composite score, root-cause classes, CI-cost impact | ❌ | ❌ | ✅ | ✅ |
-| Failure clustering | ✅ error fingerprinting | ❌ | ❌ | ✅ ML-based | ✅ |
-| AI failure diagnosis | ✅ optional, grounded in your git diff, patches validated server-side | ❌ | ❌ | ➖ ML triage | ➖ |
-| Locator healing suggestions | ✅ from prior passing runs | ❌ | ❌ | ❌ | ❌ |
-| Web vitals & network capture | ✅ | ➖ in traces | ❌ | ❌ | ✅ |
-| MCP server for AI agents | ✅ 38 tools | ❌ | ❌ | ❌ | ✅ |
-| Framework support | Playwright only (by design) | Playwright | Many | Many | Playwright, Cypress, Jest… |
-| Price | Free, MIT | Free | Free | Free (self-host) / paid SaaS | Paid |
+| | **Piwi** | Playwright HTML report | Allure Report | ReportPortal | Currents | Fault0 |
+|---|---|---|---|---|---|---|
+| Run history across builds | ✅ | ❌ per-run | ➖ manual wiring | ✅ | ✅ | ✅ |
+| Self-hosted | ✅ single container | — | ➖ static files | ✅ multi-service stack | ❌ SaaS | ✅ |
+| Live run streaming | ✅ SSE, per-test | ❌ | ❌ | ➖ | ✅ | ➖ real-time status |
+| Playwright traces, first-class | ✅ stored + viewer links | ✅ | ➖ attachments | ➖ attachments | ✅ | ✅ |
+| Flaky detection & scoring | ✅ composite score, root-cause classes, CI-cost impact | ❌ | ❌ | ✅ | ✅ | ➖ detection |
+| Failure clustering | ✅ error fingerprinting | ❌ | ❌ | ✅ ML-based | ✅ | ➖ |
+| AI failure diagnosis | ✅ optional, grounded in your git diff, patches validated server-side | ❌ | ❌ | ➖ ML triage | ➖ | ➖ |
+| Locator healing suggestions | ✅ from prior passing runs | ❌ | ❌ | ❌ | ❌ | ➖ |
+| Web vitals & network capture | ✅ | ➖ in traces | ❌ | ❌ | ✅ | ➖ |
+| MCP server for AI agents | ✅ 38 tools | ❌ | ❌ | ❌ | ✅ | ➖ |
+| Framework support | Playwright only (by design) | Playwright | Many | Many | Playwright, Cypress, Jest… | Playwright only |
+| Price | Free, MIT | Free | Free | Free (self-host) / paid SaaS | Paid | Free, OSS |
+
+In the **Fault0** column, ➖ marks a capability we did not find in its public docs at the time of writing (not necessarily a confirmed absence) — the two products share the core results-dashboard experience and differ mainly in Piwi's analysis depth. Corrections welcome.
 
 ## When Piwi is *not* the right choice
 
@@ -75,4 +78,4 @@ Modest — see [resource requirements](/deployment#resource-requirements). Disk 
 
 ---
 
-<sub>Product names are used for identification only. Piwi Dashboard is an independent project, not affiliated with, endorsed by, or connected to Microsoft Corporation (Playwright), Qameta Software (Allure), EPAM Systems (ReportPortal), or Currents Software. Details about third-party products reflect their publicly documented open-source/free tiers and may change — corrections welcome.</sub>
+<sub>Product names are used for identification only. Piwi Dashboard is an independent project, not affiliated with, endorsed by, or connected to Microsoft Corporation (Playwright), Qameta Software (Allure), EPAM Systems (ReportPortal), Currents Software, or Fault0. Details about third-party products reflect their publicly documented open-source/free tiers and may change — corrections welcome.</sub>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ layout: home
 hero:
   name: "Piwi Dashboard"
   text: "Self-hosted Playwright observability"
-  tagline: "Live dashboards, failure clustering, and flaky-test tracking for your whole team. Nothing vanishes when CI finishes — no SaaS, no lock-in."
+  tagline: "Understand and fix failures — don't just watch them. Failure clustering, flaky-test scoring, locator healing, and optional AI diagnosis on top of your Playwright results. Self-hosted, no SaaS, no lock-in."
   image: /logo-wide.svg
 
   actions:
@@ -20,39 +20,42 @@ hero:
       link: https://github.com/PiwiTests/platform
 
 features:
-  - icon: 📊
-    title: Test results storage
-    details: Store complete Playwright test run data — status, duration, retries, errors, and more — in a lightweight SQLite database.
-  - icon: 🎯
-    title: Project organization
-    details: Tests are organized by project. Unknown projects are automatically created when results are submitted via API.
+  - icon: 🧩
+    title: Failure clustering
+    details: Identical failures are grouped across specs by an error fingerprint, so one root cause is one thing to triage — not fifty scattered red tests.
+  - icon: 🤖
+    title: AI failure diagnosis
+    details: Optional, opt-in analysis grounded in your actual git diff since the last green run — with suggested-fix patches validated server-side. Runs against your own provider (or a local model); nothing leaves your server unless you configure it.
+  - icon: 📉
+    title: Flaky-test analytics
+    details: Composite flakiness score with root-cause classes (timing, network, assertion…) and CI-cost impact ranking, so you fix the flakes that actually waste the most CI minutes first.
+  - icon: 🩹
+    title: Locator healing
+    details: When a locator breaks, get ranked replacement locators captured from prior passing runs — with a convention-preserving recommended fix and a data-testid nudge when nothing is stable.
+  - icon: 🎬
+    title: Self-hosted trace viewer
+    details: Open the full Playwright trace viewer straight from a failure — bundled and served by the dashboard, so traces never leave your server.
+  - icon: 🔔
+    title: Notifications & alerts
+    details: Email, Slack, webhook, and in-browser notifications for failed runs and new failure clusters, with per-project subscriptions, filters, and digest mode.
+  - icon: ⚡
+    title: Live run streaming
+    details: Watch a run update in real time over SSE as each test finishes — no polling, no waiting on CI to upload an artifact.
   - icon: 📈
     title: Performance tracking
     details: Step-level timing, avg/P90 duration trends, slowest-tests analysis, and side-by-side run comparison.
   - icon: 🌐
-    title: Network request analysis
-    details: Find slow API endpoints grouped by HTTP method and normalized route (e.g. `/api/users/:id`).
-  - icon: 📖
-    title: Interactive API docs
-    details: Auto-generated OpenAPI 3.1 specification with a Scalar-powered reference UI at /docs — browse endpoints, schemas, and execute requests directly from the browser.
-  - icon: 🔬
-    title: Browser Web Vitals
-    details: Capture TTFB, DOMContentLoaded, FCP and more via the Performance API, displayed with color-coded thresholds.
-  - icon: 🩹
-    title: Locator healing
-    details: When a locator breaks, get ranked replacement locators captured from prior passing runs — with a convention-preserving recommended fix and a data-testid nudge when nothing is stable.
+    title: Network & Web Vitals
+    details: Slow API endpoints grouped by method and normalized route, plus Core Web Vitals (TTFB, FCP, CLS…) with color-coded thresholds.
   - icon: 🔌
-    title: Playwright reporter
-    details: Drop-in custom reporter that automatically uploads results, HTML reports, and trace files after each run.
-  - icon: 🔐
-    title: Authentication
-    details: Optional role-based access control with administrator, reporter, and user roles.
-  - icon: ☁️
-    title: Flexible storage
-    details: Local file storage by default, or S3-compatible storage (AWS S3, MinIO, DigitalOcean Spaces, Cloudflare R2).
+    title: Drop-in reporter
+    details: Add one reporter to your Playwright config and results, HTML reports, and traces upload automatically after each run.
+  - icon: 🤝
+    title: MCP server for AI agents
+    details: Query runs, failures, clusters, and flaky tests from Claude Code or any MCP client — bring test health into your coding agent.
   - icon: 🐳
-    title: Docker support
-    details: Pre-built multi-platform container images (~400 MB) available on Docker Hub.
+    title: Self-hosted, your data
+    details: One ~400 MB Docker image, SQLite or PostgreSQL, local or S3-compatible storage, optional role-based auth. Zero telemetry — nothing phones home.
 ---
 
 <div class="screenshots">

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -416,6 +416,8 @@ export default defineConfig({
 5. If `dashboardFixtures` are active, network request and web vitals attachments are included per test case.
 6. The server decompresses the report and makes it available for viewing, with fully functional HTML reports.
 
+Uploaded traces open in the dashboard's **built-in, self-hosted trace viewer** — the bytes never leave your server. See [Trace viewer](./ui-overview#trace-viewer).
+
 ## Troubleshooting
 
 ### Reporter not uploading files

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -85,6 +85,16 @@ For a failed test the page opens on the **Failure** tab, which leads with the ra
   <figcaption>The test case detail page — pass rate and duration stats, a duration trend, a status-history strip, and every recent execution of this one test.</figcaption>
 </figure>
 
+## Trace viewer
+
+Every trace shows a **View trace** button that opens the full Playwright trace viewer — the same UI as `npx playwright show-trace`, with the DOM snapshot timeline, action log, network, console, and source.
+
+The viewer is **served by the dashboard itself** (the `playwright-core` viewer assets are bundled and served at `/trace-viewer/`), so traces are never uploaded to a third party — unlike sending a colleague to `trace.playwright.dev`, the bytes stay on your server. Traces are stored efficiently: each archive is split into a slim events ZIP plus a project-wide, hash-deduplicated resource pool, and reconstructed on download (see [Storage](./storage)). Trace blobs are content-addressed, so the browser caches them and re-opening a trace is instant.
+
+::: tip Authentication caveat
+The bundled `/trace-viewer/` is same-origin, so it works whether or not [authentication](./authentication) is enabled. The hosted `trace.playwright.dev` viewer is a different origin and cannot send your session cookie, so it only works against a dashboard with auth disabled — use the built-in **View trace** button, which always works.
+:::
+
 ## Failure cluster detail
 
 Each cluster (`/failure-clusters/:id`) opens on a summary — signature, affected tests, and **Triage** (set status open/resolved/ignored and write a note) — above a two-column body. The left column collapses each investigation section to a header with an at-a-glance peek (click to expand, and the state is remembered): the raw **error message**, an **alternative-locators** panel for broken locators, **test evidence** (one tab per affected case, each linking through to its test-run case, with screenshots, traces, failing steps, console/network signals and source), and **what changed** (the SCM diff since the last green run, with a baseline-commit picker and commit browser). The right column holds the **AI diagnosis** — an SCM-grounded LLM analysis whose cited evidence links back to the matching left-column section. Full detail: [AI diagnosis & clustering](./ai-diagnosis).


### PR DESCRIPTION
## What & why

Part of the response to the [Fault0](https://fault0.com/) competitive comparison: bring the trace experience at the edges up to the level of its backend, and sharpen positioning. Bundles the trace-quality work with the docs it enables (5 commits):

- **refactor(ui)** — extract a shared `TraceListItem`, removing trace-row markup duplicated across `TestCaseSummary`, `TestCaseTracesCard`, and `TestEvidenceTraces`; also surfaces trace file size (now returned by `getTestRunCaseTraces` and typed on `TraceInfo`).
- **fix(ui)** — `getTraceViewerUrl` hard-coded absolute `/trace-viewer/` and `/api/files/` paths, which **404 when the app is served from a sub-path** (the demo at `/demo/`, or any base-path deployment). Thread the app `baseURL` through the viewer path, the trace file URL, and the download link.
- **perf(app)** — trace blobs under `/blobs/` are content-addressed by hash, so serve them with an `ETag` + immutable `Cache-Control` and answer `If-None-Match` with `304` instead of re-downloading and re-reconstructing the full ZIP on every viewer open. Non-blob files keep `no-store`. Also fetch shared trace resources in bounded batches, and correct the CORS comment (the hosted `trace.playwright.dev` viewer can't send credentials with auth enabled).
- **docs** — document the self-hosted trace viewer (privacy angle, dedup storage, auth caveat) and add a help topic.
- **docs** — add Fault0 to the comparison landscape/table/footnote (honest: shared core, Piwi's edge is the analysis layer) and rework the docs hero + README around the "resolve failures, don't just watch them" story.

## How was it tested?

- `npm run app:typecheck`, `npm run app:lint`, and the unit suite pass; added a `getTraceViewerUrl` base-path unit test.
- VitePress docs build clean (no dead links).
- Not yet exercised: the `304` behavior on a live server (open the same trace twice and confirm the second load is served from cache).

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H)_