### PR TITLE
feat(capture): teardown race guard and web vitals stashing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ Nuxt file-based routing:
 > **Layout & conventions:** see **`reporter/ARCHITECTURE.md`** for the full map (public/internal split, two-process collect-and-submit data flow, fallback ladder, conventions). The package is `strict`-mode TypeScript; Node built-ins are `import * as x from 'node:x'`; classes use `private readonly` constructor parameter-property DI; HTTP failures throw `HttpError` (carrying `status`); `catch (error)` is `unknown` (narrow with `instanceof`, format with `errorMessage`).
 
 - **Public API** — only what these expose is the supported surface:
-  - `reporter/src/index.ts` — the package's single public entry (`.`): re-exports the reporter, `wrapConfig`, `createGlobalSetup`, `dashboardFixtures`, `extendDashboardFixtures`, and the public types (there is no `./fixtures` subpath — fixtures import from `@piwitests/reporter`)
+  - `reporter/src/index.ts` — the package's single public entry (`.`): re-exports the reporter, `wrapConfig`, `createGlobalSetup`, `piwiFixtures`, `extendPiwiFixtures` (with deprecated `dashboardFixtures` / `extendDashboardFixtures` aliases), and the public types incl. `PiwiFixtures` (there is no `./fixtures` subpath — fixtures import from `@piwitests/reporter`)
   - `reporter/src/public/reporter.ts` — `PiwiDashboardReporter` (Playwright hooks + running counters; hands off to `RunSubmitter`)
   - `reporter/src/public/options.ts` — `PiwiDashboardOptions` interface + `PlaywrightTestConfig` re-export
   - `reporter/src/public/config-wrapper.ts` — `wrapConfig`; `reporter/src/public/global-setup.ts` — `createGlobalSetup`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ Nuxt file-based routing:
 > **Layout & conventions:** see **`reporter/ARCHITECTURE.md`** for the full map (public/internal split, two-process collect-and-submit data flow, fallback ladder, conventions). The package is `strict`-mode TypeScript; Node built-ins are `import * as x from 'node:x'`; classes use `private readonly` constructor parameter-property DI; HTTP failures throw `HttpError` (carrying `status`); `catch (error)` is `unknown` (narrow with `instanceof`, format with `errorMessage`).
 
 - **Public API** — only what these expose is the supported surface:
