### PR TITLE
feat(app): surface user-picked locators and trace-viewer picking in healing panel

### DIFF
--- a/application/app/components/shared/LocatorAlternativeRow.vue
+++ b/application/app/components/shared/LocatorAlternativeRow.vue
@@ -33,7 +33,20 @@ function scoreBgClass(score: number): string {
       {{ alt.score }}/100
     </UBadge>
     <div class="flex-1 min-w-0">
-      <code class="text-sm font-mono block truncate">{{ alt.locator }}</code>
+      <div class="flex items-center gap-2 min-w-0">
+        <code class="text-sm font-mono truncate">{{ alt.locator }}</code>
+        <UBadge
+          v-if="alt.pickedByUser"
+          size="sm"
+          color="primary"
+          variant="subtle"
+          icon="i-lucide-user-check"
+          class="shrink-0"
+          title="Confirmed with the locator picker on the failing page"
+        >
+          Your pick
+        </UBadge>
+      </div>
       <p v-if="note" class="text-xs text-gray-500 mt-0.5">{{ note }}</p>
     </div>
     <UButton

--- a/application/app/components/shared/LocatorHealingPanel.vue
+++ b/application/app/components/shared/LocatorHealingPanel.vue
@@ -7,6 +7,7 @@
 
 import { recommendLocatorFix } from '#shared/locator-healing';
 import type { RankedLocator, LocatorFixRecommendation, LocatorHealingResult } from '#shared/locator-healing.types';
+import type { TraceInfo } from '~~/types/api';
 import SectionCard from './SectionCard.vue';
 import CollapsibleSectionCard from './CollapsibleSectionCard.vue';
 
@@ -68,6 +69,7 @@ const supplement = computed<RankedLocator[]>(() =>
 const recommendationNote = computed(() => {
   const r = recommendation.value;
   if (!r?.recommended) return '';
+  if (r.recommended.pickedByUser) return 'Confirmed with the locator picker on the failing page';
   if (r.preservesConvention) return 'Keeps your original locator style — minimal, idiomatic edit';
   if (r.suggestAddTestId) return 'Most stable available, but still fragile';
   return 'Most stable available — a sturdier style than the original';
@@ -118,6 +120,22 @@ const sourceClass = computed(() => {
 const failingLocatorText = computed(() => {
   const f = healing.value?.failingLocator;
   return f ? `${f.method}(${JSON.stringify(f.args)})` : '';
+});
+
+// The execution's failure trace, when one was uploaded — its recorded page
+// snapshots power the trace viewer's own "Pick locator" tool, so a locator
+// can be picked visually even for CI failures nobody watched live.
+const config = useRuntimeConfig();
+const { data: traces } = useFetch<TraceInfo[]>(() => `/api/test-run-cases/${props.testRunsCaseId}/traces`, {
+  lazy: true,
+});
+const pickTraceUrl = computed(() => {
+  const trace = traces.value?.[0];
+  if (!trace) return null;
+  // Demo mode serves its committed sample trace as a static asset (the
+  // viewer's service worker bypasses the demo API SW).
+  const isDemoStaticAsset = !!config.public.demoMode && trace.filePath.startsWith('demo/');
+  return getTraceViewerUrl(trace.filePath, config.app?.baseURL, isDemoStaticAsset);
 });
 
 const { copy } = useCopy();
@@ -176,6 +194,19 @@ function locatorNote(alt: RankedLocator): string {
       <span :class="sourceClass">
         {{ sourceNote }}
       </span>
+    </template>
+    <template v-if="pickTraceUrl" #actions>
+      <UButton
+        :to="pickTraceUrl"
+        target="_blank"
+        size="xs"
+        color="neutral"
+        variant="outline"
+        icon="i-lucide-crosshair"
+        title="Open the failure trace in the trace viewer — its Pick locator tool works on the recorded page snapshots"
+      >
+        Pick from trace
+      </UButton>
     </template>
 
     <!-- Failing locator -->
@@ -314,6 +345,19 @@ function locatorNote(alt: RankedLocator): string {
   >
     <template v-if="storageKey" #folded>
       <span>No alternatives available</span>
+    </template>
+    <template v-if="pickTraceUrl" #actions>
+      <UButton
+        :to="pickTraceUrl"
+        target="_blank"
+        size="xs"
+        color="neutral"
+        variant="outline"
+        icon="i-lucide-crosshair"
+        title="Open the failure trace in the trace viewer — its Pick locator tool works on the recorded page snapshots"
+      >
+        Pick from trace
+      </UButton>
     </template>
     <UAlert
       color="neutral"

--- a/application/app/components/shared/LocatorHealingPanel.vue
+++ b/application/app/components/shared/LocatorHealingPanel.vue
@@ -47,6 +47,10 @@ const alternatives = computed<RankedLocator[]>(() => {
   return healing.value.fromElementMatch ?? healing.value.fromPriorSuccess ?? healing.value.fromAriaSnapshot ?? [];
 });
 
+// A locator a human confirmed with the failure-time picker — surfaced as a
+// prominent callout at the top so it never hides in the ranked list.
+const userPick = computed<RankedLocator | null>(() => alternatives.value.find((a) => a.pickedByUser) ?? null);
+
 // The single recommended fix — convention-preserving where possible. Computed
 // server-side; fall back to the shared picker for payloads that lack it —
 // EXCEPT when the server deliberately withheld it because every stored
@@ -208,6 +212,27 @@ function locatorNote(alt: RankedLocator): string {
         Pick from trace
       </UButton>
     </template>
+
+    <!-- Human-confirmed pick — prominent callout at the very top -->
+    <div v-if="userPick" class="rounded-lg border border-primary/50 bg-primary/10 p-3 mb-3 flex items-center gap-3">
+      <UIcon name="i-lucide-user-check" class="size-5 text-primary shrink-0" />
+      <div class="flex-1 min-w-0">
+        <p class="text-xs font-medium text-primary flex items-center gap-1.5">
+          Your pick
+          <UBadge size="sm" color="primary" variant="subtle">confirmed on the failing page</UBadge>
+        </p>
+        <code class="text-sm font-mono block truncate mt-0.5">{{ userPick.locator }}</code>
+      </div>
+      <UButton
+        size="sm"
+        color="primary"
+        variant="solid"
+        :trailing-icon="copiedKey === 'user-pick' ? 'i-lucide-check' : 'i-lucide-copy'"
+        @click="copyLocator(userPick.locator, 'user-pick')"
+      >
+        Copy
+      </UButton>
+    </div>
 
     <!-- Failing locator -->
     <div

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -514,7 +514,7 @@ export const HELP_TOPICS = {
   // ── Locator healing ────────────────────────────────────────────────────
   'locator-healing': {
     title: 'Alternative locators',
-    text: 'When a locator breaks after a UI change, Piwi suggests pre-captured alternatives from the last passing run — or from another test in the project that uses the same locator. Each alternative is ranked by stability score — prefer data-testid (100) over CSS classes (10–40).',
+    text: 'When a locator breaks after a UI change, Piwi suggests pre-captured alternatives from the last passing run — or from another test in the project that uses the same locator. Each alternative is ranked by stability score — prefer data-testid (100) over CSS classes (10–40). A "Your pick" badge marks a replacement confirmed with the reporter’s failure-time locator picker, and "Pick from trace" opens the failure trace in the trace viewer, whose Pick locator tool works on the recorded page snapshots.',
     doc: 'reporter#locator-healing',
   },
 

--- a/application/shared/locator-healing.ts
+++ b/application/shared/locator-healing.ts
@@ -71,14 +71,19 @@ export function recommendLocatorFix(
     (failingMethod ? alternatives.find((a) => a.method === failingMethod && a.score >= floor) : undefined) ??
     (family ? alternatives.find((a) => LOCATOR_FAMILY[a.method] === family && a.score >= floor) : undefined);
 
+  // A human-confirmed pick (the reporter's failure-time locator picker)
+  // outranks the convention ladder — it is the one alternative a person
+  // verified against the intended element on the failing page.
+  const userPick = alternatives.find((a) => a.pickedByUser);
+
   // Escalate to the most stable alternative when nothing in the original family
   // is stable enough to keep.
-  const recommended = conventionPick ?? durable;
+  const recommended = userPick ?? conventionPick ?? durable;
 
   return {
     recommended,
     durable,
-    preservesConvention: !!conventionPick,
+    preservesConvention: !!conventionPick && recommended === conventionPick,
     hasDurableAlternative: recommended.locator !== durable.locator,
     // Even the most stable alternative is fragile — recommend adding a test id.
     suggestAddTestId: durable.score < floor,

--- a/application/shared/locator-healing.types.ts
+++ b/application/shared/locator-healing.types.ts
@@ -14,6 +14,12 @@ export interface RankedLocator {
   args: Record<string, unknown>;
   /** 0-100 stability score. data-testid=100, semantic CSS=35-40, hash-suffixed=10. */
   score: number;
+  /**
+   * True when a human confirmed this alternative in the reporter's
+   * failure-time locator picker (`pickLocatorOnFailure`). A confirmed pick is
+   * surfaced distinctly and preferred as the recommended fix.
+   */
+  pickedByUser?: boolean;
 }
 
 /**

--- a/application/tests/unit/locator-healing.test.ts
+++ b/application/tests/unit/locator-healing.test.ts
@@ -188,6 +188,31 @@ describe('recommendLocatorFix (convention-preserving)', () => {
     expect(rec.preservesConvention).toBe(false);
   });
 
+  test('a human-confirmed pick outranks the convention ladder', () => {
+    const picked = { ...alt('getByRole', 88), pickedByUser: true };
+    const rec = recommendLocatorFix('getByText', [alt('getByTestId', 100), picked, alt('getByText', 75)]);
+    expect(rec.recommended).toBe(picked);
+    // The convention pick (getByText) was not chosen — no style preservation claim.
+    expect(rec.preservesConvention).toBe(false);
+    expect(rec.hasDurableAlternative).toBe(true);
+    expect(rec.durable?.method).toBe('getByTestId');
+  });
+
+  test('a human-confirmed pick that is also the convention pick preserves convention', () => {
+    const picked = { ...alt('getByText', 75), pickedByUser: true };
+    const rec = recommendLocatorFix('getByText', [alt('getByTestId', 100), picked]);
+    expect(rec.recommended).toBe(picked);
+    expect(rec.preservesConvention).toBe(true);
+  });
+
+  test('a human-confirmed pick wins even below the stability floor', () => {
+    const picked = { ...alt('locator', 30, '.chosen'), pickedByUser: true };
+    const rec = recommendLocatorFix('getByText', [alt('getByTestId', 100), picked]);
+    expect(rec.recommended).toBe(picked);
+    expect(rec.preservesConvention).toBe(false);
+    expect(rec.hasDurableAlternative).toBe(true);
+  });
+
   test('returns nulls for an empty alternative list', () => {
     const rec = recommendLocatorFix('getByRole', []);
     expect(rec.recommended).toBeNull();

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -320,6 +320,8 @@ The result is shown as an **Alternative locators** panel on the test-case and fa
   <figcaption>The Alternative locators panel — replacements ranked by stability score (data-testid ≈ 100, role + name ≈ 90), with a recommended fix and a copy button for each.</figcaption>
 </figure>
 
+When the failing execution has an uploaded trace, the panel offers **Pick from trace**: it opens the trace in the dashboard's bundled [trace viewer](./ui-overview#trace-viewer), whose *Pick locator* tool works on the recorded page snapshots — so a replacement locator can be picked visually even for a CI failure nobody watched live. A replacement confirmed with the reporter's failure-time locator picker (`pickLocatorOnFailure`) shows a **Your pick** badge and becomes the recommended fix.
+
 Capture adds a small per-action cost (one DOM read, sometimes an extra ARIA snapshot) in the test worker. Turn it off with `captureLocators: false` or `PIWI_CAPTURE_LOCATORS=false`; it is also disabled automatically whenever `collectPerformanceMetrics` is `false`.
 
 > Healing is read-only — it never rewrites your test. It surfaces the replacement so you can apply it yourself.


### PR DESCRIPTION
## What & why

Tier 3 of the "page inspector on test failure" plan — the dashboard side, closing the loop for failures nobody watched live (companions: #245 Inspector-on-failure, #246 failure-time locator picker; this PR is independent and mergeable on its own).

- **Pick from trace**: the *Alternative locators* panel now offers a "Pick from trace" action when the failing execution has an uploaded trace. It opens the trace in the already-bundled self-hosted trace viewer (`/trace-viewer/`), whose built-in **Pick locator** tool works on the recorded page snapshots — so a replacement locator can be picked visually for a CI failure, post-hoc, with zero new inspector code. The action is also shown on the panel's empty state (no pre-captured alternatives is exactly when it helps most), handles demo mode's static-asset traces, and self-fetches from the existing `/api/test-run-cases/[id]/traces` endpoint (already mirrored in the demo router).
- **Your pick surfacing**: `RankedLocator` gains an optional `pickedByUser` flag (written by the reporter's `pickLocatorOnFailure` picker from #246; the server already stores `alternatives` verbatim, so no ingest changes). A confirmed pick renders with a "Your pick" badge in the alternatives list, and `recommendLocatorFix` now prefers a human-confirmed pick over the convention ladder — it's the one alternative a person verified against the intended element. Since the recommendation is shared logic, the server API, the demo, and the AI diagnosis `suggestedFix` all pick it up consistently. `preservesConvention` is now claimed only when the convention pick is actually the recommended one.
- Help topic (`locator-healing`) and `docs/reporter.md` updated.

## How was it tested?

- New unit tests in `application/tests/unit/locator-healing.test.ts`: a confirmed pick outranks the convention ladder, preserves-convention semantics when the pick *is* the convention pick, and a pick winning even below the stability floor. Full unit suite: 439 tests pass.
- `npm run app:typecheck` and `npm run app:lint` clean.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125L3r4URdZwp9d4yuHdNY5

---
_Generated by [Claude Code](https://claude.ai/code/session_0125L3r4URdZwp9d4yuHdNY5)_