### PR TITLE
chore: update version references and contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all project spaces (repository, issues, pull
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer at **phenxdesign@gmail.com**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer at **piwitests@gmail.com**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Attribution
 

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -47,8 +47,8 @@ Open `http://localhost:3000`. The SQLite database and file storage are created a
 | Tag       | Description                            |
 |-----------|----------------------------------------|
 | `latest`  | Latest stable release                  |
-| `0.9.0`   | Exact version (pinned, recommended)    |
-| `0.9`     | Latest patch for a minor version       |
+| `0.11.0`  | Exact version (pinned, recommended)    |
+| `0.11`    | Latest patch for a minor version       |
 | `0`       | Latest release for a major version     |
 
 ---

--- a/application/tests/mobile-responsiveness.spec.ts
+++ b/application/tests/mobile-responsiveness.spec.ts
@@ -3,7 +3,7 @@ import { waitForHydration, retryPost } from './utils';
 import { PROJECT } from '#shared/test-project-names';
 
 /**
- * Mobile responsiveness regression suite (Phase 6 of docs/mobile-responsiveness-plan.md).
+ * Mobile responsiveness regression suite.
  *
  * Guards the fixes made across the audit: no page should ever scroll
  * horizontally, wide tables must scroll in place instead of stretching the

--- a/examples/playwright-fixtures/package.json
+++ b/examples/playwright-fixtures/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@piwitests/reporter": "^0.9.1",
+    "@piwitests/reporter": "^0.11.0",
     "@playwright/test": "^1.56.1",
     "typescript": "^5.9.3"
   }

--- a/integrations/nitro/README.md
+++ b/integrations/nitro/README.md
@@ -55,7 +55,7 @@ Playwright test
                                 └─ visible in test-case detail + AI diagnosis
 ```
 
-The plugin uses two mechanisms:
+The plugin uses three mechanisms:
 
 1. **`event.context._piwiLogs`** — a plain array attached to the H3 event, readable by both the request and `beforeResponse` hooks via the same event object (no async-context propagation needed).
 2. **`AsyncLocalStorage`** — seeded in the `request` hook so that `consola` reporters can append to the per-request buffer from within synchronous route-handler code.


### PR DESCRIPTION
## What & why

Updates documentation and dependency references to reflect the new version `0.11.0` and updates the Code of Conduct enforcement contact email to the current maintainer address.

Changes include:
- Docker Hub documentation: Updated version tags from `0.9.0`/`0.9` to `0.11.0`/`0.11`
- Code of Conduct: Updated enforcement contact email to `piwitests@gmail.com`
- Example project dependency: Updated `@piwitests/reporter` from `^0.9.1` to `^0.11.0`
- Test documentation: Removed outdated phase reference from mobile responsiveness test suite comment
- Nitro integration README: Corrected mechanism count from two to three

## How was it tested?

N/A — Documentation and configuration updates only.

## Checklist

- [x] PR title follows Conventional Commits (`chore: ...`)
- [x] Docs updated (DOCKER_HUB.md, CODE_OF_CONDUCT.md, README)

https://claude.ai/code/session_01Cp4CzYiT9uL98Pa2QMKViM