### PR TITLE
test(notifications): fix flaky bell visibility test timeout

### DIFF
--- a/application/tests/notifications.spec.ts
+++ b/application/tests/notifications.spec.ts
@@ -355,7 +355,17 @@ test.describe.serial('Subscribe Bell UI', () => {
 
   test('bell is not visible when not authenticated', async ({ page }) => {
     skip();
-    await page.goto(`${BASE}/projects/${projectId}`);
+    // Unauthenticated visits to a protected page are bounced to /login by the
+    // global auth middleware, so the bell is never reachable. The flake was the
+    // navigation, not the assertion: this is the first hit to /projects/[id] on
+    // the auth-enabled dev server, and the cold Vite route-compile under shared
+    // CI CPU can push page.goto past the 30 s test budget (hence the ~33 s
+    // timeouts). Allow slow-test headroom, resolve on DOMContentLoaded (a
+    // redirect can keep a subresource in flight and delay the `load` event), and
+    // wait for the redirect to settle before asserting.
+    test.slow();
+    await page.goto(`${BASE}/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForURL('**/login', { timeout: 30000 });
     await expect(page.getByTitle('Notification subscriptions for this project')).not.toBeVisible();
   });
 


### PR DESCRIPTION
## What & why

The "bell is not visible when not authenticated" test was flaking due to slow Vite route compilation on shared CI infrastructure. The test was hitting the 30-second timeout budget on first navigation to a protected route.

This change stabilizes the test by:
- Marking it as slow to extend the timeout budget
- Using `waitUntil: 'domcontentloaded'` instead of waiting for full page load, since redirects can keep subresources in flight and delay the `load` event
- Explicitly waiting for the redirect to `/login` to settle before asserting

The test was already skipped, so this improves the test infrastructure without changing test behavior.

## How was it tested

The test remains skipped but is now more robust for when it's re-enabled. The changes follow Playwright best practices for handling redirects and slow network conditions.

## Checklist

- [x] PR title follows Conventional Commits (`test(notifications): fix flaky bell visibility test timeout`)
- [x] Tests updated for reliability (no behavior changes, test was already skipped)
- [ ] Docs updated (not applicable)

https://claude.ai/code/session_01QwPVEBo8xojABpZNXybEvs