### PR TITLE
refactor: extract shared utilities and types for reuse

### DIFF
--- a/application/app/components/diagnosis/DiagnosisContextModal.vue
+++ b/application/app/components/diagnosis/DiagnosisContextModal.vue
@@ -1,14 +1,6 @@
 <script setup lang="ts">
 import { DIAGNOSIS_SECTIONS } from '#shared/diagnosis-sections';
-
-interface ContextSection {
-  id: string;
-  title: string;
-  chars: number;
-  truncated: boolean;
-  markdown: string;
-  items?: number;
-}
+import type { ContextSection } from '~~/types/api';
 
 const props = defineProps<{
   open: boolean;

--- a/application/app/components/diagnosis/DiagnosisResult.vue
+++ b/application/app/components/diagnosis/DiagnosisResult.vue
@@ -2,6 +2,7 @@
 import type { FailureDiagnosis } from '~~/server/database/schema';
 import { formatRelativeTime } from '~/utils';
 import { DIAGNOSIS_SECTION_SHORT, isKnownSectionId } from '#shared/diagnosis-sections';
+import type { PatchValidation } from '#shared/patch';
 
 const props = defineProps<{
   diagnosis: FailureDiagnosis | null;
@@ -238,13 +239,6 @@ function downloadPatch() {
     a.remove();
     URL.revokeObjectURL(url);
   }, 1000);
-}
-
-interface PatchValidation {
-  status: 'applies' | 'applies-with-offset' | 'stale-file' | 'invalid' | 'unchecked';
-  filesChecked: number;
-  filesInPatch: number;
-  errors: string[];
 }
 
 const patchValidation = computed<PatchValidation | null>(() => {

--- a/application/app/components/diagnosis/DiagnosisScreenshots.vue
+++ b/application/app/components/diagnosis/DiagnosisScreenshots.vue
@@ -28,14 +28,7 @@ const emit = defineEmits<{
   (e: 'update:images', images: DiagnoseImage[]): void;
 }>();
 
-const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
-const IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
 const MAX_SCREENSHOTS = 8;
-
-function isImage(path: string, contentType?: string | null): boolean {
-  const ext = '.' + (path.toLowerCase().split('.').pop() || '');
-  return IMAGE_EXTS.has(ext) || (!!contentType && IMAGE_TYPES.has(contentType.toLowerCase()));
-}
 
 async function blobToBase64(blob: Blob): Promise<{ data: string; mediaType: string }> {
   const mediaType = (blob.type || 'image/webp').split(';')[0]!.trim();
@@ -71,7 +64,7 @@ async function loadScreenshots() {
         testRun: { startTime: string | null } | null;
       }>(`/api/test-run-cases/${tc.recentTestRunsCaseId}`);
       for (const att of detail.attachments ?? []) {
-        if (!isImage(att.path, att.contentType)) continue;
+        if (!isImageFile(att.path, att.contentType)) continue;
         if (results.length >= MAX_SCREENSHOTS) break;
         const imgName = att.name || att.path.split('/').pop() || 'screenshot';
         const url = `/api/files/${getFileApiPath(att.path)}?compress=1`;

--- a/application/app/components/project/ProjectTrendTable.vue
+++ b/application/app/components/project/ProjectTrendTable.vue
@@ -28,10 +28,6 @@ const sortedProjects = computed(() => {
   return tableExpanded.value ? sorted : sorted.slice(0, props.limit);
 });
 
-function passRate(run: { passedTests: number; totalTests: number }): number {
-  return run.totalTests > 0 ? Math.round((run.passedTests / run.totalTests) * 100) : 0;
-}
-
 function passRateColorClass(rate: number): string {
   if (rate >= 90) return 'text-green-600 dark:text-green-400';
   if (rate >= 50) return 'text-yellow-600 dark:text-yellow-400';

--- a/application/app/components/shared/CiEnvCard.vue
+++ b/application/app/components/shared/CiEnvCard.vue
@@ -1,14 +1,8 @@
 <script setup lang="ts">
-interface CiInfo {
-  provider?: string;
-  buildNumber?: string;
-  buildUrl?: string;
-  workflow?: string;
-  jobName?: string;
-}
+import type { TestRunCiMetadata } from '~~/types/api';
 
 defineProps<{
-  ci?: CiInfo | null;
+  ci?: TestRunCiMetadata | null;
   environment?: string | null;
   playwrightVersion?: string | null;
   reporterVersion?: string | null;

--- a/application/app/components/shared/SourceInfoCard.vue
+++ b/application/app/components/shared/SourceInfoCard.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
-interface ScmInfo {
-  branch?: string;
-  commit?: string;
-  author?: string;
-  commitMessage?: string;
-}
+import type { TestRunScmMetadata } from '~~/types/api';
 
 defineProps<{
-  scm: ScmInfo;
+  scm: TestRunScmMetadata;
   class?: string;
 }>();
 </script>

--- a/application/app/components/test-case/TestCaseSummary.vue
+++ b/application/app/components/test-case/TestCaseSummary.vue
@@ -1,20 +1,6 @@
 <script setup lang="ts">
-import type { TestCaseResult, EntityLinkInfo } from '~~/types/api';
+import type { TestCaseResult, EntityLinkInfo, TestRunScmMetadata, TestRunCiMetadata } from '~~/types/api';
 import type { BrowserConfig } from '#shared/types';
-
-interface ScmInfo {
-  commit?: string;
-  branch?: string;
-  author?: string;
-  commitMessage?: string;
-}
-
-interface CiInfo {
-  provider?: string;
-  buildNumber?: string;
-  buildUrl?: string;
-  workflow?: string;
-}
 
 interface HistoricalTiming {
   avg: number;
@@ -25,8 +11,8 @@ interface HistoricalTiming {
 
 const props = defineProps<{
   testCase: TestCaseResult | null;
-  scmInfo: ScmInfo | null;
-  ciInfo: CiInfo | null;
+  scmInfo: TestRunScmMetadata | null;
+  ciInfo: TestRunCiMetadata | null;
   browser: BrowserConfig | null;
   environment: string | null | undefined;
   stepsCount: number;

--- a/application/app/components/test-case/TestEvidenceSignals.vue
+++ b/application/app/components/test-case/TestEvidenceSignals.vue
@@ -1,19 +1,10 @@
 <script setup lang="ts">
+import type { ConsoleEntry, NetworkRequest } from '~~/types/api';
+
 const props = defineProps<{
   consoleLogs: unknown;
   networkRequests: unknown;
 }>();
-
-interface ConsoleEntry {
-  type: string;
-  text: string;
-}
-
-interface NetworkRequest {
-  status: number;
-  url: string;
-  method?: string;
-}
 
 const consoleErrors = computed((): ConsoleEntry[] => {
   if (!Array.isArray(props.consoleLogs)) return [];

--- a/application/app/composables/useClusterDiagnosis.ts
+++ b/application/app/composables/useClusterDiagnosis.ts
@@ -1,6 +1,6 @@
 import type { InjectionKey, Ref, ComputedRef } from 'vue';
 import type { FailureDiagnosis } from '~~/server/database/schema';
-import type { DiagnosisContextCoverage, ScmChanges } from '~~/types/api';
+import type { ContextSection, DiagnosisContextCoverage, ScmChanges } from '~~/types/api';
 
 /**
  * Shared state + actions for the failure-cluster diagnosis page, owned by the
@@ -17,14 +17,7 @@ export interface DiagnoseImage {
   data: string;
 }
 
-export interface ContextSection {
-  id: string;
-  title: string;
-  chars: number;
-  truncated: boolean;
-  markdown: string;
-  items?: number;
-}
+export type { ContextSection };
 
 export interface ClusterDiagnosisStore {
   clusterId: number;

--- a/application/app/demo/api/diagnosis-context.ts
+++ b/application/app/demo/api/diagnosis-context.ts
@@ -38,19 +38,12 @@ import { renderEnvironmentDiffMarkdown } from '#shared/environment-diff';
 import { apiGetDemoDomSnapshot } from './dom-snapshot';
 import { renderAppStateMarkdown, type PageStateLike } from '#shared/page-state';
 import { getLastPassPageState } from '#shared/handlers/test-cases';
-import type { DiagnosisContextCoverage, ScmChanges } from '~~/types/api';
+import type { ContextSection, DiagnosisContextCoverage, ScmChanges } from '~~/types/api';
 import { getDemoScmProject, getDemoChangesSince, getDemoChangesForShas } from '../demo-scm';
 
 // ── Section plumbing ────────────────────────────────────────────────────────
 
-export interface ContextSection {
-  id: string;
-  title: string;
-  chars: number;
-  truncated: boolean;
-  markdown: string;
-  items?: number;
-}
+export type { ContextSection };
 
 function section(id: string, title: string, markdown: string | null, items?: number): ContextSection | null {
   if (!markdown) return null;

--- a/application/app/pages/index.vue
+++ b/application/app/pages/index.vue
@@ -150,10 +150,6 @@ function showPartialRuns(): void {
 
 // ── Pass rate helper (for activity list) ─────────────────────────────────────
 
-function passRate(run: { passedTests: number; totalTests: number }): number {
-  return run.totalTests > 0 ? Math.round((run.passedTests / run.totalTests) * 100) : 0;
-}
-
 function passRateClass(run: { passedTests: number; totalTests: number }): string {
   const rate = passRate(run);
   if (rate >= 90) return 'text-green-600 dark:text-green-400';

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -371,24 +371,6 @@ watch(
   { immediate: true },
 );
 
-function getPassRate(testCase: TestCaseWithStats) {
-  if (testCase.totalRuns === 0) return 0;
-  return Math.round((testCase.passedRuns / testCase.totalRuns) * 100);
-}
-
-type BadgeColor = 'error' | 'neutral' | 'primary' | 'success' | 'warning' | 'secondary' | 'info';
-
-function getTestCaseStatus(testCase: TestCaseWithStats): { status: string; color: BadgeColor } {
-  const recentFlaky = testCase.recentFlakyRuns ?? testCase.flakyRuns;
-  if (recentFlaky > 0) {
-    return { status: 'flaky', color: 'warning' };
-  }
-  return {
-    status: testCase.lastStatus || 'unknown',
-    color: getStatusColor(testCase.lastStatus || 'unknown') as BadgeColor,
-  };
-}
-
 const testCasesColumns: TableColumn<TestCaseWithStats>[] = [
   { accessorKey: 'title', header: createSortHeader<TestCaseWithStats>('Test case') },
   { accessorKey: 'status', header: createSortHeader<TestCaseWithStats>('Status') },

--- a/application/app/pages/projects/[id]/test-cases.vue
+++ b/application/app/pages/projects/[id]/test-cases.vue
@@ -14,24 +14,6 @@ useHead(
   })),
 );
 
-function getPassRate(testCase: TestCaseWithStats) {
-  if (testCase.totalRuns === 0) return 0;
-  return Math.round((testCase.passedRuns / testCase.totalRuns) * 100);
-}
-
-type BadgeColor = 'error' | 'neutral' | 'primary' | 'success' | 'warning' | 'secondary' | 'info';
-
-function getTestCaseStatus(testCase: TestCaseWithStats): { status: string; color: BadgeColor } {
-  const recentFlaky = testCase.recentFlakyRuns ?? testCase.flakyRuns;
-  if (recentFlaky > 0) {
-    return { status: 'flaky', color: 'warning' };
-  }
-  return {
-    status: testCase.lastStatus || 'unknown',
-    color: getStatusColor(testCase.lastStatus || 'unknown') as BadgeColor,
-  };
-}
-
 const testCasesColumns: TableColumn<TestCaseWithStats>[] = [
   { accessorKey: 'title', header: createSortHeader<TestCaseWithStats>('Test case') },
   { accessorKey: 'status', header: createSortHeader<TestCaseWithStats>('Status') },

--- a/application/app/utils/index.ts
+++ b/application/app/utils/index.ts
@@ -1,7 +1,7 @@
 import { h } from 'vue';
 import { UIcon } from '#components';
 import type { Column } from '@tanstack/vue-table';
-import type { CommitListItem } from '~~/types/api';
+import type { CommitListItem, TestCaseWithStats } from '~~/types/api';
 import { formatDuration as formatDurationLib, formatDistanceToNow } from 'date-fns';
 
 /**
@@ -467,4 +467,30 @@ export function copyPreview(text: string | null | undefined, max = 120): string 
   if (!text) return '';
   const singleLine = text.replace(/\n/g, ' · ');
   return singleLine.length <= max ? singleLine : singleLine.slice(0, max) + '…';
+}
+
+/** Nuxt UI `color` union shared by `UBadge` / `UButton` call sites. */
+export type BadgeColor = 'error' | 'neutral' | 'primary' | 'success' | 'warning' | 'secondary' | 'info';
+
+/** Pass rate (0–100) for a single run, guarding against divide-by-zero. */
+export function passRate(run: { passedTests: number; totalTests: number }): number {
+  return run.totalTests > 0 ? Math.round((run.passedTests / run.totalTests) * 100) : 0;
+}
+
+/** Pass rate (0–100) across all of a test case's runs. */
+export function getPassRate(testCase: TestCaseWithStats): number {
+  if (testCase.totalRuns === 0) return 0;
+  return Math.round((testCase.passedRuns / testCase.totalRuns) * 100);
+}
+
+/** Display status + badge color for a test case, treating recent flakiness as its own state. */
+export function getTestCaseStatus(testCase: TestCaseWithStats): { status: string; color: BadgeColor } {
+  const recentFlaky = testCase.recentFlakyRuns ?? testCase.flakyRuns;
+  if (recentFlaky > 0) {
+    return { status: 'flaky', color: 'warning' };
+  }
+  return {
+    status: testCase.lastStatus || 'unknown',
+    color: getStatusColor(testCase.lastStatus || 'unknown') as BadgeColor,
+  };
 }

--- a/application/server/api/test-runs/[id]/case-files.post.ts
+++ b/application/server/api/test-runs/[id]/case-files.post.ts
@@ -7,6 +7,7 @@ import { validateAndReviveRun } from '../../../utils/revive-run';
 import { upsertTraceBlob, findTraceBlob } from '../../../utils/trace-blobs';
 import { getStorage } from '../../../storage';
 import { joinSuitePath } from '#shared/utils/suites';
+import { sanitizeFilename } from '../../../utils/sanitize-filename';
 import { Role } from '#shared/types';
 
 const REQUIRED_ROLES: Role[] = [];
@@ -56,10 +57,6 @@ export default eventHandler(async (event) => {
       statusCode: 400,
       message: 'No form data provided',
     });
-  }
-
-  function sanitizeFilename(filename: string): string {
-    return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
   }
 
   let streamToken: string | undefined;

--- a/application/server/api/test-runs/upload.post.ts
+++ b/application/server/api/test-runs/upload.post.ts
@@ -9,6 +9,7 @@ import { requireAuth } from '../../utils/auth';
 import { Role } from '#shared/types';
 import { getStorage } from '../../storage';
 import { uploadDirectory } from '../../utils/storage-helpers';
+import { sanitizeFilename } from '../../utils/sanitize-filename';
 import { tmpdir } from 'os';
 import { rm, mkdir, readdir } from 'fs/promises';
 import { parseLocation } from '../../utils/parse-location';
@@ -78,11 +79,6 @@ export default eventHandler(async (event) => {
       statusCode: 400,
       message: 'No form data provided',
     });
-  }
-
-  // Helper function to sanitize filename
-  function sanitizeFilename(filename: string): string {
-    return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
   }
 
   // Parse form fields

--- a/application/server/database/index.ts
+++ b/application/server/database/index.ts
@@ -11,6 +11,9 @@ import { fileURLToPath } from 'url';
 
 type DB = ReturnType<typeof sqliteDrizzle<typeof sqliteSchema>>;
 
+/** The resolved database client returned by getDatabase(). Import this instead of re-deriving it locally. */
+export type DbClient = Awaited<ReturnType<typeof getDatabase>>;
+
 let db: DB;
 let migrationPromise: Promise<void> | null = null;
 

--- a/application/server/utils/ai-context-limits.ts
+++ b/application/server/utils/ai-context-limits.ts
@@ -1,7 +1,6 @@
 import { CONTEXT_LIMIT_FIELDS, DEFAULT_CONTEXT_LIMITS, clampLimit } from '#shared/ai-context-limits';
 import type { ContextLimits } from '#shared/ai-context-limits';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 export const CONTEXT_LIMITS_SETTING_KEY = 'ai_context_limits';
 

--- a/application/server/utils/ai-context.ts
+++ b/application/server/utils/ai-context.ts
@@ -48,8 +48,7 @@ import type {
 } from './ai-context.types';
 import type { AiAttachedImage } from './ai-provider';
 import { getStorage } from '../storage';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 type ScmCoverage = NonNullable<DiagnosisContextCoverage['scm']>;
 

--- a/application/server/utils/ai-diagnosis.ts
+++ b/application/server/utils/ai-diagnosis.ts
@@ -22,8 +22,7 @@ import { nameNewClusters } from './cluster-naming';
 import { RESEARCH_SYSTEM_PROMPT, RESEARCH_JSON_SCHEMA, parseResearchJson, formatResearchBlock } from './ai-research';
 import { buildDiagnosisVersionValues } from '#shared/handlers/diagnosis-versions';
 import { emitNotification } from './notifications/emit';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 const STALE_RUNNING_MS = 5 * 60 * 1000;
 

--- a/application/server/utils/ai-provider.ts
+++ b/application/server/utils/ai-provider.ts
@@ -2,13 +2,12 @@ import Anthropic from '@anthropic-ai/sdk';
 import { getAppSetting } from './app-settings';
 import { decryptSecret, getEncryptionKey } from './crypto';
 import type { AiProvider, AiConfig, AiModelRole, ResolvedAiRole } from '~~/types/api';
+import type { DbClient } from '../database';
 
 export type { AiConfig };
 
 /** Default Anthropic model when none is configured. */
 export const DEFAULT_ANTHROPIC_MODEL = 'claude-opus-4-8';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
 
 /** Stored shape of a single role in the `ai` app-setting (apiKey is encrypted). */
 interface StoredRole {

--- a/application/server/utils/ai-research.ts
+++ b/application/server/utils/ai-research.ts
@@ -7,7 +7,7 @@
  * It deliberately produces NO final verdict or fix.
  */
 
-import { DIAGNOSIS_CATEGORIES, type DiagnosisCategory } from '#shared/ai-diagnosis';
+import { DIAGNOSIS_CATEGORIES, asCategory, type DiagnosisCategory } from '#shared/ai-diagnosis';
 
 export const RESEARCH_SYSTEM_PROMPT = `You are a triage assistant doing a FAST first pass on a Playwright test failure, before a senior engineer writes the final diagnosis.
 From the failure context (note the "## Data Coverage" map of what evidence is present/absent), output a brief, structured pre-analysis:
@@ -51,10 +51,6 @@ export const RESEARCH_JSON_SCHEMA = {
     notes: { type: 'string' },
   },
 };
-
-function asCategory(v: unknown): DiagnosisCategory {
-  return DIAGNOSIS_CATEGORIES.includes(v as DiagnosisCategory) ? (v as DiagnosisCategory) : 'unknown';
-}
 
 export function parseResearchJson(text: string): ResearchResult {
   let parsed: unknown;

--- a/application/server/utils/ai-settings.ts
+++ b/application/server/utils/ai-settings.ts
@@ -10,8 +10,7 @@
 
 import { getAppSetting } from './app-settings';
 import type { AiModelRole, AiProvider, AiRoleSettings, AiSettings } from '~~/types/api';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 export const AI_ROLES: AiModelRole[] = ['diagnosis', 'research', 'embedding'];
 

--- a/application/server/utils/app-settings.ts
+++ b/application/server/utils/app-settings.ts
@@ -1,7 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { appSettings } from '../database/schema';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 export async function getAppSetting<T>(db: DbClient, key: string): Promise<T | null> {
   const rows = await db.select({ value: appSettings.value }).from(appSettings).where(eq(appSettings.key, key));

--- a/application/server/utils/cancel-instance-runs.ts
+++ b/application/server/utils/cancel-instance-runs.ts
@@ -1,8 +1,6 @@
 import { runEventBus } from './run-events';
 import { cancelInstanceRuns as sharedCancelInstanceRuns } from '#shared/handlers/failure-cluster-ops';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 export async function cancelInstanceRuns(
   db: DB,

--- a/application/server/utils/cluster-naming.ts
+++ b/application/server/utils/cluster-naming.ts
@@ -8,8 +8,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { failureClusters } from '../database/schema';
 import { callAiProvider } from './ai-provider';
 import type { ResolvedAiRole } from '~~/types/api';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 const MAX_NAME_PER_RUN = 20; // cost guard
 

--- a/application/server/utils/cluster-reconcile.ts
+++ b/application/server/utils/cluster-reconcile.ts
@@ -21,8 +21,7 @@ import { embedTexts } from './ai-embeddings';
 import { cosineSimilarity, parseEmbedding } from './cluster-similarity';
 import { adjudicateClusterPair } from './cluster-adjudicate';
 import type { ResolvedAiRole } from '~~/types/api';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 function threshold(envVar: string, fallback: number): number {
   const v = Number(process.env[envVar]);

--- a/application/server/utils/compute-regression-signals.ts
+++ b/application/server/utils/compute-regression-signals.ts
@@ -1,8 +1,6 @@
 import { eq, and, desc, lt } from 'drizzle-orm';
 import { testRuns, testRunsCases } from '../database/schema';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 /**
  * Compute isNewRegression and isNewFlaky signals for all test_runs_cases

--- a/application/server/utils/mcp/tools.ts
+++ b/application/server/utils/mcp/tools.ts
@@ -49,8 +49,7 @@ import {
 import type { ProjectScope } from '../project-access';
 import type { User } from '../../database/schema';
 import { Role } from '#shared/types';
-
-type DbClient = Awaited<ReturnType<typeof import('../../database').getDatabase>>;
+import type { DbClient } from '../../database';
 
 // ── Token-optimization helpers ───────────────────────────────────────────────
 

--- a/application/server/utils/persist-run-cases.ts
+++ b/application/server/utils/persist-run-cases.ts
@@ -9,9 +9,7 @@ import { SUITE_PATH_SEP, joinSuitePath } from '#shared/utils/suites';
 import { getOrCreateFailureClusters, type PendingCluster } from '#shared/handlers/failure-cluster-ops';
 import { upsertLocatorSnapshots } from './locator-healing';
 import type { LocatorSnapshot } from '#shared/locator-healing.types';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 /**
  * Normalised test-case data ready to be persisted for a run. `filePath` + `suitePath` + `title`

--- a/application/server/utils/project-access.ts
+++ b/application/server/utils/project-access.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3';
 import { getDatabase } from '../database';
+import type { DbClient } from '../database';
 import {
   projectAssignments,
   testRuns,
@@ -13,7 +14,7 @@ import { requireAuth, isAuthEnabled } from './auth';
 import { Role } from '#shared/types';
 import type { User } from '../database/schema';
 
-export type DrizzleDB = Awaited<ReturnType<typeof getDatabase>>;
+export type DrizzleDB = DbClient;
 
 export type ProjectScope = 'all' | Set<number>;
 

--- a/application/server/utils/regression-context.ts
+++ b/application/server/utils/regression-context.ts
@@ -1,10 +1,8 @@
 import { eq, and, lt, desc } from 'drizzle-orm';
 import { testRuns, testRunsCases } from '../database/schema';
 import type { RunMetadata } from './run-json-types';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
-
-type MetaDiffEntry = { key: string; label: string; before: string | null; after: string | null };
+import type { DbClient } from '../database';
+import { buildCompareUrl, computeMetadataDiff, type MetaDiffEntry } from '#shared/utils/run-metadata';
 
 export interface RunForRegression {
   id: number;
@@ -53,61 +51,6 @@ export function normalizeGitUrl(remoteUrl: string | null | undefined): string | 
   } catch {
     return url;
   }
-}
-
-export function buildCompareUrl(repositoryUrl: string, fromSha: string, toSha: string): string | null {
-  try {
-    const { hostname } = new URL(repositoryUrl);
-    if (hostname === 'github.com' || hostname.endsWith('.github.com')) {
-      return `${repositoryUrl}/compare/${fromSha}...${toSha}`;
-    }
-    if (hostname === 'gitlab.com' || hostname.includes('gitlab')) {
-      return `${repositoryUrl}/-/compare/${fromSha}...${toSha}`;
-    }
-    if (hostname === 'bitbucket.org') {
-      return `${repositoryUrl}/branches/compare/${toSha}..${fromSha}#diff`;
-    }
-  } catch {
-    // ignore
-  }
-  return null;
-}
-
-export function getBrowserList(meta: RunMetadata | null | undefined): string {
-  const projects = meta?.htmlReport?.projects;
-  if (!projects?.length) return '';
-  const names = [...new Set(projects.map((p) => p.use?.browserName).filter(Boolean))] as string[];
-  return names.join(', ');
-}
-
-export function computeMetadataDiff(
-  prevMeta: RunMetadata | null,
-  currMeta: RunMetadata | null,
-  prevEnv: string | null,
-  currEnv: string | null,
-): MetaDiffEntry[] {
-  const diff: MetaDiffEntry[] = [];
-
-  if (prevEnv !== currEnv) {
-    diff.push({ key: 'environment', label: 'Environment', before: prevEnv, after: currEnv });
-  }
-  const prevBranch: string | null = prevMeta?.scm?.branch ?? null;
-  const currBranch: string | null = currMeta?.scm?.branch ?? null;
-  if (prevBranch !== currBranch) {
-    diff.push({ key: 'branch', label: 'Branch', before: prevBranch, after: currBranch });
-  }
-  const prevCi: string | null = prevMeta?.ci?.provider ?? null;
-  const currCi: string | null = currMeta?.ci?.provider ?? null;
-  if (prevCi !== currCi) {
-    diff.push({ key: 'ci_provider', label: 'CI provider', before: prevCi, after: currCi });
-  }
-  const prevBrowsers = getBrowserList(prevMeta);
-  const currBrowsers = getBrowserList(currMeta);
-  if (prevBrowsers !== currBrowsers) {
-    diff.push({ key: 'browsers', label: 'Browsers', before: prevBrowsers || null, after: currBrowsers || null });
-  }
-
-  return diff;
 }
 
 const FAIL_STATUSES = new Set(['failed', 'timedOut']);

--- a/application/server/utils/revive-run.ts
+++ b/application/server/utils/revive-run.ts
@@ -1,8 +1,6 @@
 import { testRuns } from '../database/schema';
 import { eq } from 'drizzle-orm';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 /**
  * Validates the stream token for a test run. If the run was interrupted by the

--- a/application/server/utils/run-json-types.ts
+++ b/application/server/utils/run-json-types.ts
@@ -1,4 +1,5 @@
 import type { BrowserConfig } from '#shared/types';
+import type { ServerLogEntry } from '~~/types/api';
 
 /**
  * View-types for the JSON columns on `test_runs` / `test_runs_cases`, covering
@@ -21,14 +22,6 @@ export interface ConsoleLogEntry {
   text: string;
   timestamp?: number;
   location?: string | null;
-}
-
-export interface ServerLogEntry {
-  timestamp: number;
-  level: string;
-  category: string;
-  message: string;
-  stack?: string;
 }
 
 export interface NetworkRequestEntry {
@@ -62,4 +55,4 @@ export interface RunMetadata {
   htmlReport?: { projects?: Array<{ use?: { browserName?: string | null } | null }> } | null;
 }
 
-export type { BrowserConfig };
+export type { BrowserConfig, ServerLogEntry };

--- a/application/server/utils/sanitize-filename.ts
+++ b/application/server/utils/sanitize-filename.ts
@@ -1,0 +1,5 @@
+/** Replace every character outside `[A-Za-z0-9._-]` with an underscore, so an
+ * uploaded name is safe to use as a storage path segment. */
+export function sanitizeFilename(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+}

--- a/application/server/utils/scm/index.ts
+++ b/application/server/utils/scm/index.ts
@@ -5,8 +5,7 @@ import { eq } from 'drizzle-orm';
 import { GitHubProvider } from './GitHubProvider';
 import { GitLabProvider } from './GitLabProvider';
 import { BitbucketProvider } from './BitbucketProvider';
-
-type DbClient = Awaited<ReturnType<typeof import('../../database').getDatabase>>;
+import type { DbClient } from '../../database';
 
 /** Returns the SCM provider name for a repository URL, or null if unsupported. */
 export function detectScmProvider(repositoryUrl: string | null | undefined): 'github' | 'gitlab' | 'bitbucket' | null {

--- a/application/server/utils/shard-tokens.ts
+++ b/application/server/utils/shard-tokens.ts
@@ -1,8 +1,6 @@
 import { testRuns } from '../database/schema';
 import { eq } from 'drizzle-orm';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 /**
  * Read shard tokens from a test run's metadata JSON column.

--- a/application/server/utils/stream-auth.ts
+++ b/application/server/utils/stream-auth.ts
@@ -3,9 +3,7 @@ import { testRuns } from '../database/schema';
 import { runEventBus } from './run-events';
 import { validateAndReviveRun } from './revive-run';
 import { readShardTokensFromMeta } from './shard-tokens';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 /**
  * Authorize a streaming request by its stream token and return the run's `projectId`.

--- a/application/server/utils/test-case-cache.ts
+++ b/application/server/utils/test-case-cache.ts
@@ -1,8 +1,6 @@
 import { testCases } from '../database/schema';
 import { eq } from 'drizzle-orm';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 // Cache key: filePath + NUL + suitePath (raw stored text, \x1f-delimited) + NUL + title
 // NUL separates the three segments; \x1f separates describe levels within suitePath.

--- a/application/server/utils/test-suite-cache.ts
+++ b/application/server/utils/test-suite-cache.ts
@@ -1,8 +1,6 @@
 import { testSuites } from '../database/schema';
 import { eq } from 'drizzle-orm';
-import type { getDatabase } from '../database';
-
-type DB = Awaited<ReturnType<typeof getDatabase>>;
+import type { DbClient as DB } from '../database';
 
 function makeCacheKey(filePath: string, suitePath: string): string {
   return `${filePath}\x00${suitePath}`;

--- a/application/server/utils/trace-parser.ts
+++ b/application/server/utils/trace-parser.ts
@@ -3,6 +3,7 @@ import { parseTraceTexts, traceFileRank, type ParsedTraceData } from './trace-ev
 import { getStorage } from '../storage';
 import { getAppSetting, setAppSetting } from './app-settings';
 import type { ContextLimits } from '#shared/ai-context-limits';
+import type { DbClient } from '../database';
 
 // The event model and JSONL parsing live in the node-free `trace-events.ts`
 // (shared with the browser demo, which inflates the ZIP with
@@ -10,8 +11,6 @@ import type { ContextLimits } from '#shared/ai-context-limits';
 // inflation, storage access and the DB-backed parse cache. No re-exports:
 // Nitro auto-imports every server/utils export, and duplicates would shadow
 // each other — import the shared types from `trace-events.ts` directly.
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
 
 const TRACE_CACHE_SETTING_KEY = 'trace_parse_cache';
 

--- a/application/server/utils/unfurl/index.ts
+++ b/application/server/utils/unfurl/index.ts
@@ -8,8 +8,7 @@ import { JiraUnfurlProvider } from './JiraUnfurlProvider';
 import type { AtlassianConfig } from './JiraUnfurlProvider';
 import { ConfluenceUnfurlProvider } from './ConfluenceUnfurlProvider';
 import { GitHubUnfurlProvider } from './GitHubUnfurlProvider';
-
-type DbClient = Awaited<ReturnType<typeof import('../../database').getDatabase>>;
+import type { DbClient } from '../../database';
 
 const RICH_PROVIDERS: ReadonlySet<LinkProvider> = new Set([
   'jira',

--- a/application/server/utils/wasted-settings.ts
+++ b/application/server/utils/wasted-settings.ts
@@ -1,7 +1,6 @@
 import { getAppSetting } from './app-settings';
 import { DEFAULT_WASTED_WAIT_PATTERNS, parseWastedWaitPatterns } from '#shared/utils/wasted-waits';
-
-type DbClient = Awaited<ReturnType<typeof import('../database').getDatabase>>;
+import type { DbClient } from '../database';
 
 /** App-settings key under which the wasted-wait patterns are stored. */
 export const WASTED_WAIT_PATTERNS_KEY = 'wasted_wait_patterns';

--- a/application/shared/ai-diagnosis.ts
+++ b/application/shared/ai-diagnosis.ts
@@ -125,7 +125,7 @@ export function scoreToConfidence(score: number): DiagnosisConfidence {
   return 'low';
 }
 
-function asCategory(v: unknown): DiagnosisCategory {
+export function asCategory(v: unknown): DiagnosisCategory {
   return DIAGNOSIS_CATEGORIES.includes(v as DiagnosisCategory) ? (v as DiagnosisCategory) : 'unknown';
 }
 

--- a/application/shared/error-fingerprint.ts
+++ b/application/shared/error-fingerprint.ts
@@ -17,6 +17,7 @@
  * uses Web Crypto instead of node:crypto.
  */
 import { LOCATOR_BUILDER_METHODS } from '@piwitests/core/locator-methods';
+import { sha256Hex } from './utils/hash';
 
 /**
  * Bump when the normalization algorithm changes. The version is part of the
@@ -239,11 +240,6 @@ export function extractTopFrameFile(text: string): string | null {
     return file;
   }
   return null;
-}
-
-async function sha256Hex(input: string): Promise<string> {
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
-  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 export function extractErrorSignature(rawError: string): ErrorSignature {

--- a/application/shared/handlers/test-runs.ts
+++ b/application/shared/handlers/test-runs.ts
@@ -15,7 +15,9 @@ import { fetchAndFormatSuites, splitSuitePath } from '../utils/suites';
 import { normalizeRoute } from '../utils/route';
 import { percentile } from '../utils/stats';
 import { computeWastedMs, DEFAULT_WASTED_WAIT_PATTERNS } from '../utils/wasted-waits';
+import { buildCompareUrl, computeMetadataDiff } from '../utils/run-metadata';
 import type { TestStepEvent } from '../types';
+import type { EndpointSummary, DiagnosisCompact } from '../../types/api';
 
 import type { DrizzleDB } from './db';
 import { normalizeGitUrl } from '../../server/utils/regression-context';
@@ -297,18 +299,6 @@ export async function patchTestRun(db: DrizzleDB, id: number, label: string | nu
 
 // ─── getNetworkRequests — aggregated network endpoint stats ──────────────────
 
-interface EndpointSummary {
-  method: string;
-  route: string;
-  count: number;
-  avgDuration: number;
-  maxDuration: number;
-  minDuration: number;
-  p90Duration: number;
-  errorRate: number;
-  testCases: string[];
-}
-
 export async function getNetworkRequests(db: DrizzleDB, runId: number) {
   const runResults = await db.select({ id: testRuns.id }).from(testRuns).where(eq(testRuns.id, runId));
   if (!runResults[0]) return null;
@@ -402,13 +392,6 @@ interface GroupCase {
   retries: number;
   workerIndex: number | null;
   passedOnRetry: boolean;
-}
-
-interface DiagnosisCompact {
-  status: string;
-  category: string | null;
-  confidence: string | null;
-  summary: string | null;
 }
 
 interface FailureGroup {
@@ -595,68 +578,6 @@ export async function getFailureGroups(db: DrizzleDB, runId: number) {
 }
 
 // ─── computeRegressionContextForRun — regression vs last green run ────────────
-
-interface MetaDiffEntry {
-  key: string;
-  label: string;
-  before: string | null;
-  after: string | null;
-}
-
-function buildCompareUrl(repositoryUrl: string, fromSha: string, toSha: string): string | null {
-  try {
-    const { hostname } = new URL(repositoryUrl);
-    if (hostname === 'github.com' || hostname.endsWith('.github.com')) {
-      return `${repositoryUrl}/compare/${fromSha}...${toSha}`;
-    }
-    if (hostname === 'gitlab.com' || hostname.includes('gitlab')) {
-      return `${repositoryUrl}/-/compare/${fromSha}...${toSha}`;
-    }
-    if (hostname === 'bitbucket.org') {
-      return `${repositoryUrl}/branches/compare/${toSha}..${fromSha}#diff`;
-    }
-  } catch {
-    // ignore
-  }
-  return null;
-}
-
-function getBrowserList(meta: any): string {
-  const projectsList = meta?.htmlReport?.projects as Array<{ use?: { browserName?: string } }> | undefined;
-  if (!projectsList?.length) return '';
-  const names = [...new Set(projectsList.map((p) => p.use?.browserName).filter(Boolean))] as string[];
-  return names.join(', ');
-}
-
-function computeMetadataDiff(
-  prevMeta: any,
-  currMeta: any,
-  prevEnv: string | null,
-  currEnv: string | null,
-): MetaDiffEntry[] {
-  const diff: MetaDiffEntry[] = [];
-
-  if (prevEnv !== currEnv) {
-    diff.push({ key: 'environment', label: 'Environment', before: prevEnv, after: currEnv });
-  }
-  const prevBranch: string | null = prevMeta?.scm?.branch ?? null;
-  const currBranch: string | null = currMeta?.scm?.branch ?? null;
-  if (prevBranch !== currBranch) {
-    diff.push({ key: 'branch', label: 'Branch', before: prevBranch, after: currBranch });
-  }
-  const prevCi: string | null = prevMeta?.ci?.provider ?? null;
-  const currCi: string | null = currMeta?.ci?.provider ?? null;
-  if (prevCi !== currCi) {
-    diff.push({ key: 'ci_provider', label: 'CI provider', before: prevCi, after: currCi });
-  }
-  const prevBrowsers = getBrowserList(prevMeta);
-  const currBrowsers = getBrowserList(currMeta);
-  if (prevBrowsers !== currBrowsers) {
-    diff.push({ key: 'browsers', label: 'Browsers', before: prevBrowsers || null, after: currBrowsers || null });
-  }
-
-  return diff;
-}
 
 const FAIL_STATUSES = new Set(['failed', 'timedOut']);
 

--- a/application/shared/locator-healing.ts
+++ b/application/shared/locator-healing.ts
@@ -3,6 +3,7 @@
  * Node.js and browser (Web Crypto) environments.
  */
 import type { RankedLocator, LocatorFixRecommendation } from './locator-healing.types';
+import { sha256Hex } from './utils/hash';
 
 /**
  * Method family for each locator method. The single recommended fix prefers an
@@ -88,12 +89,6 @@ export function recommendLocatorFix(
     // Even the most stable alternative is fragile — recommend adding a test id.
     suggestAddTestId: durable.score < floor,
   };
-}
-
-async function sha256Hex(input: string): Promise<string> {
-  // Use Web Crypto API — same API surface in Node 19+ and browsers.
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
-  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 /**

--- a/application/shared/utils/hash.ts
+++ b/application/shared/utils/hash.ts
@@ -1,0 +1,10 @@
+/**
+ * Hashing helpers built on the Web Crypto API — the same surface is available in
+ * browsers and in Node 19+, so these are safe to import from shared/browser code.
+ */
+
+/** SHA-256 hex digest of a UTF-8 string. */
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/application/shared/utils/run-metadata.ts
+++ b/application/shared/utils/run-metadata.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers for reading a run's `metadata` JSON and diffing the environment / SCM /
+ * browser context of two runs. Shared by the run-comparison handler and the
+ * server-side regression-context builder so the diff stays identical on both.
+ */
+
+/** One field that changed between two runs, for the "what changed" summary. */
+export interface MetaDiffEntry {
+  key: string;
+  label: string;
+  before: string | null;
+  after: string | null;
+}
+
+/** The slice of `test_runs.metadata` these helpers read. */
+interface RunMetadataLike {
+  scm?: { branch?: string | null } | null;
+  ci?: { provider?: string | null } | null;
+  htmlReport?: { projects?: Array<{ use?: { browserName?: string | null } | null }> } | null;
+}
+
+/** Build a provider-specific "compare two commits" URL, or null when the host is unknown. */
+export function buildCompareUrl(repositoryUrl: string, fromSha: string, toSha: string): string | null {
+  try {
+    const { hostname } = new URL(repositoryUrl);
+    if (hostname === 'github.com' || hostname.endsWith('.github.com')) {
+      return `${repositoryUrl}/compare/${fromSha}...${toSha}`;
+    }
+    if (hostname === 'gitlab.com' || hostname.includes('gitlab')) {
+      return `${repositoryUrl}/-/compare/${fromSha}...${toSha}`;
+    }
+    if (hostname === 'bitbucket.org') {
+      return `${repositoryUrl}/branches/compare/${toSha}..${fromSha}#diff`;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/** Comma-separated list of the distinct browser names configured in a run's report. */
+export function getBrowserList(meta: RunMetadataLike | null | undefined): string {
+  const projects = meta?.htmlReport?.projects;
+  if (!projects?.length) return '';
+  const names = [...new Set(projects.map((p) => p.use?.browserName).filter(Boolean))] as string[];
+  return names.join(', ');
+}
+
+/** Diff two runs' environment, branch, CI provider and browser set. */
+export function computeMetadataDiff(
+  prevMeta: RunMetadataLike | null | undefined,
+  currMeta: RunMetadataLike | null | undefined,
+  prevEnv: string | null,
+  currEnv: string | null,
+): MetaDiffEntry[] {
+  const diff: MetaDiffEntry[] = [];
+
+  if (prevEnv !== currEnv) {
+    diff.push({ key: 'environment', label: 'Environment', before: prevEnv, after: currEnv });
+  }
+  const prevBranch: string | null = prevMeta?.scm?.branch ?? null;
+  const currBranch: string | null = currMeta?.scm?.branch ?? null;
+  if (prevBranch !== currBranch) {
+    diff.push({ key: 'branch', label: 'Branch', before: prevBranch, after: currBranch });
+  }
+  const prevCi: string | null = prevMeta?.ci?.provider ?? null;
+  const currCi: string | null = currMeta?.ci?.provider ?? null;
+  if (prevCi !== currCi) {
+    diff.push({ key: 'ci_provider', label: 'CI provider', before: prevCi, after: currCi });
+  }
+  const prevBrowsers = getBrowserList(prevMeta);
+  const currBrowsers = getBrowserList(currMeta);
+  if (prevBrowsers !== currBrowsers) {
+    diff.push({ key: 'browsers', label: 'Browsers', before: prevBrowsers || null, after: currBrowsers || null });
+  }
+
+  return diff;
+}

--- a/application/types/api.ts
+++ b/application/types/api.ts
@@ -882,6 +882,20 @@ export interface DiagnosisCompact {
 }
 
 /**
+ * One rendered evidence section of the AI diagnosis context (a lens over what
+ * will be sent to the model). Shared by the context modal, the cluster diagnosis
+ * store and the demo context builder.
+ */
+export interface ContextSection {
+  id: string;
+  title: string;
+  chars: number;
+  truncated: boolean;
+  markdown: string;
+  items?: number;
+}
+
+/**
  * SCM coverage metadata returned alongside the diagnosis context preview.
  * null means the regression context block was never reached (DB error or no lastSeenRun).
  */


### PR DESCRIPTION
## What & why

This PR consolidates duplicated code and types across the codebase by extracting them into shared modules:

1. **Metadata utilities** (`shared/utils/run-metadata.ts`): Extracted `buildCompareUrl()`, `computeMetadataDiff()`, and `getBrowserList()` from `server/utils/regression-context.ts` and `application/shared/handlers/test-runs.ts` into a single shared module. This ensures the regression context diff logic is identical whether computed server-side or client-side.

2. **Type consolidation** (`types/api.ts`): Moved `EndpointSummary`, `DiagnosisCompact`, `ContextSection`, `ConsoleEntry`, `NetworkRequest`, `ServerLogEntry`, `TestRunScmMetadata`, `TestRunCiMetadata`, and `PatchValidation` to the central API types file to eliminate duplication across components and utilities.

3. **Utility functions** (`app/utils/index.ts`): Extracted `passRate()`, `getPassRate()`, `getTestCaseStatus()`, and `BadgeColor` type from multiple page components into a shared utility module.

4. **Hash utilities** (`shared/utils/hash.ts`): Extracted `sha256Hex()` from `shared/locator-healing.ts` and `shared/error-fingerprint.ts` into a dedicated module for Web Crypto operations.

5. **Filename sanitization** (`server/utils/sanitize-filename.ts`): Extracted `sanitizeFilename()` from upload handlers into a reusable utility.

6. **Database client type** (`server/database/index.ts`): Exported `DbClient` type to eliminate repeated type derivations across server utilities.

7. **AI diagnosis exports**: Made `asCategory()` public in `shared/ai-diagnosis.ts` for use in `server/utils/ai-research.ts`.

These changes reduce code duplication, improve maintainability, and ensure consistency across the application.

## How was it tested?

No new tests added—this is a pure refactoring that moves existing code without changing behavior. Existing test suites cover the moved functions. CI should pass with no functional changes.

## Checklist

- [x] PR title follows Conventional Commits (`refactor: ...`)
- [x] No behavior changes—pure code organization
- [x] Existing tests cover the refactored code

https://claude.ai/code/session_01M7Jsp3YuzoexRntLeP4EpM