### PR TITLE
feat(snapshot): render ARIA tree as nested inspector view with toggle

### DIFF
--- a/application/app/components/shared/SnapshotLocatorPicker.vue
+++ b/application/app/components/shared/SnapshotLocatorPicker.vue
@@ -33,31 +33,62 @@ const emit = defineEmits<{
 
 const isOpen = defineModel<boolean>('open', { required: true });
 
+type SnapshotSource = 'dom' | 'aria';
+
 interface DomSnapshotResponse {
   status: 'ok' | 'no-trace' | 'no-snapshot';
   html?: string;
   snapshotName?: string;
   viewport?: { width: number; height: number };
+  source?: SnapshotSource;
+  availableSources?: SnapshotSource[];
 }
 
 const snapshotPending = ref(false);
 const snapshot = ref<DomSnapshotResponse | null>(null);
 const snapshotError = ref<string | null>(null);
+// Which representation to request — undefined lets the server choose (trace
+// DOM when available, else the ARIA tree). Set from the response and by the
+// view toggle so the ARIA tree can be viewed even when a trace exists.
+const viewSource = ref<SnapshotSource | undefined>(undefined);
 
 async function fetchSnapshot() {
   snapshotPending.value = true;
   snapshotError.value = null;
   try {
     // Same endpoint as the read-only DOM snapshot card — trace-derived DOM with
-    // an ARIA-snapshot fallback. The picker adds its own interactive overlay.
+    // an ARIA-tree fallback (or ?source=aria on demand). The picker adds its own
+    // interactive overlay.
+    const query = viewSource.value ? `?source=${viewSource.value}` : '';
     snapshot.value = await $fetch<DomSnapshotResponse>(
-      `/api/test-runs/${props.runId}/cases/${props.testRunsCaseId}/dom-snapshot`,
+      `/api/test-runs/${props.runId}/cases/${props.testRunsCaseId}/dom-snapshot${query}`,
     );
+    // Reflect what the server actually rendered so the toggle stays in sync.
+    if (snapshot.value?.source) viewSource.value = snapshot.value.source;
   } catch (err: unknown) {
     snapshotError.value = err instanceof Error ? err.message : 'Unknown error';
   } finally {
     snapshotPending.value = false;
   }
+}
+
+const availableSources = computed<SnapshotSource[]>(() => snapshot.value?.availableSources ?? []);
+
+/** Switch representation (DOM ⇄ ARIA tree) and reload the picker on the new view. */
+function selectSource(src: SnapshotSource) {
+  if (src === viewSource.value || snapshotPending.value) return;
+  viewSource.value = src;
+  iframeReady.value = false;
+  step.value = 'pick-element';
+  contentHeight.value = 0;
+  userZoomed.value = false;
+  pickedAttrs.value = null;
+  alternatives.value = [];
+  selectedAlt.value = null;
+  searchQuery.value = '';
+  searchCount.value = 0;
+  searchIndex.value = -1;
+  fetchSnapshot();
 }
 
 watch(isOpen, (open) => {
@@ -67,6 +98,8 @@ watch(isOpen, (open) => {
     step.value = 'pick-element';
     contentHeight.value = 0;
     userZoomed.value = false;
+    // Let the server choose the default view again on each open.
+    viewSource.value = undefined;
     // A previous session's pick must not leak into this one — Confirm would
     // otherwise already be enabled with a stale selection.
     pickedAttrs.value = null;
@@ -144,13 +177,16 @@ const fitZoom = computed(() => {
 
 const canvasStyle = computed(() => {
   const vp = viewport.value;
-  if (!vp) return { width: '100%', height: '100%' };
+  // No viewport (ARIA tree): fill the pane width, but grow to the reported
+  // content height once known so the stage — not the iframe — scrolls, which
+  // lets find-by-text jump to a match the same way the DOM view does.
+  if (!vp) return { width: '100%', height: contentHeight.value ? `${contentHeight.value}px` : '100%' };
   const h = contentHeight.value || vp.height;
   return { width: `${Math.round(vp.width * zoom.value)}px`, height: `${Math.round(h * zoom.value)}px` };
 });
 const iframeStyle = computed(() => {
   const vp = viewport.value;
-  if (!vp) return { width: '100%', height: '100%', border: '0' };
+  if (!vp) return { width: '100%', height: contentHeight.value ? `${contentHeight.value}px` : '100%', border: '0' };
   const h = contentHeight.value || vp.height;
   return {
     width: `${vp.width}px`,
@@ -440,24 +476,55 @@ onBeforeUnmount(() => {
       </div>
 
       <template v-else>
-        <!-- Source note -->
-        <div
-          v-if="snapshot.snapshotName"
-          class="mb-2 text-xs flex items-center gap-1"
-          :class="
-            snapshot.snapshotName === 'aria-fallback'
-              ? 'text-amber-600 dark:text-amber-400'
-              : 'text-green-600 dark:text-green-400'
-          "
-        >
-          <UIcon
-            :name="snapshot.snapshotName === 'aria-fallback' ? 'i-lucide-info' : 'i-lucide-check'"
-            class="size-3.5 shrink-0"
-          />
-          <template v-if="snapshot.snapshotName === 'aria-fallback'">
-            Rendered from the ARIA snapshot — element styles are approximate
-          </template>
-          <template v-else> Rendered from the failure-time DOM snapshot </template>
+        <!-- Source note + view toggle (DOM ⇄ accessibility tree) -->
+        <div class="mb-2 flex items-center gap-2 flex-wrap">
+          <div
+            v-if="snapshot.source"
+            class="text-xs flex items-center gap-1"
+            :class="
+              snapshot.source === 'aria' ? 'text-amber-600 dark:text-amber-400' : 'text-green-600 dark:text-green-400'
+            "
+          >
+            <UIcon
+              :name="snapshot.source === 'aria' ? 'i-lucide-accessibility' : 'i-lucide-check'"
+              class="size-3.5 shrink-0"
+            />
+            <template v-if="snapshot.source === 'aria'">
+              Accessibility tree from the failure-time ARIA snapshot — element styles are approximate
+            </template>
+            <template v-else> Rendered from the failure-time DOM snapshot </template>
+          </div>
+
+          <!-- Only offered when the case has both representations -->
+          <div
+            v-if="availableSources.length > 1"
+            class="ml-auto inline-flex rounded-md border border-default overflow-hidden text-xs"
+          >
+            <button
+              type="button"
+              class="px-2 py-1 flex items-center gap-1 transition-colors"
+              :class="
+                viewSource === 'dom' ? 'bg-primary/10 text-primary font-medium' : 'text-gray-500 hover:bg-elevated'
+              "
+              title="Rendered page from the trace"
+              @click="selectSource('dom')"
+            >
+              <UIcon name="i-lucide-layout-panel-top" class="size-3.5" />
+              DOM
+            </button>
+            <button
+              type="button"
+              class="px-2 py-1 flex items-center gap-1 border-l border-default transition-colors"
+              :class="
+                viewSource === 'aria' ? 'bg-primary/10 text-primary font-medium' : 'text-gray-500 hover:bg-elevated'
+              "
+              title="Accessibility tree from the ARIA snapshot"
+              @click="selectSource('aria')"
+            >
+              <UIcon name="i-lucide-accessibility" class="size-3.5" />
+              Tree
+            </button>
+          </div>
         </div>
 
         <!-- Zoom toolbar — only when the recorded viewport is known -->
@@ -510,14 +577,12 @@ onBeforeUnmount(() => {
 
         <!-- Iframe with the snapshot. When the viewport is known the iframe is
            sized to it and scaled with a CSS transform (proportions preserved);
-           otherwise it fills the pane (ARIA fallback has no viewport). -->
+           otherwise it fills the pane width and grows to its content height so
+           the stage scrolls (the ARIA tree has no viewport). -->
         <div
           ref="stageRef"
-          class="relative border border-default rounded-lg"
-          :class="[
-            step === 'pick-element' ? 'h-[75vh]' : 'h-80',
-            viewport ? 'overflow-auto bg-gray-100 dark:bg-gray-800' : 'overflow-hidden',
-          ]"
+          class="relative border border-default rounded-lg overflow-auto"
+          :class="[step === 'pick-element' ? 'h-[75vh]' : 'h-80', viewport ? 'bg-gray-100 dark:bg-gray-800' : '']"
         >
           <!-- Loading overlay until the picker script initializes -->
           <div

--- a/application/app/demo/api/dom-snapshot.ts
+++ b/application/app/demo/api/dom-snapshot.ts
@@ -50,30 +50,43 @@ const CHECKOUT_DOM_SNAPSHOT = {
 
 /**
  * GET /api/test-runs/:id/cases/:caseId/dom-snapshot — mirrors the server's
- * `resolveCaseDomSnapshot` order: trace-first, then the ARIA-snapshot fallback.
- * The trace path can't run in the browser (node-only zlib), so the one demo
- * case carrying the committed trace returns the pre-rendered result; every
- * other failed case renders its seeded `ariaSnapshot` with the same browser-safe
- * renderer the real app uses for trace-less failures.
+ * `resolveCaseDomSnapshot`: trace-derived DOM by default, the ARIA tree as a
+ * fallback or on demand (`?source=aria`), and `availableSources` so the picker
+ * can offer the view toggle. The trace path can't run in the browser (node-only
+ * zlib), so the one demo case carrying the committed trace returns the
+ * pre-rendered result; every failed case's seeded `ariaSnapshot` renders with
+ * the same browser-safe renderer the real app uses.
  */
-export async function apiGetDemoDomSnapshot(testRunsCaseId: number): Promise<unknown> {
+export async function apiGetDemoDomSnapshot(testRunsCaseId: number, query?: URLSearchParams): Promise<unknown> {
   const db = await getDemoDb();
-  const traceRows = await db
-    .select({ id: files.id })
-    .from(files)
-    .where(and(eq(files.testRunsCaseId, testRunsCaseId), eq(files.type, 'trace')))
-    .limit(1);
-  if (traceRows.length > 0) return CHECKOUT_DOM_SNAPSHOT;
+  const [traceRows, caseRows] = await Promise.all([
+    db
+      .select({ id: files.id })
+      .from(files)
+      .where(and(eq(files.testRunsCaseId, testRunsCaseId), eq(files.type, 'trace')))
+      .limit(1),
+    db
+      .select({ aria: testRunsCases.ariaSnapshot })
+      .from(testRunsCases)
+      .where(eq(testRunsCases.id, testRunsCaseId))
+      .limit(1),
+  ]);
 
-  const caseRows = await db
-    .select({ aria: testRunsCases.ariaSnapshot })
-    .from(testRunsCases)
-    .where(eq(testRunsCases.id, testRunsCaseId))
-    .limit(1);
-  const aria = caseRows[0]?.aria;
-  if (aria) {
-    const html = renderAriaSnapshotHtml(aria);
-    if (html) return { status: 'ok', html, truncated: false, snapshotName: 'aria-fallback' };
-  }
-  return { status: 'no-trace' };
+  const hasTrace = traceRows.length > 0;
+  const ariaHtml = caseRows[0]?.aria ? renderAriaSnapshotHtml(caseRows[0].aria) : null;
+  const availableSources = [...(hasTrace ? ['dom'] : []), ...(ariaHtml ? ['aria'] : [])];
+  const source = query?.get('source');
+  const asAria = () => ({
+    status: 'ok' as const,
+    html: ariaHtml!,
+    truncated: false,
+    snapshotName: 'aria-fallback',
+    source: 'aria' as const,
+    availableSources,
+  });
+
+  if (source === 'aria' && ariaHtml) return asAria();
+  if (hasTrace) return { ...CHECKOUT_DOM_SNAPSHOT, source: 'dom', availableSources };
+  if (ariaHtml) return asAria();
+  return { status: 'no-trace', availableSources };
 }

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -437,7 +437,7 @@ const routes: RouteEntry[] = [
   {
     method: 'GET',
     pattern: /^\/api\/test-runs\/(\d+)\/cases\/(\d+)\/dom-snapshot$/,
-    handler: async (m) => apiGetDemoDomSnapshot(+m[2]!),
+    handler: async (m, _body, query) => apiGetDemoDomSnapshot(+m[2]!, query),
   },
   // The demo cannot pixel-diff in the browser — it serves the overlay the
   // seed generated with the real diff code, straight from the files row.

--- a/application/server/api/test-runs/[id]/cases/[caseId]/dom-snapshot.get.ts
+++ b/application/server/api/test-runs/[id]/cases/[caseId]/dom-snapshot.get.ts
@@ -15,10 +15,17 @@ defineRouteMeta({
     tags: ['Test Runs'],
     summary: 'Render the failure-time DOM snapshot for a test-run case',
     description:
-      'Extracts the DOM snapshot from the stored trace ZIP, falling back to a simplified render of the captured ARIA snapshot when no trace is available. Input values, inline handlers and script bodies are never included; token-shaped strings are masked.',
+      'Extracts the DOM snapshot from the stored trace ZIP, falling back to a nested render of the captured ARIA snapshot when no trace is available. Pass `source=aria` to render the ARIA tree even when a trace exists. Input values, inline handlers and script bodies are never included; token-shaped strings are masked.',
     parameters: [
       { name: 'id', in: 'path', required: true, schema: { type: 'integer' }, description: 'Test run id' },
       { name: 'caseId', in: 'path', required: true, schema: { type: 'integer' }, description: 'Test run case id' },
+      {
+        name: 'source',
+        in: 'query',
+        required: false,
+        schema: { type: 'string', enum: ['dom', 'aria'] },
+        description: 'Which representation to render — trace-derived DOM (default) or the ARIA tree',
+      },
     ],
     'x-required-roles': REQUIRED_ROLES,
   },
@@ -33,6 +40,9 @@ export default eventHandler(async (event) => {
   // another project (the cluster page may pass a caseId from another run).
   const { db } = await requireResolvedProjectAccess(event, caseId, resolveTestRunCaseProjectId, 'Test run case');
 
+  const sourceParam = getQuery(event).source;
+  const source = sourceParam === 'aria' || sourceParam === 'dom' ? sourceParam : undefined;
+
   const [traceRows, caseRows] = await Promise.all([
     db
       .select({ path: files.path })
@@ -42,5 +52,5 @@ export default eventHandler(async (event) => {
     db.select({ aria: testRunsCases.ariaSnapshot }).from(testRunsCases).where(eq(testRunsCases.id, caseId)).limit(1),
   ]);
 
-  return resolveCaseDomSnapshot(traceRows[0]?.path ?? null, caseRows[0]?.aria ?? null);
+  return resolveCaseDomSnapshot(traceRows[0]?.path ?? null, caseRows[0]?.aria ?? null, undefined, { source });
 });

--- a/application/server/utils/dom-snapshot-aria.ts
+++ b/application/server/utils/dom-snapshot-aria.ts
@@ -1,82 +1,269 @@
 /**
- * ARIA-snapshot fallback rendering — the DOM view for executions with no stored
- * trace (only the captured ARIA tree). Kept in its own module (no node-only
- * imports) so the browser demo can render it too: the trace path in
- * `dom-snapshot.ts` pulls in node-only zlib, but this renderer needs nothing
- * beyond `parseAriaCandidates`. `dom-snapshot.ts` re-exports it, so server
- * callers are unchanged.
+ * ARIA-snapshot rendering — the accessibility-tree view of a failure. Used as
+ * the fallback for executions with no stored trace (only the captured ARIA
+ * tree), and as an on-demand alternative view even when a trace *is* available.
+ *
+ * Playwright's `ariaSnapshot()` dump is an indented, YAML-ish tree; this module
+ * parses that tree back into a real hierarchy and renders it as a nested,
+ * inspector-style view (role chips + accessible names + state badges, drawn
+ * with tree guides), rather than the old flat list of chips. Pickable rows
+ * carry real `role` / `aria-label` / `aria-level` attributes so the interactive
+ * locator picker probes them into correct `getByRole` / `getByText` locators.
+ *
+ * Kept in its own module (no node-only imports) so the browser demo can render
+ * it too: the trace path in `dom-snapshot.ts` pulls in node-only zlib, but this
+ * renderer needs nothing beyond string parsing. `dom-snapshot.ts` re-exports it,
+ * so server callers are unchanged.
  */
-import { parseAriaCandidates } from '#shared/locator-fingerprint';
 
-function escapeText(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+/** One node parsed out of an `ariaSnapshot()` dump. */
+interface AriaTreeNode {
+  role: string;
+  /** Accessible name (quoted in the dump), when present. */
+  name: string | null;
+  /** Heading level parsed from a `[level=N]` marker, null when absent. */
+  level: number | null;
+  /** State markers: `disabled`, `checked`, `expanded`, `checked=mixed`, … */
+  states: string[];
+  /** Trailing text value (for `text:`/`paragraph:` nodes with inline content). */
+  value: string | null;
+  children: AriaTreeNode[];
 }
 
-/** Role → inline chip style for the ARIA-snapshot fallback rendering. */
+/** The accessible name is untrusted tested-page DOM — escape in both contexts. */
+function escapeText(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+const unescapeName = (s: string): string => s.replace(/\\(.)/g, '$1');
+
+/** Roles that carry no useful `getByRole` locator — picked via text instead. */
+const NO_ROLE_LOCATOR = new Set(['generic', 'none', 'presentation', 'paragraph', 'text']);
+/** Nameless structural wrappers whose children are hoisted so the tree stays legible. */
+const HOISTED_WHEN_NAMELESS = new Set(['generic', 'none', 'presentation']);
+
+/** Role → inline chip style (background + text color). */
 const ARIA_ROLE_COLORS: Record<string, string> = {
   button: 'background:#dbeafe;color:#1e40af',
   link: 'background:#dbeafe;color:#1e40af',
-  heading: 'background:#f3e8ff;color:#6b21a8;font-weight:600',
+  heading: 'background:#f3e8ff;color:#6b21a8',
   textbox: 'background:#dcfce7;color:#166534',
   searchbox: 'background:#dcfce7;color:#166534',
   combobox: 'background:#dcfce7;color:#166534',
   listbox: 'background:#dcfce7;color:#166534',
   spinbutton: 'background:#dcfce7;color:#166534',
+  slider: 'background:#dcfce7;color:#166534',
   checkbox: 'background:#fef3c7;color:#92400e',
   radio: 'background:#fef3c7;color:#92400e',
   switch: 'background:#fef3c7;color:#92400e',
-  navigation: 'background:#f1f5f9;color:#334155;border:1px dashed #cbd5e1',
-  main: 'background:#f1f5f9;color:#334155;border:1px dashed #cbd5e1',
-  region: 'background:#f1f5f9;color:#334155;border:1px dashed #cbd5e1',
-  form: 'background:#f1f5f9;color:#334155;border:1px dashed #cbd5e1',
-  article: 'background:#f1f5f9;color:#334155;border:1px dashed #cbd5e1',
+  navigation: 'background:#f1f5f9;color:#334155',
+  main: 'background:#f1f5f9;color:#334155',
+  banner: 'background:#f1f5f9;color:#334155',
+  contentinfo: 'background:#f1f5f9;color:#334155',
+  complementary: 'background:#f1f5f9;color:#334155',
+  region: 'background:#f1f5f9;color:#334155',
+  form: 'background:#f1f5f9;color:#334155',
+  search: 'background:#f1f5f9;color:#334155',
+  article: 'background:#f1f5f9;color:#334155',
+  dialog: 'background:#ffe4e6;color:#9f1239',
+  alert: 'background:#fee2e2;color:#991b1b',
   img: 'background:#fce7f3;color:#9d174d',
+  list: 'background:#f8fafc;color:#475569',
   listitem: 'background:#f8fafc;color:#475569',
   tab: 'background:#e0e7ff;color:#3730a3',
+  tablist: 'background:#e0e7ff;color:#3730a3',
   tabpanel: 'background:#f5f3ff;color:#5b21b6',
   menuitem: 'background:#f8fafc;color:#475569',
+  menu: 'background:#f8fafc;color:#475569',
   option: 'background:#f8fafc;color:#475569',
   table: 'background:#f1f5f9;color:#334155',
   rowgroup: 'background:#f8fafc;color:#475569',
   row: 'background:#f8fafc;color:#475569',
   columnheader: 'background:#e0e7ff;color:#3730a3',
+  rowheader: 'background:#e0e7ff;color:#3730a3',
   cell: 'background:#f8fafc;color:#475569',
-  separator: 'background:transparent;color:#888',
+  gridcell: 'background:#f8fafc;color:#475569',
+  separator: 'background:#f8fafc;color:#94a3b8',
 };
 
+/** Parse the content after `- ` on one snapshot line into a node (null if unparseable). */
+function parseNodeContent(content: string): AriaTreeNode | null {
+  const s = content.trim();
+  if (!s) return null;
+
+  const roleMatch = s.match(/^([a-zA-Z]+)/);
+  if (!roleMatch) {
+    // A bare quoted string is a text node: `- "some text"`.
+    const quoted = s.match(/^"((?:[^"\\]|\\.)*)"/);
+    if (quoted) {
+      return { role: 'text', name: null, level: null, states: [], value: unescapeName(quoted[1]!), children: [] };
+    }
+    return null;
+  }
+
+  const role = roleMatch[1]!.toLowerCase();
+  let rest = s.slice(roleMatch[0].length);
+
+  // Accessible name, quoted right after the role.
+  let name: string | null = null;
+  const nameMatch = rest.match(/^\s+"((?:[^"\\]|\\.)*)"/);
+  if (nameMatch) {
+    name = unescapeName(nameMatch[1]!);
+    rest = rest.slice(nameMatch[0].length);
+  }
+
+  // `[level=N]` and other `[state]` / `[state=value]` markers (ignore `[ref=eN]`).
+  let level: number | null = null;
+  const states: string[] = [];
+  for (const marker of rest.matchAll(/\[([a-z][a-z0-9-]*)(?:=([^\]]*))?\]/gi)) {
+    const key = marker[1]!.toLowerCase();
+    const val = marker[2];
+    if (key === 'level') level = val != null ? Number(val) : null;
+    else if (key === 'ref') continue;
+    else states.push(val != null ? `${key}=${val}` : key);
+  }
+
+  // Inline text value: `text: hello`, `paragraph: some text` (a bare trailing
+  // `:` just opens a child block and carries no value).
+  let value: string | null = null;
+  const withoutBrackets = rest.replace(/\[[^\]]*\]/g, '').trim();
+  if (withoutBrackets.startsWith(':')) {
+    let after = withoutBrackets.slice(1).trim();
+    const q = after.match(/^"((?:[^"\\]|\\.)*)"$/);
+    if (q) after = unescapeName(q[1]!);
+    if (after) value = after;
+  }
+
+  return { role, name, level, states, value, children: [] };
+}
+
+/** Parse the whole snapshot into a tree, nesting by leading-whitespace indent. */
+function parseAriaTree(ariaSnapshot: string): AriaTreeNode[] {
+  const root: AriaTreeNode = { role: '', name: null, level: null, states: [], value: null, children: [] };
+  const stack: { indent: number; node: AriaTreeNode }[] = [{ indent: -1, node: root }];
+
+  for (const rawLine of ariaSnapshot.split('\n')) {
+    const m = rawLine.match(/^(\s*)-\s+(.*)$/);
+    if (!m) continue;
+    const indent = m[1]!.length;
+    const node = parseNodeContent(m[2]!);
+    if (!node) continue;
+    while (stack.length > 1 && stack[stack.length - 1]!.indent >= indent) stack.pop();
+    stack[stack.length - 1]!.node.children.push(node);
+    stack.push({ indent, node });
+  }
+  return root.children;
+}
+
+/** The text a node contributes to picking: its value for text nodes, else its name. */
+function nodeText(node: AriaTreeNode): string {
+  const isTextual = node.role === 'text' || (node.role === 'paragraph' && !!node.value && !node.name);
+  const raw = isTextual ? (node.value ?? '') : (node.name ?? '');
+  return raw.length > 300 ? raw.slice(0, 300) : raw;
+}
+
+function renderNode(node: AriaTreeNode): string {
+  const isTextual = node.role === 'text' || (node.role === 'paragraph' && !!node.value && !node.name);
+  const text = nodeText(node);
+  const hasRoleLocator = !NO_ROLE_LOCATOR.has(node.role);
+  // Only nodes with an accessible name (or textual value) yield a useful locator.
+  const pickable = text.trim().length > 0;
+
+  const badges: string[] = [];
+  if (node.level != null && Number.isFinite(node.level)) badges.push(`level ${node.level}`);
+  for (const st of node.states) badges.push(st);
+  const badgeStr = badges.join(' · ');
+
+  // Rows are marked and styled via data-* attributes, never `class`: the picker
+  // probe reads `class` off the picked element, so a styling class here would
+  // leak a bogus `locator('.pw-row')` alternative for every ARIA pick.
+  let attrs = ` data-pw-row data-role="${escapeAttr(node.role)}"`;
+  if (isTextual) attrs += ' data-pw-text';
+  if (node.name) attrs += ` data-name="${escapeAttr(node.name)}"`;
+  if (badgeStr) attrs += ` data-badges="${escapeAttr(badgeStr)}"`;
+
+  if (pickable) {
+    attrs += ' data-pw-pick';
+    // Real ARIA attributes so the picker probe resolves the right role/name.
+    if (hasRoleLocator) {
+      attrs += ` role="${escapeAttr(node.role)}"`;
+      if (node.name) attrs += ` aria-label="${escapeAttr(node.name)}"`;
+      if (node.level != null && Number.isFinite(node.level)) attrs += ` aria-level="${node.level}"`;
+    }
+  }
+
+  const row = `<div${attrs}>${escapeText(text)}</div>`;
+  const kids = node.children.length ? `<div data-pw-children>${renderNodes(node.children)}</div>` : '';
+  return `<div data-pw-node>${row}${kids}</div>`;
+}
+
+function renderNodes(nodes: AriaTreeNode[]): string {
+  let out = '';
+  for (const node of nodes) {
+    // Hoist the children of nameless structural wrappers so the tree isn't
+    // buried under `generic`/`presentation` rows that carry no information.
+    if (HOISTED_WHEN_NAMELESS.has(node.role) && !node.name && !node.value) {
+      out += renderNodes(node.children);
+      continue;
+    }
+    out += renderNode(node);
+  }
+  return out;
+}
+
 /**
- * Render a Playwright ARIA snapshot to a standalone HTML document — the
- * fallback for executions with no stored trace (only the captured ARIA tree).
- * Each accessibility node becomes a role-colored chip carrying its `data-role`/
- * `data-name`. Returns null when the snapshot yields no candidates.
+ * Per-role chip color rules generated from ARIA_ROLE_COLORS. Attribute values
+ * are left unquoted (valid, since roles are CSS identifiers) so the stylesheet
+ * never contains the `data-role="…"` string the rendered rows carry.
+ */
+function roleChipCss(): string {
+  return Object.entries(ARIA_ROLE_COLORS)
+    .map(([role, style]) => `[data-pw-row][data-role=${role}]::before{${style}}`)
+    .join('\n');
+}
+
+/**
+ * Render a Playwright ARIA snapshot to a standalone HTML document — a nested,
+ * inspector-style accessibility tree. Each node is a role-colored chip plus its
+ * accessible name and any level/state badges, indented under its parent with
+ * tree guides. Pickable rows carry `data-role`/`data-name` and real
+ * `role`/`aria-label`/`aria-level` so the locator picker probes them correctly.
+ * Returns null when the snapshot yields no renderable nodes.
  *
  * The accessible name is untrusted (tested-page DOM) and this HTML is loaded
- * into a same-origin iframe, so it is escaped in both attribute and text
- * contexts to prevent markup injection / XSS.
+ * into a sandboxed iframe, so it is escaped in both attribute and text contexts.
  */
 export function renderAriaSnapshotHtml(ariaSnapshot: string): string | null {
-  const candidates = parseAriaCandidates(ariaSnapshot);
-  if (candidates.length === 0) return null;
-
-  let body = '';
-  for (const c of candidates) {
-    const style = ARIA_ROLE_COLORS[c.role] ?? 'background:transparent;color:#888';
-    // The name is used in both an attribute and text, so escape all four
-    // metacharacters (& < > ") — safe in either context.
-    const name = c.name ? escapeText(c.name).replace(/>/g, '&gt;').replace(/"/g, '&quot;') : '';
-    const label = c.name ? `${c.role} "${name}"` : c.role;
-    const levelAttr = c.level != null ? ` data-level="${c.level}"` : '';
-    body +=
-      `<div data-role="${c.role}" data-name="${name}"${levelAttr} ` +
-      `style="${style};padding:3px 6px;margin:1px 0;border-radius:3px;white-space:nowrap;` +
-      `display:inline-block;max-width:100%;overflow:hidden;text-overflow:ellipsis">${label}</div>\n`;
-  }
+  const tree = parseAriaTree(ariaSnapshot);
+  const body = renderNodes(tree);
+  if (!body) return null;
 
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><style>
-  body{margin:0;padding:8px;font-family:system-ui,sans-serif;font-size:13px;line-height:1.8;color:#111;background:#fff}
-  @media(prefers-color-scheme:dark){body{color:#e5e5e5;background:#1a1a1a}}
-  [data-role]:hover{filter:brightness(.92);outline:1px solid rgba(124,58,237,.4)}
+  *{box-sizing:border-box}
+  body{margin:0;padding:10px 12px;font-family:system-ui,-apple-system,Segoe UI,sans-serif;font-size:12.5px;color:#0f172a;background:#fff}
+  [data-pw-node]{position:relative}
+  [data-pw-children]{margin-left:9px;padding-left:11px;border-left:1px solid #e2e8f0}
+  [data-pw-row]{position:relative;padding:2px 6px;margin:1px 0;border-radius:5px;line-height:1.85;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+  [data-pw-row]::before{content:attr(data-role);display:inline-block;font-size:9.5px;font-weight:600;text-transform:uppercase;letter-spacing:.03em;padding:1px 5px;border-radius:4px;margin-right:6px;background:#eef2f7;color:#475569;vertical-align:middle}
+  [data-pw-row][data-badges]::after{content:attr(data-badges);margin-left:7px;font-size:10px;color:#94a3b8;padding:0 5px;border:1px solid #e2e8f0;border-radius:4px;vertical-align:middle}
+  [data-pw-text]{color:#64748b;font-style:italic}
+  [data-pw-text]::before{background:transparent;color:#94a3b8;border:1px dashed #cbd5e1}
+  [data-pw-pick]{cursor:pointer}
+  [data-pw-pick]:hover{background:rgba(124,58,237,.10);outline:1px solid rgba(124,58,237,.35)}
+${roleChipCss()}
+  @media(prefers-color-scheme:dark){
+    body{color:#e5e7eb;background:#0b0f19}
+    [data-pw-children]{border-left-color:#334155}
+    [data-pw-row]::before{background:#1e293b;color:#94a3b8}
+    [data-pw-row][data-badges]::after{color:#94a3b8;border-color:#334155}
+    [data-pw-text]{color:#94a3b8}
+    [data-pw-text]::before{background:transparent;color:#94a3b8;border-color:#475569}
+    [data-pw-pick]:hover{background:rgba(139,92,246,.22);outline-color:rgba(139,92,246,.5)}
+  }
 </style></head>
-<body>${body}</body></html>`;
+<body><div data-pw-tree>${body}</div></body></html>`;
 }

--- a/application/server/utils/dom-snapshot.ts
+++ b/application/server/utils/dom-snapshot.ts
@@ -191,6 +191,9 @@ export function sanitizeDomSnapshot(html: string, capChars: number): { html: str
   return { html: out, truncated };
 }
 
+/** The two representations a case can be viewed as: trace-derived DOM or the ARIA tree. */
+export type DomSnapshotSource = 'dom' | 'aria';
+
 export interface DomSnapshotResult {
   status: 'ok' | 'no-trace' | 'no-snapshot';
   html?: string;
@@ -201,6 +204,13 @@ export interface DomSnapshotResult {
   action?: string;
   /** The recorded page viewport, for proportion-preserving scaled rendering. */
   viewport?: { width: number; height: number };
+  /** Which representation `html` is — the trace DOM (`dom`) or the ARIA tree (`aria`). */
+  source?: DomSnapshotSource;
+  /**
+   * Which representations exist for this case, so the UI can offer a toggle
+   * (e.g. view the ARIA tree even when a trace was uploaded).
+   */
+  availableSources?: DomSnapshotSource[];
 }
 
 /**
@@ -253,23 +263,62 @@ export async function getTraceDomSnapshot(blobPath: string, capChars: number): P
   return extractDomSnapshot(data, capChars);
 }
 
+/** Options for {@link resolveCaseDomSnapshot}. */
+export interface ResolveCaseDomSnapshotOptions {
+  /**
+   * Which representation to render. Defaults to `dom` (trace-derived) when a
+   * trace exists, falling back to `aria`. Pass `aria` to force the ARIA tree
+   * even when a trace is available (the view toggle).
+   */
+  source?: DomSnapshotSource;
+}
+
 /**
- * Resolve the failure-time snapshot for a case: the trace-derived DOM when a
- * trace is stored, else the ARIA-snapshot fallback. Shared by the dom-snapshot
- * endpoint and the interactive locator picker so both render identically.
+ * Resolve the failure-time snapshot for a case. By default it prefers the
+ * trace-derived DOM and falls back to the ARIA tree, but `source: 'aria'`
+ * forces the ARIA tree even when a trace exists. The result reports which
+ * representation it is (`source`) and every representation available for the
+ * case (`availableSources`) so the UI can offer a view toggle. Shared by the
+ * dom-snapshot endpoint and the interactive locator picker.
  */
 export async function resolveCaseDomSnapshot(
   traceBlobPath: string | null | undefined,
   ariaSnapshot: string | null | undefined,
   capChars: number = DOM_SNAPSHOT_CAP_CHARS,
+  options: ResolveCaseDomSnapshotOptions = {},
 ): Promise<DomSnapshotResult> {
+  // Render the ARIA tree up front (cheap) so we can both offer it as a toggle
+  // and serve it directly without parsing the trace when it's the one requested.
+  const ariaHtml = ariaSnapshot ? renderAriaSnapshotHtml(ariaSnapshot) : null;
+  let domAvailable = !!traceBlobPath;
+  const ariaAvailable = !!ariaHtml;
+
+  const sources = (): DomSnapshotSource[] => {
+    const list: DomSnapshotSource[] = [];
+    if (domAvailable) list.push('dom');
+    if (ariaAvailable) list.push('aria');
+    return list;
+  };
+  const asAria = (): DomSnapshotResult => ({
+    status: 'ok',
+    html: ariaHtml!,
+    truncated: false,
+    snapshotName: 'aria-fallback',
+    source: 'aria',
+    availableSources: sources(),
+  });
+
+  // Explicit ARIA request — skip the trace entirely.
+  if (options.source === 'aria' && ariaHtml) return asAria();
+
   if (traceBlobPath) {
     const result = await getTraceDomSnapshot(traceBlobPath, capChars);
-    if (result.status === 'ok' && result.html) return result;
+    if (result.status === 'ok' && result.html) {
+      return { ...result, source: 'dom', availableSources: sources() };
+    }
+    // The trace produced no usable DOM — drop it as an option and fall back.
+    domAvailable = false;
   }
-  if (ariaSnapshot) {
-    const html = renderAriaSnapshotHtml(ariaSnapshot);
-    if (html) return { status: 'ok', html, truncated: false, snapshotName: 'aria-fallback' };
-  }
-  return { status: 'no-trace' };
+  if (ariaHtml) return asAria();
+  return { status: 'no-trace', availableSources: sources() };
 }

--- a/application/tests/unit/dom-snapshot.test.ts
+++ b/application/tests/unit/dom-snapshot.test.ts
@@ -172,12 +172,56 @@ describe('sanitizeDomSnapshot', () => {
 });
 
 describe('renderAriaSnapshotHtml', () => {
-  test('renders a role-colored chip carrying data-role/data-name for each node', () => {
-    const html = renderAriaSnapshotHtml('- button "Submit"\n- heading "Title"');
+  test('renders each node with data-role/data-name plus real ARIA attrs for the picker', () => {
+    const html = renderAriaSnapshotHtml('- button "Submit"\n- heading "Title" [level=2]')!;
     expect(html).toContain('data-role="button"');
     expect(html).toContain('data-name="Submit"');
-    expect(html).toContain('button "Submit"');
+    // Real ARIA attributes so the picker probe resolves getByRole('button', { name }).
+    expect(html).toContain('role="button"');
+    expect(html).toContain('aria-label="Submit"');
     expect(html).toContain('data-role="heading"');
+    expect(html).toContain('aria-level="2"');
+    // Rendered as a tree, not a flat list.
+    expect(html).toContain('pw-node');
+  });
+
+  test('nests children under their parent inside a tree container', () => {
+    const html = renderAriaSnapshotHtml('- navigation "Main":\n  - link "Home"\n  - link "About"')!;
+    const body = html.slice(html.indexOf('<body>'));
+    // The parent row is followed by a children container holding both links.
+    expect(body).toMatch(/data-name="Main"[^]*pw-children[^]*data-name="Home"[^]*data-name="About"/);
+    expect((body.match(/data-role="link"/g) ?? []).length).toBe(2);
+  });
+
+  test('renders a heading state marker as a badge without polluting the name', () => {
+    const html = renderAriaSnapshotHtml('- button "Save" [disabled]')!;
+    expect(html).toContain('data-name="Save"');
+    expect(html).toContain('data-badges="disabled"');
+  });
+
+  test('renders text nodes as pickable text (getByText) with no role locator', () => {
+    const html = renderAriaSnapshotHtml('- text: Hello world')!;
+    expect(html).toContain('data-pw-text');
+    expect(html).toContain('data-pw-pick');
+    expect(html).toContain('Hello world');
+    // No aria-label / standalone role attribute (getByRole) for a bare text node.
+    const body = html.slice(html.indexOf('<body>'));
+    expect(body).not.toContain('aria-label=');
+    expect(body).not.toMatch(/\srole=/); // data-role is fine; a real `role=` is not
+  });
+
+  test('does not leak its own styling classes onto pickable rows (no class= to probe)', () => {
+    // The picker probes the picked element's `class`; ARIA rows must carry none,
+    // or every pick would offer a bogus `locator('.pw-row')` alternative.
+    const html = renderAriaSnapshotHtml('- button "Go"')!;
+    const body = html.slice(html.indexOf('<body>'));
+    expect(body).not.toContain('class=');
+  });
+
+  test('hoists nameless generic wrappers so their children stay at the top level', () => {
+    const html = renderAriaSnapshotHtml('- generic:\n  - button "Go"')!;
+    expect(html).toContain('data-role="button"');
+    expect(html).not.toContain('data-role="generic"');
   });
 
   test('returns null when the ARIA snapshot yields no candidates', () => {
@@ -220,10 +264,22 @@ describe('renderAriaSnapshotHtml', () => {
 });
 
 describe('resolveCaseDomSnapshot', () => {
-  test('falls back to the ARIA snapshot when there is no trace', async () => {
+  test('falls back to the ARIA tree when there is no trace', async () => {
     const res = await resolveCaseDomSnapshot(null, '- button "Go"');
     expect(res.status).toBe('ok');
     expect(res.snapshotName).toBe('aria-fallback');
+    expect(res.source).toBe('aria');
+    expect(res.availableSources).toEqual(['aria']);
+    expect(res.html).toContain('data-role="button"');
+  });
+
+  test('source:aria renders the ARIA tree without parsing the trace, and lists both sources', async () => {
+    // A trace path is present, but source:aria short-circuits before touching it,
+    // so the toggle can still offer to switch back to the DOM view.
+    const res = await resolveCaseDomSnapshot('demo/trace.zip', '- button "Go"', undefined, { source: 'aria' });
+    expect(res.status).toBe('ok');
+    expect(res.source).toBe('aria');
+    expect(res.availableSources).toEqual(['dom', 'aria']);
     expect(res.html).toContain('data-role="button"');
   });
 


### PR DESCRIPTION
## What & why

Replaces the flat list of role chips with a proper nested, inspector-style accessibility tree view. The ARIA snapshot is now parsed into a real hierarchy and rendered with tree guides, role-colored chips, accessible names, and state badges (e.g., `disabled`, `checked`, heading levels).

Key improvements:
- **Hierarchical rendering**: Children nest under parents with visual tree guides, making the structure clear
- **Richer node information**: Each node shows its role, accessible name, heading level (if applicable), and state markers as badges
- **Pickable rows**: Nodes with accessible names or text content are clickable and carry real `role`/`aria-label`/`aria-level` attributes so the locator picker probes them into correct `getByRole`/`getByText` locators
- **View toggle**: When both trace-derived DOM and ARIA tree are available, the picker UI offers a toggle to switch between them without closing the picker
- **Smart hoisting**: Nameless structural wrappers (`generic`, `presentation`) are hoisted so their children stay at the top level, keeping the tree legible
- **Improved styling**: Updated color scheme and typography for better readability in both light and dark modes

The ARIA tree is now a first-class view alongside the DOM snapshot, not just a fallback. The `resolveCaseDomSnapshot` function now reports which representations are available (`availableSources`) and which one is being rendered (`source`), enabling the UI to offer the toggle.

## How was it tested?

- Added comprehensive unit tests covering:
  - Parsing of ARIA snapshot format (roles, names, states, heading levels, inline text values)
  - Nesting of children under parents
  - Rendering of pickable rows with correct ARIA attributes
  - Hoisting of nameless structural wrappers
  - Text node handling
  - Escaping of untrusted content in both attribute and text contexts
- Existing tests updated to reflect the new nested structure and data attributes
- Demo API updated to mirror server behavior and support the `?source=aria` query parameter

## Checklist

- [x] PR title follows Conventional Commits (`feat(snapshot): …`)
- [x] Tests added/updated for behavior changes (unit tests for parsing and rendering)
- [x] No user-facing docs changes needed (internal snapshot rendering)

https://claude.ai/code/session_01DdfZqZYVjwB57FqoEakp8H