### PR TITLE
feat(reporter): open Playwright Inspector on failing page with inspectOnFailure

### DIFF
--- a/application/tests/fixtures.ts
+++ b/application/tests/fixtures.ts
@@ -36,6 +36,11 @@ import {
   probeElementAttrs,
   CAPTURED_ATTRS_ARG,
 } from '../../reporter/dist/internal/capture/capture-fixtures.js';
+import {
+  inspectionGateFromTestInfo,
+  pauseForInspection,
+  shouldInspectOnFailure,
+} from '../../reporter/dist/internal/capture/inspect-on-failure.js';
 import { ATTACHMENT_NAMES, LOCATOR_SUGGESTION_ANNOTATION } from '../../reporter/dist/internal/capture/attachments.js';
 
 type NetworkRequest = {
@@ -430,6 +435,15 @@ export const test = base.extend<{ page: Page }>({
     }
 
     await flush();
+
+    // Failure-time inspection (dogfooding: mirrors the reporter fixture) —
+    // hands the still-open failing page to the Playwright Inspector when
+    // PIWI_INSPECT_ON_FAIL=true and the browser is headed (never in CI). Runs
+    // after all capture so the attached evidence reflects the page as the test
+    // left it, not as the human poked at it.
+    if (shouldInspectOnFailure(inspectionGateFromTestInfo(testInfo))) {
+      await pauseForInspection(page, testInfo);
+    }
   },
 });
 

--- a/docs/capture-fixtures.md
+++ b/docs/capture-fixtures.md
@@ -123,6 +123,7 @@ Capture is designed to never fail or noticeably slow down a test:
 | `collectPerformanceMetrics: false` | Master switch — disables all fixture capture |
 | `captureLocators: false` (or `PIWI_CAPTURE_LOCATORS=false`) | Disables only the per-action locator snapshots; network, console, and Web Vitals stay on |
 | `capturePageState: false` (or `PIWI_CAPTURE_PAGE_STATE=false`) | Disables only the test-end app-state capture (URL, storage key names, cookie flags — values are never captured) |
