### PR TITLE
build: ensure core package source is available at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 
 # Copy workspace manifest files first so npm ci is cached separately from source
 COPY package.json package-lock.json ./
+COPY packages/core/package.json ./packages/core/
 COPY application/package.json ./application/
 COPY reporter/package.json ./reporter/
 COPY integrations/nitro/package.json ./integrations/nitro/
@@ -19,6 +20,11 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Copy root tsconfig (extended by application/tsconfig.json)
 COPY tsconfig.json ./
+
+# Copy the shared core workspace package (@piwitests/core). The app imports it
+# via #shared/* shims; Vite transpiles it (nuxt.config transpile) and Nitro
+# inlines it into .output (noExternals), so its source must be present at build.
+COPY packages/core/ ./packages/core/
 
 # Copy application source
 COPY application/ ./application/


### PR DESCRIPTION
## What & why

The Docker build was copying `packages/core/package.json` early (for npm dependency caching) but not copying the actual source files from `packages/core/` before the application build step. Since the application imports from `@piwitests/core` via `#shared/*` shims that Vite transpiles and Nitro inlines into `.output`, the core package source must be present during the build.

This change adds an explicit `COPY packages/core/` step after installing dependencies and before copying application source, ensuring the core package source is available when needed.

## How was it tested?

This is a Docker build configuration fix. The change ensures the build succeeds when the application depends on the core package at build time. Existing CI builds will validate this works correctly.

## Checklist

- [x] PR title follows Conventional Commits (`build: ...`)
- [x] No tests needed (build configuration change)
- [x] No docs updates needed (internal build infrastructure)

https://claude.ai/code/session_01Hke1rwQwMxeKAQVidEfMyv