### PR TITLE
feat(notifications): embed failing-test context in run and cluster alerts

### DIFF
--- a/application/app/composables/useDemoNotifications.ts
+++ b/application/app/composables/useDemoNotifications.ts
@@ -26,7 +26,7 @@ function buildScenarios(projectLabel: string, events: string[]): Scenario[] {
       event: 'run.failed',
       scenario: {
         title: `Test run failed — ${projectLabel}`,
-        description: '3 of 12 tests failed on main',
+        description: '3 of 12 tests failed on main — checkout › applies discount code +2 more',
         icon: 'i-lucide-circle-x',
         color: 'error',
       },
@@ -35,7 +35,7 @@ function buildScenarios(projectLabel: string, events: string[]): Scenario[] {
       event: 'run.failed.default_branch',
       scenario: {
         title: `Test run failed on main — ${projectLabel}`,
-        description: '2 of 12 tests failed · branch: main',
+        description: '2 of 12 tests failed · main — auth › logs in with valid credentials +1 more',
         icon: 'i-lucide-circle-x',
         color: 'error',
       },

--- a/application/app/composables/useNotificationStream.ts
+++ b/application/app/composables/useNotificationStream.ts
@@ -20,6 +20,8 @@ interface NotificationEventData {
   rootCause?: string | null;
   category?: string | null;
   confidence?: string | null;
+  topFailures?: { title: string }[];
+  affectedCases?: number;
 }
 
 function renderBody(data: NotificationEventData): string {
@@ -40,6 +42,10 @@ function renderBody(data: NotificationEventData): string {
       else if (data.type === 'flakiness.spike') lines.push(`${name}: flakiness spike detected`);
       else if (data.type === 'perf.regression') lines.push(`${name}: performance regression detected`);
       if (data.failedTests) lines.push(`${data.failedTests} failed, ${data.totalTests} total`);
+      if (data.topFailures?.length) {
+        const [first, ...rest] = data.topFailures;
+        lines.push(rest.length ? `${first!.title} +${rest.length} more` : first!.title);
+      }
       break;
     }
     case 'cluster.new':

--- a/application/server/utils/email.ts
+++ b/application/server/utils/email.ts
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer';
 import type { Transporter } from 'nodemailer';
+import type { TopFailure } from '#shared/notification-events';
 
 export interface SmtpConfig {
   host: string;
@@ -77,6 +78,16 @@ export async function sendEmail(opts: SendEmailOptions): Promise<void> {
 // ── Email templates ───────────────────────────────────────────────────────────
 
 const siteUrl = () => process.env.PIWI_SITE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+
+/** Escape user-controlled text (test titles, error messages) for HTML emails. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 function emailLayout(title: string, body: string): { html: string; text: string } {
   const html = `<!DOCTYPE html>
@@ -158,12 +169,41 @@ export function renderRunNotificationEmail(opts: {
   totalTests: number;
   failedTests: number;
   branch?: string;
+  topFailures?: TopFailure[];
 }): { html: string; text: string } {
   const url = `${siteUrl()}/test-runs/${opts.runId}`;
   const statusColor = opts.status === 'passed' ? '#22c55e' : '#ef4444';
+
+  const failures = opts.topFailures ?? [];
+  let failuresHtml = '';
+  let failuresText = '';
+  if (failures.length > 0) {
+    const rows = failures
+      .map((f) => {
+        const caseUrl = f.testCaseId ? `${siteUrl()}/test-cases/${f.testCaseId}` : url;
+        const title = escapeHtml(f.title);
+        const titleHtml = `<a href="${caseUrl}" style="color:#18181b;font-weight:600;text-decoration:none;">${title}</a>`;
+        const loc = f.filePath ? `<div style="color:#a1a1aa;font-size:12px;">${escapeHtml(f.filePath)}</div>` : '';
+        const excerpt = f.errorExcerpt
+          ? `<pre style="margin:6px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px;color:#52525b;background:#fafafa;padding:8px;border-radius:4px;">${escapeHtml(f.errorExcerpt)}</pre>`
+          : '';
+        return `<li style="margin-bottom:12px;list-style:none;">${titleHtml}${loc}${excerpt}</li>`;
+      })
+      .join('');
+    failuresHtml = `<ul style="margin:0 0 24px;padding:0;">${rows}</ul>`;
+    failuresText = failures
+      .map((f) => {
+        const caseUrl = f.testCaseId ? `${siteUrl()}/test-cases/${f.testCaseId}` : url;
+        const loc = f.filePath ? ` (${f.filePath})` : '';
+        const excerpt = f.errorExcerpt ? `\n    ${f.errorExcerpt.replace(/\n/g, '\n    ')}` : '';
+        return `- ${f.title}${loc}\n  ${caseUrl}${excerpt}`;
+      })
+      .join('\n');
+  }
+
   const body = `
     <h2 style="margin:0 0 8px;font-size:20px;color:#18181b;">Test run ${opts.status}</h2>
-    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${opts.projectName}${opts.branch ? ` · ${opts.branch}` : ''}</p>
+    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${escapeHtml(opts.projectName)}${opts.branch ? ` · ${escapeHtml(opts.branch)}` : ''}</p>
     <table cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
       <tr>
         <td style="padding:8px 16px;background:#f4f4f5;border-radius:6px;font-size:14px;">
@@ -173,23 +213,39 @@ export function renderRunNotificationEmail(opts: {
         </td>
       </tr>
     </table>
+    ${failuresHtml}
     <a href="${url}" style="display:inline-block;background:#18181b;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;">View run</a>`;
   const { html } = emailLayout(`Test run ${opts.status} — ${opts.projectName}`, body);
-  const text = `Test run ${opts.status}: ${opts.projectName}${opts.branch ? ` (${opts.branch})` : ''}\n${opts.totalTests} tests${opts.failedTests > 0 ? `, ${opts.failedTests} failed` : ''}\n\nView run: ${url}`;
+  const text = `Test run ${opts.status}: ${opts.projectName}${opts.branch ? ` (${opts.branch})` : ''}\n${opts.totalTests} tests${opts.failedTests > 0 ? `, ${opts.failedTests} failed` : ''}${failuresText ? `\n\n${failuresText}` : ''}\n\nView run: ${url}`;
   return { html, text };
 }
 
-export function renderNewClusterEmail(opts: { projectName: string; clusterId: number; signature: string }): {
+export function renderNewClusterEmail(opts: {
+  projectName: string;
+  clusterId: number;
+  signature: string;
+  sampleErrorExcerpt?: string;
+  affectedCases?: number;
+}): {
   html: string;
   text: string;
 } {
   const url = `${siteUrl()}/failure-clusters/${opts.clusterId}`;
+  const affected =
+    opts.affectedCases && opts.affectedCases > 0
+      ? `<p style="margin:0 0 16px;color:#52525b;font-size:13px;">${opts.affectedCases} affected test${opts.affectedCases === 1 ? '' : 's'} in this run</p>`
+      : '';
+  const excerpt = opts.sampleErrorExcerpt
+    ? `<pre style="margin:0 0 24px;white-space:pre-wrap;word-break:break-word;font-size:12px;color:#52525b;background:#fafafa;padding:12px;border-radius:6px;">${escapeHtml(opts.sampleErrorExcerpt)}</pre>`
+    : '';
   const body = `
     <h2 style="margin:0 0 8px;font-size:20px;color:#18181b;">New failure cluster</h2>
-    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${opts.projectName}</p>
-    <p style="margin:0 0 24px;font-family:monospace;font-size:13px;background:#f4f4f5;padding:12px;border-radius:6px;overflow:auto;">${opts.signature}</p>
+    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${escapeHtml(opts.projectName)}</p>
+    <p style="margin:0 0 16px;font-family:monospace;font-size:13px;background:#f4f4f5;padding:12px;border-radius:6px;overflow:auto;">${escapeHtml(opts.signature)}</p>
+    ${affected}
+    ${excerpt}
     <a href="${url}" style="display:inline-block;background:#18181b;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;">View cluster</a>`;
   const { html } = emailLayout(`New failure cluster — ${opts.projectName}`, body);
-  const text = `New failure cluster in ${opts.projectName}\n\n${opts.signature}\n\nView: ${url}`;
+  const text = `New failure cluster in ${opts.projectName}${opts.affectedCases ? ` (${opts.affectedCases} affected)` : ''}\n\n${opts.signature}${opts.sampleErrorExcerpt ? `\n\n${opts.sampleErrorExcerpt}` : ''}\n\nView: ${url}`;
   return { html, text };
 }

--- a/application/server/utils/notifications/dispatch.ts
+++ b/application/server/utils/notifications/dispatch.ts
@@ -32,6 +32,7 @@ async function sendToEmail(config: Record<string, unknown>, event: NotificationE
       totalTests: p.totalTests,
       failedTests: p.failedTests,
       branch: p.branch,
+      topFailures: p.topFailures,
     }));
   } else if (event === 'cluster.new') {
     const p = payload as ClusterNewPayload;
@@ -39,6 +40,8 @@ async function sendToEmail(config: Record<string, unknown>, event: NotificationE
       projectName: p.projectName,
       clusterId: p.clusterId,
       signature: p.signature,
+      sampleErrorExcerpt: p.sampleErrorExcerpt,
+      affectedCases: p.affectedCases,
     }));
   } else {
     const subject = renderEventSubject(event, payload);
@@ -60,15 +63,29 @@ async function sendToSlack(config: Record<string, unknown>, event: NotificationE
   else if (event === 'cluster.new') emoji = ':bug:';
   else if (event === 'flakiness.spike') emoji = ':game_die:';
 
-  const body = {
-    text: `${emoji} *${text}*`,
-    blocks: [
-      {
-        type: 'section',
-        text: { type: 'mrkdwn', text: `${emoji} *${text}*` },
-      },
-    ],
-  };
+  const base = process.env.PIWI_SITE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+  // Slack section text is capped at 3000 chars; keep excerpts short.
+  const slackExcerpt = (s: string) => (s.length > 600 ? s.slice(0, 600) + '…' : s);
+
+  const blocks: Record<string, unknown>[] = [{ type: 'section', text: { type: 'mrkdwn', text: `${emoji} *${text}*` } }];
+
+  if (event.startsWith('run.')) {
+    const p = payload as RunFinishedPayload;
+    for (const f of p.topFailures ?? []) {
+      const link = f.testCaseId ? `<${base}/test-cases/${f.testCaseId}|${f.title}>` : f.title;
+      const excerpt = f.errorExcerpt ? `\n\`\`\`${slackExcerpt(f.errorExcerpt)}\`\`\`` : '';
+      blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `• *${link}*${excerpt}` } });
+    }
+  } else if (event === 'cluster.new') {
+    const p = payload as ClusterNewPayload;
+    const parts: string[] = [];
+    if (p.affectedCases) parts.push(`${p.affectedCases} affected test${p.affectedCases === 1 ? '' : 's'}`);
+    if (p.sampleErrorExcerpt) parts.push(`\`\`\`${slackExcerpt(p.sampleErrorExcerpt)}\`\`\``);
+    parts.push(`<${base}/failure-clusters/${p.clusterId}|View cluster>`);
+    blocks.push({ type: 'section', text: { type: 'mrkdwn', text: parts.join('\n') } });
+  }
+
+  const body = { text: `${emoji} *${text}*`, blocks };
 
   const res = await fetch(webhookUrl, {
     method: 'POST',

--- a/application/server/utils/notifications/run-notifications.ts
+++ b/application/server/utils/notifications/run-notifications.ts
@@ -1,6 +1,7 @@
-import { eq, and } from 'drizzle-orm';
-import { projects, testRuns, failureClusters } from '../../database/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import { projects, testRuns, failureClusters, testRunsCases, testCases } from '../../database/schema';
 import { emitNotification } from './emit';
+import { buildTopFailures, truncateExcerpt, TOP_FAILURES_LIMIT } from '#shared/notification-events';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 
 /**
@@ -22,6 +23,23 @@ export async function emitRunNotifications(db: LibSQLDatabase<any>, runId: numbe
     const defaultBranch = (meta.defaultBranch as string | undefined) || 'main';
     const isDefaultBranch = branch ? branch === defaultBranch : false;
 
+    // A few failing tests (title + error excerpt + deep-link ids) so a
+    // notification carries enough context to start debugging without opening
+    // the dashboard first.
+    const failedRows = await db
+      .select({
+        title: testCases.title,
+        filePath: testCases.filePath,
+        error: testRunsCases.error,
+        testCaseId: testRunsCases.testCaseId,
+        executionId: testRunsCases.id,
+      })
+      .from(testRunsCases)
+      .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
+      .where(and(eq(testRunsCases.testRunId, runId), inArray(testRunsCases.status, ['failed', 'timedout'])))
+      .limit(TOP_FAILURES_LIMIT);
+    const topFailures = buildTopFailures(failedRows);
+
     const runPayload = {
       runId,
       projectId: runRow.projectId,
@@ -33,6 +51,7 @@ export async function emitRunNotifications(db: LibSQLDatabase<any>, runId: numbe
       flakyTests: runRow.flakyTests,
       branch,
       isDefaultBranch,
+      topFailures,
     };
 
     await emitNotification(db, 'run.finished', runPayload);
@@ -46,17 +65,28 @@ export async function emitRunNotifications(db: LibSQLDatabase<any>, runId: numbe
 
     // Emit cluster.new for any clusters first seen in this run
     const newClusters = await db
-      .select({ id: failureClusters.id, signature: failureClusters.signature })
+      .select({
+        id: failureClusters.id,
+        signature: failureClusters.signature,
+        sampleError: failureClusters.sampleError,
+      })
       .from(failureClusters)
       .where(and(eq(failureClusters.firstSeenRunId, runId), eq(failureClusters.projectId, runRow.projectId)));
 
     for (const cluster of newClusters) {
+      const affected = await db
+        .select({ id: testRunsCases.id })
+        .from(testRunsCases)
+        .where(and(eq(testRunsCases.testRunId, runId), eq(testRunsCases.failureClusterId, cluster.id)));
+
       await emitNotification(db, 'cluster.new', {
         clusterId: cluster.id,
         projectId: runRow.projectId,
         projectName: project.label || project.name,
         signature: cluster.signature,
         runId,
+        sampleErrorExcerpt: truncateExcerpt(cluster.sampleError),
+        affectedCases: affected.length,
       });
     }
   } catch (e) {

--- a/application/shared/notification-events.ts
+++ b/application/shared/notification-events.ts
@@ -11,6 +11,20 @@ export const NOTIFICATION_EVENTS = [
 
 export type NotificationEvent = (typeof NOTIFICATION_EVENTS)[number];
 
+/** How many failing tests to embed in a run notification. */
+export const TOP_FAILURES_LIMIT = 3;
+/** Max characters kept from an error message embedded in a notification. */
+export const ERROR_EXCERPT_MAX = 300;
+
+/** A single failing test embedded in a run notification for debugging context. */
+export interface TopFailure {
+  title: string;
+  filePath?: string;
+  errorExcerpt?: string;
+  testCaseId?: number;
+  executionId?: number;
+}
+
 export interface RunFinishedPayload {
   runId: number;
   projectId: number;
@@ -23,6 +37,7 @@ export interface RunFinishedPayload {
   branch?: string;
   isDefaultBranch?: boolean;
   flakinessRate?: number; // 0-1
+  topFailures?: TopFailure[];
 }
 
 export interface ClusterNewPayload {
@@ -31,6 +46,46 @@ export interface ClusterNewPayload {
   projectName: string;
   signature: string;
   runId: number;
+  sampleErrorExcerpt?: string;
+  affectedCases?: number;
+}
+
+/**
+ * Trim, strip ANSI colour codes, and cap an error message so it can be embedded
+ * in a notification payload (and rendered in email/Slack) without bloating it.
+ * Returns undefined for empty input.
+ */
+export function truncateExcerpt(text?: string | null, max: number = ERROR_EXCERPT_MAX): string | undefined {
+  if (!text) return undefined;
+  const esc = String.fromCharCode(27);
+  const clean = text.replace(new RegExp(esc + '\\[[0-9;]*m', 'g'), '').trim();
+  if (!clean) return undefined;
+  return clean.length > max ? clean.slice(0, max).trimEnd() + '…' : clean;
+}
+
+/** Raw failing-case row shape consumed by {@link buildTopFailures}. */
+export interface TopFailureInput {
+  title: string;
+  filePath?: string | null;
+  error?: string | null;
+  testCaseId?: number | null;
+  executionId?: number | null;
+}
+
+/**
+ * Map raw failing-case rows to the compact {@link TopFailure} shape embedded in
+ * run notifications: capped to `limit` entries with truncated error excerpts.
+ */
+export function buildTopFailures(rows: TopFailureInput[], limit: number = TOP_FAILURES_LIMIT): TopFailure[] {
+  return rows.slice(0, limit).map((r) => {
+    const failure: TopFailure = { title: r.title };
+    if (r.filePath) failure.filePath = r.filePath;
+    if (r.testCaseId != null) failure.testCaseId = r.testCaseId;
+    if (r.executionId != null) failure.executionId = r.executionId;
+    const excerpt = truncateExcerpt(r.error);
+    if (excerpt) failure.errorExcerpt = excerpt;
+    return failure;
+  });
 }
 
 export interface DiagnosisCompletedPayload {

--- a/application/tests/unit/notification-events.test.ts
+++ b/application/tests/unit/notification-events.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from 'vitest';
-import { renderEventSubject, type RunFinishedPayload, type ClusterNewPayload } from '#shared/notification-events';
+import {
+  renderEventSubject,
+  buildTopFailures,
+  truncateExcerpt,
+  TOP_FAILURES_LIMIT,
+  ERROR_EXCERPT_MAX,
+  type RunFinishedPayload,
+  type ClusterNewPayload,
+} from '#shared/notification-events';
 
 const runPayload: RunFinishedPayload = {
   runId: 1,
@@ -40,5 +48,53 @@ describe('renderEventSubject', () => {
   test('flakiness.spike and perf.regression produce distinct subjects', () => {
     expect(renderEventSubject('flakiness.spike', runPayload)).toBe('Flakiness spike — my-project');
     expect(renderEventSubject('perf.regression', runPayload)).toBe('Performance regression — my-project');
+  });
+});
+
+describe('truncateExcerpt', () => {
+  test('returns undefined for empty/whitespace input', () => {
+    expect(truncateExcerpt(undefined)).toBeUndefined();
+    expect(truncateExcerpt(null)).toBeUndefined();
+    expect(truncateExcerpt('   \n  ')).toBeUndefined();
+  });
+
+  test('strips ANSI colour codes and trims', () => {
+    const esc = String.fromCharCode(27);
+    expect(truncateExcerpt(`  ${esc}[31mError${esc}[0m: boom  `)).toBe('Error: boom');
+  });
+
+  test('caps to ERROR_EXCERPT_MAX with an ellipsis', () => {
+    const long = 'x'.repeat(ERROR_EXCERPT_MAX + 50);
+    const out = truncateExcerpt(long)!;
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBe(ERROR_EXCERPT_MAX + 1); // max chars + ellipsis
+  });
+});
+
+describe('buildTopFailures', () => {
+  test('caps to the limit and maps fields, dropping empty ones', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      title: `test ${i}`,
+      filePath: i === 0 ? 'tests/a.spec.ts' : null,
+      error: i === 0 ? 'boom' : null,
+      testCaseId: i,
+      executionId: i + 100,
+    }));
+    const out = buildTopFailures(rows);
+    expect(out).toHaveLength(TOP_FAILURES_LIMIT);
+    expect(out[0]).toEqual({
+      title: 'test 0',
+      filePath: 'tests/a.spec.ts',
+      errorExcerpt: 'boom',
+      testCaseId: 0,
+      executionId: 100,
+    });
+    // Row without filePath/error omits those keys entirely
+    expect(out[1]).toEqual({ title: 'test 1', testCaseId: 1, executionId: 101 });
+  });
+
+  test('respects a custom limit', () => {
+    const rows = [{ title: 'a' }, { title: 'b' }];
+    expect(buildTopFailures(rows, 1)).toHaveLength(1);
   });
 });

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -53,6 +53,34 @@ Create an [incoming webhook](https://api.slack.com/messaging/webhooks) in Slack 
 
 Piwi `POST`s a JSON payload to your URL. Each request is signed with an HMAC-SHA256 `X-Piwi-Signature` header derived from the channel's secret, so you can verify authenticity. Webhook secrets are encrypted at rest.
 
+The body is `{ "event": "run.failed", "payload": { … }, "timestamp": "…" }`. For run events the payload includes up to three failing tests so you can act without a round-trip to the dashboard:
+
+```json
+{
+  "event": "run.failed",
+  "payload": {
+    "runId": 42,
+    "projectName": "checkout",
+    "status": "failed",
+    "totalTests": 120,
+    "failedTests": 3,
+    "branch": "main",
+    "topFailures": [
+      {
+        "title": "applies discount code",
+        "filePath": "tests/checkout.spec.ts",
+        "errorExcerpt": "TimeoutError: locator.click: Timeout 30000ms exceeded",
+        "testCaseId": 815,
+        "executionId": 9001
+      }
+    ]
+  },
+  "timestamp": "2026-07-11T10:00:00.000Z"
+}
+```
+
+`cluster.new` payloads similarly carry `sampleErrorExcerpt` and `affectedCases`. These fields are **additive** — existing consumers keep working, but if you re-serialize the payload to re-check the HMAC, sign the exact bytes you received.
+
 Admins can mark a channel **global** so it is available to all users.
 
 ## Subscriptions


### PR DESCRIPTION
## What & why

Part of the [Fault0](https://fault0.com/) competitive response. Notifications had solid delivery infrastructure but the payloads were count-level only — no failing test titles, error excerpts, or deep links, so "notifications with full context to debug faster" wasn't actually true.

- Run notifications now carry up to three failing tests (title, file, truncated error excerpt, and deep-link ids) and cluster alerts carry a sample error excerpt plus an affected-case count, built **at emit time** so the outbox delivery payload is self-contained.
- Rendered in **email** (per-case links + error `<pre>`), **Slack** (context blocks per failure), and the **browser** toast (first failing title + count). **Webhook** consumers receive the same additive fields verbatim.
- Titles and error text are HTML-escaped in email.

Additive only — existing webhook consumers keep working (documented in `docs/notifications.md`).

## How was it tested?

- New unit tests for the pure helpers (`buildTopFailures`, `truncateExcerpt`): cap, truncation, ANSI stripping, empty-input, and field-omission cases.
- `npm run app:typecheck`, `npm run app:lint`, and the full unit suite pass.
- Not yet exercised: a live end-to-end delivery to email/Slack/webhook (recommend firing a failing run with those channels subscribed).

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H)_