+| `inspectOnFailure: true` (or `PIWI_INSPECT_ON_FAIL=true`) | Opt-in local debugging aid — a failing test opens the Playwright Inspector on its still-open page (headed browsers only, never in CI). See [Inspect the failing page live](./reporter#inspect-the-failing-page-live-local-runs) |
 
 ## Troubleshooting
 

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -108,6 +108,7 @@ Any attachments Playwright records — including **videos** (`video: 'retain-on-
 | `collectCiInfo`             | boolean  | `true`                    | Auto-collect CI environment info                                                            |
 | `collectPerformanceMetrics` | boolean  | `true`                    | Collect step timings, network requests and web vitals                                       |
 | `captureLocators`           | boolean  | `true`                    | Capture per-action element snapshots that power [locator healing](#locator-healing). Auto-disabled when `collectPerformanceMetrics` is `false` |
+| `inspectOnFailure`          | boolean  | `false`                   | Open the Playwright Inspector on the failing page after a local headed failure (see [Inspect the failing page live](#inspect-the-failing-page-live-local-runs)). Never activates under CI |
 | `username`                  | string   | —                         | Username for dashboard login (use `apiKey` instead when possible)                           |
 | `password`                  | string   | —                         | Password for dashboard login (used with `username`)                                         |
 | `apiKey`                    | string   | —                         | API key for authentication (preferred over `username`/`password` for CI)                    |
@@ -135,6 +136,7 @@ Every option above can also be set via a `PIWI_*` environment variable. Env vars
 | `PIWI_UPLOAD_TRACES`            | `uploadTraces`          | `true`/`false`  |
 | `PIWI_UPLOAD_REPORT`            | `uploadReport`          | `true`/`false`  |
 | `PIWI_CAPTURE_LOCATORS`         | `captureLocators`       | `true`/`false`  |
+| `PIWI_INSPECT_ON_FAIL`          | `inspectOnFailure`      | `true`/`false`  |
 | `PIWI_VERBOSE`                  | `verbose`               | `true`/`false`  |
 
 `wrapConfig` forwards the same `PIWI_*` vars into the isolated `global-setup` process so the run registration step shares the reporter's server/auth config.
@@ -323,6 +325,20 @@ The result is shown as an **Alternative locators** panel on the test-case and fa
 Capture adds a small per-action cost (one DOM read, sometimes an extra ARIA snapshot) in the test worker. Turn it off with `captureLocators: false` or `PIWI_CAPTURE_LOCATORS=false`; it is also disabled automatically whenever `collectPerformanceMetrics` is `false`.
 
 > Healing is read-only — it never rewrites your test. It surfaces the replacement so you can apply it yourself.
+
+### Inspect the failing page live (local runs)
+
+When a locator breaks while you're developing locally, the fastest fix is often to just look at the page. With `inspectOnFailure: true` (or `PIWI_INSPECT_ON_FAIL=true`), a failing test hands its still-open page to the **Playwright Inspector** right before the browser would close — use the Inspector's *Pick locator* tool to click the element and copy a working locator, then resume (▶) to let the run finish and upload as usual.
+
+```bash
+# Linux / macOS
+PIWI_INSPECT_ON_FAIL=true npx playwright test --headed
+
+# Windows (PowerShell)
+$env:PIWI_INSPECT_ON_FAIL='true'; npx playwright test --headed
+```
+
+Inspection is a local debugging aid and is deliberately conservative: it requires a **headed** browser (`--headed` / `headless: false`), never activates under CI (any `CI` env var), skips expected failures (`test.fail()`), and with retries configured it only pauses on the final attempt. While paused the run waits indefinitely (the test timeout is lifted), so prefer `--workers=1` when enabling it.
 
 ## Automatic metadata collection
 

--- a/reporter/src/internal/capture/capture-fixtures.ts
+++ b/reporter/src/internal/capture/capture-fixtures.ts
@@ -33,6 +33,7 @@ import {
   type FailedLocatorInfo,
 } from './locator-healing.js';
 import { ATTACHMENT_NAMES, LOCATOR_SUGGESTION_ANNOTATION } from './attachments.js';
+import { inspectionGateFromTestInfo, pauseForInspection, shouldInspectOnFailure } from './inspect-on-failure.js';
 
 /** A Playwright fixture's `use` callback — hands the fixture value to the test. */
 type UseFn<T> = (value: T) => Promise<void>;
@@ -182,6 +183,9 @@ interface CaptureSink {
   stashedWebVitals: WebVitals | null;
   stashedPageState: PageState | null;
   stashedAria: string | null;
+  // The failing page was already handed to the Inspector once this test —
+  // several close wrappers can fire for the same teardown.
+  inspected: boolean;
 }
 
 function createSink(): CaptureSink {
@@ -197,6 +201,7 @@ function createSink(): CaptureSink {
     stashedWebVitals: null,
     stashedPageState: null,
     stashedAria: null,
+    inspected: false,
   };
 }
 
@@ -496,6 +501,29 @@ async function stashPageState(sink: CaptureSink, closing: { page?: Page; context
     const aria = await ariaSnapshotBestEffort(page.locator(':root'), 1000);
     if (aria) sink.stashedAria = aria;
   }
+}
+
+/**
+ * Hand the failing page to the Playwright Inspector before it closes, when
+ * failure-time inspection is enabled (see `inspect-on-failure.ts` for the
+ * gate: opt-in, headed, never in CI, final attempt only). Runs after
+ * `stashPageState` so the captured failure evidence reflects the page as the
+ * test left it, not as the human poked at it.
+ */
+async function maybeInspectOnFailure(
+  sink: CaptureSink,
+  closing: { page?: Page; context?: BrowserContext },
+): Promise<void> {
+  if (sink.inspected) return;
+  const page = sink.lastActivePage;
+  const testInfo = sink.testInfo;
+  if (!page || !testInfo || isPageClosed(page)) return;
+  const belongsToClosing =
+    closing.page === page || (closing.context !== undefined && pageContext(page) === closing.context);
+  if (!belongsToClosing) return;
+  if (!shouldInspectOnFailure(inspectionGateFromTestInfo(testInfo))) return;
+  sink.inspected = true;
+  await pauseForInspection(page, testInfo);
 }
 
 // Idempotency guards: a page/context/browser can be reached through several
@@ -913,7 +941,10 @@ function instrumentPage(page: Page): void {
     page.close = async (...args: Parameters<Page['close']>): Promise<void> => {
       await drainPendingProbes(1000);
       const sink = currentSink;
-      if (sink) await stashPageState(sink, { page });
+      if (sink) {
+        await stashPageState(sink, { page });
+        await maybeInspectOnFailure(sink, { page });
+      }
       return originalClose(...args);
     };
   }
@@ -1028,7 +1059,10 @@ function instrumentContext(context: BrowserContext): void {
     context.close = async (...args: Parameters<BrowserContext['close']>): Promise<void> => {
       await drainPendingProbes(1000);
       const sink = currentSink;
-      if (sink) await stashPageState(sink, { context });
+      if (sink) {
+        await stashPageState(sink, { context });
+        await maybeInspectOnFailure(sink, { context });
+      }
       return originalClose(...args);
     };
   }
@@ -1142,6 +1176,13 @@ async function flushSink(sink: CaptureSink, testInfo: TestInfo): Promise<void> {
       }
     } catch {
       /* ignore */
+    }
+
+    // A page the test left open (e.g. a raw browser.newPage) never passes
+    // through the close wrappers — offer it to the Inspector here instead.
+    if (pageReadable && !sink.inspected && shouldInspectOnFailure(inspectionGateFromTestInfo(testInfo))) {
+      sink.inspected = true;
+      await pauseForInspection(page, testInfo);
     }
   }
 

--- a/reporter/src/internal/capture/inspect-on-failure.ts
+++ b/reporter/src/internal/capture/inspect-on-failure.ts
@@ -1,0 +1,75 @@
+import type { Page, TestInfo } from '@playwright/test';
+
+/**
+ * Failure-time inspection: when enabled (opt-in via the `inspectOnFailure`
+ * reporter option / `PIWI_INSPECT_ON_FAIL`), a failing test's page is handed
+ * to the Playwright Inspector (`page.pause()`) just before it would close, so
+ * the failing page can be examined live — including the Inspector's
+ * "Pick locator" tool to choose a replacement for a broken locator.
+ *
+ * Local-only by design: inspection needs a human and a visible browser, so the
+ * gate requires a headed browser and refuses to run under CI regardless of the
+ * flag. It also waits for the final attempt when retries are configured — an
+ * attempt that is about to be retried closes without pausing.
+ */
+
+/** Everything the gate reads, as plain values so it stays unit-testable. */
+export interface InspectionGate {
+  /** Raw `PIWI_INSPECT_ON_FAIL` env value — only the string `'true'` enables. */
+  enabled: string | undefined;
+  /** Raw `CI` env value. Anything except unset/empty/`'false'` counts as CI. */
+  ci: string | undefined;
+  /** `testInfo.status` at teardown. */
+  status: string | undefined;
+  /** `testInfo.expectedStatus` — an expected failure (test.fail()) never pauses. */
+  expectedStatus: string | undefined;
+  /** `testInfo.project.use.headless` — must be explicitly `false` (headed). */
+  headless: unknown;
+  /** Zero-based attempt index (`testInfo.retry`). */
+  retry: number;
+  /** Configured retry count for the project (`testInfo.project.retries`). */
+  retries: number;
+}
+
+/** Decide whether the failing page should be handed to the Inspector. */
+export function shouldInspectOnFailure(gate: InspectionGate): boolean {
+  if (gate.enabled !== 'true') return false;
+  if (gate.ci !== undefined && gate.ci !== '' && gate.ci !== 'false') return false;
+  if (gate.headless !== false) return false;
+  if (gate.status !== 'failed' && gate.status !== 'timedOut') return false;
+  if (gate.status === gate.expectedStatus) return false;
+  // Another attempt is coming — inspect the final failure, not each retry.
+  return gate.retry >= gate.retries;
+}
+
+/** Project the live TestInfo + process env into the plain gate shape. */
+export function inspectionGateFromTestInfo(testInfo: TestInfo): InspectionGate {
+  const use = (testInfo.project?.use ?? {}) as { headless?: unknown };
+  return {
+    enabled: process.env.PIWI_INSPECT_ON_FAIL,
+    ci: process.env.CI,
+    status: testInfo.status,
+    expectedStatus: testInfo.expectedStatus,
+    headless: use.headless,
+    retry: testInfo.retry,
+    retries: testInfo.project?.retries ?? 0,
+  };
+}
+
+/**
+ * Open the Playwright Inspector on the failing page and wait for the human to
+ * resume. Lifts the test timeout first — the run stays paused indefinitely —
+ * and never throws (a broken inspector must not mask the test's own failure).
+ */
+export async function pauseForInspection(page: Page, testInfo: TestInfo): Promise<void> {
+  try {
+    testInfo.setTimeout(0);
+    console.log(
+      `\n[piwi] "${testInfo.title}" ${testInfo.status} — opening the Playwright Inspector on the failing page. ` +
+        'Use "Pick locator" to choose a replacement locator, then resume (▶) to finish the run.',
+    );
+    await page.pause();
+  } catch {
+    // Inspection is best-effort — teardown continues either way.
+  }
+}

--- a/reporter/src/internal/config/env.ts
+++ b/reporter/src/internal/config/env.ts
@@ -47,6 +47,7 @@ export const PIWI_ENV_KEYS = {
   uploadReport: 'PIWI_UPLOAD_REPORT',
   captureLocators: 'PIWI_CAPTURE_LOCATORS',
   capturePageState: 'PIWI_CAPTURE_PAGE_STATE',
+  inspectOnFailure: 'PIWI_INSPECT_ON_FAIL',
 } as const;
 
 function readBool(val: string | undefined): boolean | undefined {
@@ -92,6 +93,7 @@ const ENV_FALLBACK_SPECS: ReadonlyArray<{
   { option: 'uploadReport', env: PIWI_ENV_KEYS.uploadReport, kind: 'bool' },
   { option: 'captureLocators', env: PIWI_ENV_KEYS.captureLocators, kind: 'bool' },
   { option: 'capturePageState', env: PIWI_ENV_KEYS.capturePageState, kind: 'bool' },
+  { option: 'inspectOnFailure', env: PIWI_ENV_KEYS.inspectOnFailure, kind: 'bool' },
 ];
 
 /**
@@ -156,4 +158,7 @@ export function applyOptionsToEnv(options: PiwiDashboardOptions): void {
   if (options.capturePageState === false || options.collectPerformanceMetrics === false)
     env[PIWI_ENV_KEYS.capturePageState] = 'false';
   else if (options.capturePageState === true) env[PIWI_ENV_KEYS.capturePageState] = 'true';
+  // Failure-time inspection runs in the worker fixture, so bridge it into the
+  // env the same way (default-off: only an explicit option value is written).
+  if (options.inspectOnFailure !== undefined) env[PIWI_ENV_KEYS.inspectOnFailure] = String(options.inspectOnFailure);
 }

--- a/reporter/src/public/options.ts
+++ b/reporter/src/public/options.ts
@@ -51,6 +51,16 @@ export interface PiwiDashboardOptions extends PlaywrightTestConfig {
    * also be forced off with `PIWI_CAPTURE_PAGE_STATE=false`.
    */
   capturePageState?: boolean;
+  /**
+   * Open the Playwright Inspector on the failing page when a test fails, so a
+   * replacement locator can be picked from the live page ("Pick locator")
+   * before the browser closes. Local debugging aid: only takes effect in a
+   * headed browser (`headless: false` / `--headed`), never under CI, and only
+   * on a test's final attempt when retries are configured. The run stays
+   * paused until the Inspector is resumed. Defaults to `false`. Can also be
+   * enabled with `PIWI_INSPECT_ON_FAIL=true`.
+   */
+  inspectOnFailure?: boolean;
   /** Enable live streaming of results (falls back to batch if unsupported). Defaults to `true`. */
   streaming?: boolean;
   /** Number of test results to batch before sending during streaming. Defaults to `5`. */

--- a/reporter/tests/inspect-on-failure.spec.ts
+++ b/reporter/tests/inspect-on-failure.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { shouldInspectOnFailure, type InspectionGate } from '../src/internal/capture/inspect-on-failure.js';
+import { resolveOptions, applyOptionsToEnv, PIWI_ENV_KEYS } from '../src/internal/config/env.js';
+
+/** A gate that passes every check — each test flips exactly one field. */
+function openGate(overrides: Partial<InspectionGate> = {}): InspectionGate {
+  return {
+    enabled: 'true',
+    ci: undefined,
+    status: 'failed',
+    expectedStatus: 'passed',
+    headless: false,
+    retry: 0,
+    retries: 0,
+    ...overrides,
+  };
+}
+
+describe('shouldInspectOnFailure', () => {
+  it('opens for a headed local failure when enabled', () => {
+    expect(shouldInspectOnFailure(openGate())).toBe(true);
+  });
+
+  it('opens for a timed-out test', () => {
+    expect(shouldInspectOnFailure(openGate({ status: 'timedOut' }))).toBe(true);
+  });
+
+  it('stays closed unless the flag is exactly "true"', () => {
+    expect(shouldInspectOnFailure(openGate({ enabled: undefined }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ enabled: 'false' }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ enabled: '1' }))).toBe(false);
+  });
+
+  it('never opens under CI, even when enabled', () => {
+    expect(shouldInspectOnFailure(openGate({ ci: 'true' }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ ci: '1' }))).toBe(false);
+  });
+
+  it('tolerates CI explicitly set to false or empty', () => {
+    expect(shouldInspectOnFailure(openGate({ ci: 'false' }))).toBe(true);
+    expect(shouldInspectOnFailure(openGate({ ci: '' }))).toBe(true);
+  });
+
+  it('requires an explicitly headed browser', () => {
+    expect(shouldInspectOnFailure(openGate({ headless: true }))).toBe(false);
+    // Unset headless means Playwright's default (headless) — stays closed.
+    expect(shouldInspectOnFailure(openGate({ headless: undefined }))).toBe(false);
+  });
+
+  it('only opens for failed/timedOut outcomes', () => {
+    expect(shouldInspectOnFailure(openGate({ status: 'passed' }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ status: 'skipped' }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ status: 'interrupted' }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ status: undefined }))).toBe(false);
+  });
+
+  it('skips an expected failure (test.fail())', () => {
+    expect(shouldInspectOnFailure(openGate({ expectedStatus: 'failed' }))).toBe(false);
+  });
+
+  it('waits for the final attempt when retries are configured', () => {
+    expect(shouldInspectOnFailure(openGate({ retry: 0, retries: 2 }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ retry: 1, retries: 2 }))).toBe(false);
+    expect(shouldInspectOnFailure(openGate({ retry: 2, retries: 2 }))).toBe(true);
+  });
+});
+
+describe('inspectOnFailure option plumbing', () => {
+  it('reads PIWI_INSPECT_ON_FAIL as a boolean fallback', () => {
+    const saved = process.env.PIWI_INSPECT_ON_FAIL;
+    try {
+      process.env.PIWI_INSPECT_ON_FAIL = 'true';
+      expect(resolveOptions({}).inspectOnFailure).toBe(true);
+      process.env.PIWI_INSPECT_ON_FAIL = 'false';
+      expect(resolveOptions({}).inspectOnFailure).toBe(false);
+      expect(resolveOptions({ inspectOnFailure: true }).inspectOnFailure).toBe(true);
+    } finally {
+      if (saved === undefined) delete process.env.PIWI_INSPECT_ON_FAIL;
+      else process.env.PIWI_INSPECT_ON_FAIL = saved;
+    }
+  });
+
+  it('bridges the option into the worker env', () => {
+    const saved = process.env.PIWI_INSPECT_ON_FAIL;
+    try {
+      delete process.env.PIWI_INSPECT_ON_FAIL;
+      applyOptionsToEnv({ inspectOnFailure: true });
+      expect(process.env[PIWI_ENV_KEYS.inspectOnFailure]).toBe('true');
+      applyOptionsToEnv({ inspectOnFailure: false });
+      expect(process.env[PIWI_ENV_KEYS.inspectOnFailure]).toBe('false');
+      // Unset option leaves the env untouched (default-off lives in the gate).
+      delete process.env.PIWI_INSPECT_ON_FAIL;
+      applyOptionsToEnv({});
+      expect(process.env[PIWI_ENV_KEYS.inspectOnFailure]).toBeUndefined();
+    } finally {
+      if (saved === undefined) delete process.env.PIWI_INSPECT_ON_FAIL;
+      else process.env.PIWI_INSPECT_ON_FAIL = saved;
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Tier 1 of the "page inspector on test failure" plan: an opt-in way to inspect the failing page **live** and pick a replacement locator before the browser closes.

- New reporter option `inspectOnFailure` (default `false`) + `PIWI_INSPECT_ON_FAIL` env var, bridged into the worker env like `captureLocators`.
- When a test fails locally in a headed browser, the capture fixtures hand the still-open page to the **Playwright Inspector** (`page.pause()`) just before the page/context would close. The Inspector's *Pick locator* tool then works on the real failing page; resuming lets teardown, upload, and reporting continue as usual.
- The pause runs **after** `stashPageState`, so the captured failure evidence (ARIA snapshot, web vitals, page state) reflects the page as the test left it — not as the human poked at it.
- Deliberately conservative gate (`shouldInspectOnFailure`): only the literal flag `true`, never under CI (any `CI` env value), requires `headless: false`/`--headed`, only `failed`/`timedOut` outcomes, skips expected failures (`test.fail()`), and with retries configured it pauses only on the final attempt. The test timeout is lifted while paused, and a broken inspector can never mask the test's own failure.
- Pages that never pass through a close wrapper (e.g. a raw `browser.newPage()` left open) get a fallback offer in `flushSink`.
- The dogfood fixture (`application/tests/fixtures.ts`) mirrors the behavior.

## How was it tested?

- New unit spec `reporter/tests/inspect-on-failure.spec.ts` covering every gate dimension (flag, CI, headless, status, expected status, retries) plus the `resolveOptions`/`applyOptionsToEnv` plumbing.
- Full reporter suite: 349 tests pass; `reporter:lint` and `oxfmt` clean.
- `npm run app:typecheck` passes for the dogfood fixture change.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125L3r4URdZwp9d4yuHdNY5

---
_Generated by [Claude Code](https://claude.ai/code/session_0125L3r4URdZwp9d4yuHdNY5)_