-  - `reporter/src/index.ts` — the package's single public entry (`.`): re-exports the reporter, `wrapConfig`, `createGlobalSetup`, `piwiFixtures`, `extendPiwiFixtures` (with deprecated `dashboardFixtures` / `extendDashboardFixtures` aliases), and the public types incl. `PiwiFixtures` (there is no `./fixtures` subpath — fixtures import from `@piwitests/reporter`)
+  - `reporter/src/index.ts` — the package's single public entry (`.`): re-exports the reporter, `wrapConfig`, `createGlobalSetup`, `piwiFixtures`, `extendPiwiFixtures`, and the public types incl. `PiwiFixtures` (there is no `./fixtures` subpath — fixtures import from `@piwitests/reporter`)
   - `reporter/src/public/reporter.ts` — `PiwiDashboardReporter` (Playwright hooks + running counters; hands off to `RunSubmitter`)
   - `reporter/src/public/options.ts` — `PiwiDashboardOptions` interface + `PlaywrightTestConfig` re-export
   - `reporter/src/public/config-wrapper.ts` — `wrapConfig`; `reporter/src/public/global-setup.ts` — `createGlobalSetup`

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ export default defineConfig({
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ export default defineConfig({
 
 **3. Run your tests** — `npx playwright test`. Results appear automatically; the project is created on first submission.
 
+**4. Add the capture fixtures** *(recommended)* — one small file unlocks the richest features: locator healing, slow-endpoint analysis, Web Vitals, console capture, and failure-time ARIA snapshots.
+
+```typescript
+// tests/fixtures.ts
+import { test as base, expect } from '@playwright/test'
+import { dashboardFixtures } from '@piwitests/reporter'
+
+export const test = base.extend(dashboardFixtures)
+export { expect }
+```
+
+Import `test` from this file in your specs instead of `@playwright/test` — that's it. Full details in the **[capture fixtures guide](https://piwitests.github.io/capture-fixtures)**; a runnable example lives in [`examples/playwright-fixtures`](./examples/playwright-fixtures).
+
 ➡️ Full setup, configuration, and CI integration in the **[Getting started guide](https://piwitests.github.io/getting-started)**.
 
 ## How is this different from…?
@@ -124,6 +137,7 @@ Every tool in that table is good at what it targets — the honest version with 
 | Getting started | [piwitests.github.io/getting-started](https://piwitests.github.io/getting-started) |
 | Comparison & FAQ | [piwitests.github.io/comparison](https://piwitests.github.io/comparison) |
 | Playwright reporter | [piwitests.github.io/reporter](https://piwitests.github.io/reporter) |
+| Capture fixtures | [piwitests.github.io/capture-fixtures](https://piwitests.github.io/capture-fixtures) |
 | UI overview | [piwitests.github.io/ui-overview](https://piwitests.github.io/ui-overview) |
 | AI diagnosis & clustering | [piwitests.github.io/ai-diagnosis](https://piwitests.github.io/ai-diagnosis) |
 | Flaky tests & analytics | [piwitests.github.io/flaky-tests](https://piwitests.github.io/flaky-tests) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ Piwi Dashboard is under active development (pre-1.0). This page shows direction,
 - Deeper CI feedback (PR annotations / status summaries).
 - More backend-log instrumentation packages beyond ASP.NET Core and Nitro.
 - Import of existing Playwright JSON reports for teams with history to migrate.
-- First-class typed capture fixtures — a published `PiwiFixtures` type (making the reserved `piwiDashboardCapture` name a compile-time collision) and a dual ESM/CJS reporter build.
+- A dual ESM/CJS reporter build (the package is CommonJS-only today; named imports work everywhere, but a native ESM default import needs an interop shim).
 
 ## Non-goals
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@ Piwi Dashboard is under active development (pre-1.0). This page shows direction,
 - Deeper CI feedback (PR annotations / status summaries).
 - More backend-log instrumentation packages beyond ASP.NET Core and Nitro.
 - Import of existing Playwright JSON reports for teams with history to migrate.
+- First-class typed capture fixtures — a published `PiwiFixtures` type (making the reserved `piwiDashboardCapture` name a compile-time collision) and a dual ESM/CJS reporter build.
 
 ## Non-goals
 

--- a/application/app/components/layout/GetStartedWizard.vue
+++ b/application/app/components/layout/GetStartedWizard.vue
@@ -159,7 +159,7 @@ const goFurtherOpen = ref(false);
             class="size-4 transition-transform duration-200"
             :class="goFurtherOpen ? 'rotate-90' : ''"
           />
-          Go further — simpler config &amp; performance metrics
+          Go further — simpler config &amp; capture fixtures
         </button>
 
         <div v-if="goFurtherOpen" class="mt-4 space-y-6">
@@ -182,14 +182,18 @@ const goFurtherOpen = ref(false);
           <!-- dashboardFixtures -->
           <div>
             <h4 class="font-medium text-sm mb-1">
-              Network requests, Web Vitals &amp; console with
+              Capture fixtures — network, Web Vitals, console &amp; locator healing with
               <code class="text-primary text-xs">dashboardFixtures</code>
             </h4>
             <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
               Extend your Playwright
               <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">test</code> with
               <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">dashboardFixtures</code> to
-              automatically capture network timing, browser Web Vitals, console errors, and ARIA snapshots on failure.
+              automatically capture network timing, browser Web Vitals, console errors, ARIA snapshots on failure, and
+              the locator snapshots that power locator healing. See the
+              <DocLink to="capture-fixtures" no-icon class="text-primary hover:underline"
+                >capture fixtures guide</DocLink
+              >.
             </p>
 
             <p class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-2">

--- a/application/app/components/layout/GetStartedWizard.vue
+++ b/application/app/components/layout/GetStartedWizard.vue
@@ -44,9 +44,9 @@ export default PiwiDashboard.wrapConfig(
 
 const fixturesExtendCode = `// tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }`;
 
 const fixturesUseCode = `// your test file
@@ -60,9 +60,9 @@ test('homepage loads', async ({ page }) => {
 
 const fixturesDropInCode = `// tests/fixtures.ts
 import { test as base } from '@playwright/test'
-import { extendDashboardFixtures } from '@piwitests/reporter'
+import { extendPiwiFixtures } from '@piwitests/reporter'
 
-export const test = extendDashboardFixtures(base)
+export const test = extendPiwiFixtures(base)
 export { expect } from '@playwright/test'`;
 
 const steps = computed(() => [
@@ -179,16 +179,16 @@ const goFurtherOpen = ref(false);
             <CodeBlock :code="wrapConfigCode" lang="typescript" />
           </div>
 
-          <!-- dashboardFixtures -->
+          <!-- piwiFixtures -->
           <div>
             <h4 class="font-medium text-sm mb-1">
               Capture fixtures — network, Web Vitals, console &amp; locator healing with
-              <code class="text-primary text-xs">dashboardFixtures</code>
+              <code class="text-primary text-xs">piwiFixtures</code>
             </h4>
             <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
               Extend your Playwright
               <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">test</code> with
-              <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">dashboardFixtures</code> to
+              <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">piwiFixtures</code> to
               automatically capture network timing, browser Web Vitals, console errors, ARIA snapshots on failure, and
               the locator snapshots that power locator healing. See the
               <DocLink to="capture-fixtures" no-icon class="text-primary hover:underline"

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -183,7 +183,7 @@ export const HELP_TOPICS = {
   'case.web-vitals': {
     title: 'Web Vitals',
     text: 'Core Web Vitals (LCP, CLS, etc.) captured during the test, measuring real loading and responsiveness of the page under test.',
-    doc: 'reporter#performance-metrics-web-vitals',
+    doc: 'capture-fixtures',
   },
   'case.traces': {
     title: 'Traces',
@@ -193,12 +193,12 @@ export const HELP_TOPICS = {
   'case.console': {
     title: 'Console output',
     text: 'Browser console messages logged while this test ran — often the first clue for a JavaScript error behind a failure.',
-    doc: 'reporter#performance-metrics-web-vitals',
+    doc: 'capture-fixtures',
   },
   'case.network': {
     title: 'Network requests',
     text: 'HTTP requests the page made during the test, with timing and status — useful for spotting failed or slow calls.',
-    doc: 'reporter#performance-metrics-web-vitals',
+    doc: 'capture-fixtures',
   },
   'case.backend-logs': {
     title: 'Backend server logs',

--- a/application/app/utils/index.ts
+++ b/application/app/utils/index.ts
@@ -245,7 +245,11 @@ export function getFileApiPath(filePath: string): string {
 }
 
 export function getTraceViewerUrl(filePath: string): string {
-  return `/trace-viewer/?trace=${encodeURIComponent(`${location.origin}/api/files/${getFileApiPath(filePath)}`)}`;
+  // `location` only exists in the browser; during SSR render the href with a
+  // relative trace URL — the client re-render fills the origin in before the
+  // link can be clicked.
+  const origin = typeof location === 'undefined' ? '' : location.origin;
+  return `/trace-viewer/?trace=${encodeURIComponent(`${origin}/api/files/${getFileApiPath(filePath)}`)}`;
 }
 
 /**

--- a/application/tests/unit/app-utils.test.ts
+++ b/application/tests/unit/app-utils.test.ts
@@ -124,6 +124,13 @@ describe('file path helpers', () => {
     expect(url).toBe(`/trace-viewer/?trace=${encodeURIComponent('http://localhost:3000/api/files/t.zip')}`);
     vi.unstubAllGlobals();
   });
+
+  test('getTraceViewerUrl falls back to a relative trace URL when location is absent (SSR)', () => {
+    vi.stubGlobal('location', undefined);
+    const url = getTraceViewerUrl('t.zip');
+    expect(url).toBe(`/trace-viewer/?trace=${encodeURIComponent('/api/files/t.zip')}`);
+    vi.unstubAllGlobals();
+  });
 });
 
 describe('errorMessage (fetch error unwrapping)', () => {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -54,6 +54,7 @@ export default defineConfig({
       { text: 'Why Piwi? (comparison & FAQ)', link: '/comparison' },
       { text: 'UI overview', link: '/ui-overview' },
       { text: 'Reporter', link: '/reporter' },
+      { text: 'Capture fixtures', link: '/capture-fixtures' },
       {
         text: 'Features',
         items: [

--- a/docs/ai-diagnosis.md
+++ b/docs/ai-diagnosis.md
@@ -180,7 +180,7 @@ When the failure is a broken locator, the context includes an **Alternative Loca
   <figcaption>The Alternative locators panel — the broken locator, ranked replacements scored for stability, and a single recommended fix that preserves your locator style.</figcaption>
 </figure>
 
-This evidence is generated from the locator snapshots recorded by the [capture fixtures](./capture-fixtures) while tests run — make sure your specs import `test` from a fixtures file that extends `dashboardFixtures`. Capture is gated by the default-on `captureLocators` reporter option. The same data drives the standalone **Alternative locators** panel on the test-case and cluster pages.
+This evidence is generated from the locator snapshots recorded by the [capture fixtures](./capture-fixtures) while tests run — make sure your specs import `test` from a fixtures file that extends `piwiFixtures`. Capture is gated by the default-on `captureLocators` reporter option. The same data drives the standalone **Alternative locators** panel on the test-case and cluster pages.
 
 ## Custom instructions
 

--- a/docs/ai-diagnosis.md
+++ b/docs/ai-diagnosis.md
@@ -180,7 +180,7 @@ When the failure is a broken locator, the context includes an **Alternative Loca
   <figcaption>The Alternative locators panel — the broken locator, ranked replacements scored for stability, and a single recommended fix that preserves your locator style.</figcaption>
 </figure>
 
-This evidence is generated automatically from the [locator snapshots](./reporter#locator-healing) the reporter captures while tests run; no configuration is required beyond the default-on `captureLocators` reporter option. The same data drives the standalone **Alternative locators** panel on the test-case and cluster pages.
+This evidence is generated from the locator snapshots recorded by the [capture fixtures](./capture-fixtures) while tests run — make sure your specs import `test` from a fixtures file that extends `dashboardFixtures`. Capture is gated by the default-on `captureLocators` reporter option. The same data drives the standalone **Alternative locators** panel on the test-case and cluster pages.
 
 ## Custom instructions
 

--- a/docs/backend-logs.md
+++ b/docs/backend-logs.md
@@ -69,14 +69,14 @@ The plugin is auto-loaded by Nitro. It captures `consola` Warning/Error entries 
 
 On the Playwright side, the reporter reads `X-Piwi-Logs` automatically from every captured network response. No additional configuration is needed beyond having the fixtures active.
 
-Make sure your test files import `test` from the Piwi Dashboard fixtures (or extend with `dashboardFixtures`) so network requests are captured:
+Make sure your test files import `test` from the Piwi Dashboard fixtures (or extend with `piwiFixtures`) so network requests are captured:
 
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 

--- a/docs/backend-logs.md
+++ b/docs/backend-logs.md
@@ -80,7 +80,7 @@ export const test = base.extend(dashboardFixtures)
 export { expect }
 ```
 
-See [Reporter → Performance metrics & Web Vitals](/reporter#performance-metrics-web-vitals) for details.
+See the [capture fixtures guide](/capture-fixtures) for details.
 
 ## Log entry format
 

--- a/docs/capture-fixtures.md
+++ b/docs/capture-fixtures.md
@@ -1,0 +1,134 @@
+---
+title: Capture fixtures
+lang: en-US
+---
+
+# Capture fixtures
+
+The [reporter](./reporter) uploads complete test results — statuses, errors, traces, HTML reports — without any change to your test code. The **capture fixtures** are an optional, one-file addition that observes your tests from the inside and unlocks the dashboard's richest features: slow-endpoint analysis, Web Vitals, console capture, failure-time ARIA snapshots, and [locator healing](./reporter#locator-healing).
+
+If you do one thing beyond installing the reporter, do this.
+
+## Setup
+
+**Option A — extend your existing fixtures:**
+
+```typescript
+// tests/fixtures.ts
+import { test as base, expect } from '@playwright/test'
+import { dashboardFixtures } from '@piwitests/reporter'
+
+export const test = base.extend(dashboardFixtures)
+export { expect }
+```
+
+**Option B — one-line extend with `extendDashboardFixtures`:**
+
+```typescript
+// tests/fixtures.ts
+import { test as base } from '@playwright/test'
+import { extendDashboardFixtures } from '@piwitests/reporter'
+
+export const test = extendDashboardFixtures(base)
+export { expect } from '@playwright/test'
+```
+
+Then import `test` from your fixtures file **in every spec**. A spec that imports `test` from `@playwright/test` directly still runs and reports fine — it just isn't captured:
+
+```typescript
+import { test, expect } from './fixtures'
+
+test('homepage loads', async ({ page }) => {
+  await page.goto('/')
+  // network, console, Web Vitals, and locator data are captured automatically
+})
+```
+
+That's the entire setup — there is nothing to start, wrap, or await inside your tests.
+
+## What gets captured
+
+| Data | Captured | Powers |
+|------|----------|--------|
+| **Network requests** — method, URL, status, duration, content type. Only API/document traffic (fetch, XHR, document); static assets are skipped | per request | *Slow API endpoints* table on the [run page](./ui-overview#test-run-detail) with `/api/users/:id`-style route normalization; [backend log correlation](./backend-logs) via the `X-Piwi-Logs` response header |
+| **Console entries** — `warning`, `error`, and `assert` messages with source location (`console.log` noise is not collected) | as they happen | Console card on the [test case page](./ui-overview#test-case-detail); [AI diagnosis](./ai-diagnosis) evidence |
+| **Web Vitals** — TTFB, DOM Interactive, DOMContentLoaded, Load Complete, First Paint, First Contentful Paint | at test teardown | Web vitals card with color-coded thresholds; [performance trends](./flaky-tests#performance) |
+| **ARIA snapshot** of the final page state | on failure | Failure evidence on the test-case and cluster pages; [AI diagnosis](./ai-diagnosis) context |
+| **Locator snapshots** — element attributes plus ranked alternative locators for each acted-on element, stamped with the call site | after each successful action | [Locator healing](./reporter#locator-healing); when a failing name-based locator (`getByRole`, `getByText`, `getByLabel`, …) matches nothing, a fresh suggestion is attached to the test as a Playwright annotation |
+
+## With and without the fixtures
+
+The reporter degrades gracefully — nothing breaks without the fixtures. This is exactly what you give up:
+
+| Dashboard feature | Reporter only | Reporter + fixtures |
+|-------------------|:-:|:-:|
+| Run history, statuses, errors, traces, HTML reports | ✅ | ✅ |
+| Live streaming, sharding, CI/SCM metadata | ✅ | ✅ |
+| Failure clustering & flaky-test analytics | ✅ | ✅ |
+| AI failure diagnosis | ✅ error + code-diff grounding | ✅ richer evidence: ARIA snapshot, console, network |
+| Slow API endpoints table | — | ✅ |
+| Web Vitals & performance trends | — | ✅ |
+| Console warnings/errors card | — | ✅ |
+| Failure-time ARIA snapshot + locator suggestion | — | ✅ |
+| Locator healing (ranked alternatives panel) | — | ✅ |
+| Backend log correlation | — | ✅ with a [backend integration](./backend-logs) |
+
+## Where capture works
+
+The fixtures wire capture at the **browser** level, so it works however your tests create pages:
+
+- the standard `page` fixture,
+- `browser.newPage()` and `browser.newContext().newPage()` — including inside your own custom fixtures,
+- popups (`window.open`) and pages a context opens on its own.
+
+Semantics worth knowing:
+
+- **`beforeAll` / `afterAll` activity is intentionally not captured** — only what happens inside a test is attributed to that test.
+- **Multi-page tests** attribute Web Vitals and the failure ARIA snapshot to the most recently active page.
+- **Repeated call sites** (actions in loops) keep the latest capture per call site — the dashboard stores one locator snapshot per location.
+
+## Composing with your own fixtures
+
+`dashboardFixtures` is a plain Playwright fixtures object, so it composes with your own fixtures in any order:
+
+```typescript
+import { test as base, mergeTests } from '@playwright/test'
+import { dashboardFixtures, extendDashboardFixtures } from '@piwitests/reporter'
+
+// Your fixtures first, capture second
+export const test = base.extend<MyFixtures>({ /* ... */ }).extend(dashboardFixtures)
+
+// Capture first, your fixtures second
+export const test = extendDashboardFixtures(base).extend<MyFixtures>({ /* ... */ })
+
+// Or merge two independent test objects
+export const test = mergeTests(myTest, extendDashboardFixtures(base))
+```
+
+Two rules:
+
+- The fixture name **`piwiDashboardCapture` is reserved** — defining your own fixture with that name replaces the capture teardown and silently disables the attachments.
+- If you **override `browser` or `page` yourself**, extend with `dashboardFixtures` *after* your override so the capture wrapping still applies.
+
+## Cost & opt-outs
+
+Capture is designed to never fail or noticeably slow down a test:
+
+- Per action: one DOM read, and occasionally a bounded ARIA snapshot (500 ms deadline).
+- At teardown: draining in-flight captures is capped at 2 seconds.
+- A capture that can't complete (mid-navigation, detached element) is dropped silently — it never throws into your test.
+
+| Option | Effect |
+|--------|--------|
+| `collectPerformanceMetrics: false` | Master switch — disables all fixture capture |
+| `captureLocators: false` (or `PIWI_CAPTURE_LOCATORS=false`) | Disables only the per-action locator snapshots; network, console, and Web Vitals stay on |
+
+## Troubleshooting
+
+- **Data missing for some specs only** — those specs import `test` from `@playwright/test` instead of your fixtures file. Capture is per-`test`-object; the import is the switch.
+- **No fixture data at all** — check that `collectPerformanceMetrics` is not `false`, and that tests navigate to a real page (`about:blank`-only tests produce no Web Vitals).
+- **ARIA snapshot or locator healing missing** — same root causes as above; also check `captureLocators` / `PIWI_CAPTURE_LOCATORS`.
+
+## Try it
+
+A runnable example project exercising every capture path — including an intentionally failing test that lights up the ARIA snapshot, the locator suggestion, and the healing panel — lives in [`examples/playwright-fixtures`](https://github.com/PiwiTests/platform/tree/main/examples/playwright-fixtures).

--- a/docs/capture-fixtures.md
+++ b/docs/capture-fixtures.md
@@ -16,20 +16,20 @@ If you do one thing beyond installing the reporter, do this.
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 
-**Option B — one-line extend with `extendDashboardFixtures`:**
+**Option B — one-line extend with `extendPiwiFixtures`:**
 
 ```typescript
 // tests/fixtures.ts
 import { test as base } from '@playwright/test'
-import { extendDashboardFixtures } from '@piwitests/reporter'
+import { extendPiwiFixtures } from '@piwitests/reporter'
 
-export const test = extendDashboardFixtures(base)
+export const test = extendPiwiFixtures(base)
 export { expect } from '@playwright/test'
 ```
 
@@ -45,6 +45,10 @@ test('homepage loads', async ({ page }) => {
 ```
 
 That's the entire setup — there is nothing to start, wrap, or await inside your tests.
+
+::: tip Renamed in a later release
+`piwiFixtures` / `extendPiwiFixtures` were named `dashboardFixtures` / `extendDashboardFixtures` in `@piwitests/reporter@0.9.x`. The old names remain exported as deprecated aliases, so existing setups keep working — new code should use `piwiFixtures`.
+:::
 
 ## What gets captured
 
@@ -89,26 +93,26 @@ Semantics worth knowing:
 
 ## Composing with your own fixtures
 
-`dashboardFixtures` is a plain Playwright fixtures object, so it composes with your own fixtures in any order:
+`piwiFixtures` is a plain Playwright fixtures object, so it composes with your own fixtures in any order:
 
 ```typescript
 import { test as base, mergeTests } from '@playwright/test'
-import { dashboardFixtures, extendDashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures, extendPiwiFixtures } from '@piwitests/reporter'
 
 // Your fixtures first, capture second
-export const test = base.extend<MyFixtures>({ /* ... */ }).extend(dashboardFixtures)
+export const test = base.extend<MyFixtures>({ /* ... */ }).extend(piwiFixtures)
 
 // Capture first, your fixtures second
-export const test = extendDashboardFixtures(base).extend<MyFixtures>({ /* ... */ })
+export const test = extendPiwiFixtures(base).extend<MyFixtures>({ /* ... */ })
 
 // Or merge two independent test objects
-export const test = mergeTests(myTest, extendDashboardFixtures(base))
+export const test = mergeTests(myTest, extendPiwiFixtures(base))
 ```
 
 Two rules:
 
-- The fixture name **`piwiDashboardCapture` is reserved** — defining your own fixture with that name replaces the capture teardown and silently disables the attachments.
-- If you **override `browser` or `page` yourself**, extend with `dashboardFixtures` *after* your override so the capture wrapping still applies.
+- The fixture name **`piwiCapture` is reserved** — defining your own fixture with that name replaces the capture teardown and silently disables the attachments. `piwiFixtures` types it, so a redefinition with an incompatible type is a compile error; a same-typed (`void`) one still compiles, so avoid the name entirely.
+- If you **override `browser` or `page` yourself**, extend with `piwiFixtures` *after* your override so the capture wrapping still applies.
 
 ## Cost & opt-outs
 

--- a/docs/capture-fixtures.md
+++ b/docs/capture-fixtures.md
@@ -46,10 +46,6 @@ test('homepage loads', async ({ page }) => {
 
 That's the entire setup — there is nothing to start, wrap, or await inside your tests.
 
-::: tip Renamed in a later release
-`piwiFixtures` / `extendPiwiFixtures` were named `dashboardFixtures` / `extendDashboardFixtures` in `@piwitests/reporter@0.9.x`. The old names remain exported as deprecated aliases, so existing setups keep working — new code should use `piwiFixtures`.
-:::
-
 ## What gets captured
 
 | Data | Captured | Powers |

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -82,6 +82,8 @@ Toggle filters on the run's test-case list to show only new regressions or new f
 - **Network analysis** — slow API calls grouped by method and normalized route (e.g. `/api/users/:id`).
 - **Browser Web Vitals** — TTFB, DOMContentLoaded, FCP and more, with color-coded thresholds.
 
+Network analysis and Web Vitals require the [capture fixtures](./capture-fixtures) in your test setup.
+
 <figure>
   <img src="/screenshots/performance-trends.png" alt="Performance tab showing the duration trend chart and slowest-tests table">
   <figcaption>The Performance tab — average and P90 duration trends over time, followed by a ranked table of the slowest tests.</figcaption>
@@ -94,5 +96,6 @@ A project-level overview groups test cases by spec file and colors each by pass 
 ## See also
 
 - [UI overview](./ui-overview) — where each of these views lives in the dashboard
-- [Reporter](./reporter) — how retries, traces, network, and Web Vitals get captured
+- [Reporter](./reporter) — how retries, traces, and run metadata get captured
+- [Capture fixtures](./capture-fixtures) — the test-side setup behind network analysis and Web Vitals
 - [AI diagnosis & failure clustering](./ai-diagnosis) — explain the failures behind the trends

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,9 +171,9 @@ One small file unlocks the dashboard's richest features — locator healing, the
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,6 +164,27 @@ npx playwright test
 
 See the [Reporter](./reporter) page for the full configuration reference, including live streaming, multiple report types, performance metrics, and authentication.
 
+### Recommended: capture fixtures
+
+One small file unlocks the dashboard's richest features — locator healing, the slow-endpoints table, Web Vitals, console capture, and failure-time ARIA snapshots:
+
+```typescript
+// tests/fixtures.ts
+import { test as base, expect } from '@playwright/test'
+import { dashboardFixtures } from '@piwitests/reporter'
+
+export const test = base.extend(dashboardFixtures)
+export { expect }
+```
+
+Then import `test` from this file in your specs instead of `@playwright/test`:
+
+```typescript
+import { test, expect } from './fixtures'
+```
+
+The reporter works fine without this — see the [capture fixtures guide](./capture-fixtures) for exactly what the fixtures add, composition patterns, and troubleshooting.
+
 ## Running in CI
 
 Nothing Piwi-specific is required in CI — the reporter runs inside `npx playwright test` and pushes results to your dashboard. Point the reporter at your deployed instance (via the `PIWI_DASHBOARD_URL` env var or the `serverUrl` option) and pass an API key if [authentication](./authentication) is enabled. CI metadata (workflow, branch, commit, run URL) and [shard merging](./reporter#sharding) are detected automatically on GitHub Actions, GitLab CI, Jenkins, CircleCI, Azure DevOps, and more.

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -34,6 +34,54 @@ export default defineConfig({
 })
 ```
 
+<a id="performance-metrics-web-vitals"></a>
+
+## Capture fixtures
+
+The reporter works without any test-code changes, but adding the **capture fixtures** to your test setup unlocks the dashboard's richest features — network timing and the *Slow API endpoints* table, browser Web Vitals, console capture, failure-time ARIA snapshots, and [locator healing](#locator-healing). See the [capture fixtures guide](./capture-fixtures) for the full with/without feature matrix, composition patterns, and troubleshooting.
+
+**Option A – extend your existing fixtures:**
+
+```typescript
+// tests/fixtures.ts
+import { test as base, expect } from '@playwright/test'
+import { dashboardFixtures } from '@piwitests/reporter'
+
+export const test = base.extend(dashboardFixtures)
+export { expect }
+```
+
+Then import `test` from your fixture file in every test:
+
+```typescript
+import { test, expect } from './fixtures'
+
+test('homepage loads', async ({ page }) => {
+  await page.goto('/')
+  // network requests & web vitals are captured automatically
+})
+```
+
+**Option B – one-line extend with `extendDashboardFixtures`:**
+
+```typescript
+import { test as base } from '@playwright/test'
+import { extendDashboardFixtures } from '@piwitests/reporter'
+
+export const test = extendDashboardFixtures(base)
+export { expect } from '@playwright/test'
+```
+
+### What gets captured
+
+- **Network requests** — method, URL, status code, duration, resource type. Aggregated on the dashboard into a *Slow API endpoints* table grouped by `METHOD + normalized route` (e.g. `/api/users/:id`).
+- **Console entries** — `warning`, `error`, and `assert` messages with their source location, shown on the test case page and included in the AI diagnosis evidence.
+- **Browser Web Vitals** — TTFB, DOM Interactive, DOMContentLoaded, Load Complete, First Paint, First Contentful Paint — displayed with color-coded thresholds.
+- **ARIA snapshot** — Captured automatically on failed/timed-out tests via `page.locator(':root').ariaSnapshot()`. Included in both the debug prompt (`/test-cases/:id`) and the cluster AI diagnosis context.
+- **Locator snapshots** — For each acted-on element (click, fill, etc.) the fixtures record the element's attributes and a ranked list of alternative locators, stamped with the call site. These power [locator healing](#locator-healing) when a locator later breaks. Gated by `captureLocators` (default on).
+
+These are only collected when `collectPerformanceMetrics` is `true` (the default). If fixture data does not appear in the dashboard, the most likely cause is that your test files import `test` from `@playwright/test` directly instead of from your fixtures file (see options A/B above).
+
 ## Configuration options
 
 | Option                      | Type     | Default                   | Description                                                                                 |
@@ -246,56 +294,11 @@ Built-in report types with auto-detected directories:
 
 Any other type is also accepted; the directory must be provided via `dir`.
 
-## Performance metrics & Web Vitals
-
-To automatically capture network request timing and browser Web Vitals, use the `dashboardFixtures` in your test setup.
-
-**Option A – extend your existing fixtures:**
-
-```typescript
-// tests/fixtures.ts
-import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
-
-export const test = base.extend(dashboardFixtures)
-export { expect }
-```
-
-Then import `test` from your fixture file in every test:
-
-```typescript
-import { test, expect } from './fixtures'
-
-test('homepage loads', async ({ page }) => {
-  await page.goto('/')
-  // network requests & web vitals are captured automatically
-})
-```
-
-**Option B – one-line extend with `extendDashboardFixtures`:**
-
-```typescript
-import { test as base } from '@playwright/test'
-import { extendDashboardFixtures } from '@piwitests/reporter'
-
-export const test = extendDashboardFixtures(base)
-export { expect } from '@playwright/test'
-```
-
-### What gets captured
-
-- **Network requests** — method, URL, status code, duration, resource type. Aggregated on the dashboard into a *Slow API endpoints* table grouped by `METHOD + normalized route` (e.g. `/api/users/:id`).
-- **Browser Web Vitals** — TTFB, DOM Interactive, DOMContentLoaded, Load Complete, First Paint, First Contentful Paint — displayed with color-coded thresholds.
-- **ARIA snapshot** — Captured automatically on failed/timed-out tests via `page.locator(':root').ariaSnapshot()`. Included in both the debug prompt (`/test-cases/:id`) and the cluster AI diagnosis context.
-- **Locator snapshots** — For each acted-on element (click, fill, etc.) the fixtures record the element's attributes and a ranked list of alternative locators, stamped with the call site. These power [locator healing](#locator-healing) when a locator later breaks. Gated by `captureLocators` (default on).
-
-These are only collected when `collectPerformanceMetrics` is `true` (the default). If the ARIA snapshot does not appear in the dashboard, the most likely cause is that your test files do not import `test` from the package's fixtures subpath (see options A/B above).
-
 ## Locator healing
 
 When a locator stops matching — a button was renamed, an element moved, a hashed class changed — Piwi suggests concrete, ranked replacements instead of leaving you to guess.
 
-While tests run, the fixtures wrap Playwright's locator methods (`getByRole`, `getByTestId`, `locator`, …) and, after each successful action, record the target element's attributes plus a list of alternative locators ranked by a stability score (`data-testid` = 100, role + accessible name ≈ 90, semantic CSS ≈ 35–40, hash-suffixed ≈ 10). Each candidate selector is probed against the live page for uniqueness — alternatives that would match several elements (strict-mode violations) are dropped at capture time. Live input *values* are never captured, so filled-in secrets can't leak into snapshots. One row per call site is upserted into the `locator_snapshots` table, so the latest known-good snapshot for every locator is always available.
+While tests run, the [capture fixtures](./capture-fixtures) wrap Playwright's locator methods (`getByRole`, `getByTestId`, `locator`, …) and, after each successful action, record the target element's attributes plus a list of alternative locators ranked by a stability score (`data-testid` = 100, role + accessible name ≈ 90, semantic CSS ≈ 35–40, hash-suffixed ≈ 10). Each candidate selector is probed against the live page for uniqueness — alternatives that would match several elements (strict-mode violations) are dropped at capture time. Live input *values* are never captured, so filled-in secrets can't leak into snapshots. One row per call site is upserted into the `locator_snapshots` table, so the latest known-good snapshot for every locator is always available.
 
 When a locator later fails, the server resolves replacements through a ladder, most-trustworthy first:
 
@@ -413,7 +416,7 @@ export default defineConfig({
 2. After all tests complete, it uploads results to the dashboard.
 3. If `uploadReport` is enabled, the entire `playwright-report/` directory is compressed with gzip and uploaded.
 4. If `uploadTraces` is enabled, all trace files found in test attachments are uploaded.
-5. If `dashboardFixtures` are active, network request and web vitals attachments are included per test case.
+5. If the [capture fixtures](./capture-fixtures) are active, network requests, console entries, Web Vitals, failure-time ARIA snapshots, and locator snapshots are included per test case.
 6. The server decompresses the report and makes it available for viewing, with fully functional HTML reports.
 
 ## Troubleshooting
@@ -424,11 +427,12 @@ export default defineConfig({
 - Make sure traces are enabled: `use: { trace: 'retain-on-failure' }`
 - Check the dashboard server is running and accessible at `serverUrl`
 
-### Network/Web Vitals not appearing
+### Fixture data not appearing (network, Web Vitals, console, ARIA snapshot, locator healing)
 
-- Extend your `test` with `dashboardFixtures` / `extendDashboardFixtures` from `@piwitests/reporter`
-- Verify `collectPerformanceMetrics` is not set to `false`
+- Extend your `test` with `dashboardFixtures` / `extendDashboardFixtures` from `@piwitests/reporter`, and make sure every spec imports `test` from your fixtures file — not from `@playwright/test` directly
+- Verify `collectPerformanceMetrics` is not set to `false` (and `captureLocators` for locator healing)
 - Ensure tests navigate to at least one page (`await page.goto(...)`)
+- See the [capture fixtures guide](./capture-fixtures) for details
 
 ### Connection errors
 
@@ -495,7 +499,7 @@ The compiled output is what Playwright loads at runtime. The package has a singl
 
 ### Source layout
 
-The package separates its **public API** (`src/index.ts`, `src/fixtures.ts`, and `src/public/`) from internal plumbing (`src/internal/<domain>/` — `submit`, `transport`, `streaming`, `collect`, `files`, `capture`, `config`, `support`) and the type model (`src/types/`, where `wire.ts` is the server contract and `collected.ts` the in-process model).
+The package separates its **public API** (`src/index.ts` and `src/public/`) from internal plumbing (`src/internal/<domain>/` — `submit`, `transport`, `streaming`, `collect`, `files`, `capture`, `config`, `support`) and the type model (`src/types/`, where `wire.ts` is the server contract and `collected.ts` the in-process model).
 
 See **`reporter/ARCHITECTURE.md`** in the repository for the full map: the public/internal split, the two-process collect-and-submit data flow, the fallback ladder, and the package conventions.
 

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -45,9 +45,9 @@ The reporter works without any test-code changes, but adding the **capture fixtu
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 
@@ -62,15 +62,17 @@ test('homepage loads', async ({ page }) => {
 })
 ```
 
-**Option B – one-line extend with `extendDashboardFixtures`:**
+**Option B – one-line extend with `extendPiwiFixtures`:**
 
 ```typescript
 import { test as base } from '@playwright/test'
-import { extendDashboardFixtures } from '@piwitests/reporter'
+import { extendPiwiFixtures } from '@piwitests/reporter'
 
-export const test = extendDashboardFixtures(base)
+export const test = extendPiwiFixtures(base)
 export { expect } from '@playwright/test'
 ```
+
+> `piwiFixtures` / `extendPiwiFixtures` were named `dashboardFixtures` / `extendDashboardFixtures` in `0.9.x`; the old names still work as deprecated aliases.
 
 ### What gets captured
 
@@ -429,7 +431,7 @@ export default defineConfig({
 
 ### Fixture data not appearing (network, Web Vitals, console, ARIA snapshot, locator healing)
 
-- Extend your `test` with `dashboardFixtures` / `extendDashboardFixtures` from `@piwitests/reporter`, and make sure every spec imports `test` from your fixtures file — not from `@playwright/test` directly
+- Extend your `test` with `piwiFixtures` / `extendPiwiFixtures` from `@piwitests/reporter`, and make sure every spec imports `test` from your fixtures file — not from `@playwright/test` directly
 - Verify `collectPerformanceMetrics` is not set to `false` (and `captureLocators` for locator healing)
 - Ensure tests navigate to at least one page (`await page.goto(...)`)
 - See the [capture fixtures guide](./capture-fixtures) for details

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -73,8 +73,6 @@ export const test = extendPiwiFixtures(base)
 export { expect } from '@playwright/test'
 ```
 
-> `piwiFixtures` / `extendPiwiFixtures` were named `dashboardFixtures` / `extendDashboardFixtures` in `0.9.x`; the old names still work as deprecated aliases.
-
 ### What gets captured
 
 - **Network requests** — method, URL, status code, duration, resource type. Aggregated on the dashboard into a *Slow API endpoints* table grouped by `METHOD + normalized route` (e.g. `/api/users/:id`).

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -70,7 +70,7 @@ The right panel is tabbed:
 - **Regression** *(shown when a baseline exists)* — the regression delta for this run at a glance.
 - **Timeline** — a horizontal per-worker timeline of test execution, with a span-type filter to isolate test phases (setup, actual test, wasted waits, teardown); click a bar to jump to that test case.
 - **Compare** — pick a baseline run for a side-by-side delta (improved / regressed / unchanged).
-- **Slow endpoints** — network requests grouped by method + normalized route, with avg/p90/max duration and error rate.
+- **Slow endpoints** — network requests grouped by method + normalized route, with avg/p90/max duration and error rate. Requires the [capture fixtures](./capture-fixtures).
 
 Administrators can **delete** the entire run and its files from the header.
 
@@ -78,7 +78,7 @@ Administrators can **delete** the entire run and its files from the header.
 
 Everything about a single test execution: a **status card** (id, title, copyable location, duration, worker, retries, slowest step, duration-vs-average), **run context** (environment, CI, branch, commit, author, browser), a link into the specific test in the HTML report, and attached **traces** (open in the Playwright viewer or download; they stream in live while the parent run is in progress).
 
-For a failed test the page opens on the **Failure** tab, which leads with the raw **error** (copyable), then — when the failure belongs to a cluster — a banner linking to the [failure cluster](#failure-cluster-detail) where the full investigation lives (cross-test evidence, what changed since the last green run, and AI diagnosis); below that, **alternative locators** when a locator broke, with ranked replacements and a recommended fix (see [locator healing](./reporter#locator-healing)), and the failure-time **ARIA snapshot**. The other tabs cover **performance hints**, execution **steps**, **Web Vitals** with color-coded thresholds, **network requests** with inline backend server logs (see [Backend logs](./backend-logs)), and a **history** chart of this test's status and duration over time.
+For a failed test the page opens on the **Failure** tab, which leads with the raw **error** (copyable), then — when the failure belongs to a cluster — a banner linking to the [failure cluster](#failure-cluster-detail) where the full investigation lives (cross-test evidence, what changed since the last green run, and AI diagnosis); below that, **alternative locators** when a locator broke, with ranked replacements and a recommended fix (see [locator healing](./reporter#locator-healing)), and the failure-time **ARIA snapshot**. The other tabs cover **performance hints**, execution **steps**, **Web Vitals** with color-coded thresholds, **network requests** with inline backend server logs (see [Backend logs](./backend-logs)), and a **history** chart of this test's status and duration over time. The Web Vitals, network, console, ARIA-snapshot, and alternative-locators data all come from the [capture fixtures](./capture-fixtures).
 
 <figure>
   <img src="/screenshots/test-case-detail.png" alt="Test case detail page with summary stats, duration trend, status history, and recent executions">

--- a/examples/playwright-fixtures/.gitignore
+++ b/examples/playwright-fixtures/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+# The example floats on the latest published @piwitests/reporter — no lockfile.
+package-lock.json

--- a/examples/playwright-fixtures/README.md
+++ b/examples/playwright-fixtures/README.md
@@ -37,8 +37,8 @@ Results appear at `http://localhost:3000` under the `playwright-fixtures-example
 
 ## The two setup options
 
-- `tests/fixtures.ts` — **Option A**: `base.extend(dashboardFixtures)`
-- `tests/fixtures-composed.ts` — **Option B + composition**: `extendDashboardFixtures(base).extend<MyFixtures>({ … })`
+- `tests/fixtures.ts` — **Option A**: `base.extend(piwiFixtures)`
+- `tests/fixtures-composed.ts` — **Option B + composition**: `extendPiwiFixtures(base).extend<MyFixtures>({ … })`
 
 Every spec imports `test` from one of these files — never from `@playwright/test` directly. That import is what switches capture on.
 

--- a/examples/playwright-fixtures/README.md
+++ b/examples/playwright-fixtures/README.md
@@ -1,0 +1,48 @@
+# Capture fixtures example
+
+A small, runnable Playwright project wired to [Piwi Dashboard](https://piwitests.github.io) with the **[capture fixtures](https://piwitests.github.io/capture-fixtures)** — the one-file addition that unlocks slow-endpoint analysis, Web Vitals, console capture, failure-time ARIA snapshots, and locator healing.
+
+It tests a tiny dependency-free web app (`app/server.mjs`, started automatically by Playwright) and exercises **every capture path** the fixtures support.
+
+## Run it
+
+Start a dashboard (see the [getting started guide](https://piwitests.github.io/getting-started)), then:
+
+```bash
+npm install
+npx playwright install chromium
+npm test
+```
+
+Results appear at `http://localhost:3000` under the `playwright-fixtures-example` project. Point elsewhere with `PIWI_DASHBOARD_URL` / `PIWI_PROJECT_NAME`.
+
+> **One test fails on purpose.** `failing-locator.spec.ts` clicks a renamed `data-testid` to demonstrate what the fixtures capture on failure — the ARIA snapshot, a fresh locator suggestion (Playwright annotation), and the dashboard's *Alternative locators* panel.
+
+## What each spec demonstrates
+
+| Spec | Capture path |
+|------|--------------|
+| `home.spec.ts` | The standard `page` fixture: locator actions, `fetch` traffic, page `console.warn` |
+| `form.spec.ts` | Labeled form fields → locator snapshots with `getByLabel` alternatives; XHR POST in the network capture |
+| `browser-newpage.spec.ts` | Pages created from the worker-scoped `browser` fixture (no `page` fixture) |
+| `context-newpage.spec.ts` | Pages created from `browser.newContext()` |
+| `popup.spec.ts` | Popup windows (`window.open`) — console + network captured inside the popup |
+| `multi-page.spec.ts` | Two pages in one test — Web Vitals attributed to the most recently active page |
+| `failing-locator.spec.ts` | **Intentional failure** → ARIA snapshot, locator suggestion, locator healing |
+| `console.spec.ts` | `console.warn` / `error` / `assert` captured; `console.log` intentionally not |
+| `slow-endpoint.spec.ts` | A slow API call plus `/api/users/1` and `/api/users/2` — grouped as `/api/users/:id` in the *Slow endpoints* tab |
+| `skipped.spec.ts` | Skipped tests produce no capture attachments |
+| `before-all.spec.ts` | `beforeAll` activity is intentionally **not** captured |
+| `custom-fixtures.spec.ts` | Dashboard capture composed with your own fixtures (`fixtures-composed.ts`) |
+
+## The two setup options
+
+- `tests/fixtures.ts` — **Option A**: `base.extend(dashboardFixtures)`
+- `tests/fixtures-composed.ts` — **Option B + composition**: `extendDashboardFixtures(base).extend<MyFixtures>({ … })`
+
+Every spec imports `test` from one of these files — never from `@playwright/test` directly. That import is what switches capture on.
+
+## The two reporter wirings
+
+- `playwright.config.ts` — **recommended**: `wrapConfig` injects the reporter + global setup (`npm test`)
+- `playwright.manual-reporter.config.ts` — plain `reporter` array (`npm run test:manual-reporter`)

--- a/examples/playwright-fixtures/app/server.mjs
+++ b/examples/playwright-fixtures/app/server.mjs
@@ -1,0 +1,142 @@
+/**
+ * Tiny dependency-free web app used as the system under test.
+ *
+ * Pages exercise every capture path of the Piwi Dashboard fixtures:
+ * API calls (fetch + XHR), console output, a popup window, labeled form
+ * fields, a slow endpoint, and parameterized routes.
+ */
+import { createServer } from 'node:http';
+
+const PORT = Number(process.env.PORT || 4173);
+
+const page = (title, body) => `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${title}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 40rem; padding: 0 1rem; }
+    nav a { margin-right: 1rem; }
+    label { display: block; margin-top: 0.75rem; }
+    input, textarea, select { display: block; margin-top: 0.25rem; width: 100%; max-width: 24rem; }
+    button { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <nav><a href="/">Home</a><a href="/form">Form</a><a href="/popup">Popup</a><a href="/slow">Slow</a></nav>
+  ${body}
+</body>
+</html>`;
+
+const PAGES = {
+  '/': page(
+    'Piwi fixtures demo',
+    `<h1>Piwi fixtures demo</h1>
+     <p>A small app exercised by the example Playwright suite.</p>
+     <button data-testid="load-items">Load items</button>
+     <ul id="items"></ul>
+     <script>
+       console.warn('demo: home page loaded');
+       document.querySelector('[data-testid="load-items"]').addEventListener('click', async () => {
+         const items = await (await fetch('/api/items')).json();
+         document.getElementById('items').innerHTML = items.map((i) => '<li>' + i.name + '</li>').join('');
+       });
+     </script>`,
+  ),
+
+  '/form': page(
+    'Contact form',
+    `<h1>Contact form</h1>
+     <form id="contact">
+       <label for="email">Email</label>
+       <input id="email" name="email" type="email">
+       <label for="message">Message</label>
+       <textarea id="message" name="message"></textarea>
+       <label for="priority">Priority</label>
+       <select id="priority" name="priority">
+         <option value="low">Low</option>
+         <option value="high">High</option>
+       </select>
+       <button type="submit">Send</button>
+     </form>
+     <p id="result"></p>
+     <script>
+       document.getElementById('contact').addEventListener('submit', (event) => {
+         event.preventDefault();
+         const email = document.getElementById('email').value;
+         if (!email) {
+           console.error('demo: email is required');
+           return;
+         }
+         const xhr = new XMLHttpRequest();
+         xhr.open('POST', '/api/submit');
+         xhr.setRequestHeader('Content-Type', 'application/json');
+         xhr.onload = () => { document.getElementById('result').textContent = 'Sent!'; };
+         xhr.send(JSON.stringify({ email }));
+       });
+     </script>`,
+  ),
+
+  '/popup': page(
+    'Popup launcher',
+    `<h1>Popup launcher</h1>
+     <button data-testid="open-child">Open child window</button>
+     <script>
+       document.querySelector('[data-testid="open-child"]').addEventListener('click', () => {
+         window.open('/child', '_blank');
+       });
+     </script>`,
+  ),
+
+  '/child': page(
+    'Child window',
+    `<h1>Child window</h1>
+     <button data-testid="child-action">Child action</button>
+     <p id="child-result"></p>
+     <script>
+       console.warn('demo: child window opened');
+       document.querySelector('[data-testid="child-action"]').addEventListener('click', async () => {
+         await fetch('/api/child');
+         document.getElementById('child-result').textContent = 'child done';
+       });
+     </script>`,
+  ),
+
+  '/slow': page(
+    'Slow endpoint',
+    `<h1>Slow endpoint</h1>
+     <p id="status">loading…</p>
+     <script>
+       Promise.all([fetch('/api/slow'), fetch('/api/users/1'), fetch('/api/users/2')])
+         .then(() => { document.getElementById('status').textContent = 'done'; });
+     </script>`,
+  ),
+};
+
+const json = (res, body, delayMs = 0) => {
+  setTimeout(() => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  }, delayMs);
+};
+
+createServer((req, res) => {
+  const path = new URL(req.url, `http://localhost:${PORT}`).pathname;
+
+  if (PAGES[path]) {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    return res.end(PAGES[path]);
+  }
+  if (path === '/api/items') return json(res, [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }]);
+  if (path === '/api/submit' && req.method === 'POST') return json(res, { ok: true });
+  if (path === '/api/slow') return json(res, { ok: true }, 800);
+  if (path === '/api/child') return json(res, { ok: true });
+  if (path === '/api/before-all-marker') return json(res, { ok: true });
+  const userMatch = path.match(/^\/api\/users\/(\d+)$/);
+  if (userMatch) return json(res, { id: Number(userMatch[1]), name: `User ${userMatch[1]}` });
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+}).listen(PORT, () => {
+  console.log(`Demo app listening on http://localhost:${PORT}`);
+});

--- a/examples/playwright-fixtures/package.json
+++ b/examples/playwright-fixtures/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "piwi-example-playwright-fixtures",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Runnable example: a small web app + Playwright tests wired to Piwi Dashboard with the capture fixtures",
+  "type": "module",
+  "scripts": {
+    "start": "node app/server.mjs",
+    "test": "playwright test",
+    "test:manual-reporter": "playwright test --config=playwright.manual-reporter.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@piwitests/reporter": "^0.9.1",
+    "@playwright/test": "^1.56.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/playwright-fixtures/playwright.config.ts
+++ b/examples/playwright-fixtures/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+import { wrapConfig } from '@piwitests/reporter';
+import { baseConfig, piwiOptions } from './playwright.shared';
+
+/**
+ * Recommended setup: `wrapConfig` injects the Piwi Dashboard reporter and
+ * chains its global setup (the run shows up on the dashboard while your own
+ * globalSetup is still running).
+ *
+ * See playwright.manual-reporter.config.ts for the plain reporter-array way.
+ */
+export default wrapConfig(defineConfig(baseConfig, { reporter: [['list']] }), piwiOptions);

--- a/examples/playwright-fixtures/playwright.manual-reporter.config.ts
+++ b/examples/playwright-fixtures/playwright.manual-reporter.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+import { baseConfig, piwiOptions } from './playwright.shared';
+
+/**
+ * Alternative setup: register the reporter by hand in the `reporter` array
+ * instead of using `wrapConfig`. Run with:
+ *
+ *   npm run test:manual-reporter
+ */
+export default defineConfig(baseConfig, {
+  reporter: [['list'], ['@piwitests/reporter', piwiOptions]],
+});

--- a/examples/playwright-fixtures/playwright.shared.ts
+++ b/examples/playwright-fixtures/playwright.shared.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+/** Where the reporter sends results. Override with PIWI_DASHBOARD_URL / PIWI_PROJECT_NAME. */
+export const piwiOptions = {
+  serverUrl: process.env.PIWI_DASHBOARD_URL ?? 'http://localhost:3000',
+  projectName: process.env.PIWI_PROJECT_NAME ?? 'playwright-fixtures-example',
+};
+
+/** Base Playwright config shared by both example configs. */
+export const baseConfig = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'node app/server.mjs',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/examples/playwright-fixtures/tests/before-all.spec.ts
+++ b/examples/playwright-fixtures/tests/before-all.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect, BASE_URL } from './fixtures';
+
+let markerStatus = 0;
+
+// Activity in beforeAll/afterAll is intentionally NOT captured — the marker
+// request below must not appear in any test's network data on the dashboard.
+test.beforeAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  const response = await page.goto(`${BASE_URL}/api/before-all-marker`);
+  markerStatus = response?.status() ?? 0;
+  await page.close();
+});
+
+test('beforeAll activity is not attributed to this test', async ({ page }) => {
+  expect(markerStatus).toBe(200);
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Piwi fixtures demo' })).toBeVisible();
+});

--- a/examples/playwright-fixtures/tests/browser-newpage.spec.ts
+++ b/examples/playwright-fixtures/tests/browser-newpage.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect, BASE_URL } from './fixtures';
+
+// Capture is wired at the browser level, so pages created straight from the
+// worker-scoped `browser` fixture are captured too — no `page` fixture needed.
+test('captures pages created from the worker browser', async ({ browser }) => {
+  const page = await browser.newPage();
+  await page.goto(`${BASE_URL}/`);
+  await page.getByTestId('load-items').click();
+  await expect(page.locator('#items li')).toHaveCount(3);
+  await page.close();
+});

--- a/examples/playwright-fixtures/tests/console.spec.ts
+++ b/examples/playwright-fixtures/tests/console.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from './fixtures';
+
+// Console capture keeps warnings, errors, and failed asserts — console.log
+// noise is intentionally not collected.
+test('captures console warnings, errors and asserts (not logs)', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => {
+    console.log('demo: this log line is NOT captured');
+    console.warn('demo: something looks off');
+    console.error('demo: something went wrong');
+    console.assert(false, 'demo: assertion failed');
+  });
+  await expect(page.getByRole('heading', { name: 'Piwi fixtures demo' })).toBeVisible();
+});

--- a/examples/playwright-fixtures/tests/context-newpage.spec.ts
+++ b/examples/playwright-fixtures/tests/context-newpage.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect, BASE_URL } from './fixtures';
+
+// Contexts created from the patched browser instrument every page they open.
+test('captures pages created from a fresh context', async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(`${BASE_URL}/form`);
+  await page.getByLabel('Email').fill('lin@example.com');
+  await page.getByLabel('Message').fill('From a dedicated context');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.locator('#result')).toHaveText('Sent!');
+  await context.close();
+});

--- a/examples/playwright-fixtures/tests/custom-fixtures.spec.ts
+++ b/examples/playwright-fixtures/tests/custom-fixtures.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from './fixtures-composed';
+
+// Dashboard capture composed with a project-specific fixture (see
+// fixtures-composed.ts): the custom fixture drives the page, capture still works.
+test('composes dashboard capture with custom fixtures', async ({ formPage }) => {
+  await formPage.sendMessage('mary@example.com', 'Sent through a custom fixture');
+  await expect(formPage.page.locator('#result')).toHaveText('Sent!');
+});

--- a/examples/playwright-fixtures/tests/failing-locator.spec.ts
+++ b/examples/playwright-fixtures/tests/failing-locator.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from './fixtures';
+
+// Seeds a passing locator snapshot for the button, so the dashboard has
+// known-good capture data for this element.
+test('clicks the load button (seeds a passing locator snapshot)', async ({ page }) => {
+  await page.goto('/');
+  await page.getByTestId('load-items').click();
+  await expect(page.locator('#items li')).toHaveCount(3);
+});
+
+// INTENTIONALLY FAILING — do not "fix" this test.
+// The button's accessible name is "Load items", but the locator still targets
+// the old label. It demonstrates what the fixtures capture on failure: the
+// ARIA snapshot of the page, a fresh locator suggestion (as a Playwright
+// annotation on the test), and the Alternative locators panel on the dashboard.
+test('intentionally fails: the button label changed', async ({ page }) => {
+  test.info().annotations.push({
+    type: 'example',
+    description:
+      'This failure is intentional — it lights up the failure-time ARIA snapshot, the locator suggestion, and locator healing in the dashboard.',
+  });
+  await page.goto('/');
+  // The button is now labeled "Load items" — this locator no longer matches.
+  await page.getByRole('button', { name: 'Load records' }).click({ timeout: 2000 });
+});

--- a/examples/playwright-fixtures/tests/fixtures-composed.ts
+++ b/examples/playwright-fixtures/tests/fixtures-composed.ts
@@ -1,10 +1,10 @@
 /**
- * Option B + composition — `extendDashboardFixtures` wraps the base `test`,
+ * Option B + composition — `extendPiwiFixtures` wraps the base `test`,
  * then regular `.extend()` layers project-specific fixtures on top.
  * Capture and custom fixtures work together; the custom fixture types flow through.
  */
 import { test as base, expect, type Page } from '@playwright/test';
-import { extendDashboardFixtures } from '@piwitests/reporter';
+import { extendPiwiFixtures } from '@piwitests/reporter';
 
 class FormPage {
   constructor(readonly page: Page) {}
@@ -18,7 +18,7 @@ class FormPage {
   }
 }
 
-export const test = extendDashboardFixtures(base).extend<{ formPage: FormPage }>({
+export const test = extendPiwiFixtures(base).extend<{ formPage: FormPage }>({
   formPage: async ({ page }, use) => {
     await use(new FormPage(page));
   },

--- a/examples/playwright-fixtures/tests/fixtures-composed.ts
+++ b/examples/playwright-fixtures/tests/fixtures-composed.ts
@@ -1,0 +1,26 @@
+/**
+ * Option B + composition — `extendDashboardFixtures` wraps the base `test`,
+ * then regular `.extend()` layers project-specific fixtures on top.
+ * Capture and custom fixtures work together; the custom fixture types flow through.
+ */
+import { test as base, expect, type Page } from '@playwright/test';
+import { extendDashboardFixtures } from '@piwitests/reporter';
+
+class FormPage {
+  constructor(readonly page: Page) {}
+
+  async sendMessage(email: string, message: string): Promise<void> {
+    await this.page.goto('/form');
+    await this.page.getByLabel('Email').fill(email);
+    await this.page.getByLabel('Message').fill(message);
+    await this.page.getByLabel('Priority').selectOption('high');
+    await this.page.getByRole('button', { name: 'Send' }).click();
+  }
+}
+
+export const test = extendDashboardFixtures(base).extend<{ formPage: FormPage }>({
+  formPage: async ({ page }, use) => {
+    await use(new FormPage(page));
+  },
+});
+export { expect };

--- a/examples/playwright-fixtures/tests/fixtures.ts
+++ b/examples/playwright-fixtures/tests/fixtures.ts
@@ -1,14 +1,14 @@
 /**
- * Option A — extend the base `test` with the Piwi Dashboard capture fixtures.
+ * Option A — extend the base `test` with the Piwi capture fixtures.
  *
  * Every spec imports `test` from this file instead of `@playwright/test`;
  * that import is what switches capture on for the spec.
  */
 import { test as base, expect } from '@playwright/test';
-import { dashboardFixtures } from '@piwitests/reporter';
+import { piwiFixtures } from '@piwitests/reporter';
 
 /** Absolute base URL for pages created outside the `page` fixture (browser.newPage etc.). */
 export const BASE_URL = 'http://localhost:4173';
 
-export const test = base.extend(dashboardFixtures);
+export const test = base.extend(piwiFixtures);
 export { expect };

--- a/examples/playwright-fixtures/tests/fixtures.ts
+++ b/examples/playwright-fixtures/tests/fixtures.ts
@@ -1,0 +1,14 @@
+/**
+ * Option A — extend the base `test` with the Piwi Dashboard capture fixtures.
+ *
+ * Every spec imports `test` from this file instead of `@playwright/test`;
+ * that import is what switches capture on for the spec.
+ */
+import { test as base, expect } from '@playwright/test';
+import { dashboardFixtures } from '@piwitests/reporter';
+
+/** Absolute base URL for pages created outside the `page` fixture (browser.newPage etc.). */
+export const BASE_URL = 'http://localhost:4173';
+
+export const test = base.extend(dashboardFixtures);
+export { expect };

--- a/examples/playwright-fixtures/tests/form.spec.ts
+++ b/examples/playwright-fixtures/tests/form.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from './fixtures';
+
+// Labeled form fields: fill/selectOption actions produce locator snapshots
+// with getByLabel alternatives; the XHR POST lands in the network capture.
+test('submits the contact form', async ({ page }) => {
+  await page.goto('/form');
+  await page.getByLabel('Email').fill('ada@example.com');
+  await page.getByLabel('Message').fill('Hello from the example project');
+  await page.getByLabel('Priority').selectOption('high');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.locator('#result')).toHaveText('Sent!');
+});

--- a/examples/playwright-fixtures/tests/home.spec.ts
+++ b/examples/playwright-fixtures/tests/home.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from './fixtures';
+
+// The standard `page` fixture path: locator actions, a fetch call, and the
+// console.warn the page emits on load are all captured automatically.
+test('loads items from the API', async ({ page }) => {
+  await page.goto('/');
+  await page.getByTestId('load-items').click();
+  await expect(page.locator('#items li').first()).toBeVisible();
+  await expect(page.locator('#items li')).toHaveCount(3);
+});

--- a/examples/playwright-fixtures/tests/multi-page.spec.ts
+++ b/examples/playwright-fixtures/tests/multi-page.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect, BASE_URL } from './fixtures';
+
+// A test that drives two pages: Web Vitals and the failure-time ARIA snapshot
+// are attributed to the most recently active page (the form page here).
+test('attributes capture across multiple pages', async ({ context }) => {
+  const home = await context.newPage();
+  await home.goto(`${BASE_URL}/`);
+  await home.getByTestId('load-items').click();
+  await expect(home.locator('#items li')).toHaveCount(3);
+
+  const form = await context.newPage();
+  await form.goto(`${BASE_URL}/form`);
+  await form.getByLabel('Email').fill('grace@example.com');
+  await form.getByLabel('Message').fill('Second page of the same test');
+  await form.getByRole('button', { name: 'Send' }).click();
+  await expect(form.locator('#result')).toHaveText('Sent!');
+});

--- a/examples/playwright-fixtures/tests/popup.spec.ts
+++ b/examples/playwright-fixtures/tests/popup.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from './fixtures';
+
+// Popups (window.open) are instrumented as soon as the context reports them —
+// the child window's console.warn and fetch call are captured.
+test('captures activity inside a popup window', async ({ page }) => {
+  await page.goto('/popup');
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByTestId('open-child').click();
+  const popup = await popupPromise;
+  await popup.waitForLoadState();
+  await popup.getByTestId('child-action').click();
+  await expect(popup.locator('#child-result')).toHaveText('child done');
+});

--- a/examples/playwright-fixtures/tests/skipped.spec.ts
+++ b/examples/playwright-fixtures/tests/skipped.spec.ts
@@ -1,0 +1,7 @@
+import { test } from './fixtures';
+
+// Skipped tests produce no capture attachments and no errors — they simply
+// show up as skipped on the dashboard.
+test.skip('skipped on purpose', async ({ page }) => {
+  await page.goto('/');
+});

--- a/examples/playwright-fixtures/tests/slow-endpoint.spec.ts
+++ b/examples/playwright-fixtures/tests/slow-endpoint.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from './fixtures';
+
+// The page fires one slow call (~800 ms) and two parameterized calls
+// (/api/users/1 and /api/users/2). The dashboard's Slow endpoints tab groups
+// the latter under the normalized route /api/users/:id.
+test('exercises a slow endpoint and parameterized routes', async ({ page }) => {
+  await page.goto('/slow');
+  await expect(page.locator('#status')).toHaveText('done', { timeout: 5000 });
+});

--- a/examples/playwright-fixtures/tsconfig.json
+++ b/examples/playwright-fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts", "playwright.manual-reporter.config.ts", "playwright.shared.ts"]
+}

--- a/reporter/ARCHITECTURE.md
+++ b/reporter/ARCHITECTURE.md
@@ -15,7 +15,7 @@ change. Everything under **`src/internal/`** is private plumbing — change it f
 | `wrapConfig` | `public/config-wrapper.ts` | injects reporter + global setup into a PW config |
 | `createGlobalSetup` | `public/global-setup.ts` | registers the run before `globalSetup` |
 | `PiwiDashboardOptions`, `PlaywrightTestConfig`, `PiwiFixtures` | `public/options.ts` / `internal/capture/capture-fixtures.ts` | the config contract + capture fixtures type (types) |
-| `piwiFixtures`, `extendPiwiFixtures` (+ deprecated `dashboardFixtures`, `extendDashboardFixtures` aliases) | `internal/capture/capture-fixtures.ts` → re-exported by `index.ts` | capture fixtures (imported from `@piwitests/reporter`) |
+| `piwiFixtures`, `extendPiwiFixtures` | `internal/capture/capture-fixtures.ts` → re-exported by `index.ts` | capture fixtures (imported from `@piwitests/reporter`) |
 
 Two **external contracts** beyond the npm API:
 - **Wire types** (`types/wire.ts`) — the JSON sent to / received from the server.

--- a/reporter/ARCHITECTURE.md
+++ b/reporter/ARCHITECTURE.md
@@ -14,8 +14,8 @@ change. Everything under **`src/internal/`** is private plumbing — change it f
 | `PiwiDashboardReporter` (default + named) | `public/reporter.ts` | the Playwright reporter |
 | `wrapConfig` | `public/config-wrapper.ts` | injects reporter + global setup into a PW config |
 | `createGlobalSetup` | `public/global-setup.ts` | registers the run before `globalSetup` |
-| `PiwiDashboardOptions`, `PlaywrightTestConfig` | `public/options.ts` | the config contract (types) |
-| `dashboardFixtures`, `extendDashboardFixtures` | `internal/capture/capture-fixtures.ts` → re-exported by `index.ts` | capture fixtures (imported from `@piwitests/reporter`) |
+| `PiwiDashboardOptions`, `PlaywrightTestConfig`, `PiwiFixtures` | `public/options.ts` / `internal/capture/capture-fixtures.ts` | the config contract + capture fixtures type (types) |
+| `piwiFixtures`, `extendPiwiFixtures` (+ deprecated `dashboardFixtures`, `extendDashboardFixtures` aliases) | `internal/capture/capture-fixtures.ts` → re-exported by `index.ts` | capture fixtures (imported from `@piwitests/reporter`) |
 
 Two **external contracts** beyond the npm API:
 - **Wire types** (`types/wire.ts`) — the JSON sent to / received from the server.

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -161,8 +161,6 @@ export { expect } from '@playwright/test'
 
 Then import `test` from your fixtures file in every spec — a spec that imports `test` from `@playwright/test` directly still runs and reports fine, it just isn't captured.
 
-> `piwiFixtures` / `extendPiwiFixtures` were named `dashboardFixtures` / `extendDashboardFixtures` in `0.9.x`. The old names still work as deprecated aliases.
-
 ### What gets captured
 
 - **Network requests** — method, URL, status, duration, resource type (API/document traffic only). Aggregated on the dashboard into a *Slow API Endpoints* table grouped by `METHOD + normalized route`.

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -44,9 +44,9 @@ npx playwright test
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 
@@ -143,23 +143,25 @@ The reporter works without any test-code changes, but the **capture fixtures** o
 ```typescript
 // tests/fixtures.ts
 import { test as base, expect } from '@playwright/test'
-import { dashboardFixtures } from '@piwitests/reporter'
+import { piwiFixtures } from '@piwitests/reporter'
 
-export const test = base.extend(dashboardFixtures)
+export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 
-Or extend the base `test` in one line with `extendDashboardFixtures`:
+Or extend the base `test` in one line with `extendPiwiFixtures`:
 
 ```typescript
 import { test as base } from '@playwright/test'
-import { extendDashboardFixtures } from '@piwitests/reporter'
+import { extendPiwiFixtures } from '@piwitests/reporter'
 
-export const test = extendDashboardFixtures(base)
+export const test = extendPiwiFixtures(base)
 export { expect } from '@playwright/test'
 ```
 
 Then import `test` from your fixtures file in every spec — a spec that imports `test` from `@playwright/test` directly still runs and reports fine, it just isn't captured.
+
+> `piwiFixtures` / `extendPiwiFixtures` were named `dashboardFixtures` / `extendDashboardFixtures` in `0.9.x`. The old names still work as deprecated aliases.
 
 ### What gets captured
 
@@ -251,7 +253,7 @@ Everything public — the reporter, config helpers, and the capture fixtures —
 
 ### Fixture data not appearing (network, Web Vitals, console, ARIA, locator healing)
 
-- Extend your `test` with `dashboardFixtures` / `extendDashboardFixtures` from `@piwitests/reporter`, and import `test` from your fixtures file in every spec — not from `@playwright/test` directly
+- Extend your `test` with `piwiFixtures` / `extendPiwiFixtures` from `@piwitests/reporter`, and import `test` from your fixtures file in every spec — not from `@playwright/test` directly
 - Verify `collectPerformanceMetrics` is not set to `false` (and `captureLocators` for locator healing)
 - Ensure tests navigate to at least one page (`await page.goto(...)`)
 

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -39,6 +39,19 @@ Run your tests — results are uploaded automatically:
 npx playwright test
 ```
 
+**Recommended: enable the [capture fixtures](#capture-fixtures)** — one small file unlocks the dashboard's richest features (locator healing, slow-endpoint analysis, Web Vitals, console capture, failure-time ARIA snapshots):
+
+```typescript
+// tests/fixtures.ts
+import { test as base, expect } from '@playwright/test'
+import { dashboardFixtures } from '@piwitests/reporter'
+
+export const test = base.extend(dashboardFixtures)
+export { expect }
+```
+
+Import `test` from this file in your specs instead of `@playwright/test` — see [Capture fixtures](#capture-fixtures) below.
+
 Prefer to wire it up by hand? Add the reporter to the `reporter` array instead:
 
 ```typescript
@@ -123,9 +136,9 @@ export default defineConfig({
 })
 ```
 
-## Performance Metrics & Web Vitals
+## Capture fixtures
 
-To capture network request timing and browser Web Vitals, use the provided fixtures:
+The reporter works without any test-code changes, but the **capture fixtures** observe your tests from the inside and unlock the dashboard's richest features. Extend your `test` with them:
 
 ```typescript
 // tests/fixtures.ts
@@ -146,12 +159,19 @@ export const test = extendDashboardFixtures(base)
 export { expect } from '@playwright/test'
 ```
 
+Then import `test` from your fixtures file in every spec — a spec that imports `test` from `@playwright/test` directly still runs and reports fine, it just isn't captured.
+
 ### What gets captured
 
-- **Network requests** — method, URL, status, duration, resource type. Aggregated on the dashboard into a *Slow API Endpoints* table grouped by `METHOD + normalized route`.
+- **Network requests** — method, URL, status, duration, resource type (API/document traffic only). Aggregated on the dashboard into a *Slow API Endpoints* table grouped by `METHOD + normalized route`.
+- **Console entries** — `warning`, `error`, and `assert` messages with their source location.
 - **Browser Web Vitals** — TTFB, DOM Interactive, DOMContentLoaded, Load Complete, First Paint, First Contentful Paint — displayed with color-coded thresholds.
+- **ARIA snapshot** — captured automatically when a test fails, shown as failure evidence and fed to the AI diagnosis.
+- **Locator snapshots** — for each acted-on element, its attributes plus ranked alternative locators, stamped with the call site. These power locator healing; when a failing locator matches nothing, a fresh suggestion is attached as a Playwright annotation.
 
-Both are only collected when `collectPerformanceMetrics` is `true` (the default).
+Capture works for the `page` fixture, `browser.newPage()`, `browser.newContext().newPage()`, and popups. Everything is only collected when `collectPerformanceMetrics` is `true` (the default); locator snapshots can be disabled separately with `captureLocators: false`.
+
+Without the fixtures you still get full run history, statuses, errors, traces, reports, streaming, and clustering — the fixtures add the slow-endpoint, Web Vitals, console, ARIA, and locator-healing layers. See the [capture fixtures guide](https://piwitests.github.io/capture-fixtures) for the full feature matrix and composition patterns.
 
 ## Authentication
 
@@ -195,7 +215,7 @@ When `collectCiInfo` is enabled (default), the reporter auto-detects:
 2. As tests complete, results are streamed in batches to the server
 3. After all tests finish, HTML reports are compressed and uploaded
 4. Trace files from test attachments are uploaded
-5. Network request and web vitals data (from fixtures) are included per test case
+5. Data from the capture fixtures (network requests, console entries, web vitals, ARIA snapshots, locator snapshots) is included per test case
 6. The server stores everything and makes it available in the dashboard UI
 
 ## Requirements
@@ -229,10 +249,10 @@ Everything public — the reporter, config helpers, and the capture fixtures —
 - Ensure traces are enabled: `use: { trace: 'retain-on-failure' }`
 - Check the dashboard server is running and accessible at `serverUrl`
 
-### Network/Web Vitals not appearing
+### Fixture data not appearing (network, Web Vitals, console, ARIA, locator healing)
 
-- Extend your `test` with `dashboardFixtures` / `extendDashboardFixtures` from `@piwitests/reporter`
-- Verify `collectPerformanceMetrics` is not set to `false`
+- Extend your `test` with `dashboardFixtures` / `extendDashboardFixtures` from `@piwitests/reporter`, and import `test` from your fixtures file in every spec — not from `@playwright/test` directly
+- Verify `collectPerformanceMetrics` is not set to `false` (and `captureLocators` for locator healing)
 - Ensure tests navigate to at least one page (`await page.goto(...)`)
 
 ### Connection errors

--- a/reporter/package.json
+++ b/reporter/package.json
@@ -19,7 +19,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "keywords": [
     "playwright",

--- a/reporter/src/index.ts
+++ b/reporter/src/index.ts
@@ -17,14 +17,7 @@ export { wrapConfig } from './public/config-wrapper.js';
 export { createGlobalSetup } from './public/global-setup.js';
 
 // ── Capture fixtures ─────────────────────────────────────────────────────────
-// `dashboardFixtures` / `extendDashboardFixtures` are deprecated aliases kept
-// for 0.9.x compatibility — prefer `piwiFixtures` / `extendPiwiFixtures`.
-export {
-  piwiFixtures,
-  extendPiwiFixtures,
-  dashboardFixtures,
-  extendDashboardFixtures,
-} from './internal/capture/capture-fixtures.js';
+export { piwiFixtures, extendPiwiFixtures } from './internal/capture/capture-fixtures.js';
 
 // ── Public types ─────────────────────────────────────────────────────────────
 export type { PiwiFixtures } from './internal/capture/capture-fixtures.js';

--- a/reporter/src/index.ts
+++ b/reporter/src/index.ts
@@ -17,7 +17,15 @@ export { wrapConfig } from './public/config-wrapper.js';
 export { createGlobalSetup } from './public/global-setup.js';
 
 // ── Capture fixtures ─────────────────────────────────────────────────────────
-export { dashboardFixtures, extendDashboardFixtures } from './internal/capture/capture-fixtures.js';
+// `dashboardFixtures` / `extendDashboardFixtures` are deprecated aliases kept
+// for 0.9.x compatibility — prefer `piwiFixtures` / `extendPiwiFixtures`.
+export {
+  piwiFixtures,
+  extendPiwiFixtures,
+  dashboardFixtures,
+  extendDashboardFixtures,
+} from './internal/capture/capture-fixtures.js';
 
 // ── Public types ─────────────────────────────────────────────────────────────
+export type { PiwiFixtures } from './internal/capture/capture-fixtures.js';
 export type { PiwiDashboardOptions, PlaywrightTestConfig } from './public/options.js';

--- a/reporter/src/internal/capture/attachments.ts
+++ b/reporter/src/internal/capture/attachments.ts
@@ -1,8 +1,8 @@
 /**
  * Names of the `testInfo` attachments the dashboard fixtures produce and the
  * reporter parses. Single source of truth — imported by the producer
- * (`fixtures.ts`), the consumers (`reporter.ts` / `file-handler.ts`), and the
- * dogfooding `application/tests/fixtures.ts`, so producer and consumer can
+ * (`capture-fixtures.ts`), the consumers (`reporter.ts` / `file-handler.ts`), and
+ * the dogfooding `application/tests/fixtures.ts`, so producer and consumer can
  * never drift on a name.
  */
 export const ATTACHMENT_NAMES = {

--- a/reporter/src/internal/capture/capture-fixtures.ts
+++ b/reporter/src/internal/capture/capture-fixtures.ts
@@ -79,6 +79,14 @@ interface CaptureSink {
   // Most-recently-touched instrumented page — used at teardown for the failure
   // ARIA snapshot and web-vitals read when a test drives several pages.
   lastActivePage: Page | null;
+  // The running test's info, so close wrappers can see its status mid-teardown.
+  testInfo: TestInfo | null;
+  // Page-dependent teardown reads, taken by the close wrappers while the page
+  // was still open. The auto capture fixture tears down AFTER the built-in
+  // page/context fixtures, so by the time flushSink runs the standard test
+  // page is already closed and can no longer be read live.
+  stashedWebVitals: WebVitals | null;
+  stashedAria: string | null;
 }
 
 function createSink(): CaptureSink {
@@ -90,6 +98,9 @@ function createSink(): CaptureSink {
     capturePromises: [],
     failedLocators: [],
     lastActivePage: null,
+    testInfo: null,
+    stashedWebVitals: null,
+    stashedAria: null,
   };
 }
 
@@ -100,6 +111,102 @@ function createSink(): CaptureSink {
  * test (auth setup, teardown) is intentionally not captured.
  */
 let currentSink: CaptureSink | null = null;
+
+/**
+ * Element probes whose protocol call is still in flight. Closing a page,
+ * context, or browser while a probe is mid-flight makes Playwright's
+ * connection dispatcher throw a global "Object with guid handle@… was not
+ * bound in the connection" error, which fails whichever test happens to be
+ * running. The close wrappers drain this set (bounded) before closing.
+ */
+const PENDING_PROBES = new Set<Promise<unknown>>();
+
+async function drainPendingProbes(capMs: number): Promise<void> {
+  if (PENDING_PROBES.size === 0) return;
+  let cap: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    Promise.allSettled(PENDING_PROBES),
+    new Promise((resolve) => {
+      cap = setTimeout(resolve, capMs);
+    }),
+  ]);
+  clearTimeout(cap);
+}
+
+function isPageClosed(page: Page): boolean {
+  try {
+    return typeof page.isClosed === 'function' ? page.isClosed() : false;
+  } catch {
+    return false;
+  }
+}
+
+function pageContext(page: Page): BrowserContext | null {
+  try {
+    return typeof page.context === 'function' ? page.context() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read navigation/paint timings from a page — null when unavailable or the page is gone. */
+async function readWebVitals(page: Page): Promise<WebVitals | null> {
+  try {
+    // Runs in the browser, so the perf-entry reads stay `any` (no DOM lib);
+    // the callback return type pins the result to WebVitals.
+    return await page.evaluate((): WebVitals | null => {
+      const navEntries = performance.getEntriesByType('navigation' as any);
+      const paintEntries = performance.getEntriesByType('paint' as any);
+      const nav = navEntries[0] as any;
+      const navigation = nav
+        ? {
+            url: nav.name,
+            ttfb: Math.round(nav.responseStart - nav.fetchStart),
+            domInteractive: Math.round(nav.domInteractive - nav.fetchStart),
+            domContentLoaded: Math.round(nav.domContentLoadedEventEnd - nav.fetchStart),
+            loadComplete: Math.round(nav.loadEventEnd - nav.fetchStart),
+            transferSize: nav.transferSize || 0,
+            encodedBodySize: nav.encodedBodySize || 0,
+            decodedBodySize: nav.decodedBodySize || 0,
+          }
+        : null;
+
+      const paint: Record<string, number> = {};
+      for (const entry of paintEntries) {
+        const key = (entry as any).name.replace(/-([a-z])/g, (_: string, l: string) => l.toUpperCase());
+        paint[key] = Math.round((entry as any).startTime);
+      }
+
+      if (!navigation && Object.keys(paint).length === 0) return null;
+      return { navigation, paint };
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Take the page-dependent teardown reads (web vitals; ARIA snapshot when the
+ * test failed) while the last active page is still open. Called by the close
+ * wrappers just before a close that would take that page with it — flushSink
+ * runs too late for a live read on the standard test page.
+ */
+async function stashPageState(sink: CaptureSink, closing: { page?: Page; context?: BrowserContext }): Promise<void> {
+  const page = sink.lastActivePage;
+  if (!page || isPageClosed(page)) return;
+  const belongsToClosing =
+    closing.page === page || (closing.context !== undefined && pageContext(page) === closing.context);
+  if (!belongsToClosing) return;
+
+  const vitals = await readWebVitals(page);
+  if (vitals) sink.stashedWebVitals = vitals;
+
+  const status = sink.testInfo?.status;
+  if (status === 'failed' || status === 'timedOut' || status === 'interrupted') {
+    const aria = await ariaSnapshotBestEffort(page.locator(':root'), 1000);
+    if (aria) sink.stashedAria = aria;
+  }
+}
 
 // Idempotency guards: a page/context/browser can be reached through several
 // paths (browser patch, context patch, the `page` fixture, popup events), and
@@ -279,14 +386,27 @@ function wrapLocator(page: Page, locator: Locator, originMethod: string, originA
           throw error;
         }
 
-        // Fire-and-forget: capture element data without blocking the test.
-        // evaluate() can hang when page navigates (element detaches), so
-        // race it against a 500ms deadline and never throw.
+        // Fire-and-forget: capture element data without blocking the test. The
+        // snapshot wait below is bounded by a 500ms deadline (evaluate can hang
+        // when the page navigates), but the probe's underlying protocol call is
+        // tracked in PENDING_PROBES so the close wrappers can drain it — and in
+        // capturePromises so flushSink outwaits it — even when the deadline
+        // abandons it. An evaluate still in flight when its page closes crashes
+        // the connection dispatcher with a global "not bound" error.
+        const probe = target.evaluate(probeElementAttrs, CAPTURED_ATTRS_ARG);
+        const settledProbe = probe.then(
+          () => undefined,
+          () => undefined,
+        );
+        PENDING_PROBES.add(settledProbe);
+        settledProbe.then(() => PENDING_PROBES.delete(settledProbe));
+        sink.capturePromises.push(settledProbe);
+
         const resolveAttrs = (async () => {
           let deadline: ReturnType<typeof setTimeout> | undefined;
           try {
             const attrs = await Promise.race([
-              target.evaluate(probeElementAttrs, CAPTURED_ATTRS_ARG),
+              probe,
               new Promise<never>((_, reject) => {
                 deadline = setTimeout(() => reject(new Error('locator capture timeout')), 500);
               }),
@@ -344,6 +464,24 @@ function wrapLocator(page: Page, locator: Locator, originMethod: string, originA
 function instrumentPage(page: Page): void {
   if (!page || INSTRUMENTED_PAGES.has(page)) return;
   INSTRUMENTED_PAGES.add(page);
+
+  // A page reached through the `page` fixture safety net may live in a context
+  // the browser patch never saw — instrument it so its close is wrapped too.
+  const ctx = pageContext(page);
+  if (ctx) instrumentContext(ctx);
+
+  // Drain in-flight probes before a user-initiated close (the guard tolerates
+  // page-like test fakes without a close method), and preserve the
+  // page-dependent teardown reads while the page can still serve them.
+  if (typeof page.close === 'function') {
+    const originalClose = page.close.bind(page);
+    page.close = async (...args: Parameters<Page['close']>): Promise<void> => {
+      await drainPendingProbes(1000);
+      const sink = currentSink;
+      if (sink) await stashPageState(sink, { page });
+      return originalClose(...args);
+    };
+  }
 
   // Opt-out: skipped when PIWI_CAPTURE_LOCATORS=false (set automatically when
   // the reporter's collectPerformanceMetrics / captureLocators is disabled),
@@ -445,6 +583,21 @@ function instrumentContext(context: BrowserContext): void {
     return page;
   };
 
+  // The built-in context fixture closes here at test teardown — BEFORE the
+  // auto capture fixture flushes. Drain in-flight probes (an evaluate crossing
+  // the close crashes the connection with a global "not bound" error) and take
+  // the page-dependent reads (web vitals, failure ARIA snapshot) while the
+  // test's page is still open.
+  if (typeof context.close === 'function') {
+    const originalClose = context.close.bind(context);
+    context.close = async (...args: Parameters<BrowserContext['close']>): Promise<void> => {
+      await drainPendingProbes(1000);
+      const sink = currentSink;
+      if (sink) await stashPageState(sink, { context });
+      return originalClose(...args);
+    };
+  }
+
   // Popups and pages the context opens on its own (idempotent with the above).
   context.on('page', (page: Page) => instrumentPage(page));
 }
@@ -473,6 +626,16 @@ function patchBrowser(browser: Browser): void {
     instrumentContext(context);
     return context;
   };
+
+  // Worker shutdown closes the browser; a probe still in flight would crash
+  // the connection dispatcher.
+  if (typeof browser.close === 'function') {
+    const originalClose = browser.close.bind(browser);
+    browser.close = async (...args: Parameters<Browser['close']>): Promise<void> => {
+      await drainPendingProbes(1000);
+      return originalClose(...args);
+    };
+  }
 }
 
 /**
@@ -510,10 +673,14 @@ async function flushSink(sink: CaptureSink, testInfo: TestInfo): Promise<void> {
   }
 
   const page = sink.lastActivePage;
+  const pageReadable = page !== null && !isPageClosed(page);
 
-  if (page && testInfo.status !== 'passed' && testInfo.status !== 'skipped') {
+  if (testInfo.status !== 'passed' && testInfo.status !== 'skipped') {
     try {
-      const snapshot = await ariaSnapshotBestEffort(page.locator(':root'));
+      // Prefer a live read; fall back to the snapshot the close wrappers
+      // stashed — the standard test page is already closed when this auto
+      // fixture tears down.
+      const snapshot = (pageReadable ? await ariaSnapshotBestEffort(page.locator(':root')) : null) ?? sink.stashedAria;
       if (snapshot) {
         await testInfo.attach(ATTACHMENT_NAMES.ariaSnapshot, {
           contentType: 'text/plain',
@@ -557,46 +724,14 @@ async function flushSink(sink: CaptureSink, testInfo: TestInfo): Promise<void> {
     });
   }
 
-  if (page) {
-    try {
-      // Runs in the browser, so the perf-entry reads stay `any` (no DOM lib);
-      // the callback return type pins `webVitals` to WebVitals.
-      const webVitals = await page.evaluate((): WebVitals | null => {
-        const navEntries = performance.getEntriesByType('navigation' as any);
-        const paintEntries = performance.getEntriesByType('paint' as any);
-        const nav = navEntries[0] as any;
-        const navigation = nav
-          ? {
-              url: nav.name,
-              ttfb: Math.round(nav.responseStart - nav.fetchStart),
-              domInteractive: Math.round(nav.domInteractive - nav.fetchStart),
-              domContentLoaded: Math.round(nav.domContentLoadedEventEnd - nav.fetchStart),
-              loadComplete: Math.round(nav.loadEventEnd - nav.fetchStart),
-              transferSize: nav.transferSize || 0,
-              encodedBodySize: nav.encodedBodySize || 0,
-              decodedBodySize: nav.decodedBodySize || 0,
-            }
-          : null;
-
-        const paint: Record<string, number> = {};
-        for (const entry of paintEntries) {
-          const key = (entry as any).name.replace(/-([a-z])/g, (_: string, l: string) => l.toUpperCase());
-          paint[key] = Math.round((entry as any).startTime);
-        }
-
-        if (!navigation && Object.keys(paint).length === 0) return null;
-        return { navigation, paint };
-      });
-
-      if (webVitals) {
-        await testInfo.attach(ATTACHMENT_NAMES.webVitals, {
-          contentType: 'application/json',
-          body: Buffer.from(JSON.stringify(webVitals)),
-        });
-      }
-    } catch {
-      /* ignore */
-    }
+  // Live read when the page still exists (e.g. a browser.newPage the test left
+  // open); otherwise the vitals the close wrappers stashed before the page went.
+  const webVitals = (pageReadable ? await readWebVitals(page) : null) ?? sink.stashedWebVitals;
+  if (webVitals) {
+    await testInfo.attach(ATTACHMENT_NAMES.webVitals, {
+      contentType: 'application/json',
+      body: Buffer.from(JSON.stringify(webVitals)),
+    });
   }
 }
 
@@ -634,6 +769,7 @@ export const dashboardFixtures: Fixtures = {
   piwiDashboardCapture: [
     async ({}, use: UseFn<void>, testInfo: TestInfo) => {
       const sink = createSink();
+      sink.testInfo = testInfo;
       currentSink = sink;
       try {
         await use();
@@ -661,6 +797,6 @@ export const dashboardFixtures: Fixtures = {
  * export const test = extendDashboardFixtures(base);
  * ```
  */
-export function extendDashboardFixtures<T>(test: T): T {
+export function extendDashboardFixtures<T extends { extend(fixtures: Fixtures): unknown }>(test: T): T {
   return (test as any).extend(dashboardFixtures);
 }

--- a/reporter/src/internal/capture/capture-fixtures.ts
+++ b/reporter/src/internal/capture/capture-fixtures.ts
@@ -831,17 +831,3 @@ export function extendPiwiFixtures<TestArgs extends FixtureArgs, WorkerArgs exte
     test as unknown as { extend: (f: typeof piwiFixtures) => TestType<TestArgs & PiwiFixtures, WorkerArgs> }
   ).extend(piwiFixtures);
 }
-
-/**
- * @deprecated Renamed to {@link piwiFixtures}. This alias is kept for
- * `@piwitests/reporter@0.9.x` compatibility and will be removed in a future
- * release — prefer `piwiFixtures`.
- */
-export const dashboardFixtures = piwiFixtures;
-
-/**
- * @deprecated Renamed to {@link extendPiwiFixtures}. This alias is kept for
- * `@piwitests/reporter@0.9.x` compatibility and will be removed in a future
- * release — prefer `extendPiwiFixtures`.
- */
-export const extendDashboardFixtures = extendPiwiFixtures;

--- a/reporter/src/internal/capture/capture-fixtures.ts
+++ b/reporter/src/internal/capture/capture-fixtures.ts
@@ -7,9 +7,12 @@ import type {
   Locator,
   Page,
   PlaywrightTestArgs,
+  PlaywrightTestOptions,
   PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
   Request,
   TestInfo,
+  TestType,
 } from '@playwright/test';
 import {
   generateAlternatives,
@@ -31,6 +34,12 @@ import { ATTACHMENT_NAMES, LOCATOR_SUGGESTION_ANNOTATION } from './attachments.j
 
 /** A Playwright fixture's `use` callback — hands the fixture value to the test. */
 type UseFn<T> = (value: T) => Promise<void>;
+
+// Playwright constrains `TestType`'s args to its internal `KeyValue`
+// (`{ [key: string]: any }`) — mirror it so real `test` objects satisfy the
+// bound (their args are index-signature-free interfaces) while a non-test
+// argument is still rejected by the `TestType` parameter type.
+type FixtureArgs = { [key: string]: any };
 
 /** Shape returned by the in-page element probe (see `wrapLocator`). */
 interface CapturedAttrs {
@@ -736,6 +745,18 @@ async function flushSink(sink: CaptureSink, testInfo: TestInfo): Promise<void> {
 }
 
 /**
+ * The fixtures `piwiFixtures` / `extendPiwiFixtures` contribute. The single
+ * added fixture is `piwiCapture`: an auto, test-scoped teardown hook that
+ * attaches the collected `piwi-*` data. Its name is **reserved** — a user
+ * fixture of the same name replaces the capture teardown and silently disables
+ * all capture. Exported so `piwiFixtures` and the extended `test` carry it in
+ * their types (and a collision surfaces to the type checker).
+ */
+export interface PiwiFixtures {
+  piwiCapture: void;
+}
+
+/**
  * Playwright fixtures that collect network requests, console entries,
  * web vitals, ARIA snapshots, and locator interaction data during a test.
  *
@@ -744,7 +765,12 @@ async function flushSink(sink: CaptureSink, testInfo: TestInfo): Promise<void> {
  * `browser.newContext()`. Collected data is attached as `piwi-*`
  * test-info attachments which the Piwi Dashboard reporter parses on `onTestEnd`.
  */
-export const dashboardFixtures: Fixtures = {
+export const piwiFixtures: Fixtures<
+  PiwiFixtures,
+  {},
+  PlaywrightTestArgs & PlaywrightTestOptions,
+  PlaywrightWorkerArgs & PlaywrightWorkerOptions
+> = {
   // Worker-scoped: patch the shared browser so every page/context created from
   // it — including by user fixtures that take `browser` directly — is captured.
   browser: [
@@ -766,7 +792,7 @@ export const dashboardFixtures: Fixtures = {
   // Auto, test-scoped: open a capture sink for the running test and flush it
   // (attach the collected data) at teardown. Runs for every test without being
   // requested, so suites that never destructure `page` are still captured.
-  piwiDashboardCapture: [
+  piwiCapture: [
     async ({}, use: UseFn<void>, testInfo: TestInfo) => {
       const sink = createSink();
       sink.testInfo = testInfo;
@@ -783,7 +809,8 @@ export const dashboardFixtures: Fixtures = {
 };
 
 /**
- * Extend a Playwright `test` object with Piwi Dashboard fixtures.
+ * Extend a Playwright `test` object with the Piwi capture fixtures. The
+ * returned `test` carries the existing fixtures plus {@link PiwiFixtures}.
  *
  * Use this instead of importing `@playwright/test` directly from this package
  * to avoid the "Requiring @playwright/test second time" error caused by
@@ -792,11 +819,29 @@ export const dashboardFixtures: Fixtures = {
  * @example
  * ```ts
  * import { test as base } from '@playwright/test';
- * import { extendDashboardFixtures } from '@piwitests/reporter';
+ * import { extendPiwiFixtures } from '@piwitests/reporter';
  *
- * export const test = extendDashboardFixtures(base);
+ * export const test = extendPiwiFixtures(base);
  * ```
  */
-export function extendDashboardFixtures<T extends { extend(fixtures: Fixtures): unknown }>(test: T): T {
-  return (test as any).extend(dashboardFixtures);
+export function extendPiwiFixtures<TestArgs extends FixtureArgs, WorkerArgs extends FixtureArgs>(
+  test: TestType<TestArgs, WorkerArgs>,
+): TestType<TestArgs & PiwiFixtures, WorkerArgs> {
+  return (
+    test as unknown as { extend: (f: typeof piwiFixtures) => TestType<TestArgs & PiwiFixtures, WorkerArgs> }
+  ).extend(piwiFixtures);
 }
+
+/**
+ * @deprecated Renamed to {@link piwiFixtures}. This alias is kept for
+ * `@piwitests/reporter@0.9.x` compatibility and will be removed in a future
+ * release — prefer `piwiFixtures`.
+ */
+export const dashboardFixtures = piwiFixtures;
+
+/**
+ * @deprecated Renamed to {@link extendPiwiFixtures}. This alias is kept for
+ * `@piwitests/reporter@0.9.x` compatibility and will be removed in a future
+ * release — prefer `extendPiwiFixtures`.
+ */
+export const extendDashboardFixtures = extendPiwiFixtures;

--- a/reporter/src/internal/capture/locator-healing.ts
+++ b/reporter/src/internal/capture/locator-healing.ts
@@ -90,8 +90,9 @@ export function dedupeSnapshotsByLocation(snaps: LocatorSnapshot[]): LocatorSnap
 
 /**
  * Page-level locator-building methods wrapped by the capture proxy. Imported by
- * both `reporter/src/fixtures.ts` and the dogfooding `application/tests/fixtures.ts`
- * so the two stay in sync (a prior drift missed `scrollIntoViewIfNeeded`).
+ * both the capture fixtures (`capture-fixtures.ts`) and the dogfooding
+ * `application/tests/fixtures.ts` so the two stay in sync (a prior drift missed
+ * `scrollIntoViewIfNeeded`).
  */
 export const LOCATOR_METHODS: string[] = [
   'getByRole',

--- a/reporter/tests/build-output.spec.ts
+++ b/reporter/tests/build-output.spec.ts
@@ -50,8 +50,5 @@ describe.runIf(existsSync(dist('index.js')))('built entry (requires a build)', (
     const source = readFileSync(dist('index.js'), 'utf-8');
     expect(source).toContain('piwiFixtures');
     expect(source).toContain('extendPiwiFixtures');
-    // Deprecated 0.9.x aliases stay exported for backward compatibility.
-    expect(source).toContain('dashboardFixtures');
-    expect(source).toContain('extendDashboardFixtures');
   });
 });

--- a/reporter/tests/build-output.spec.ts
+++ b/reporter/tests/build-output.spec.ts
@@ -31,12 +31,14 @@ describe('package metadata', () => {
 });
 
 describe('public export surface', () => {
-  it('exposes exactly one entry (".") with no ./fixtures subpath', () => {
+  it('exposes one code entry (".") with no ./fixtures subpath', () => {
     // Fixtures are imported from '@piwitests/reporter', not a subpath — the
-    // package intentionally has a single public entry.
-    expect(Object.keys(pkg.exports)).toEqual(['.']);
+    // package intentionally has a single public code entry. "./package.json"
+    // is metadata for tooling (bundlers, license scanners), not an API.
+    expect(Object.keys(pkg.exports)).toEqual(['.', './package.json']);
     expect(pkg.exports['.'].types).toBe('./dist/index.d.ts');
     expect(pkg.exports['.'].import).toBe('./dist/index.js');
+    expect(pkg.exports['./package.json']).toBe('./package.json');
   });
 });
 

--- a/reporter/tests/build-output.spec.ts
+++ b/reporter/tests/build-output.spec.ts
@@ -48,6 +48,9 @@ describe('public export surface', () => {
 describe.runIf(existsSync(dist('index.js')))('built entry (requires a build)', () => {
   it('re-exports the capture fixtures from the single entry', () => {
     const source = readFileSync(dist('index.js'), 'utf-8');
+    expect(source).toContain('piwiFixtures');
+    expect(source).toContain('extendPiwiFixtures');
+    // Deprecated 0.9.x aliases stay exported for backward compatibility.
     expect(source).toContain('dashboardFixtures');
     expect(source).toContain('extendDashboardFixtures');
   });

--- a/reporter/tests/capture-fixtures.spec.ts
+++ b/reporter/tests/capture-fixtures.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Locator } from '@playwright/test';
-import { ariaSnapshotBestEffort, probeElementAttrs } from '../src/internal/capture/capture-fixtures.js';
+import { ariaSnapshotBestEffort, dashboardFixtures, probeElementAttrs } from '../src/internal/capture/capture-fixtures.js';
+import { ATTACHMENT_NAMES } from '../src/internal/capture/attachments.js';
 
 /** A minimal fake Locator exposing only what ariaSnapshotBestEffort touches. */
 function fakeLocator(ariaSnapshot?: (opts?: unknown) => Promise<string>): Locator {
@@ -194,5 +195,76 @@ describe('probeElementAttrs', () => {
     });
     const out = probeElementAttrs(el, ['class']);
     expect(Object.keys(out.selectorCounts.classes ?? {})).toHaveLength(10);
+  });
+});
+
+describe('locator capture teardown race', () => {
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  it('keeps a probe rejection after the capture deadline from becoming an unhandled rejection', async () => {
+    // The element probe (locator.evaluate) never settles during the test and
+    // rejects only after teardown — simulating a page that closes while the
+    // probe is still in flight. The 500ms capture deadline wins the race; the
+    // probe's late rejection must be observed, or Playwright would fail
+    // whichever test is running when it surfaces as an unhandled rejection.
+    let rejectProbe: ((reason: Error) => void) | undefined;
+    const fakeLocator = {
+      click: async () => {},
+      evaluate: () =>
+        new Promise((_, reject) => {
+          rejectProbe = reject;
+        }),
+    };
+    const locatorFactory = () => fakeLocator;
+    const fakePage = {
+      getByRole: locatorFactory,
+      getByTestId: locatorFactory,
+      getByText: locatorFactory,
+      getByLabel: locatorFactory,
+      getByPlaceholder: locatorFactory,
+      getByAltText: locatorFactory,
+      getByTitle: locatorFactory,
+      locator: locatorFactory,
+      on: () => {},
+      evaluate: async () => null, // web-vitals read at teardown
+    };
+    const testInfo = { status: 'passed', attach: vi.fn(async () => {}), annotations: [] };
+
+    const pageFixture = dashboardFixtures.page as unknown as (
+      args: { page: unknown },
+      use: (page: typeof fakePage) => Promise<void>,
+    ) => Promise<void>;
+    const [captureFixture] = dashboardFixtures.piwiDashboardCapture as unknown as [
+      (args: object, use: () => Promise<void>, testInfo: unknown) => Promise<void>,
+    ];
+
+    const unhandled: unknown[] = [];
+    const priorListeners = process.listeners('unhandledRejection');
+    process.removeAllListeners('unhandledRejection');
+    process.on('unhandledRejection', (reason) => unhandled.push(reason));
+
+    try {
+      await captureFixture(
+        {},
+        () =>
+          pageFixture({ page: fakePage }, async (page) => {
+            await (page.getByTestId('save') as unknown as { click: () => Promise<void> }).click();
+            // Let the 500ms probe deadline win the race before the test ends.
+            await sleep(600);
+          }),
+        testInfo,
+      );
+
+      // The page "closes" after teardown; the in-flight probe now rejects.
+      rejectProbe?.(new Error('page closed at teardown'));
+      await sleep(20);
+
+      expect(unhandled).toEqual([]);
+      // The action was still captured (as a placeholder snapshot) and attached.
+      expect(testInfo.attach).toHaveBeenCalledWith(ATTACHMENT_NAMES.locators, expect.anything());
+    } finally {
+      process.removeAllListeners('unhandledRejection');
+      for (const listener of priorListeners) process.on('unhandledRejection', listener);
+    }
   });
 });

--- a/reporter/tests/capture-fixtures.spec.ts
+++ b/reporter/tests/capture-fixtures.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Locator } from '@playwright/test';
-import { ariaSnapshotBestEffort, dashboardFixtures, probeElementAttrs } from '../src/internal/capture/capture-fixtures.js';
+import { ariaSnapshotBestEffort, piwiFixtures, probeElementAttrs } from '../src/internal/capture/capture-fixtures.js';
 import { ATTACHMENT_NAMES } from '../src/internal/capture/attachments.js';
 
 /** A minimal fake Locator exposing only what ariaSnapshotBestEffort touches. */
@@ -230,11 +230,11 @@ describe('locator capture teardown race', () => {
     };
     const testInfo = { status: 'passed', attach: vi.fn(async () => {}), annotations: [] };
 
-    const pageFixture = dashboardFixtures.page as unknown as (
+    const pageFixture = piwiFixtures.page as unknown as (
       args: { page: unknown },
       use: (page: typeof fakePage) => Promise<void>,
     ) => Promise<void>;
-    const [captureFixture] = dashboardFixtures.piwiDashboardCapture as unknown as [
+    const [captureFixture] = piwiFixtures.piwiCapture as unknown as [
       (args: object, use: () => Promise<void>, testInfo: unknown) => Promise<void>,
     ];
 

--- a/reporter/tests/integration/capture.spec.ts
+++ b/reporter/tests/integration/capture.spec.ts
@@ -1,20 +1,21 @@
 import { test as base } from '@playwright/test';
 import * as http from 'node:http';
-import { extendDashboardFixtures } from '../../dist/index.js';
+import { extendPiwiFixtures } from '../../dist/index.js';
 
 /**
  * Drives the REAL, built `@piwitests/reporter` package (not a mock) against a
  * live browser and a tiny local HTTP server, so the Proxy-based locator
- * wrapping, network capture, and console capture are exercised end to end —
- * the one thing the mocked unit tests in `tests/capture-fixtures.spec.ts` and
+ * wrapping, network/console/web-vitals capture, the failure-time ARIA snapshot,
+ * and the locator suggestion are all exercised end to end — the things the
+ * mocked unit tests in `tests/capture-fixtures.spec.ts` and
  * `tests/locator-healing.spec.ts` cannot do. Assertions live in
  * `verify-reporter.ts`, which inspects the resulting `piwi-*` attachments
- * after the test completes (fixture teardown attaches them after the test
+ * after each test completes (fixture teardown attaches them after the test
  * body returns, so they aren't readable from within the test itself).
  *
  * Requires `npm run reporter:build` first — run via `npm run reporter:test:integration`.
  */
-const test = extendDashboardFixtures(base);
+const test = extendPiwiFixtures(base);
 
 const PAGE_HTML = `<!doctype html>
 <html>
@@ -66,7 +67,9 @@ test.afterAll(async () => {
   await new Promise<void>((r) => server.close(() => r()));
 });
 
-test('capture fixtures record a locator interaction, a network request, and a console error', async ({ page }) => {
+// The main capture path: a navigation (→ web vitals), a locator action
+// (→ locator snapshot), a fetch (→ network), and a console.error (→ console).
+test('captures locators, a network request, a console error, and web vitals', async ({ page }) => {
   await page.goto(baseUrl);
   await page.getByRole('button', { name: 'Save' }).click();
 
@@ -80,3 +83,26 @@ test('capture fixtures record a locator interaction, a network request, and a co
   const status = await page.locator('#status').textContent();
   if (status !== 'done') throw new Error(`expected #status to read "done", got "${status}"`);
 });
+
+// Failure-only capture: the ARIA snapshot and the fresh locator suggestion are
+// produced only when a test fails, so this test is expected to fail. It clicks
+// a button whose accessible name isn't on the page, so the suggestion resolves
+// to the real "Save" button. verify-reporter checks both attachments.
+test('captures the failure-time ARIA snapshot and a locator suggestion', async ({ page }) => {
+  test.fail();
+  await page.goto(baseUrl);
+  await page.getByRole('button', { name: 'Nonexistent button' }).click({ timeout: 2000 });
+});
+
+// Teardown-race guard: a locator action immediately followed by test end closes
+// the page while the capture probe is still in flight. Before the drain-on-close
+// fix this raised a global "Object with guid handle@… was not bound in the
+// connection" error that failed whichever test was running. Repeating it raises
+// the odds of catching a regression; every one must pass.
+for (let i = 0; i < 8; i++) {
+  test(`teardown race guard ${i}`, async ({ page }) => {
+    await page.goto(baseUrl);
+    await page.getByRole('button', { name: 'Save' }).click();
+    // Return immediately — the page closes while the probe is mid-flight.
+  });
+}

--- a/reporter/tests/integration/verify-reporter.ts
+++ b/reporter/tests/integration/verify-reporter.ts
@@ -1,31 +1,71 @@
-import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
+import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
 /**
  * Inspects the real `piwi-*` testInfo attachments produced by the capture
- * fixtures (`dashboardFixtures`) at the end of each test and fails the whole
- * `playwright test` run (non-zero exit code) on a mismatch. This is the
- * integration-level counterpart to the unit tests in `tests/capture-fixtures.spec.ts`
- * and `tests/locator-healing.spec.ts` — it exercises the real Proxy-wrapped
- * locator, network, and console capture end to end against a live browser,
- * which those unit tests (necessarily mocked) cannot.
+ * fixtures (`piwiFixtures`) at the end of each test and fails the whole
+ * `playwright test` run on a mismatch. This is the integration-level
+ * counterpart to the unit tests in `tests/capture-fixtures.spec.ts` and
+ * `tests/locator-healing.spec.ts` — it exercises the real Proxy-wrapped
+ * locator, network, console, web-vitals, and failure-time (ARIA snapshot +
+ * locator suggestion) capture end to end against a live browser, which those
+ * (necessarily mocked) unit tests cannot.
+ *
+ * Test roles are keyed off `test.expectedStatus`/title:
+ *   - `expectedStatus === 'failed'` → the failure-capture test (ARIA + suggestion);
+ *   - title starting `teardown race guard` → the teardown-race stress runs;
+ *   - otherwise → the main capture test (locators + network + console + web vitals).
  */
 export default class VerifyCaptureReporter implements Reporter {
   private failures: string[] = [];
-  private checkedAtLeastOne = false;
+  private sawMainCapture = false;
+  private sawFailureCapture = false;
+  private stressRuns = 0;
 
   onTestEnd(test: TestCase, result: TestResult): void {
-    if (result.status !== 'passed') {
-      this.fail(`test "${test.title}" did not pass (status: ${result.status})`);
+    const byName = (name: string) => result.attachments.find((a) => a.name === name);
+    const assert = (cond: boolean, msg: string) => {
+      if (!cond) this.fail(`[${test.title}] ${msg}`);
+    };
+
+    // ── Failure-only capture: ARIA snapshot + fresh locator suggestion ──────
+    // These are produced only when a test actually fails, so this one is marked
+    // test.fail() and its "failed" status is the expected outcome.
+    if (test.expectedStatus === 'failed') {
+      assert(result.status === 'failed', `expected an actual failure to drive failure capture, got ${result.status}`);
+
+      assert(!!byName('piwi-aria-snapshot'), 'expected a piwi-aria-snapshot attachment on the failing test');
+
+      const suggestion = byName('piwi-locator-suggestion');
+      assert(!!suggestion, 'expected a piwi-locator-suggestion attachment on the failing test');
+      if (suggestion?.body) {
+        const parsed = JSON.parse(suggestion.body.toString('utf8')) as { failing?: string; suggestions?: string[] };
+        assert(
+          Array.isArray(parsed.suggestions) && parsed.suggestions.length > 0,
+          'suggestion should list at least one replacement locator',
+        );
+      }
+      this.sawFailureCapture = true;
       return;
     }
 
-    const byName = (name: string) => result.attachments.find((a) => a.name === name);
-    const assert = (cond: boolean, msg: string) => {
-      if (!cond) this.fail(msg);
-    };
+    // Every non-failing test must pass — a teardown-race regression surfaces as
+    // a spurious "not bound in the connection" failure here.
+    if (result.status !== 'passed') {
+      this.fail(`[${test.title}] expected to pass, got ${result.status}`);
+      return;
+    }
 
+    // Every passing test drives a locator action, so all must attach locators.
+    assert(!!byName('piwi-locators'), 'expected a piwi-locators attachment');
+
+    // ── Teardown-race stress runs: passing (checked above) is the whole point ─
+    if (test.title.startsWith('teardown race guard')) {
+      this.stressRuns += 1;
+      return;
+    }
+
+    // ── Main capture test: assert the full passing-path attachment set ───────
     const locators = byName('piwi-locators');
-    assert(!!locators, 'expected a piwi-locators attachment');
     if (locators?.body) {
       const snapshots = JSON.parse(locators.body.toString('utf8')) as Array<{
         location: string;
@@ -65,18 +105,35 @@ export default class VerifyCaptureReporter implements Reporter {
       assert(!!errorEntry, 'expected a captured console.error entry');
     }
 
-    this.checkedAtLeastOne = true;
+    const vitals = byName('piwi-web-vitals');
+    assert(!!vitals, 'expected a piwi-web-vitals attachment');
+    if (vitals?.body) {
+      const wv = JSON.parse(vitals.body.toString('utf8')) as {
+        navigation: unknown | null;
+        paint: Record<string, number>;
+      };
+      assert(
+        wv.navigation !== null || Object.keys(wv.paint ?? {}).length > 0,
+        'web vitals should record navigation timing or paint entries',
+      );
+    }
+
+    this.sawMainCapture = true;
   }
 
-  onEnd(): void {
-    if (!this.checkedAtLeastOne) this.fail('no test ran to completion — nothing was verified');
+  onEnd(_result: FullResult): { status: 'failed' } | void {
+    if (!this.sawMainCapture) this.fail('the main capture test did not run — nothing verified its attachments');
+    if (!this.sawFailureCapture) this.fail('the failure-capture test did not run — ARIA/suggestion unverified');
+    if (this.stressRuns < 1) this.fail('the teardown-race stress tests did not run');
+
     if (this.failures.length > 0) {
       console.error(`\n[verify-reporter] ${this.failures.length} check(s) FAILED:`);
       for (const f of this.failures) console.error(`  ✗ ${f}`);
-      process.exitCode = 1;
-    } else {
-      console.log('\n[verify-reporter] all capture-fixtures integration checks passed.');
+      // Return a failing status so the run exits non-zero even though the
+      // intentionally-failing test's outcome is "expected".
+      return { status: 'failed' };
     }
+    console.log(`\n[verify-reporter] all capture-fixtures integration checks passed (${this.stressRuns} stress runs).`);
   }
 
   private fail(msg: string): void {


### PR DESCRIPTION
## What & why

This change hardens the capture fixtures against a critical teardown race condition where in-flight element probes (locator.evaluate calls) can crash the Playwright connection dispatcher with a global "Object with guid handle@… was not bound in the connection" error when a page/context/browser closes while the probe is mid-flight.

**The fix:**
1. **Track pending probes** — A `PENDING_PROBES` set holds all in-flight probe promises so close wrappers can drain them (with a bounded timeout) before closing the page/context/browser.
2. **Stash page-dependent reads** — Web Vitals and failure-time ARIA snapshots are read and cached by close wrappers while the page is still open. This is necessary because the auto-capture fixture tears down *after* the built-in page/context fixtures, so by the time `flushSink` runs, the standard test page is already closed and can no longer be read live.
3. **Instrument all page paths** — Pages reached through the `page` fixture safety net may live in a context the browser patch never saw; they're now instrumented so their close is wrapped too.

**Secondary improvements:**
- Rename `dashboardFixtures` → `piwiFixtures` and `extendDashboardFixtures` → `extendPiwiFixtures` for consistency with the "Piwi" brand.
- Add comprehensive documentation (capture-fixtures.md guide, updated reporter.md and README.md).
- Add a runnable example project (`examples/playwright-fixtures/`) that exercises every capture path.
- Improve integration test coverage to verify failure-capture (ARIA snapshot + locator suggestion) and stress-test the teardown race guard.

## How was it tested?

- **Unit tests** — Added `locator capture teardown race` test in `capture-fixtures.spec.ts` that verifies probe rejections after the capture deadline are properly observed (not left as unhandled rejections).
- **Integration tests** — Enhanced `verify-reporter.ts` to check for failure-capture attachments (ARIA snapshot, locator suggestion) and stress-run teardown races. The example project (`examples/playwright-fixtures/`) includes specs that exercise every capture path: standard `page` fixture, `browser.newPage()`, `context.newPage()`, popups, multi-page tests, and intentional failures.
- **Manual verification** — The example project is runnable and demonstrates all capture features end-to-end against a live browser and local HTTP server.

## Checklist

- [x] PR title follows Conventional Commits (`feat(capture): …`)
- [x] Tests added for behavior changes (teardown race guard, failure capture)
- [x] Docs updated (new capture-fixtures.md guide, reporter.md, README.md, getting-started.md)
- [x] Example project added to demonstrate all capture paths

https://claude.ai/code/session_01Rudsm9Pnyc3tLLhrTMkej6