### PR TITLE
chore: fix pre-launch nits in docs, example, and metadata

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all project spaces (repository, issues, pull
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer at **phenxdesign@gmail.com**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer at **piwitests@gmail.com**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Attribution
 

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -47,8 +47,8 @@ Open `http://localhost:3000`. The SQLite database and file storage are created a
 | Tag       | Description                            |
 |-----------|----------------------------------------|
 | `latest`  | Latest stable release                  |
-| `0.9.0`   | Exact version (pinned, recommended)    |
-| `0.9`     | Latest patch for a minor version       |
+| `0.11.0`  | Exact version (pinned, recommended)    |
+| `0.11`    | Latest patch for a minor version       |
 | `0`       | Latest release for a major version     |
 
 ---

--- a/application/tests/mobile-responsiveness.spec.ts
+++ b/application/tests/mobile-responsiveness.spec.ts
@@ -3,7 +3,7 @@ import { waitForHydration, retryPost } from './utils';
 import { PROJECT } from '#shared/test-project-names';
 
 /**
- * Mobile responsiveness regression suite (Phase 6 of docs/mobile-responsiveness-plan.md).
+ * Mobile responsiveness regression suite.
  *
  * Guards the fixes made across the audit: no page should ever scroll
  * horizontally, wide tables must scroll in place instead of stretching the

--- a/examples/playwright-fixtures/package.json
+++ b/examples/playwright-fixtures/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@piwitests/reporter": "^0.9.1",
+    "@piwitests/reporter": "^0.11.0",
     "@playwright/test": "^1.56.1",
     "typescript": "^5.9.3"
   }

--- a/integrations/nitro/README.md
+++ b/integrations/nitro/README.md
@@ -55,7 +55,7 @@ Playwright test
                                 └─ visible in test-case detail + AI diagnosis
 ```
 
-The plugin uses two mechanisms:
+The plugin uses three mechanisms:
 
 1. **`event.context._piwiLogs`** — a plain array attached to the H3 event, readable by both the request and `beforeResponse` hooks via the same event object (no async-context propagation needed).
 2. **`AsyncLocalStorage`** — seeded in the `request` hook so that `consola` reporters can append to the per-request buffer from within synchronous route-handler code.


### PR DESCRIPTION
- CODE_OF_CONDUCT: use the project contact address (piwitests@gmail.com)
- DOCKER_HUB: bump the example image tags to the current 0.11.x scheme
- nitro integration README: correct "two mechanisms" to three
- example playwright-fixtures: bump the reporter dev dep to ^0.11.0
- mobile-responsiveness spec: drop the dangling internal plan reference


Claude-Session: https://claude.ai/code/session_01Cp4CzYiT9uL98Pa2QMKViM

<!--
Thanks for contributing! Two things to know:

1. PRs are squash-merged, so the PR TITLE becomes the commit on main and drives
   the release changelog. Give it a Conventional Commit title, e.g.
   `feat(reporter): support custom run labels` — see CONTRIBUTING.md.
2. For non-trivial changes, consider opening an issue/discussion first.
-->

## What & why

<!-- What does this change do, and what problem does it solve?
     Link related issues: Fixes #123 -->

## How was it tested?

<!-- Unit tests / E2E tests / manual steps. `npm test` runs the full suite. -->

## Checklist

- [ ] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (`docs/`, README, or reporter README)
