### PR TITLE
feat(notifications): embed top failures and error excerpts

### DIFF
--- a/application/app/components/cluster/ClusterTestEvidence.vue
+++ b/application/app/components/cluster/ClusterTestEvidence.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { TraceInfo, AttachmentInfo } from '~~/types/api';
-import { isImageFile } from '~/utils/text-format';
+import { isImageFile, isVideoFile } from '~/utils/text-format';
 
 interface AffectedCase {
   testCaseId: number;
@@ -107,6 +107,7 @@ const evidenceChips = computed(() => {
   const d = caseDetail.value;
   if (!d) return [];
   const screenshots = d.attachments.filter((a) => isImageFile(a.path, a.contentType)).length;
+  const videos = d.attachments.filter((a) => isVideoFile(a.path, a.contentType)).length;
   const consoleCount = Array.isArray(d.consoleLogs)
     ? (d.consoleLogs as Array<{ type?: string }>).filter((l) => l.type === 'error' || l.type === 'warning').length
     : 0;
@@ -115,6 +116,7 @@ const evidenceChips = computed(() => {
     : 0;
   return [
     { icon: 'i-lucide-image', label: 'screenshots', count: screenshots },
+    { icon: 'i-lucide-video', label: 'videos', count: videos },
     { icon: 'i-lucide-bug-play', label: 'traces', count: traces.value.length },
     { icon: 'i-lucide-list-checks', label: 'failing steps', count: failingSteps.value.length },
     { icon: 'i-lucide-triangle-alert', label: 'signals', count: consoleCount + failedRequests },
@@ -184,6 +186,9 @@ const evidenceChips = computed(() => {
 
       <!-- Screenshots -->
       <TestEvidenceScreenshots :attachments="caseDetail.attachments" />
+
+      <!-- Videos -->
+      <TestEvidenceVideos :attachments="caseDetail.attachments" />
 
       <!-- Traces -->
       <TestEvidenceTraces :traces="traces" :loading="tracesLoading" />

--- a/application/app/components/project/FlakyTestsList.vue
+++ b/application/app/components/project/FlakyTestsList.vue
@@ -4,14 +4,19 @@ import type { FlakyTest } from '~~/types/api';
 
 const props = defineProps<{
   projectId: string | number;
+  environment?: string | null;
 }>();
 
 const runsWindow = ref(50);
 const rootCauseFilter = ref<string[]>([]);
 
 const { data: tests, pending: loading } = await useFetch<FlakyTest[]>(
-  () => `/api/projects/${props.projectId}/flaky-tests?runs=${runsWindow.value}`,
-  { lazy: true, server: false, watch: [runsWindow] },
+  () => {
+    const params = new URLSearchParams({ runs: String(runsWindow.value) });
+    if (props.environment) params.set('environment', props.environment);
+    return `/api/projects/${props.projectId}/flaky-tests?${params.toString()}`;
+  },
+  { lazy: true, server: false, watch: [runsWindow, () => props.environment] },
 );
 
 const filteredTests = computed(() => {
@@ -79,6 +84,10 @@ const columns: TableColumn<FlakyTest>[] = [
             Tests that fail intermittently — detected by retry passes and status alternations
             <HelpHint topic="project.flaky-tests" />
           </p>
+          <UBadge v-if="environment" color="neutral" variant="subtle" size="sm" class="gap-1">
+            <UIcon name="i-lucide-layers" class="size-3" />
+            {{ environment }}
+          </UBadge>
           <div class="flex items-center gap-1.5">
             <UButton
               v-for="opt in ROOT_CAUSE_OPTIONS"

--- a/application/app/components/shared/VideoPlayer.vue
+++ b/application/app/components/shared/VideoPlayer.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{
+  src: string;
+  label?: string | null;
+}>();
+</script>
+
+<template>
+  <figure class="m-0">
+    <div class="bg-black rounded overflow-hidden">
+      <video :src="src" controls preload="metadata" class="w-full max-h-96">
+        Your browser does not support the video tag.
+      </video>
+    </div>
+    <figcaption v-if="label" class="mt-1 text-xs text-gray-400 truncate" :title="label">{{ label }}</figcaption>
+  </figure>
+</template>

--- a/application/app/components/test-case/TestCaseAttachmentsCard.vue
+++ b/application/app/components/test-case/TestCaseAttachmentsCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AttachmentInfo } from '~~/types/api';
+import { isImageFile, isVideoFile } from '~/utils/text-format';
 
 const props = defineProps<{
   attachments: AttachmentInfo[];
@@ -9,7 +10,7 @@ const currentImageIndex = ref<number | null>(null);
 
 const imageAttachments = computed(() =>
   props.attachments
-    .filter((att) => isImage(att.path, att.contentType))
+    .filter((att) => isImageFile(att.path, att.contentType))
     .map((att) => ({
       src: fileUrl(att.path, att.contentType),
       name: att.name || fileName(att.path),
@@ -20,27 +21,11 @@ function openLightbox(index: number) {
   currentImageIndex.value = index;
 }
 
-const imageExts = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp']);
-const videoExts = new Set(['.webm', '.mp4', '.ogg', '.mov']);
 const markdownExts = new Set(['.md', '.mdx', '.markdown']);
-const imageMimes = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp']);
-const videoMimes = new Set(['video/webm', 'video/mp4', 'video/ogg', 'video/quicktime']);
 const markdownMimes = new Set(['text/markdown', 'text/x-markdown']);
 
 function getExt(path: string): string {
   return path.toLowerCase().split('.').pop() || '';
-}
-
-function isImage(path: string, contentType?: string | null): boolean {
-  if (imageExts.has(getExt(path))) return true;
-  if (contentType && imageMimes.has(contentType.toLowerCase())) return true;
-  return false;
-}
-
-function isVideo(path: string, contentType?: string | null): boolean {
-  if (videoExts.has(getExt(path))) return true;
-  if (contentType && videoMimes.has(contentType.toLowerCase())) return true;
-  return false;
 }
 
 function isMarkdown(path: string, contentType?: string | null): boolean {
@@ -110,9 +95,9 @@ function togglePreview(attId: number, att: AttachmentInfo) {
           <div class="flex items-center gap-2 min-w-0">
             <UIcon
               :name="
-                isImage(att.path, att.contentType)
+                isImageFile(att.path, att.contentType)
                   ? 'i-lucide-image'
-                  : isVideo(att.path, att.contentType)
+                  : isVideoFile(att.path, att.contentType)
                     ? 'i-lucide-video'
                     : isMarkdown(att.path, att.contentType)
                       ? 'i-lucide-file-text'
@@ -145,7 +130,7 @@ function togglePreview(attId: number, att: AttachmentInfo) {
           </div>
         </div>
 
-        <div v-if="isImage(att.path, att.contentType)" class="bg-gray-100 dark:bg-gray-900">
+        <div v-if="isImageFile(att.path, att.contentType)" class="bg-gray-100 dark:bg-gray-900">
           <img
             :src="fileUrl(att.path, att.contentType)"
             :alt="att.name || 'Screenshot'"
@@ -155,15 +140,8 @@ function togglePreview(attId: number, att: AttachmentInfo) {
           />
         </div>
 
-        <div v-else-if="isVideo(att.path, att.contentType)" class="bg-black">
-          <video
-            :src="fileUrl(att.path, att.contentType)"
-            controls
-            preload="metadata"
-            class="max-w-full max-h-96 mx-auto"
-          >
-            Your browser does not support the video tag.
-          </video>
+        <div v-else-if="isVideoFile(att.path, att.contentType)" class="bg-black">
+          <VideoPlayer :src="fileUrl(att.path, att.contentType)" />
         </div>
 
         <div

--- a/application/app/components/test-case/TestEvidenceVideos.vue
+++ b/application/app/components/test-case/TestEvidenceVideos.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { AttachmentInfo } from '~~/types/api';
+import { isVideoFile } from '~/utils/text-format';
+
+const props = defineProps<{
+  attachments: AttachmentInfo[];
+}>();
+
+function getExt(path: string): string {
+  return '.' + (path.toLowerCase().split('.').pop() || '');
+}
+
+function fileUrl(path: string, contentType?: string | null): string {
+  let url = `/api/files/${getFileApiPath(path)}`;
+  if (contentType && getExt(path) === '.') url += `?contentType=${encodeURIComponent(contentType)}`;
+  return url;
+}
+
+function fileName(path: string): string {
+  return path.split('/').pop() || path;
+}
+
+const videos = computed(() =>
+  props.attachments
+    .filter((att) => isVideoFile(att.path, att.contentType))
+    .map((att) => ({
+      src: fileUrl(att.path, att.contentType),
+      name: att.name || fileName(att.path),
+    })),
+);
+</script>
+
+<template>
+  <TestEvidenceSection
+    v-if="videos.length > 0"
+    icon="i-lucide-video"
+    label="Videos"
+    :count="videos.length"
+    :collapsible="false"
+  >
+    <div class="space-y-2 p-2 bg-gray-50 dark:bg-gray-900">
+      <VideoPlayer v-for="video in videos" :key="video.src" :src="video.src" :label="video.name" />
+    </div>
+  </TestEvidenceSection>
+</template>

--- a/application/app/composables/useDemoNotifications.ts
+++ b/application/app/composables/useDemoNotifications.ts
@@ -26,7 +26,7 @@ function buildScenarios(projectLabel: string, events: string[]): Scenario[] {
       event: 'run.failed',
       scenario: {
         title: `Test run failed — ${projectLabel}`,
-        description: '3 of 12 tests failed on main',
+        description: '3 of 12 tests failed on main — checkout › applies discount code +2 more',
         icon: 'i-lucide-circle-x',
         color: 'error',
       },
@@ -35,7 +35,7 @@ function buildScenarios(projectLabel: string, events: string[]): Scenario[] {
       event: 'run.failed.default_branch',
       scenario: {
         title: `Test run failed on main — ${projectLabel}`,
-        description: '2 of 12 tests failed · branch: main',
+        description: '2 of 12 tests failed · main — auth › logs in with valid credentials +1 more',
         icon: 'i-lucide-circle-x',
         color: 'error',
       },

--- a/application/app/composables/useNotificationStream.ts
+++ b/application/app/composables/useNotificationStream.ts
@@ -20,6 +20,8 @@ interface NotificationEventData {
   rootCause?: string | null;
   category?: string | null;
   confidence?: string | null;
+  topFailures?: { title: string }[];
+  affectedCases?: number;
 }
 
 function renderBody(data: NotificationEventData): string {
@@ -40,6 +42,10 @@ function renderBody(data: NotificationEventData): string {
       else if (data.type === 'flakiness.spike') lines.push(`${name}: flakiness spike detected`);
       else if (data.type === 'perf.regression') lines.push(`${name}: performance regression detected`);
       if (data.failedTests) lines.push(`${data.failedTests} failed, ${data.totalTests} total`);
+      if (data.topFailures?.length) {
+        const [first, ...rest] = data.topFailures;
+        lines.push(rest.length ? `${first!.title} +${rest.length} more` : first!.title);
+      }
       break;
     }
     case 'cluster.new':

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -198,7 +198,8 @@ const routes: RouteEntry[] = [
     pattern: /^\/api\/projects\/(\d+)\/flaky-tests$/,
     handler: async (m, _, q) => {
       const limit = q ? Number(q.get('runs')) || 50 : 50;
-      return getProjectFlakyTests(await getDemoDb(), +m[1]!, limit);
+      const environment = q?.get('environment') || undefined;
+      return getProjectFlakyTests(await getDemoDb(), +m[1]!, limit, environment);
     },
   },
 

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -279,6 +279,12 @@ const filteredRuns = computed(() => {
   return runs.filter((r) => r.environment && selectedEnvironments.value.includes(r.environment));
 });
 
+// When exactly one environment is selected, scope the (server-side) flaky
+// analysis to it so staging vs production stability can be compared.
+const flakyEnvironment = computed(() =>
+  selectedEnvironments.value.length === 1 ? selectedEnvironments.value[0] : undefined,
+);
+
 const chartRuns = computed(() => {
   const runs = project.value?.testRuns || [];
   if (fullRunsOnly.value) {
@@ -880,7 +886,11 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
 
           <!-- FLAKY TESTS TAB -->
           <template #flaky-tests>
-            <FlakyTestsList v-if="activeTab === 'flaky-tests'" :project-id="String(projectId)" />
+            <FlakyTestsList
+              v-if="activeTab === 'flaky-tests'"
+              :project-id="String(projectId)"
+              :environment="flakyEnvironment"
+            />
           </template>
 
           <!-- PERFORMANCE TAB -->

--- a/application/app/utils/text-format.ts
+++ b/application/app/utils/text-format.ts
@@ -6,11 +6,22 @@
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp']);
 const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp']);
 
+const VIDEO_EXTS = new Set(['.webm', '.mp4', '.ogg', '.mov']);
+const VIDEO_MIMES = new Set(['video/webm', 'video/mp4', 'video/ogg', 'video/quicktime']);
+
 /** Whether a file path (or its content type) refers to a displayable image. */
 export function isImageFile(path: string, contentType?: string | null): boolean {
   const ext = '.' + (path.toLowerCase().split('.').pop() || '');
   if (IMAGE_EXTS.has(ext)) return true;
   if (contentType && IMAGE_MIMES.has(contentType.toLowerCase())) return true;
+  return false;
+}
+
+/** Whether a file path (or its content type) refers to a playable video. */
+export function isVideoFile(path: string, contentType?: string | null): boolean {
+  const ext = '.' + (path.toLowerCase().split('.').pop() || '');
+  if (VIDEO_EXTS.has(ext)) return true;
+  if (contentType && VIDEO_MIMES.has(contentType.toLowerCase())) return true;
   return false;
 }
 

--- a/application/server/api/projects/[id]/flaky-tests.get.ts
+++ b/application/server/api/projects/[id]/flaky-tests.get.ts
@@ -10,8 +10,12 @@ defineRouteMeta({
     tags: ['Test Cases'],
     summary: 'Flaky test analysis',
     description:
-      'Analyzes test flakiness across recent runs using retry-pass detection and pass/fail alternation scoring',
-    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+      'Analyzes test flakiness across recent runs using retry-pass detection and pass/fail alternation scoring. Pass an environment to scope the analysis to runs from that deployment environment.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+      { name: 'runs', in: 'query', required: false, schema: { type: 'integer' } },
+      { name: 'environment', in: 'query', required: false, schema: { type: 'string' } },
+    ],
     'x-required-roles': REQUIRED_ROLES,
   },
 });
@@ -20,13 +24,15 @@ export default eventHandler(async (event) => {
   const projectId = requireRouteId(event, 'id', 'project ID');
   await requireProjectAccess(event, projectId);
 
-  const runsParam = parseInt((getQuery(event).runs as string) || '50');
+  const query = getQuery(event);
+  const runsParam = parseInt((query.runs as string) || '50');
   const runsLimit = Math.min(200, Math.max(1, isNaN(runsParam) ? 50 : runsParam));
+  const environment = typeof query.environment === 'string' && query.environment ? query.environment : undefined;
 
   const db = await getDatabase();
 
   try {
-    return await getProjectFlakyTests(db, projectId, runsLimit);
+    return await getProjectFlakyTests(db, projectId, runsLimit, environment);
   } catch (e: any) {
     if (e?.message === 'Project not found') {
       throw createError({ statusCode: 404, message: 'Project not found' });

--- a/application/server/utils/email.ts
+++ b/application/server/utils/email.ts
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer';
 import type { Transporter } from 'nodemailer';
+import type { TopFailure } from '#shared/notification-events';
 
 export interface SmtpConfig {
   host: string;
@@ -77,6 +78,16 @@ export async function sendEmail(opts: SendEmailOptions): Promise<void> {
 // ── Email templates ───────────────────────────────────────────────────────────
 
 const siteUrl = () => process.env.PIWI_SITE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+
+/** Escape user-controlled text (test titles, error messages) for HTML emails. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 function emailLayout(title: string, body: string): { html: string; text: string } {
   const html = `<!DOCTYPE html>
@@ -158,12 +169,41 @@ export function renderRunNotificationEmail(opts: {
   totalTests: number;
   failedTests: number;
   branch?: string;
+  topFailures?: TopFailure[];
 }): { html: string; text: string } {
   const url = `${siteUrl()}/test-runs/${opts.runId}`;
   const statusColor = opts.status === 'passed' ? '#22c55e' : '#ef4444';
+
+  const failures = opts.topFailures ?? [];
+  let failuresHtml = '';
+  let failuresText = '';
+  if (failures.length > 0) {
+    const rows = failures
+      .map((f) => {
+        const caseUrl = f.testCaseId ? `${siteUrl()}/test-cases/${f.testCaseId}` : url;
+        const title = escapeHtml(f.title);
+        const titleHtml = `<a href="${caseUrl}" style="color:#18181b;font-weight:600;text-decoration:none;">${title}</a>`;
+        const loc = f.filePath ? `<div style="color:#a1a1aa;font-size:12px;">${escapeHtml(f.filePath)}</div>` : '';
+        const excerpt = f.errorExcerpt
+          ? `<pre style="margin:6px 0 0;white-space:pre-wrap;word-break:break-word;font-size:12px;color:#52525b;background:#fafafa;padding:8px;border-radius:4px;">${escapeHtml(f.errorExcerpt)}</pre>`
+          : '';
+        return `<li style="margin-bottom:12px;list-style:none;">${titleHtml}${loc}${excerpt}</li>`;
+      })
+      .join('');
+    failuresHtml = `<ul style="margin:0 0 24px;padding:0;">${rows}</ul>`;
+    failuresText = failures
+      .map((f) => {
+        const caseUrl = f.testCaseId ? `${siteUrl()}/test-cases/${f.testCaseId}` : url;
+        const loc = f.filePath ? ` (${f.filePath})` : '';
+        const excerpt = f.errorExcerpt ? `\n    ${f.errorExcerpt.replace(/\n/g, '\n    ')}` : '';
+        return `- ${f.title}${loc}\n  ${caseUrl}${excerpt}`;
+      })
+      .join('\n');
+  }
+
   const body = `
     <h2 style="margin:0 0 8px;font-size:20px;color:#18181b;">Test run ${opts.status}</h2>
-    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${opts.projectName}${opts.branch ? ` · ${opts.branch}` : ''}</p>
+    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${escapeHtml(opts.projectName)}${opts.branch ? ` · ${escapeHtml(opts.branch)}` : ''}</p>
     <table cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
       <tr>
         <td style="padding:8px 16px;background:#f4f4f5;border-radius:6px;font-size:14px;">
@@ -173,23 +213,39 @@ export function renderRunNotificationEmail(opts: {
         </td>
       </tr>
     </table>
+    ${failuresHtml}
     <a href="${url}" style="display:inline-block;background:#18181b;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;">View run</a>`;
   const { html } = emailLayout(`Test run ${opts.status} — ${opts.projectName}`, body);
-  const text = `Test run ${opts.status}: ${opts.projectName}${opts.branch ? ` (${opts.branch})` : ''}\n${opts.totalTests} tests${opts.failedTests > 0 ? `, ${opts.failedTests} failed` : ''}\n\nView run: ${url}`;
+  const text = `Test run ${opts.status}: ${opts.projectName}${opts.branch ? ` (${opts.branch})` : ''}\n${opts.totalTests} tests${opts.failedTests > 0 ? `, ${opts.failedTests} failed` : ''}${failuresText ? `\n\n${failuresText}` : ''}\n\nView run: ${url}`;
   return { html, text };
 }
 
-export function renderNewClusterEmail(opts: { projectName: string; clusterId: number; signature: string }): {
+export function renderNewClusterEmail(opts: {
+  projectName: string;
+  clusterId: number;
+  signature: string;
+  sampleErrorExcerpt?: string;
+  affectedCases?: number;
+}): {
   html: string;
   text: string;
 } {
   const url = `${siteUrl()}/failure-clusters/${opts.clusterId}`;
+  const affected =
+    opts.affectedCases && opts.affectedCases > 0
+      ? `<p style="margin:0 0 16px;color:#52525b;font-size:13px;">${opts.affectedCases} affected test${opts.affectedCases === 1 ? '' : 's'} in this run</p>`
+      : '';
+  const excerpt = opts.sampleErrorExcerpt
+    ? `<pre style="margin:0 0 24px;white-space:pre-wrap;word-break:break-word;font-size:12px;color:#52525b;background:#fafafa;padding:12px;border-radius:6px;">${escapeHtml(opts.sampleErrorExcerpt)}</pre>`
+    : '';
   const body = `
     <h2 style="margin:0 0 8px;font-size:20px;color:#18181b;">New failure cluster</h2>
-    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${opts.projectName}</p>
-    <p style="margin:0 0 24px;font-family:monospace;font-size:13px;background:#f4f4f5;padding:12px;border-radius:6px;overflow:auto;">${opts.signature}</p>
+    <p style="margin:0 0 24px;color:#52525b;font-size:14px;">${escapeHtml(opts.projectName)}</p>
+    <p style="margin:0 0 16px;font-family:monospace;font-size:13px;background:#f4f4f5;padding:12px;border-radius:6px;overflow:auto;">${escapeHtml(opts.signature)}</p>
+    ${affected}
+    ${excerpt}
     <a href="${url}" style="display:inline-block;background:#18181b;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;">View cluster</a>`;
   const { html } = emailLayout(`New failure cluster — ${opts.projectName}`, body);
-  const text = `New failure cluster in ${opts.projectName}\n\n${opts.signature}\n\nView: ${url}`;
+  const text = `New failure cluster in ${opts.projectName}${opts.affectedCases ? ` (${opts.affectedCases} affected)` : ''}\n\n${opts.signature}${opts.sampleErrorExcerpt ? `\n\n${opts.sampleErrorExcerpt}` : ''}\n\nView: ${url}`;
   return { html, text };
 }

--- a/application/server/utils/notifications/dispatch.ts
+++ b/application/server/utils/notifications/dispatch.ts
@@ -32,6 +32,7 @@ async function sendToEmail(config: Record<string, unknown>, event: NotificationE
       totalTests: p.totalTests,
       failedTests: p.failedTests,
       branch: p.branch,
+      topFailures: p.topFailures,
     }));
   } else if (event === 'cluster.new') {
     const p = payload as ClusterNewPayload;
@@ -39,6 +40,8 @@ async function sendToEmail(config: Record<string, unknown>, event: NotificationE
       projectName: p.projectName,
       clusterId: p.clusterId,
       signature: p.signature,
+      sampleErrorExcerpt: p.sampleErrorExcerpt,
+      affectedCases: p.affectedCases,
     }));
   } else {
     const subject = renderEventSubject(event, payload);
@@ -60,15 +63,29 @@ async function sendToSlack(config: Record<string, unknown>, event: NotificationE
   else if (event === 'cluster.new') emoji = ':bug:';
   else if (event === 'flakiness.spike') emoji = ':game_die:';
 
-  const body = {
-    text: `${emoji} *${text}*`,
-    blocks: [
-      {
-        type: 'section',
-        text: { type: 'mrkdwn', text: `${emoji} *${text}*` },
-      },
-    ],
-  };
+  const base = process.env.PIWI_SITE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+  // Slack section text is capped at 3000 chars; keep excerpts short.
+  const slackExcerpt = (s: string) => (s.length > 600 ? s.slice(0, 600) + '…' : s);
+
+  const blocks: Record<string, unknown>[] = [{ type: 'section', text: { type: 'mrkdwn', text: `${emoji} *${text}*` } }];
+
+  if (event.startsWith('run.')) {
+    const p = payload as RunFinishedPayload;
+    for (const f of p.topFailures ?? []) {
+      const link = f.testCaseId ? `<${base}/test-cases/${f.testCaseId}|${f.title}>` : f.title;
+      const excerpt = f.errorExcerpt ? `\n\`\`\`${slackExcerpt(f.errorExcerpt)}\`\`\`` : '';
+      blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `• *${link}*${excerpt}` } });
+    }
+  } else if (event === 'cluster.new') {
+    const p = payload as ClusterNewPayload;
+    const parts: string[] = [];
+    if (p.affectedCases) parts.push(`${p.affectedCases} affected test${p.affectedCases === 1 ? '' : 's'}`);
+    if (p.sampleErrorExcerpt) parts.push(`\`\`\`${slackExcerpt(p.sampleErrorExcerpt)}\`\`\``);
+    parts.push(`<${base}/failure-clusters/${p.clusterId}|View cluster>`);
+    blocks.push({ type: 'section', text: { type: 'mrkdwn', text: parts.join('\n') } });
+  }
+
+  const body = { text: `${emoji} *${text}*`, blocks };
 
   const res = await fetch(webhookUrl, {
     method: 'POST',

--- a/application/server/utils/notifications/run-notifications.ts
+++ b/application/server/utils/notifications/run-notifications.ts
@@ -1,6 +1,7 @@
-import { eq, and } from 'drizzle-orm';
-import { projects, testRuns, failureClusters } from '../../database/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import { projects, testRuns, failureClusters, testRunsCases, testCases } from '../../database/schema';
 import { emitNotification } from './emit';
+import { buildTopFailures, truncateExcerpt, TOP_FAILURES_LIMIT } from '#shared/notification-events';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 
 /**
@@ -22,6 +23,23 @@ export async function emitRunNotifications(db: LibSQLDatabase<any>, runId: numbe
     const defaultBranch = (meta.defaultBranch as string | undefined) || 'main';
     const isDefaultBranch = branch ? branch === defaultBranch : false;
 
+    // A few failing tests (title + error excerpt + deep-link ids) so a
+    // notification carries enough context to start debugging without opening
+    // the dashboard first.
+    const failedRows = await db
+      .select({
+        title: testCases.title,
+        filePath: testCases.filePath,
+        error: testRunsCases.error,
+        testCaseId: testRunsCases.testCaseId,
+        executionId: testRunsCases.id,
+      })
+      .from(testRunsCases)
+      .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
+      .where(and(eq(testRunsCases.testRunId, runId), inArray(testRunsCases.status, ['failed', 'timedout'])))
+      .limit(TOP_FAILURES_LIMIT);
+    const topFailures = buildTopFailures(failedRows);
+
     const runPayload = {
       runId,
       projectId: runRow.projectId,
@@ -33,6 +51,7 @@ export async function emitRunNotifications(db: LibSQLDatabase<any>, runId: numbe
       flakyTests: runRow.flakyTests,
       branch,
       isDefaultBranch,
+      topFailures,
     };
 
     await emitNotification(db, 'run.finished', runPayload);
@@ -46,17 +65,28 @@ export async function emitRunNotifications(db: LibSQLDatabase<any>, runId: numbe
 
     // Emit cluster.new for any clusters first seen in this run
     const newClusters = await db
-      .select({ id: failureClusters.id, signature: failureClusters.signature })
+      .select({
+        id: failureClusters.id,
+        signature: failureClusters.signature,
+        sampleError: failureClusters.sampleError,
+      })
       .from(failureClusters)
       .where(and(eq(failureClusters.firstSeenRunId, runId), eq(failureClusters.projectId, runRow.projectId)));
 
     for (const cluster of newClusters) {
+      const affected = await db
+        .select({ id: testRunsCases.id })
+        .from(testRunsCases)
+        .where(and(eq(testRunsCases.testRunId, runId), eq(testRunsCases.failureClusterId, cluster.id)));
+
       await emitNotification(db, 'cluster.new', {
         clusterId: cluster.id,
         projectId: runRow.projectId,
         projectName: project.label || project.name,
         signature: cluster.signature,
         runId,
+        sampleErrorExcerpt: truncateExcerpt(cluster.sampleError),
+        affectedCases: affected.length,
       });
     }
   } catch (e) {

--- a/application/shared/handlers/projects.ts
+++ b/application/shared/handlers/projects.ts
@@ -762,18 +762,27 @@ export async function getProjectFailureClusters(db: DrizzleDB, projectId: number
 
 const TERMINAL_STATUSES = ['passed', 'failed', 'timedout', 'interrupted'];
 
-export async function getProjectFlakyTests(db: DrizzleDB, projectId: number, runsLimit: number) {
+export async function getProjectFlakyTests(
+  db: DrizzleDB,
+  projectId: number,
+  runsLimit: number,
+  environment?: string | null,
+) {
   const projectResults: any[] = await db.select({ id: projects.id }).from(projects).where(eq(projects.id, projectId));
   const project = projectResults[0];
   if (!project) throw new Error('Project not found');
 
   const effectiveLimit = Math.min(200, Math.max(1, runsLimit));
 
-  // Step 1: Last N terminal runs
+  // Step 1: Last N terminal runs (optionally scoped to one environment so
+  // stability can be compared per environment, e.g. staging vs production)
+  const runsWhere = environment
+    ? and(eq(testRuns.projectId, projectId), eq(testRuns.environment, environment))
+    : eq(testRuns.projectId, projectId);
   const recentRuns: any[] = await db
     .select({ id: testRuns.id, startTime: testRuns.startTime })
     .from(testRuns)
-    .where(eq(testRuns.projectId, projectId))
+    .where(runsWhere)
     .orderBy(desc(testRuns.startTime))
     .limit(effectiveLimit);
 

--- a/application/shared/notification-events.ts
+++ b/application/shared/notification-events.ts
@@ -11,6 +11,20 @@ export const NOTIFICATION_EVENTS = [
 
 export type NotificationEvent = (typeof NOTIFICATION_EVENTS)[number];
 
+/** How many failing tests to embed in a run notification. */
+export const TOP_FAILURES_LIMIT = 3;
+/** Max characters kept from an error message embedded in a notification. */
+export const ERROR_EXCERPT_MAX = 300;
+
+/** A single failing test embedded in a run notification for debugging context. */
+export interface TopFailure {
+  title: string;
+  filePath?: string;
+  errorExcerpt?: string;
+  testCaseId?: number;
+  executionId?: number;
+}
+
 export interface RunFinishedPayload {
   runId: number;
   projectId: number;
@@ -23,6 +37,7 @@ export interface RunFinishedPayload {
   branch?: string;
   isDefaultBranch?: boolean;
   flakinessRate?: number; // 0-1
+  topFailures?: TopFailure[];
 }
 
 export interface ClusterNewPayload {
@@ -31,6 +46,46 @@ export interface ClusterNewPayload {
   projectName: string;
   signature: string;
   runId: number;
+  sampleErrorExcerpt?: string;
+  affectedCases?: number;
+}
+
+/**
+ * Trim, strip ANSI colour codes, and cap an error message so it can be embedded
+ * in a notification payload (and rendered in email/Slack) without bloating it.
+ * Returns undefined for empty input.
+ */
+export function truncateExcerpt(text?: string | null, max: number = ERROR_EXCERPT_MAX): string | undefined {
+  if (!text) return undefined;
+  const esc = String.fromCharCode(27);
+  const clean = text.replace(new RegExp(esc + '\\[[0-9;]*m', 'g'), '').trim();
+  if (!clean) return undefined;
+  return clean.length > max ? clean.slice(0, max).trimEnd() + '…' : clean;
+}
+
+/** Raw failing-case row shape consumed by {@link buildTopFailures}. */
+export interface TopFailureInput {
+  title: string;
+  filePath?: string | null;
+  error?: string | null;
+  testCaseId?: number | null;
+  executionId?: number | null;
+}
+
+/**
+ * Map raw failing-case rows to the compact {@link TopFailure} shape embedded in
+ * run notifications: capped to `limit` entries with truncated error excerpts.
+ */
+export function buildTopFailures(rows: TopFailureInput[], limit: number = TOP_FAILURES_LIMIT): TopFailure[] {
+  return rows.slice(0, limit).map((r) => {
+    const failure: TopFailure = { title: r.title };
+    if (r.filePath) failure.filePath = r.filePath;
+    if (r.testCaseId != null) failure.testCaseId = r.testCaseId;
+    if (r.executionId != null) failure.executionId = r.executionId;
+    const excerpt = truncateExcerpt(r.error);
+    if (excerpt) failure.errorExcerpt = excerpt;
+    return failure;
+  });
 }
 
 export interface DiagnosisCompletedPayload {

--- a/application/tests/unit/notification-events.test.ts
+++ b/application/tests/unit/notification-events.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from 'vitest';
-import { renderEventSubject, type RunFinishedPayload, type ClusterNewPayload } from '#shared/notification-events';
+import {
+  renderEventSubject,
+  buildTopFailures,
+  truncateExcerpt,
+  TOP_FAILURES_LIMIT,
+  ERROR_EXCERPT_MAX,
+  type RunFinishedPayload,
+  type ClusterNewPayload,
+} from '#shared/notification-events';
 
 const runPayload: RunFinishedPayload = {
   runId: 1,
@@ -40,5 +48,53 @@ describe('renderEventSubject', () => {
   test('flakiness.spike and perf.regression produce distinct subjects', () => {
     expect(renderEventSubject('flakiness.spike', runPayload)).toBe('Flakiness spike — my-project');
     expect(renderEventSubject('perf.regression', runPayload)).toBe('Performance regression — my-project');
+  });
+});
+
+describe('truncateExcerpt', () => {
+  test('returns undefined for empty/whitespace input', () => {
+    expect(truncateExcerpt(undefined)).toBeUndefined();
+    expect(truncateExcerpt(null)).toBeUndefined();
+    expect(truncateExcerpt('   \n  ')).toBeUndefined();
+  });
+
+  test('strips ANSI colour codes and trims', () => {
+    const esc = String.fromCharCode(27);
+    expect(truncateExcerpt(`  ${esc}[31mError${esc}[0m: boom  `)).toBe('Error: boom');
+  });
+
+  test('caps to ERROR_EXCERPT_MAX with an ellipsis', () => {
+    const long = 'x'.repeat(ERROR_EXCERPT_MAX + 50);
+    const out = truncateExcerpt(long)!;
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBe(ERROR_EXCERPT_MAX + 1); // max chars + ellipsis
+  });
+});
+
+describe('buildTopFailures', () => {
+  test('caps to the limit and maps fields, dropping empty ones', () => {
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      title: `test ${i}`,
+      filePath: i === 0 ? 'tests/a.spec.ts' : null,
+      error: i === 0 ? 'boom' : null,
+      testCaseId: i,
+      executionId: i + 100,
+    }));
+    const out = buildTopFailures(rows);
+    expect(out).toHaveLength(TOP_FAILURES_LIMIT);
+    expect(out[0]).toEqual({
+      title: 'test 0',
+      filePath: 'tests/a.spec.ts',
+      errorExcerpt: 'boom',
+      testCaseId: 0,
+      executionId: 100,
+    });
+    // Row without filePath/error omits those keys entirely
+    expect(out[1]).toEqual({ title: 'test 1', testCaseId: 1, executionId: 101 });
+  });
+
+  test('respects a custom limit', () => {
+    const rows = [{ title: 'a' }, { title: 'b' }];
+    expect(buildTopFailures(rows, 1)).toHaveLength(1);
   });
 });

--- a/application/tests/unit/text-format.test.ts
+++ b/application/tests/unit/text-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { stripAnsi, isImageFile } from '../../app/utils/text-format';
+import { stripAnsi, isImageFile, isVideoFile } from '../../app/utils/text-format';
 
 const ESC = String.fromCharCode(27); // ANSI escape
 
@@ -27,5 +27,19 @@ describe('isImageFile', () => {
   test('detects by content type when the extension is absent', () => {
     expect(isImageFile('attachment', 'image/png')).toBe(true);
     expect(isImageFile('attachment', 'application/zip')).toBe(false);
+  });
+});
+
+describe('isVideoFile', () => {
+  test('detects by extension (case-insensitive)', () => {
+    expect(isVideoFile('run.WEBM')).toBe(true);
+    expect(isVideoFile('a/b/clip.mp4')).toBe(true);
+    expect(isVideoFile('shot.png')).toBe(false);
+    expect(isVideoFile('trace.zip')).toBe(false);
+  });
+
+  test('detects by content type when the extension is absent', () => {
+    expect(isVideoFile('attachment', 'video/webm')).toBe(true);
+    expect(isVideoFile('attachment', 'image/png')).toBe(false);
   });
 });

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -17,6 +17,8 @@ A test is flaky when its result isn't deterministic. Piwi computes a **composite
 
 Each project has a dedicated **Flaky tests** tab with a **configurable lookback window** so you can focus on recent behavior or a longer baseline.
 
+**Per-environment scoping** — select a single environment in the project's environment filter and the flaky analysis is scoped to runs from that environment, so you can compare stability across `staging`, `production`, and `development` instead of blending them. (Set the environment via the reporter's `environment` option / `PIWI_ENVIRONMENT`; see the [reporter](./reporter) docs.)
+
 <figure>
   <img src="/screenshots/flaky-detection.png" alt="Flaky tests tab listing tests with composite score, failure rate, retry passes, and flip counts">
   <figcaption>The Flaky tests tab — each intermittent test scored by retry passes, status flips, and failure rate, ranked by impact and filterable by root-cause category.</figcaption>

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -53,6 +53,34 @@ Create an [incoming webhook](https://api.slack.com/messaging/webhooks) in Slack 
 
 Piwi `POST`s a JSON payload to your URL. Each request is signed with an HMAC-SHA256 `X-Piwi-Signature` header derived from the channel's secret, so you can verify authenticity. Webhook secrets are encrypted at rest.
 
+The body is `{ "event": "run.failed", "payload": { … }, "timestamp": "…" }`. For run events the payload includes up to three failing tests so you can act without a round-trip to the dashboard:
+
+```json
+{
+  "event": "run.failed",
+  "payload": {
+    "runId": 42,
+    "projectName": "checkout",
+    "status": "failed",
+    "totalTests": 120,
+    "failedTests": 3,
+    "branch": "main",
+    "topFailures": [
+      {
+        "title": "applies discount code",
+        "filePath": "tests/checkout.spec.ts",
+        "errorExcerpt": "TimeoutError: locator.click: Timeout 30000ms exceeded",
+        "testCaseId": 815,
+        "executionId": 9001
+      }
+    ]
+  },
+  "timestamp": "2026-07-11T10:00:00.000Z"
+}
+```
+
+`cluster.new` payloads similarly carry `sampleErrorExcerpt` and `affectedCases`. These fields are **additive** — existing consumers keep working, but if you re-serialize the payload to re-check the HMAC, sign the exact bytes you received.
+
 Admins can mark a channel **global** so it is available to all users.
 
 ## Subscriptions

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -30,9 +30,12 @@ export default defineConfig({
   ],
   use: {
     trace: 'retain-on-failure',
+    video: 'retain-on-failure',
   },
 })
 ```
+
+Any attachments Playwright records — including **videos** (`video: 'retain-on-failure'`) and screenshots — are uploaded automatically and shown as first-class evidence on the test-case and failure-cluster pages, alongside traces. Videos can be large, so pair `retain-on-failure` with periodic [storage cleanup](./storage#storage-management).
 
 ## Configuration options
 


### PR DESCRIPTION
## What & why

Enhance notification payloads and rendering to include debugging context without requiring a dashboard round-trip:

- **Run notifications** now embed up to 3 failing tests (title, file path, error excerpt, deep-link IDs) so recipients can start investigating immediately
- **Cluster notifications** include a sample error excerpt and count of affected tests in the run
- **Email rendering** displays top failures as a styled list with clickable test case links and error previews
- **Slack rendering** shows failure details inline with code-block excerpts (capped at 600 chars to respect Slack's 3000-char section limit)
- **HTML escaping** added to prevent injection in email templates (project names, branch names, test titles, error messages)

New shared utilities:
- `truncateExcerpt()`: Strips ANSI codes, trims, and caps error messages to 300 chars with ellipsis
- `buildTopFailures()`: Maps raw failure rows to the compact `TopFailure` shape with truncated excerpts

Also refactors video file detection into a reusable `isVideoFile()` utility (parallel to existing `isImageFile()`), adds a `VideoPlayer` component for consistent video rendering, and updates the flaky tests analysis to support per-environment scoping (e.g., staging vs production stability comparison).

## How was it tested?

- Added unit tests for `truncateExcerpt()` and `buildTopFailures()` covering ANSI stripping, truncation, and field mapping
- Added unit tests for `isVideoFile()` covering extension and MIME type detection
- Existing notification dispatch tests pass with new payload fields
- Email and Slack rendering tested with sample payloads containing top failures

## Checklist

- [x] PR title follows Conventional Commits (`feat(notifications): ...`)
- [x] Tests added for new utilities (`truncateExcerpt`, `buildTopFailures`, `isVideoFile`)
- [x] Docs updated (`docs/notifications.md` with payload examples, `docs/reporter.md` and `docs/flaky-tests.md` with feature notes)

https://claude.ai/code/session_01HTJPY8sttVW3u6StfLC23H