### PR TITLE
feat(ui): surface test videos as first-class evidence

### DIFF
--- a/application/app/components/cluster/ClusterTestEvidence.vue
+++ b/application/app/components/cluster/ClusterTestEvidence.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { TraceInfo, AttachmentInfo } from '~~/types/api';
-import { isImageFile } from '~/utils/text-format';
+import { isImageFile, isVideoFile } from '~/utils/text-format';
 
 interface AffectedCase {
   testCaseId: number;
@@ -107,6 +107,7 @@ const evidenceChips = computed(() => {
   const d = caseDetail.value;
   if (!d) return [];
   const screenshots = d.attachments.filter((a) => isImageFile(a.path, a.contentType)).length;
+  const videos = d.attachments.filter((a) => isVideoFile(a.path, a.contentType)).length;
   const consoleCount = Array.isArray(d.consoleLogs)
     ? (d.consoleLogs as Array<{ type?: string }>).filter((l) => l.type === 'error' || l.type === 'warning').length
     : 0;
@@ -115,6 +116,7 @@ const evidenceChips = computed(() => {
     : 0;
   return [
     { icon: 'i-lucide-image', label: 'screenshots', count: screenshots },
+    { icon: 'i-lucide-video', label: 'videos', count: videos },
     { icon: 'i-lucide-bug-play', label: 'traces', count: traces.value.length },
     { icon: 'i-lucide-list-checks', label: 'failing steps', count: failingSteps.value.length },
     { icon: 'i-lucide-triangle-alert', label: 'signals', count: consoleCount + failedRequests },
@@ -184,6 +186,9 @@ const evidenceChips = computed(() => {
 
       <!-- Screenshots -->
       <TestEvidenceScreenshots :attachments="caseDetail.attachments" />
+
+      <!-- Videos -->
+      <TestEvidenceVideos :attachments="caseDetail.attachments" />
 
       <!-- Traces -->
       <TestEvidenceTraces :traces="traces" :loading="tracesLoading" />

--- a/application/app/components/shared/VideoPlayer.vue
+++ b/application/app/components/shared/VideoPlayer.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{
+  src: string;
+  label?: string | null;
+}>();
+</script>
+
+<template>
+  <figure class="m-0">
+    <div class="bg-black rounded overflow-hidden">
+      <video :src="src" controls preload="metadata" class="w-full max-h-96">
+        Your browser does not support the video tag.
+      </video>
+    </div>
+    <figcaption v-if="label" class="mt-1 text-xs text-gray-400 truncate" :title="label">{{ label }}</figcaption>
+  </figure>
+</template>

--- a/application/app/components/test-case/TestCaseAttachmentsCard.vue
+++ b/application/app/components/test-case/TestCaseAttachmentsCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AttachmentInfo } from '~~/types/api';
+import { isImageFile, isVideoFile } from '~/utils/text-format';
 
 const props = defineProps<{
   attachments: AttachmentInfo[];
@@ -9,7 +10,7 @@ const currentImageIndex = ref<number | null>(null);
 
 const imageAttachments = computed(() =>
   props.attachments
-    .filter((att) => isImage(att.path, att.contentType))
+    .filter((att) => isImageFile(att.path, att.contentType))
     .map((att) => ({
       src: fileUrl(att.path, att.contentType),
       name: att.name || fileName(att.path),
@@ -20,27 +21,11 @@ function openLightbox(index: number) {
   currentImageIndex.value = index;
 }
 
-const imageExts = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp']);
-const videoExts = new Set(['.webm', '.mp4', '.ogg', '.mov']);
 const markdownExts = new Set(['.md', '.mdx', '.markdown']);
-const imageMimes = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp']);
-const videoMimes = new Set(['video/webm', 'video/mp4', 'video/ogg', 'video/quicktime']);
 const markdownMimes = new Set(['text/markdown', 'text/x-markdown']);
 
 function getExt(path: string): string {
   return path.toLowerCase().split('.').pop() || '';
-}
-
-function isImage(path: string, contentType?: string | null): boolean {
-  if (imageExts.has(getExt(path))) return true;
-  if (contentType && imageMimes.has(contentType.toLowerCase())) return true;
-  return false;
-}
-
-function isVideo(path: string, contentType?: string | null): boolean {
-  if (videoExts.has(getExt(path))) return true;
-  if (contentType && videoMimes.has(contentType.toLowerCase())) return true;
-  return false;
 }
 
 function isMarkdown(path: string, contentType?: string | null): boolean {
@@ -110,9 +95,9 @@ function togglePreview(attId: number, att: AttachmentInfo) {
           <div class="flex items-center gap-2 min-w-0">
             <UIcon
               :name="
-                isImage(att.path, att.contentType)
+                isImageFile(att.path, att.contentType)
                   ? 'i-lucide-image'
-                  : isVideo(att.path, att.contentType)
+                  : isVideoFile(att.path, att.contentType)
                     ? 'i-lucide-video'
                     : isMarkdown(att.path, att.contentType)
                       ? 'i-lucide-file-text'
@@ -145,7 +130,7 @@ function togglePreview(attId: number, att: AttachmentInfo) {
           </div>
         </div>
 
-        <div v-if="isImage(att.path, att.contentType)" class="bg-gray-100 dark:bg-gray-900">
+        <div v-if="isImageFile(att.path, att.contentType)" class="bg-gray-100 dark:bg-gray-900">
           <img
             :src="fileUrl(att.path, att.contentType)"
             :alt="att.name || 'Screenshot'"
@@ -155,15 +140,8 @@ function togglePreview(attId: number, att: AttachmentInfo) {
           />
         </div>
 
-        <div v-else-if="isVideo(att.path, att.contentType)" class="bg-black">
-          <video
-            :src="fileUrl(att.path, att.contentType)"
-            controls
-            preload="metadata"
-            class="max-w-full max-h-96 mx-auto"
-          >
-            Your browser does not support the video tag.
-          </video>
+        <div v-else-if="isVideoFile(att.path, att.contentType)" class="bg-black">
+          <VideoPlayer :src="fileUrl(att.path, att.contentType)" />
         </div>
 
         <div

--- a/application/app/components/test-case/TestEvidenceVideos.vue
+++ b/application/app/components/test-case/TestEvidenceVideos.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { AttachmentInfo } from '~~/types/api';
+import { isVideoFile } from '~/utils/text-format';
+
+const props = defineProps<{
+  attachments: AttachmentInfo[];
+}>();
+
+function getExt(path: string): string {
+  return '.' + (path.toLowerCase().split('.').pop() || '');
+}
+
+function fileUrl(path: string, contentType?: string | null): string {
+  let url = `/api/files/${getFileApiPath(path)}`;
+  if (contentType && getExt(path) === '.') url += `?contentType=${encodeURIComponent(contentType)}`;
+  return url;
+}
+
+function fileName(path: string): string {
+  return path.split('/').pop() || path;
+}
+
+const videos = computed(() =>
+  props.attachments
+    .filter((att) => isVideoFile(att.path, att.contentType))
+    .map((att) => ({
+      src: fileUrl(att.path, att.contentType),
+      name: att.name || fileName(att.path),
+    })),
+);
+</script>
+
+<template>
+  <TestEvidenceSection
+    v-if="videos.length > 0"
+    icon="i-lucide-video"
+    label="Videos"
+    :count="videos.length"
+    :collapsible="false"
+  >
+    <div class="space-y-2 p-2 bg-gray-50 dark:bg-gray-900">
+      <VideoPlayer v-for="video in videos" :key="video.src" :src="video.src" :label="video.name" />
+    </div>
+  </TestEvidenceSection>
+</template>

--- a/application/app/utils/text-format.ts
+++ b/application/app/utils/text-format.ts
@@ -6,11 +6,22 @@
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp']);
 const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp']);
 
+const VIDEO_EXTS = new Set(['.webm', '.mp4', '.ogg', '.mov']);
+const VIDEO_MIMES = new Set(['video/webm', 'video/mp4', 'video/ogg', 'video/quicktime']);
+
 /** Whether a file path (or its content type) refers to a displayable image. */
 export function isImageFile(path: string, contentType?: string | null): boolean {
   const ext = '.' + (path.toLowerCase().split('.').pop() || '');
   if (IMAGE_EXTS.has(ext)) return true;
   if (contentType && IMAGE_MIMES.has(contentType.toLowerCase())) return true;
+  return false;
+}
+
+/** Whether a file path (or its content type) refers to a playable video. */
+export function isVideoFile(path: string, contentType?: string | null): boolean {
+  const ext = '.' + (path.toLowerCase().split('.').pop() || '');
+  if (VIDEO_EXTS.has(ext)) return true;
+  if (contentType && VIDEO_MIMES.has(contentType.toLowerCase())) return true;
   return false;
 }
 

--- a/application/tests/unit/text-format.test.ts
+++ b/application/tests/unit/text-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { stripAnsi, isImageFile } from '../../app/utils/text-format';
+import { stripAnsi, isImageFile, isVideoFile } from '../../app/utils/text-format';
 
 const ESC = String.fromCharCode(27); // ANSI escape
 
@@ -27,5 +27,19 @@ describe('isImageFile', () => {
   test('detects by content type when the extension is absent', () => {
     expect(isImageFile('attachment', 'image/png')).toBe(true);
     expect(isImageFile('attachment', 'application/zip')).toBe(false);
+  });
+});
+
+describe('isVideoFile', () => {
+  test('detects by extension (case-insensitive)', () => {
+    expect(isVideoFile('run.WEBM')).toBe(true);
+    expect(isVideoFile('a/b/clip.mp4')).toBe(true);
+    expect(isVideoFile('shot.png')).toBe(false);
+    expect(isVideoFile('trace.zip')).toBe(false);
+  });
+
+  test('detects by content type when the extension is absent', () => {
+    expect(isVideoFile('attachment', 'video/webm')).toBe(true);
+    expect(isVideoFile('attachment', 'image/png')).toBe(false);
   });
 });

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -30,9 +30,12 @@ export default defineConfig({
   ],
   use: {
     trace: 'retain-on-failure',
+    video: 'retain-on-failure',
   },
 })
 ```
+
+Any attachments Playwright records — including **videos** (`video: 'retain-on-failure'`) and screenshots — are uploaded automatically and shown as first-class evidence on the test-case and failure-cluster pages, alongside traces. Videos can be large, so pair `retain-on-failure` with periodic [storage cleanup](./storage#storage-management).
 
 ## Configuration options
 


### PR DESCRIPTION
## What & why

Part of the [Fault0](https://fault0.com/) competitive response, which markets video as a headline debug artifact. Piwi already stored videos (as generic attachments) but never showed them on the failure-cluster page, where screenshots render but videos were invisible.

- Add a shared `VideoPlayer` and a **Videos** evidence block to the failure-cluster per-case tabs, with a video chip in the evidence strip.
- Extract a shared `isVideoFile` helper (next to `isImageFile`) and reuse it plus `VideoPlayer` in the test-case attachments card, removing the duplicated detection/`<video>` markup.
- Reporter flow audited: video attachments already upload via `findAllAttachments` (only `trace` and internal `piwi-*` are skipped), preserving `contentType` — no reporter change needed.
- Document recording videos (`video: 'retain-on-failure'`) in the reporter guide, with a note about storage/pruning.

## How was it tested?

- New unit tests for `isVideoFile` (extension + content-type detection).
- `npm run app:typecheck`, `npm run app:lint`, and the full unit suite pass.
- Not yet exercised: viewing a real uploaded video in the cluster evidence tab on a live server.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H)_