### PR TITLE
feat(app): scope flaky-test analysis to a single environment

### DIFF
--- a/application/app/components/project/FlakyTestsList.vue
+++ b/application/app/components/project/FlakyTestsList.vue
@@ -4,14 +4,19 @@ import type { FlakyTest } from '~~/types/api';
 
 const props = defineProps<{
   projectId: string | number;
+  environment?: string | null;
 }>();
 
 const runsWindow = ref(50);
 const rootCauseFilter = ref<string[]>([]);
 
 const { data: tests, pending: loading } = await useFetch<FlakyTest[]>(
-  () => `/api/projects/${props.projectId}/flaky-tests?runs=${runsWindow.value}`,
-  { lazy: true, server: false, watch: [runsWindow] },
+  () => {
+    const params = new URLSearchParams({ runs: String(runsWindow.value) });
+    if (props.environment) params.set('environment', props.environment);
+    return `/api/projects/${props.projectId}/flaky-tests?${params.toString()}`;
+  },
+  { lazy: true, server: false, watch: [runsWindow, () => props.environment] },
 );
 
 const filteredTests = computed(() => {
@@ -79,6 +84,10 @@ const columns: TableColumn<FlakyTest>[] = [
             Tests that fail intermittently — detected by retry passes and status alternations
             <HelpHint topic="project.flaky-tests" />
           </p>
+          <UBadge v-if="environment" color="neutral" variant="subtle" size="sm" class="gap-1">
+            <UIcon name="i-lucide-layers" class="size-3" />
+            {{ environment }}
+          </UBadge>
           <div class="flex items-center gap-1.5">
             <UButton
               v-for="opt in ROOT_CAUSE_OPTIONS"

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -198,7 +198,8 @@ const routes: RouteEntry[] = [
     pattern: /^\/api\/projects\/(\d+)\/flaky-tests$/,
     handler: async (m, _, q) => {
       const limit = q ? Number(q.get('runs')) || 50 : 50;
-      return getProjectFlakyTests(await getDemoDb(), +m[1]!, limit);
+      const environment = q?.get('environment') || undefined;
+      return getProjectFlakyTests(await getDemoDb(), +m[1]!, limit, environment);
     },
   },
 

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -279,6 +279,12 @@ const filteredRuns = computed(() => {
   return runs.filter((r) => r.environment && selectedEnvironments.value.includes(r.environment));
 });
 
+// When exactly one environment is selected, scope the (server-side) flaky
+// analysis to it so staging vs production stability can be compared.
+const flakyEnvironment = computed(() =>
+  selectedEnvironments.value.length === 1 ? selectedEnvironments.value[0] : undefined,
+);
+
 const chartRuns = computed(() => {
   const runs = project.value?.testRuns || [];
   if (fullRunsOnly.value) {
@@ -880,7 +886,11 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
 
           <!-- FLAKY TESTS TAB -->
           <template #flaky-tests>
-            <FlakyTestsList v-if="activeTab === 'flaky-tests'" :project-id="String(projectId)" />
+            <FlakyTestsList
+              v-if="activeTab === 'flaky-tests'"
+              :project-id="String(projectId)"
+              :environment="flakyEnvironment"
+            />
           </template>
 
           <!-- PERFORMANCE TAB -->

--- a/application/server/api/projects/[id]/flaky-tests.get.ts
+++ b/application/server/api/projects/[id]/flaky-tests.get.ts
@@ -10,8 +10,12 @@ defineRouteMeta({
     tags: ['Test Cases'],
     summary: 'Flaky test analysis',
     description:
-      'Analyzes test flakiness across recent runs using retry-pass detection and pass/fail alternation scoring',
-    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+      'Analyzes test flakiness across recent runs using retry-pass detection and pass/fail alternation scoring. Pass an environment to scope the analysis to runs from that deployment environment.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+      { name: 'runs', in: 'query', required: false, schema: { type: 'integer' } },
+      { name: 'environment', in: 'query', required: false, schema: { type: 'string' } },
+    ],
     'x-required-roles': REQUIRED_ROLES,
   },
 });
@@ -20,13 +24,15 @@ export default eventHandler(async (event) => {
   const projectId = requireRouteId(event, 'id', 'project ID');
   await requireProjectAccess(event, projectId);
 
-  const runsParam = parseInt((getQuery(event).runs as string) || '50');
+  const query = getQuery(event);
+  const runsParam = parseInt((query.runs as string) || '50');
   const runsLimit = Math.min(200, Math.max(1, isNaN(runsParam) ? 50 : runsParam));
+  const environment = typeof query.environment === 'string' && query.environment ? query.environment : undefined;
 
   const db = await getDatabase();
 
   try {
-    return await getProjectFlakyTests(db, projectId, runsLimit);
+    return await getProjectFlakyTests(db, projectId, runsLimit, environment);
   } catch (e: any) {
     if (e?.message === 'Project not found') {
       throw createError({ statusCode: 404, message: 'Project not found' });

--- a/application/shared/handlers/projects.ts
+++ b/application/shared/handlers/projects.ts
@@ -762,18 +762,27 @@ export async function getProjectFailureClusters(db: DrizzleDB, projectId: number
 
 const TERMINAL_STATUSES = ['passed', 'failed', 'timedout', 'interrupted'];
 
-export async function getProjectFlakyTests(db: DrizzleDB, projectId: number, runsLimit: number) {
+export async function getProjectFlakyTests(
+  db: DrizzleDB,
+  projectId: number,
+  runsLimit: number,
+  environment?: string | null,
+) {
   const projectResults: any[] = await db.select({ id: projects.id }).from(projects).where(eq(projects.id, projectId));
   const project = projectResults[0];
   if (!project) throw new Error('Project not found');
 
   const effectiveLimit = Math.min(200, Math.max(1, runsLimit));
 
-  // Step 1: Last N terminal runs
+  // Step 1: Last N terminal runs (optionally scoped to one environment so
+  // stability can be compared per environment, e.g. staging vs production)
+  const runsWhere = environment
+    ? and(eq(testRuns.projectId, projectId), eq(testRuns.environment, environment))
+    : eq(testRuns.projectId, projectId);
   const recentRuns: any[] = await db
     .select({ id: testRuns.id, startTime: testRuns.startTime })
     .from(testRuns)
-    .where(eq(testRuns.projectId, projectId))
+    .where(runsWhere)
     .orderBy(desc(testRuns.startTime))
     .limit(effectiveLimit);
 

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -17,6 +17,8 @@ A test is flaky when its result isn't deterministic. Piwi computes a **composite
 
 Each project has a dedicated **Flaky tests** tab with a **configurable lookback window** so you can focus on recent behavior or a longer baseline.
 
+**Per-environment scoping** — select a single environment in the project's environment filter and the flaky analysis is scoped to runs from that environment, so you can compare stability across `staging`, `production`, and `development` instead of blending them. (Set the environment via the reporter's `environment` option / `PIWI_ENVIRONMENT`; see the [reporter](./reporter) docs.)
+
 <figure>
   <img src="/screenshots/flaky-detection.png" alt="Flaky tests tab listing tests with composite score, failure rate, retry passes, and flip counts">
   <figcaption>The Flaky tests tab — each intermittent test scored by retry passes, status flips, and failure rate, ranked by impact and filterable by root-cause category.</figcaption>


### PR DESCRIPTION
## What & why

Part of the [Fault0](https://fault0.com/) competitive response ("track stability across staging/production/dev"). The `environment` field was stored and filtered the runs table, but flaky analysis blended all environments together, so "compare staging vs production stability" wasn't answerable.

- Add an optional `environment` filter to `getProjectFlakyTests` and the `/api/projects/:id/flaky-tests` endpoint (with an OpenAPI param) — it scopes the analyzed run set.
- The project page scopes the flaky tab when **exactly one** environment is selected in the existing environment filter; `FlakyTestsList` shows the active scope as a badge.
- The demo API mirror honors the same param.
- Documented in `docs/flaky-tests.md`.

Backward compatible — omitting the param preserves previous behavior.

## How was it tested?

- `npm run app:typecheck`, `npm run app:lint`, and the full unit suite pass.
- Not yet exercised on a live server, and the demo seed currently has limited environment variety (a follow-up will add multi-environment seed data to make the filter demonstrable).

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes <!-- handler is DB-integration-shaped; covered by typecheck + existing flaky tests -->
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H)_