### PR TITLE
feat(app): add cross-project analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Native Playwright HTML reports are great for local debugging — but they're eph
 - ⚡ **Live streaming** — watch runs in real time as CI executes; no polling, no waiting.
 - 🔗 **Failure clustering** — failures sharing a root cause are auto-grouped by error fingerprint.
 - 📈 **Performance & flaky tracking** — P90 duration trends, slowest tests, composite flakiness scores.
+- 📊 **Cross-project analytics** — a portfolio dashboard with pass-rate trends, a project × time heatmap, CI-time and wasted-time trends, a global flaky leaderboard, and an auto-generated insights feed for higher-level decisions.
 - 🩹 **Locator healing** — when a locator breaks, ranked replacement locators captured from prior passing runs, with a recommended fix.
 - 🎬 **Self-hosted trace viewer** — open the full Playwright trace viewer from any failure; the trace stays on your server.
 - 🔔 **Notifications** — email, Slack, webhook, and in-browser alerts for failed runs and new failure clusters.

--- a/application/app/components/analytics/AnalyticsScopeBar.vue
+++ b/application/app/components/analytics/AnalyticsScopeBar.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { MAX_ANALYTICS_DAYS } from '#shared/analytics/scope';
+import type { AnalyticsScopeState } from '~/composables/useAnalyticsScope';
+
+const props = defineProps<{
+  modelValue: AnalyticsScopeState;
+  availableEnvironments: string[];
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: AnalyticsScopeState];
+}>();
+
+const PERIOD_ITEMS = [
+  { label: 'Last 7 days', value: 7 },
+  { label: 'Last 30 days', value: 30 },
+  { label: 'Last 90 days', value: 90 },
+  { label: 'Last year', value: 365 },
+  { label: 'All time', value: MAX_ANALYTICS_DAYS },
+];
+
+const days = computed({
+  get: () => props.modelValue.days,
+  set: (val: number) => emit('update:modelValue', { ...props.modelValue, days: val }),
+});
+
+const ENV_ALL = 'All environments';
+
+const environment = computed({
+  get: () => props.modelValue.environment ?? ENV_ALL,
+  set: (val: string) => emit('update:modelValue', { ...props.modelValue, environment: val === ENV_ALL ? null : val }),
+});
+
+const environmentItems = computed(() => [ENV_ALL, ...props.availableEnvironments]);
+
+const fullRunsOnly = computed({
+  get: () => props.modelValue.fullRunsOnly,
+  set: (val: boolean) => emit('update:modelValue', { ...props.modelValue, fullRunsOnly: val }),
+});
+</script>
+
+<template>
+  <div class="flex items-center gap-3 flex-wrap">
+    <USelect v-model="days" :items="PERIOD_ITEMS" size="sm" class="min-w-[140px]" icon="i-lucide-calendar-range" />
+
+    <USelect
+      v-if="availableEnvironments.length > 0"
+      v-model="environment"
+      :items="environmentItems"
+      size="sm"
+      class="min-w-[160px]"
+      icon="i-lucide-server"
+    />
+
+    <label
+      class="flex items-center gap-1.5 cursor-pointer select-none text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+    >
+      <UCheckbox v-model="fullRunsOnly" size="sm" />
+      Full runs only
+    </label>
+  </div>
+</template>

--- a/application/app/components/analytics/CiTimeTrendChart.vue
+++ b/application/app/components/analytics/CiTimeTrendChart.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { VisXYContainer, VisArea, VisAxis, VisLine } from '@unovis/vue';
+import { CurveType } from '@unovis/ts';
+import type { AnalyticsCiTimeTrend } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: trend,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsCiTimeTrend>('ci-time-trend', () => props.query);
+
+type DataPoint = { date: Date; totalMinutes: number; runCount: number };
+
+const chartData = computed<DataPoint[]>(
+  () => trend.value?.points.map((p) => ({ date: new Date(p.date), totalMinutes: p.totalMinutes, runCount: p.runCount })) ?? [],
+);
+
+const hasData = computed(() => chartData.value.some((p) => p.runCount > 0));
+
+const x = (d: DataPoint) => d.date;
+const y = (d: DataPoint) => d.totalMinutes;
+const lineColor = 'rgb(59, 130, 246)';
+
+const xyContainerRef = ref<UnovisContainerRef | null>(null);
+const { tooltipData, tooltipPos, onRenderComplete } = useChartMarkers(xyContainerRef, chartData, {
+  x: (d) => d.date,
+  series: [{ y: (d) => d.totalMinutes, color: lineColor }],
+});
+
+const deltaBadge = computed(() => {
+  if (!trend.value || trend.value.deltaPct === null) return null;
+  const pct = trend.value.deltaPct;
+  return {
+    label: `${pct > 0 ? '+' : ''}${pct}% vs previous period`,
+    class: pct > 25 ? 'text-red-600 dark:text-red-400' : pct < -10 ? 'text-green-600 dark:text-green-400' : 'text-gray-500',
+  };
+});
+
+const subtitle = computed(() => {
+  if (!trend.value) return undefined;
+  const total = trend.value.totalMinutes;
+  const label = total < 60 ? `${Math.round(total)} min` : `${Math.round((total / 60) * 10) / 10} h`;
+  return `${label} across ${trend.value.runCount} runs`;
+});
+</script>
+
+<template>
+  <ChartCard icon="i-lucide-timer" title="CI time" :subtitle="subtitle" help="analytics.ci-time">
+    <template #actions>
+      <span v-if="deltaBadge" class="text-xs font-medium tabular-nums" :class="deltaBadge.class">
+        {{ deltaBadge.label }}
+      </span>
+    </template>
+
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load CI time: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!hasData" text="No runs in this period." />
+    <div v-else class="w-full relative">
+      <VisXYContainer
+        ref="xyContainerRef"
+        :data="chartData"
+        :height="220"
+        :padding="{ top: 10, right: 10, bottom: 0, left: 0 }"
+        :on-render-complete="onRenderComplete"
+      >
+        <VisArea :x="x" :y="y" :color="'rgba(59, 130, 246, 0.15)'" :curve-type="CurveType.MonotoneX" />
+        <VisLine :x="x" :y="y" :color="lineColor" :curve-type="CurveType.MonotoneX" :line-width="2" />
+        <VisAxis
+          type="x"
+          :tick-format="(d: Date) => new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })"
+        />
+        <VisAxis type="y" label="Minutes" :tick-format="(d: number) => d.toString()" />
+      </VisXYContainer>
+
+      <div
+        v-if="tooltipData"
+        class="fixed z-50 pointer-events-none bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 max-w-[240px]"
+        :style="{ left: `${tooltipPos.x}px`, top: `${tooltipPos.y}px` }"
+      >
+        <div class="p-2 text-sm text-gray-900 dark:text-gray-100">
+          <div class="font-semibold mb-1">
+            {{ new Date(tooltipData.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) }}
+          </div>
+          <div>{{ tooltipData.totalMinutes }} minutes</div>
+          <div class="text-gray-400 text-xs">{{ tooltipData.runCount }} runs</div>
+        </div>
+      </div>
+    </div>
+  </ChartCard>
+</template>

--- a/application/app/components/analytics/ClusterLandscape.vue
+++ b/application/app/components/analytics/ClusterLandscape.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { AnalyticsClusterLandscape } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: landscape,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsClusterLandscape>('cluster-landscape', () => props.query);
+
+function ageClass(ageDays: number): string {
+  if (ageDays >= 30) return 'text-red-600 dark:text-red-400';
+  if (ageDays >= 14) return 'text-amber-600 dark:text-amber-400';
+  return 'text-gray-500';
+}
+</script>
+
+<template>
+  <SectionCard
+    icon="i-lucide-layers"
+    title="Failure clusters"
+    subtitle="Open root causes across all projects"
+    help="analytics.cluster-landscape"
+  >
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load clusters: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState
+      v-else-if="!landscape || (landscape.totalOpen === 0 && landscape.resolvedInPeriod === 0)"
+      icon="i-lucide-check-circle"
+      text="No open failure clusters."
+    />
+    <div v-else class="space-y-4">
+      <StatTileGrid>
+        <StatTile
+          label="Open"
+          :value="landscape.totalOpen"
+          :value-class="landscape.totalOpen > 0 ? 'text-red-600 dark:text-red-400' : ''"
+        />
+        <StatTile label="Resolved this period" :value="landscape.resolvedInPeriod" />
+        <StatTile
+          label="Oldest open"
+          :value="landscape.clusters.length > 0 ? `${Math.max(...landscape.clusters.map((c) => c.ageDays))} d` : '—'"
+          size="lg"
+        />
+      </StatTileGrid>
+
+      <div v-if="landscape.byErrorType.length > 0" class="flex flex-wrap gap-1.5">
+        <UBadge
+          v-for="entry in landscape.byErrorType"
+          :key="entry.errorType"
+          :color="clusterErrorTypeColor(entry.errorType)"
+          variant="subtle"
+          size="sm"
+        >
+          {{ entry.errorType }} · {{ entry.count }}
+        </UBadge>
+      </div>
+
+      <div class="divide-y divide-gray-100 dark:divide-gray-800">
+        <NuxtLink
+          v-for="cluster in landscape.clusters.slice(0, 8)"
+          :key="cluster.id"
+          :to="`/failure-clusters/${cluster.id}`"
+          class="flex items-center gap-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-800/60 rounded transition-colors"
+        >
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium truncate">{{ cluster.title || cluster.signature }}</p>
+            <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {{ cluster.projectLabel || cluster.projectName }}
+              <template v-if="cluster.errorType"> · {{ cluster.errorType }}</template>
+            </p>
+          </div>
+          <div class="text-right text-xs shrink-0">
+            <p class="tabular-nums font-medium">{{ cluster.occurrences }}×</p>
+            <p class="tabular-nums" :class="ageClass(cluster.ageDays)">{{ cluster.ageDays }} d open</p>
+          </div>
+        </NuxtLink>
+      </div>
+    </div>
+  </SectionCard>
+</template>

--- a/application/app/components/analytics/GlobalFlakyLeaderboard.vue
+++ b/application/app/components/analytics/GlobalFlakyLeaderboard.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import type { AnalyticsFlakyRow } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: rows,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsFlakyRow[]>('flaky-leaderboard', () => props.query);
+
+function scoreColor(score: number): string {
+  if (score >= 60) return 'text-red-600 dark:text-red-400';
+  if (score >= 30) return 'text-amber-600 dark:text-amber-400';
+  return 'text-gray-500';
+}
+
+/** Retry-pass flakes read as "flaked N/M runs"; alternation-only flakes as status flips. */
+function flakeSummary(row: AnalyticsFlakyRow): string {
+  if (row.retryPassRuns > 0) return `flaked ${row.retryPassRuns}/${row.totalRuns} runs`;
+  return `${row.alternations} status flips in ${row.totalRuns} runs`;
+}
+</script>
+
+<template>
+  <SectionCard
+    icon="i-lucide-repeat"
+    title="Flakiest tests"
+    :count="rows?.length || undefined"
+    subtitle="Across all projects, sorted by impact"
+    help="analytics.flaky-leaderboard"
+  >
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load flaky tests: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!rows || rows.length === 0" text="No flaky tests detected. Nice and stable." />
+    <div v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+      <NuxtLink
+        v-for="row in rows"
+        :key="`${row.projectId}-${row.testCaseId}`"
+        :to="`/test-cases/${row.testCaseId}`"
+        class="flex items-center gap-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-800/60 rounded transition-colors"
+      >
+        <span class="tabular-nums font-bold text-sm w-10 text-right shrink-0" :class="scoreColor(row.score)">
+          {{ row.score }}
+        </span>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-medium truncate">{{ row.title }}</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
+            {{ row.projectLabel || row.projectName }} · {{ flakeSummary(row) }}
+            <template v-if="row.lastFlakeAt"> · last {{ formatRelativeTime(row.lastFlakeAt) }}</template>
+          </p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-sm tabular-nums" :class="row.wastedCiMinutes >= 30 ? 'text-red-600 dark:text-red-400' : row.wastedCiMinutes >= 5 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500'">
+            {{ Math.round(row.wastedCiMinutes) }} min
+          </p>
+          <TagBadge v-if="row.rootCause" :text="row.rootCause" color="neutral" />
+        </div>
+      </NuxtLink>
+    </div>
+  </SectionCard>
+</template>

--- a/application/app/components/analytics/InsightsFeed.vue
+++ b/application/app/components/analytics/InsightsFeed.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { AnalyticsInsight, AnalyticsInsightSeverity } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: insights,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsInsight[]>('insights', () => props.query);
+
+const NuxtLink = resolveComponent('NuxtLink');
+
+const SEVERITY_META: Record<AnalyticsInsightSeverity, { icon: string; class: string; border: string }> = {
+  critical: { icon: 'i-lucide-octagon-alert', class: 'text-red-500', border: 'border-l-red-500' },
+  warning: { icon: 'i-lucide-triangle-alert', class: 'text-amber-500', border: 'border-l-amber-400' },
+  info: { icon: 'i-lucide-info', class: 'text-blue-500', border: 'border-l-blue-400' },
+  positive: { icon: 'i-lucide-trending-up', class: 'text-green-500', border: 'border-l-green-500' },
+};
+</script>
+
+<template>
+  <SectionCard icon="i-lucide-lightbulb" title="Insights" :count="insights?.length || undefined" help="analytics.insights">
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load insights: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState
+      v-else-if="!insights || insights.length === 0"
+      icon="i-lucide-check-circle"
+      text="Nothing needs your attention in this period."
+    />
+    <div v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+      <component
+        :is="insight.to ? NuxtLink : 'div'"
+        v-for="insight in insights"
+        :key="insight.id"
+        :to="insight.to"
+        class="flex items-start gap-3 py-3 pl-3 border-l-2"
+        :class="[
+          SEVERITY_META[insight.severity].border,
+          insight.to ? 'hover:bg-gray-50 dark:hover:bg-gray-800/60 rounded-r transition-colors' : '',
+        ]"
+      >
+        <UIcon
+          :name="SEVERITY_META[insight.severity].icon"
+          class="size-4 mt-0.5 shrink-0"
+          :class="SEVERITY_META[insight.severity].class"
+        />
+        <div class="min-w-0">
+          <p class="text-sm font-medium">{{ insight.message }}</p>
+          <p v-if="insight.detail" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ insight.detail }}</p>
+        </div>
+      </component>
+    </div>
+  </SectionCard>
+</template>

--- a/application/app/components/analytics/PassRateHeatmap.vue
+++ b/application/app/components/analytics/PassRateHeatmap.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import type { AnalyticsHeatmap } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: heatmap,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsHeatmap>('pass-rate-heatmap', () => props.query);
+
+function cellStyle(rate: number | null): Record<string, string> {
+  if (rate === null) return {};
+  // Green (high) → amber → red (low), with alpha rising as it worsens.
+  if (rate >= 99.5) return { backgroundColor: 'rgba(34, 197, 94, 0.85)' };
+  if (rate >= 90) return { backgroundColor: 'rgba(34, 197, 94, 0.5)' };
+  if (rate >= 75) return { backgroundColor: 'rgba(245, 158, 11, 0.55)' };
+  if (rate >= 50) return { backgroundColor: 'rgba(249, 115, 22, 0.65)' };
+  return { backgroundColor: 'rgba(239, 68, 68, 0.75)' };
+}
+
+function cellTitle(row: { name: string; label: string | null }, index: number, rate: number | null): string {
+  const date = heatmap.value?.buckets[index] ?? '';
+  const span = (heatmap.value?.bucketDays ?? 1) > 1 ? ` (${heatmap.value!.bucketDays} days)` : '';
+  return `${row.label || row.name} · ${date}${span}: ${rate !== null ? `${rate}% passed` : 'no runs'}`;
+}
+
+const legendItems = [
+  { color: 'rgba(34, 197, 94, 0.85)', label: '100%' },
+  { color: 'rgba(34, 197, 94, 0.5)', label: '≥ 90%' },
+  { color: 'rgba(245, 158, 11, 0.55)', label: '≥ 75%' },
+  { color: 'rgba(249, 115, 22, 0.65)', label: '≥ 50%' },
+  { color: 'rgba(239, 68, 68, 0.75)', label: '< 50%' },
+];
+
+const subtitle = computed(() => {
+  const bucketDays = heatmap.value?.bucketDays ?? 1;
+  return bucketDays > 1 ? `One cell = ${bucketDays} days` : 'One cell = one day';
+});
+</script>
+
+<template>
+  <ChartCard icon="i-lucide-grid-3x3" title="Pass rate heatmap" :subtitle="subtitle" help="analytics.heatmap">
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load the heatmap: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!heatmap || heatmap.rows.length === 0" text="No runs in this period." />
+    <TableScroller v-else min-width="40rem">
+      <div class="space-y-1">
+        <div
+          v-for="row in heatmap.rows"
+          :key="row.projectId"
+          class="grid items-center gap-2"
+          style="grid-template-columns: 10rem 1fr"
+        >
+          <NuxtLink
+            :to="`/projects/${row.projectId}`"
+            class="text-sm truncate hover:text-primary"
+            :title="row.label || row.name"
+          >
+            {{ row.label || row.name }}
+          </NuxtLink>
+          <div class="flex gap-px">
+            <div
+              v-for="(rate, index) in row.cells"
+              :key="index"
+              class="h-6 flex-1 rounded-sm min-w-1 bg-gray-100 dark:bg-gray-800"
+              :style="cellStyle(rate)"
+              :title="cellTitle(row, index, rate)"
+            />
+          </div>
+        </div>
+        <div class="grid gap-2" style="grid-template-columns: 10rem 1fr">
+          <span />
+          <div class="flex justify-between text-xs text-gray-400">
+            <span>{{ heatmap.buckets[0] }}</span>
+            <span>{{ heatmap.buckets[heatmap.buckets.length - 1] }}</span>
+          </div>
+        </div>
+        <ChartLegend :items="legendItems" dense />
+      </div>
+    </TableScroller>
+  </ChartCard>
+</template>

--- a/application/app/components/analytics/PortfolioScorecard.vue
+++ b/application/app/components/analytics/PortfolioScorecard.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import type { AnalyticsPortfolioRow } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: rows,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsPortfolioRow[]>('portfolio', () => props.query);
+
+function passRateClass(rate: number | null): string {
+  if (rate === null) return 'text-gray-400';
+  if (rate >= 90) return 'text-green-600 dark:text-green-400';
+  if (rate >= 50) return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-red-600 dark:text-red-400';
+}
+
+function deltaMeta(delta: number | null): { icon: string; class: string } | null {
+  if (delta === null || Math.abs(delta) < 1) return null;
+  return delta > 0
+    ? { icon: 'i-lucide-trending-up', class: 'text-green-600 dark:text-green-400' }
+    : { icon: 'i-lucide-trending-down', class: 'text-red-600 dark:text-red-400' };
+}
+</script>
+
+<template>
+  <SectionCard
+    icon="i-lucide-table-properties"
+    title="Portfolio health"
+    :count="rows?.length || undefined"
+    help="analytics.portfolio"
+  >
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load the portfolio: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!rows || rows.length === 0" text="No projects with runs in this period." />
+    <template v-else>
+      <!-- Mobile: card list -->
+      <div class="md:hidden space-y-3">
+        <div
+          v-for="row in rows"
+          :key="row.projectId"
+          class="rounded-lg border border-gray-200 dark:border-gray-800 p-3 space-y-2"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <NuxtLink :to="`/projects/${row.projectId}`" class="font-medium truncate hover:text-primary">
+              {{ row.label || row.name }}
+            </NuxtLink>
+            <span class="tabular-nums font-semibold shrink-0" :class="passRateClass(row.passRate)">
+              {{ row.passRate !== null ? `${row.passRate}%` : '—' }}
+            </span>
+          </div>
+          <MiniRunBars :runs="row.recentRuns" :height="20" />
+          <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <span>{{ row.runCount }} runs · {{ row.flakyTests }} flaky · {{ row.openClusters }} open clusters</span>
+            <span v-if="row.latestRun">{{ formatRelativeTime(row.latestRun.startTime) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop: table -->
+      <div class="hidden md:block">
+        <TableScroller min-width="52rem">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs text-gray-500 uppercase tracking-wider border-b border-gray-200 dark:border-gray-800">
+                <th class="py-2 pr-4 font-medium">Project</th>
+                <th class="py-2 pr-4 font-medium">Trend</th>
+                <th class="py-2 pr-4 font-medium text-right">Pass rate</th>
+                <th class="py-2 pr-4 font-medium text-right">Runs</th>
+                <th class="py-2 pr-4 font-medium text-right">Flaky</th>
+                <th class="py-2 pr-4 font-medium text-right">Avg run</th>
+                <th class="py-2 pr-4 font-medium text-right">Open clusters</th>
+                <th class="py-2 font-medium text-right">Latest run</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+              <tr v-for="row in rows" :key="row.projectId">
+                <td class="py-2.5 pr-4">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <NuxtLink :to="`/projects/${row.projectId}`" class="font-medium truncate hover:text-primary">
+                      {{ row.label || row.name }}
+                    </NuxtLink>
+                    <TagBadge v-for="tag in row.tags.slice(0, 2)" :key="tag.id" :text="tag.text" :color="tag.color" />
+                  </div>
+                </td>
+                <td class="py-2.5 pr-4">
+                  <div class="w-36">
+                    <MiniRunBars :runs="row.recentRuns" :height="22" />
+                  </div>
+                </td>
+                <td class="py-2.5 pr-4 text-right">
+                  <span class="inline-flex items-center gap-1 tabular-nums font-semibold" :class="passRateClass(row.passRate)">
+                    {{ row.passRate !== null ? `${row.passRate}%` : '—' }}
+                    <UIcon
+                      v-if="deltaMeta(row.passRateDelta)"
+                      :name="deltaMeta(row.passRateDelta)!.icon"
+                      class="size-3.5"
+                      :class="deltaMeta(row.passRateDelta)!.class"
+                      :title="`${row.passRateDelta! > 0 ? '+' : ''}${row.passRateDelta} pts vs previous period`"
+                    />
+                  </span>
+                </td>
+                <td class="py-2.5 pr-4 text-right tabular-nums">{{ row.runCount }}</td>
+                <td class="py-2.5 pr-4 text-right tabular-nums" :class="row.flakyTests > 0 ? 'text-amber-600 dark:text-amber-400' : ''">
+                  {{ row.flakyTests }}
+                </td>
+                <td class="py-2.5 pr-4 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                  {{ row.avgRunDurationMs ? formatDuration(row.avgRunDurationMs) : '—' }}
+                </td>
+                <td class="py-2.5 pr-4 text-right tabular-nums" :class="row.openClusters > 0 ? 'text-red-600 dark:text-red-400' : ''">
+                  {{ row.openClusters }}
+                </td>
+                <td class="py-2.5 text-right">
+                  <NuxtLink
+                    v-if="row.latestRun"
+                    :to="`/test-runs/${row.latestRun.id}`"
+                    class="inline-flex items-center gap-2 hover:text-primary"
+                  >
+                    <RunStatusBadge :status="row.latestRun.status" />
+                    <span class="text-xs text-gray-500 dark:text-gray-400">
+                      {{ formatRelativeTime(row.latestRun.startTime) }}
+                    </span>
+                  </NuxtLink>
+                  <span v-else class="text-xs text-gray-400">No runs</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </TableScroller>
+      </div>
+    </template>
+  </SectionCard>
+</template>

--- a/application/app/components/analytics/WastedTimeChart.vue
+++ b/application/app/components/analytics/WastedTimeChart.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { VisXYContainer, VisArea, VisAxis } from '@unovis/vue';
+import { CurveType } from '@unovis/ts';
+import type { AnalyticsWastedTime } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: wasted,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsWastedTime>('wasted-time', () => props.query);
+
+type DataPoint = { date: Date; waitMinutes: number; failedExecMinutes: number };
+
+const chartData = computed<DataPoint[]>(
+  () =>
+    wasted.value?.points.map((p) => ({
+      date: new Date(p.date),
+      waitMinutes: p.waitMinutes,
+      failedExecMinutes: p.failedExecMinutes,
+    })) ?? [],
+);
+
+const hasData = computed(() => chartData.value.some((p) => p.waitMinutes > 0 || p.failedExecMinutes > 0));
+
+const x = (d: DataPoint) => d.date;
+const areaColors = ['rgb(245, 158, 11)', 'rgb(239, 68, 68)'] as const;
+
+const xyContainerRef = ref<UnovisContainerRef | null>(null);
+const { tooltipData, tooltipPos, onRenderComplete } = useChartMarkers(xyContainerRef, chartData, {
+  x: (d) => d.date,
+  series: [
+    { y: (d) => d.waitMinutes, color: areaColors[0] },
+    { y: (d) => d.failedExecMinutes, color: areaColors[1] },
+  ],
+});
+
+const legendItems = [
+  { color: areaColors[0], label: 'Wait steps' },
+  { color: areaColors[1], label: 'Failed attempts' },
+];
+
+const subtitle = computed(() => {
+  if (!wasted.value) return undefined;
+  const total = wasted.value.totalWaitMinutes + wasted.value.totalFailedExecMinutes;
+  const label = total < 60 ? `${Math.round(total)} min` : `${Math.round((total / 60) * 10) / 10} h`;
+  return `${label} of CI time produced no signal`;
+});
+</script>
+
+<template>
+  <ChartCard icon="i-lucide-hourglass" title="Wasted CI time" :subtitle="subtitle" help="analytics.wasted-time">
+    <template #legend>
+      <ChartLegend :items="legendItems" dense />
+    </template>
+
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load wasted time: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!hasData" text="No wasted time recorded in this period." />
+    <div v-else class="w-full relative">
+      <VisXYContainer
+        ref="xyContainerRef"
+        :data="chartData"
+        :height="220"
+        :padding="{ top: 10, right: 10, bottom: 0, left: 0 }"
+        :on-render-complete="onRenderComplete"
+      >
+        <VisArea
+          :x="x"
+          :y="[(d: DataPoint) => d.waitMinutes, (d: DataPoint) => d.failedExecMinutes]"
+          :color="areaColors"
+          :curve-type="CurveType.MonotoneX"
+        />
+        <VisAxis
+          type="x"
+          :tick-format="(d: Date) => new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })"
+        />
+        <VisAxis type="y" label="Minutes" :tick-format="(d: number) => d.toString()" />
+      </VisXYContainer>
+
+      <div
+        v-if="tooltipData"
+        class="fixed z-50 pointer-events-none bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 max-w-[240px]"
+        :style="{ left: `${tooltipPos.x}px`, top: `${tooltipPos.y}px` }"
+      >
+        <div class="p-2 text-sm text-gray-900 dark:text-gray-100">
+          <div class="font-semibold mb-1">
+            {{ new Date(tooltipData.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) }}
+          </div>
+          <div><span class="text-amber-500">&#9679;</span> Wait steps: {{ tooltipData.waitMinutes }} min</div>
+          <div><span class="text-red-500">&#9679;</span> Failed attempts: {{ tooltipData.failedExecMinutes }} min</div>
+        </div>
+      </div>
+
+      <div v-if="wasted && wasted.byProject.length > 0" class="mt-4 space-y-1">
+        <div
+          v-for="project in wasted.byProject.slice(0, 5)"
+          :key="project.projectId"
+          class="flex items-center justify-between text-sm"
+        >
+          <NuxtLink :to="`/projects/${project.projectId}`" class="truncate hover:text-primary">
+            {{ project.label || project.name }}
+          </NuxtLink>
+          <span class="tabular-nums text-gray-500 dark:text-gray-400 shrink-0">
+            {{ Math.round(project.waitMinutes + project.failedExecMinutes) }} min
+          </span>
+        </div>
+      </div>
+    </div>
+  </ChartCard>
+</template>

--- a/application/app/composables/useAnalyticsScope.ts
+++ b/application/app/composables/useAnalyticsScope.ts
@@ -1,0 +1,58 @@
+import {
+  analyticsScopeToQuery,
+  DEFAULT_ANALYTICS_DAYS,
+  type AnalyticsScope,
+} from '#shared/analytics/scope';
+import type { AnalyticsWidgetId } from '#shared/analytics/registry';
+
+export interface AnalyticsScopeState {
+  days: number;
+  environment: string | null;
+  fullRunsOnly: boolean;
+}
+
+const DEFAULT_STATE: AnalyticsScopeState = {
+  days: DEFAULT_ANALYTICS_DAYS,
+  environment: null,
+  fullRunsOnly: true,
+};
+
+/**
+ * The `/analytics` page's global filter state (persisted per user in a
+ * cookie, SSR-safe) plus the query object every widget fetch derives from.
+ */
+export function useAnalyticsScope() {
+  const state = useCookie<AnalyticsScopeState>('piwi-analytics-scope', {
+    default: () => ({ ...DEFAULT_STATE }),
+    encode: (v) => JSON.stringify(v),
+    decode: (v) => {
+      try {
+        return v ? { ...DEFAULT_STATE, ...(JSON.parse(v) as Partial<AnalyticsScopeState>) } : { ...DEFAULT_STATE };
+      } catch {
+        return { ...DEFAULT_STATE };
+      }
+    },
+  });
+
+  const scope = computed<AnalyticsScope>(() => ({
+    days: state.value.days,
+    environment: state.value.environment,
+    fullRunsOnly: state.value.fullRunsOnly,
+  }));
+
+  const scopeQuery = computed(() => analyticsScopeToQuery(scope.value));
+
+  return { state, scope, scopeQuery };
+}
+
+/**
+ * Fetch one analytics widget's data. The query is reactive — changing the
+ * scope refetches every mounted widget.
+ */
+export function useAnalyticsWidget<T>(widget: AnalyticsWidgetId, query: () => Record<string, string>) {
+  return useFetch<T>(`/api/analytics/${widget}`, {
+    query: computed(query),
+    lazy: true,
+    server: false,
+  });
+}

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -59,6 +59,8 @@ import {
   computeRegressionContextForRun,
 } from '#shared/handlers/test-runs';
 import { computeRunInsights } from '#shared/handlers/run-insights';
+import { isAnalyticsWidgetId, runAnalyticsWidget } from '#shared/handlers/analytics';
+import { parseAnalyticsScope } from '#shared/analytics/scope';
 import {
   listUsers,
   createUserRecord,
@@ -128,6 +130,16 @@ async function resolveDemoScope(actingUserId: number | null): Promise<ProjectSco
 }
 
 const routes: RouteEntry[] = [
+  // Analytics — one generic entry; widgets dispatch through the shared handler map
+  {
+    method: 'GET',
+    pattern: /^\/api\/analytics\/([\w-]+)$/,
+    handler: async (m, _, q, ctx) => {
+      const widget = m[1]!;
+      if (!isAnalyticsWidgetId(widget)) throw new Error('Unknown analytics widget');
+      return runAnalyticsWidget(await getDemoDb(), widget, parseAnalyticsScope(q), ctx?.scope ?? 'all');
+    },
+  },
   // Projects
   {
     method: 'GET',

--- a/application/app/layouts/default.vue
+++ b/application/app/layouts/default.vue
@@ -178,6 +178,14 @@ const links = computed(() => {
         },
       },
       {
+        label: 'Analytics',
+        icon: 'i-lucide-chart-line',
+        to: '/analytics',
+        onSelect: () => {
+          open.value = false;
+        },
+      },
+      {
         label: 'Projects',
         icon: 'i-lucide-folder',
         to: '/projects',

--- a/application/app/pages/analytics.vue
+++ b/application/app/pages/analytics.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import type { Component } from 'vue';
+import { ANALYTICS_WIDGETS, type AnalyticsWidgetId } from '#shared/analytics/registry';
+import type { TestRunForChart } from '~~/types/api';
+import {
+  InsightsFeed,
+  PortfolioScorecard,
+  PassRateHeatmap,
+  CiTimeTrendChart,
+  WastedTimeChart,
+  GlobalFlakyLeaderboard,
+  ClusterLandscape,
+} from '#components';
+
+useHead({ title: 'Analytics - Piwi Dashboard' });
+
+const { state, scopeQuery } = useAnalyticsScope();
+
+// Environment options for the scope bar (same source as the home filters).
+const { data: recentTestRuns } = await useFetch<TestRunForChart[]>('/api/test-runs/recent', {
+  lazy: true,
+  server: false,
+  default: () => [] as TestRunForChart[],
+});
+
+const availableEnvironments = computed(() => {
+  const envSet = new Set<string>();
+  for (const run of recentTestRuns.value ?? []) {
+    if (run.environment) envSet.add(run.environment);
+  }
+  return [...envSet].sort();
+});
+
+/**
+ * Widget id → component. Keyed by the registry union, so registering a widget
+ * without wiring its component (or vice versa) is a compile error.
+ */
+const WIDGET_COMPONENTS: Record<AnalyticsWidgetId, Component> = {
+  insights: InsightsFeed,
+  portfolio: PortfolioScorecard,
+  'pass-rate-heatmap': PassRateHeatmap,
+  'ci-time-trend': CiTimeTrendChart,
+  'wasted-time': WastedTimeChart,
+  'flaky-leaderboard': GlobalFlakyLeaderboard,
+  'cluster-landscape': ClusterLandscape,
+};
+</script>
+
+<template>
+  <UDashboardPanel id="analytics">
+    <template #header>
+      <UDashboardNavbar>
+        <template #leading>
+          <UDashboardSidebarCollapse />
+          <UBreadcrumb :items="[{ label: 'Analytics', icon: 'i-lucide-chart-line', to: '/analytics' }]" />
+        </template>
+      </UDashboardNavbar>
+    </template>
+
+    <template #body>
+      <div class="p-6 space-y-6">
+        <FilterToolbar>
+          <AnalyticsScopeBar v-model="state" :available-environments="availableEnvironments" />
+        </FilterToolbar>
+
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
+          <div
+            v-for="widget in ANALYTICS_WIDGETS"
+            :key="widget.id"
+            :class="widget.size === 'full' ? 'xl:col-span-2' : ''"
+          >
+            <component :is="WIDGET_COMPONENTS[widget.id]" :query="scopeQuery" />
+          </div>
+        </div>
+      </div>
+    </template>
+  </UDashboardPanel>
+</template>

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -57,6 +57,38 @@ export const HELP_TOPICS = {
     doc: 'getting-started#using-the-piwi-dashboard-reporter',
   },
 
+  // ── Analytics ─────────────────────────────────────────────────────────
+  'analytics.insights': {
+    title: 'Insights',
+    text: 'Auto-generated findings over the selected period — pass-rate drops, failing streaks, stale clusters, wasted CI time. Ranked by severity; click one to jump to the source.',
+  },
+  'analytics.portfolio': {
+    title: 'Portfolio health',
+    text: 'Every project over the selected period: pass rate with its change vs the previous period, flaky volume, open failure clusters, and the latest run. Worst health sorts first.',
+  },
+  'analytics.heatmap': {
+    title: 'Pass rate heatmap',
+    text: 'Each cell is the aggregate pass rate of one project over one time bucket — green is healthy, red is broken, gray means no runs. Longer periods use wider buckets.',
+  },
+  'analytics.ci-time': {
+    title: 'CI time',
+    text: 'Total minutes your test runs consumed, over time, with the change vs the previous equal-length period. Steady growth here is a capacity conversation.',
+  },
+  'analytics.wasted-time': {
+    title: 'Wasted CI time',
+    text: 'Minutes that produced no signal: time inside wait steps plus time executing attempts that ended failed or timed out. The strongest argument for fixing slow waits and flaky tests.',
+  },
+  'analytics.flaky-leaderboard': {
+    title: 'Flakiest tests',
+    text: 'The worst flaky tests across all projects, using the same scoring as each project’s Flaky tests tab, sorted by wasted-CI impact.',
+    doc: 'flaky-tests#flaky-test-detection',
+  },
+  'analytics.cluster-landscape': {
+    title: 'Failure clusters',
+    text: 'Open failure clusters across all projects — the biggest and oldest unresolved root causes. Clusters outlive run retention, so this works on long horizons.',
+    doc: 'failure-clustering',
+  },
+
   // ── Projects list ─────────────────────────────────────────────────────
   'projects.tag-filter': {
     text: 'Filter projects by tag. Selecting several tags uses OR logic — a project matching any of them is shown.',

--- a/application/server/api/analytics/[widget].get.ts
+++ b/application/server/api/analytics/[widget].get.ts
@@ -1,0 +1,59 @@
+import { requireAuth } from '../../utils/auth';
+import { getProjectScope } from '../../utils/project-access';
+import { getDatabase } from '../../database';
+import { isAnalyticsWidgetId, runAnalyticsWidget } from '#shared/handlers/analytics';
+import { parseAnalyticsScope } from '#shared/analytics/scope';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Analytics'],
+    summary: 'Cross-project analytics widget data',
+    description:
+      'Returns the data for one analytics widget (see the widget registry: insights, portfolio, pass-rate-heatmap, ci-time-trend, wasted-time, flaky-leaderboard, cluster-landscape), aggregated across every project the caller can see.',
+    parameters: [
+      { name: 'widget', in: 'path', required: true, schema: { type: 'string' } },
+      {
+        name: 'days',
+        in: 'query',
+        required: false,
+        schema: { type: 'integer', default: 30, maximum: 3650 },
+        description: 'Period length in days (the period ends now)',
+      },
+      {
+        name: 'projects',
+        in: 'query',
+        required: false,
+        schema: { type: 'string' },
+        description: 'Comma-separated project ids to restrict to',
+      },
+      {
+        name: 'environment',
+        in: 'query',
+        required: false,
+        schema: { type: 'string' },
+        description: 'Restrict to runs reported for one environment',
+      },
+      {
+        name: 'fullRunsOnly',
+        in: 'query',
+        required: false,
+        schema: { type: 'boolean', default: true },
+        description: 'Only count full-suite runs',
+      },
+    ],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const user = await requireAuth(event);
+  const widget = getRouterParam(event, 'widget');
+  if (!isAnalyticsWidgetId(widget)) {
+    throw createError({ statusCode: 404, message: 'Unknown analytics widget' });
+  }
+
+  const db = await getDatabase();
+  const access = await getProjectScope(db, user as any);
+  const scope = parseAnalyticsScope(getQuery(event));
+  return runAnalyticsWidget(db, widget, scope, access);
+});

--- a/application/shared/analytics/insight-rules.ts
+++ b/application/shared/analytics/insight-rules.ts
@@ -1,0 +1,177 @@
+/**
+ * Rule registry for the analytics insights feed. Every rule is a pure
+ * function over the already-computed widget aggregates — no DB access — so
+ * rules are trivially unit-testable and adding one is a single entry here.
+ */
+
+import type {
+  AnalyticsCiTimeTrend,
+  AnalyticsClusterLandscape,
+  AnalyticsFlakyRow,
+  AnalyticsInsight,
+  AnalyticsPortfolioRow,
+  AnalyticsWastedTime,
+} from './types';
+import type { AnalyticsScope } from './scope';
+
+export interface InsightContext {
+  scope: AnalyticsScope;
+  portfolio: AnalyticsPortfolioRow[];
+  ciTime: AnalyticsCiTimeTrend;
+  wastedTime: AnalyticsWastedTime;
+  clusters: AnalyticsClusterLandscape;
+  flakyTests: AnalyticsFlakyRow[];
+}
+
+export interface InsightRule {
+  id: string;
+  evaluate(ctx: InsightContext): AnalyticsInsight[];
+}
+
+const SEVERITY_ORDER: Record<AnalyticsInsight['severity'], number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+  positive: 3,
+};
+
+function projectDisplay(row: { name: string; label: string | null }): string {
+  return row.label || row.name;
+}
+
+const passRateDrop: InsightRule = {
+  id: 'pass-rate-drop',
+  evaluate: ({ portfolio, scope }) =>
+    portfolio
+      .filter((p) => p.passRateDelta !== null && p.passRateDelta <= -5 && p.runCount >= 3)
+      .map((p) => ({
+        id: `pass-rate-drop:${p.projectId}`,
+        ruleId: 'pass-rate-drop',
+        severity: p.passRateDelta! <= -15 ? ('critical' as const) : ('warning' as const),
+        message: `${projectDisplay(p)} pass rate dropped ${Math.abs(p.passRateDelta!)} pts vs the previous ${scope.days} days`,
+        detail: `Now at ${p.passRate}% over ${p.runCount} runs.`,
+        to: `/projects/${p.projectId}`,
+        projectId: p.projectId,
+      })),
+};
+
+const passRateRecovery: InsightRule = {
+  id: 'pass-rate-recovery',
+  evaluate: ({ portfolio, scope }) =>
+    portfolio
+      .filter((p) => p.passRateDelta !== null && p.passRateDelta >= 10 && p.runCount >= 3)
+      .map((p) => ({
+        id: `pass-rate-recovery:${p.projectId}`,
+        ruleId: 'pass-rate-recovery',
+        severity: 'positive' as const,
+        message: `${projectDisplay(p)} pass rate improved ${p.passRateDelta} pts vs the previous ${scope.days} days`,
+        detail: `Now at ${p.passRate}% over ${p.runCount} runs.`,
+        to: `/projects/${p.projectId}`,
+        projectId: p.projectId,
+      })),
+};
+
+const failingStreak: InsightRule = {
+  id: 'failing-streak',
+  evaluate: ({ portfolio }) =>
+    portfolio
+      .filter((p) => p.failingStreak >= 3)
+      .map((p) => ({
+        id: `failing-streak:${p.projectId}`,
+        ruleId: 'failing-streak',
+        severity: 'critical' as const,
+        message: `${projectDisplay(p)} has failed ${p.failingStreak} runs in a row`,
+        detail: p.latestRun ? `Latest run #${p.latestRun.id} ${p.latestRun.status}.` : undefined,
+        to: `/projects/${p.projectId}`,
+        projectId: p.projectId,
+      })),
+};
+
+const staleCluster: InsightRule = {
+  id: 'stale-cluster',
+  evaluate: ({ clusters }) =>
+    clusters.clusters
+      .filter((c) => c.ageDays >= 14 && c.occurrences >= 10)
+      .slice(0, 3)
+      .map((c) => ({
+        id: `stale-cluster:${c.id}`,
+        ruleId: 'stale-cluster',
+        severity: c.ageDays >= 30 ? ('critical' as const) : ('warning' as const),
+        message: `"${c.title || c.signature}" has been open for ${c.ageDays} days (${c.occurrences} occurrences)`,
+        detail: `${projectDisplay({ name: c.projectName, label: c.projectLabel })} · ${c.errorType ?? 'unknown'} error.`,
+        to: `/failure-clusters/${c.id}`,
+        projectId: c.projectId,
+      })),
+};
+
+const ciTimeGrowth: InsightRule = {
+  id: 'ci-time-growth',
+  evaluate: ({ ciTime, scope }) => {
+    if (ciTime.deltaPct === null || ciTime.deltaPct < 25 || ciTime.totalMinutes < 30) return [];
+    return [
+      {
+        id: 'ci-time-growth',
+        ruleId: 'ci-time-growth',
+        severity: ciTime.deltaPct >= 50 ? 'warning' : 'info',
+        message: `CI time grew ${ciTime.deltaPct}% vs the previous ${scope.days} days`,
+        detail: `${Math.round(ciTime.totalMinutes)} minutes across ${ciTime.runCount} runs this period.`,
+      },
+    ];
+  },
+};
+
+const wastedCiTime: InsightRule = {
+  id: 'wasted-ci-time',
+  evaluate: ({ wastedTime }) => {
+    const totalWasted = wastedTime.totalWaitMinutes + wastedTime.totalFailedExecMinutes;
+    if (totalWasted < 60) return [];
+    const worst = wastedTime.byProject[0];
+    const hours = Math.round((totalWasted / 60) * 10) / 10;
+    return [
+      {
+        id: 'wasted-ci-time',
+        ruleId: 'wasted-ci-time',
+        severity: totalWasted >= 240 ? 'warning' : 'info',
+        message: `${hours} h of CI time went to waits and failed attempts this period`,
+        detail: worst
+          ? `${projectDisplay(worst)} alone accounts for ${Math.round(worst.waitMinutes + worst.failedExecMinutes)} minutes.`
+          : undefined,
+        to: worst ? `/projects/${worst.projectId}` : undefined,
+        projectId: worst?.projectId,
+      },
+    ];
+  },
+};
+
+const topFlakyImpact: InsightRule = {
+  id: 'top-flaky-impact',
+  evaluate: ({ flakyTests }) =>
+    flakyTests
+      .filter((t) => t.wastedCiMinutes >= 10)
+      .slice(0, 2)
+      .map((t) => ({
+        id: `top-flaky-impact:${t.testCaseId}`,
+        ruleId: 'top-flaky-impact',
+        severity: 'warning' as const,
+        message: `"${t.title}" wasted ${Math.round(t.wastedCiMinutes)} CI minutes on flaky retries`,
+        detail: `${projectDisplay({ name: t.projectName, label: t.projectLabel })} · flaked in ${t.retryPassRuns} of ${t.totalRuns} recent runs.`,
+        to: `/test-cases/${t.testCaseId}`,
+        projectId: t.projectId,
+      })),
+};
+
+export const INSIGHT_RULES: InsightRule[] = [
+  failingStreak,
+  passRateDrop,
+  staleCluster,
+  topFlakyImpact,
+  wastedCiTime,
+  ciTimeGrowth,
+  passRateRecovery,
+];
+
+export function evaluateInsightRules(ctx: InsightContext): AnalyticsInsight[] {
+  return INSIGHT_RULES.flatMap((rule) => rule.evaluate(ctx)).sort(
+    (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
+  );
+}

--- a/application/shared/analytics/registry.ts
+++ b/application/shared/analytics/registry.ts
@@ -1,0 +1,72 @@
+/**
+ * Single source of truth for every cross-project analytics widget.
+ *
+ * Each entry describes one widget on the `/analytics` page. The generic
+ * `GET /api/analytics/[widget]` route dispatches by `id` through the handler
+ * map in `shared/handlers/analytics`, and the page maps the same `id` to a Vue
+ * component — so adding a widget means: one entry here, one handler file, one
+ * component. No routing changes on either the server or the demo mirror.
+ */
+
+export interface AnalyticsWidgetMeta {
+  id: string;
+  /** Card title (sentence case). */
+  title: string;
+  /** Lucide icon for the card header. */
+  icon: string;
+  /** Layout hint: `full` spans the grid, `half` shares a row on wide screens. */
+  size: 'full' | 'half';
+}
+
+export const ANALYTICS_WIDGETS = [
+  {
+    id: 'insights',
+    title: 'Insights',
+    icon: 'i-lucide-lightbulb',
+    size: 'full',
+  },
+  {
+    id: 'portfolio',
+    title: 'Portfolio health',
+    icon: 'i-lucide-table-properties',
+    size: 'full',
+  },
+  {
+    id: 'pass-rate-heatmap',
+    title: 'Pass rate heatmap',
+    icon: 'i-lucide-grid-3x3',
+    size: 'full',
+  },
+  {
+    id: 'ci-time-trend',
+    title: 'CI time',
+    icon: 'i-lucide-timer',
+    size: 'half',
+  },
+  {
+    id: 'wasted-time',
+    title: 'Wasted CI time',
+    icon: 'i-lucide-hourglass',
+    size: 'half',
+  },
+  {
+    id: 'flaky-leaderboard',
+    title: 'Flakiest tests',
+    icon: 'i-lucide-repeat',
+    size: 'half',
+  },
+  {
+    id: 'cluster-landscape',
+    title: 'Failure clusters',
+    icon: 'i-lucide-layers',
+    size: 'half',
+  },
+] as const satisfies readonly AnalyticsWidgetMeta[];
+
+export type AnalyticsWidgetId = (typeof ANALYTICS_WIDGETS)[number]['id'];
+
+const WIDGET_IDS = new Set<string>(ANALYTICS_WIDGETS.map((w) => w.id));
+
+export function isAnalyticsWidgetId(value: unknown): value is AnalyticsWidgetId {
+  return typeof value === 'string' && WIDGET_IDS.has(value);
+}

--- a/application/shared/analytics/scope.ts
+++ b/application/shared/analytics/scope.ts
@@ -1,0 +1,66 @@
+/**
+ * The one filter object every analytics widget receives. Parsed from the
+ * request query on both the server route and the demo router so the two stay
+ * identical by construction.
+ */
+
+export interface AnalyticsScope {
+  /** Period length in days (clamped to 1–3650). The period ends now. */
+  days: number;
+  /** Optional explicit project filter (always intersected with the caller's access scope). */
+  projectIds?: number[];
+  /** Restrict to runs reported for one deployment environment. */
+  environment?: string | null;
+  /** Only count full-suite runs (default) — partial/--grep runs skew every rate. */
+  fullRunsOnly: boolean;
+}
+
+export const ANALYTICS_PERIODS = [7, 30, 90, 365] as const;
+
+export const DEFAULT_ANALYTICS_DAYS = 30;
+
+/** "All time" is expressed as a 10-year window so the bucket math needs no special case. */
+export const MAX_ANALYTICS_DAYS = 3650;
+
+type QueryLike = URLSearchParams | Record<string, unknown> | undefined | null;
+
+function pick(query: QueryLike, key: string): string | null {
+  if (!query) return null;
+  if (query instanceof URLSearchParams) return query.get(key);
+  const value = (query as Record<string, unknown>)[key];
+  if (value == null) return null;
+  return Array.isArray(value) ? String(value[0] ?? '') : String(value);
+}
+
+export function parseAnalyticsScope(query: QueryLike): AnalyticsScope {
+  const rawDays = Number(pick(query, 'days'));
+  const days =
+    Number.isFinite(rawDays) && rawDays > 0 ? Math.min(MAX_ANALYTICS_DAYS, Math.round(rawDays)) : DEFAULT_ANALYTICS_DAYS;
+
+  const rawProjects = pick(query, 'projects');
+  const projectIds = rawProjects
+    ? rawProjects
+        .split(',')
+        .map((p) => Number(p))
+        .filter((p) => Number.isInteger(p) && p > 0)
+    : undefined;
+
+  const environment = pick(query, 'environment') || null;
+  const fullRunsOnly = pick(query, 'fullRunsOnly') !== 'false';
+
+  return {
+    days,
+    projectIds: projectIds && projectIds.length > 0 ? projectIds : undefined,
+    environment,
+    fullRunsOnly,
+  };
+}
+
+/** Serialize a scope back into query params (used by the client composable). */
+export function analyticsScopeToQuery(scope: AnalyticsScope): Record<string, string> {
+  const query: Record<string, string> = { days: String(scope.days) };
+  if (scope.projectIds && scope.projectIds.length > 0) query.projects = scope.projectIds.join(',');
+  if (scope.environment) query.environment = scope.environment;
+  if (!scope.fullRunsOnly) query.fullRunsOnly = 'false';
+  return query;
+}

--- a/application/shared/analytics/types.ts
+++ b/application/shared/analytics/types.ts
@@ -1,0 +1,167 @@
+/**
+ * Response payload shapes for the analytics widgets — shared between the
+ * handlers (`shared/handlers/analytics/`), the demo router, and the client
+ * components, so there is exactly one definition per widget payload.
+ */
+
+export interface AnalyticsTagInfo {
+  id: number;
+  text: string;
+  color: string;
+}
+
+export interface AnalyticsSparkRun {
+  id: number;
+  status: string;
+  passedTests: number;
+  failedTests: number;
+  flakyTests: number;
+  totalTests: number;
+  startTime: string | Date;
+}
+
+// ── Portfolio scorecard ──────────────────────────────────────────────────────
+
+export interface AnalyticsPortfolioRow {
+  projectId: number;
+  name: string;
+  label: string | null;
+  tags: AnalyticsTagInfo[];
+  /** Terminal runs inside the period. */
+  runCount: number;
+  /** Tests passed / tests run across all period runs, 0–100. Null when no tests ran. */
+  passRate: number | null;
+  /** Percentage-point change vs the previous equal-length period. Null without a baseline. */
+  passRateDelta: number | null;
+  /** Sum of flaky test occurrences across period runs. */
+  flakyTests: number;
+  avgRunDurationMs: number | null;
+  openClusters: number;
+  /** Consecutive failing runs at the newest end of the period. */
+  failingStreak: number;
+  latestRun: { id: number; status: string; startTime: string | Date } | null;
+  /** Last runs of the period (oldest → newest), for the trend bars. */
+  recentRuns: AnalyticsSparkRun[];
+}
+
+// ── Pass-rate heatmap ────────────────────────────────────────────────────────
+
+export interface AnalyticsHeatmap {
+  /** Bucket start dates (ISO `YYYY-MM-DD`), oldest → newest. */
+  buckets: string[];
+  /** Days covered by one bucket (1 = daily, 7 = weekly, …). */
+  bucketDays: number;
+  rows: Array<{
+    projectId: number;
+    name: string;
+    label: string | null;
+    /** Pass rate (0–100) per bucket; null = no runs in that bucket. */
+    cells: Array<number | null>;
+  }>;
+}
+
+// ── CI time trend ────────────────────────────────────────────────────────────
+
+export interface AnalyticsCiTimePoint {
+  /** Bucket start date (ISO `YYYY-MM-DD`). */
+  date: string;
+  totalMinutes: number;
+  runCount: number;
+}
+
+export interface AnalyticsCiTimeTrend {
+  points: AnalyticsCiTimePoint[];
+  bucketDays: number;
+  totalMinutes: number;
+  runCount: number;
+  /** Total minutes in the previous equal-length period. Null without a baseline. */
+  prevTotalMinutes: number | null;
+  /** Percent change vs the previous period. Null without a baseline. */
+  deltaPct: number | null;
+  avgRunMinutes: number | null;
+}
+
+// ── Wasted CI time ───────────────────────────────────────────────────────────
+
+export interface AnalyticsWastedTimePoint {
+  /** Bucket start date (ISO `YYYY-MM-DD`). */
+  date: string;
+  /** Minutes spent inside wait steps (waitFor*, timeouts). */
+  waitMinutes: number;
+  /** Minutes spent executing attempts that ended failed or timed out. */
+  failedExecMinutes: number;
+}
+
+export interface AnalyticsWastedTime {
+  points: AnalyticsWastedTimePoint[];
+  bucketDays: number;
+  totalWaitMinutes: number;
+  totalFailedExecMinutes: number;
+  byProject: Array<{
+    projectId: number;
+    name: string;
+    label: string | null;
+    waitMinutes: number;
+    failedExecMinutes: number;
+  }>;
+}
+
+// ── Global flaky leaderboard ─────────────────────────────────────────────────
+
+export interface AnalyticsFlakyRow {
+  projectId: number;
+  projectName: string;
+  projectLabel: string | null;
+  testCaseId: number;
+  latestRunsCaseId: number;
+  title: string;
+  filePath: string;
+  totalRuns: number;
+  retryPassRuns: number;
+  alternations: number;
+  score: number;
+  rootCause: string | null;
+  impact: number;
+  wastedCiMinutes: number;
+  lastFlakeAt: string | Date | null;
+}
+
+// ── Failure-cluster landscape ────────────────────────────────────────────────
+
+export interface AnalyticsClusterRow {
+  id: number;
+  projectId: number;
+  projectName: string;
+  projectLabel: string | null;
+  title: string | null;
+  signature: string;
+  errorType: string | null;
+  occurrences: number;
+  ageDays: number;
+  firstSeenAt: string | Date;
+}
+
+export interface AnalyticsClusterLandscape {
+  totalOpen: number;
+  /** Clusters resolved inside the period (by `updatedAt`). */
+  resolvedInPeriod: number;
+  byErrorType: Array<{ errorType: string; count: number }>;
+  /** Top open clusters by occurrences. */
+  clusters: AnalyticsClusterRow[];
+}
+
+// ── Insights feed ────────────────────────────────────────────────────────────
+
+export type AnalyticsInsightSeverity = 'critical' | 'warning' | 'info' | 'positive';
+
+export interface AnalyticsInsight {
+  /** Stable id (`ruleId:subject`) so the client can key the list. */
+  id: string;
+  ruleId: string;
+  severity: AnalyticsInsightSeverity;
+  message: string;
+  detail?: string;
+  /** In-app route the insight deep-links to. */
+  to?: string;
+  projectId?: number;
+}

--- a/application/shared/handlers/analytics/ci-time-trend.ts
+++ b/application/shared/handlers/analytics/ci-time-trend.ts
@@ -1,0 +1,59 @@
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsCiTimeTrend } from '../../analytics/types';
+import { fetchScopedRuns, firstNonEmptyIndex, makeTimeBuckets, minutes, periodStart, type ProjectAccess } from './common';
+
+/**
+ * Total CI minutes consumed by test runs over time, with the previous
+ * equal-length period as a growth baseline — the capacity/budget view.
+ */
+export async function getAnalyticsCiTimeTrend(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsCiTimeTrend> {
+  const runs = await fetchScopedRuns(db, scope, access, scope.days * 2);
+  const cutoff = periodStart(scope.days);
+  const buckets = makeTimeBuckets(scope.days);
+
+  const byBucket = new Map<string, { totalMs: number; runCount: number }>();
+  let totalMs = 0;
+  let runCount = 0;
+  let prevTotalMs = 0;
+  let hasPrevious = false;
+
+  for (const run of runs) {
+    const durationMs = run.duration ?? 0;
+    if (run.startTime.getTime() < cutoff) {
+      hasPrevious = true;
+      prevTotalMs += durationMs;
+      continue;
+    }
+    totalMs += durationMs;
+    runCount++;
+    const key = buckets.keyFor(run.startTime);
+    if (!key) continue;
+    const bucket = byBucket.get(key) ?? { totalMs: 0, runCount: 0 };
+    bucket.totalMs += durationMs;
+    bucket.runCount++;
+    byBucket.set(key, bucket);
+  }
+
+  const deltaPct =
+    hasPrevious && prevTotalMs > 0 ? Math.round(((totalMs - prevTotalMs) / prevTotalMs) * 1000) / 10 : null;
+
+  const points = buckets.keys.map((date) => {
+    const bucket = byBucket.get(date);
+    return { date, totalMinutes: minutes(bucket?.totalMs ?? 0), runCount: bucket?.runCount ?? 0 };
+  });
+
+  return {
+    points: points.slice(firstNonEmptyIndex(points, (p) => p.runCount === 0)),
+    bucketDays: buckets.bucketDays,
+    totalMinutes: minutes(totalMs),
+    runCount,
+    prevTotalMinutes: hasPrevious ? minutes(prevTotalMs) : null,
+    deltaPct,
+    avgRunMinutes: runCount > 0 ? minutes(totalMs / runCount) : null,
+  };
+}

--- a/application/shared/handlers/analytics/cluster-landscape.ts
+++ b/application/shared/handlers/analytics/cluster-landscape.ts
@@ -1,0 +1,82 @@
+import { inArray } from 'drizzle-orm';
+import { failureClusters } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsClusterLandscape, AnalyticsClusterRow } from '../../analytics/types';
+import { DAY_MS, fetchScopedProjects, periodStart, resolveAllowedProjects, type ProjectAccess } from './common';
+
+const TOP_CLUSTERS = 15;
+
+/**
+ * Open failure clusters across every project the caller can see: the biggest
+ * and oldest unresolved root causes, plus the error-type mix. Clusters survive
+ * run retention, so this view works on long horizons too.
+ */
+export async function getAnalyticsClusterLandscape(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsClusterLandscape> {
+  const empty: AnalyticsClusterLandscape = { totalOpen: 0, resolvedInPeriod: 0, byErrorType: [], clusters: [] };
+
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return empty;
+
+  const rows: any[] = await db
+    .select({
+      id: failureClusters.id,
+      projectId: failureClusters.projectId,
+      title: failureClusters.title,
+      signature: failureClusters.signature,
+      errorType: failureClusters.errorType,
+      occurrences: failureClusters.occurrences,
+      status: failureClusters.status,
+      createdAt: failureClusters.createdAt,
+      updatedAt: failureClusters.updatedAt,
+    })
+    .from(failureClusters)
+    .where(allowed === 'all' ? undefined : inArray(failureClusters.projectId, allowed));
+
+  const cutoff = periodStart(scope.days);
+  const open = rows.filter((c) => c.status === 'open');
+  const resolvedInPeriod = rows.filter(
+    (c) => c.status === 'resolved' && c.updatedAt && new Date(c.updatedAt).getTime() >= cutoff,
+  ).length;
+
+  const byErrorType = new Map<string, number>();
+  for (const cluster of open) {
+    const type = cluster.errorType ?? 'unknown';
+    byErrorType.set(type, (byErrorType.get(type) ?? 0) + 1);
+  }
+
+  const scopedProjects = await fetchScopedProjects(db, scope, access);
+  const projectById = new Map(scopedProjects.map((p) => [p.id, p]));
+  const now = Date.now();
+
+  const clusters = open
+    .sort((a, b) => (b.occurrences ?? 0) - (a.occurrences ?? 0))
+    .slice(0, TOP_CLUSTERS)
+    .map(
+      (cluster): AnalyticsClusterRow => ({
+        id: cluster.id,
+        projectId: cluster.projectId,
+        projectName: projectById.get(cluster.projectId)?.name ?? `Project ${cluster.projectId}`,
+        projectLabel: projectById.get(cluster.projectId)?.label ?? null,
+        title: cluster.title,
+        signature: cluster.signature,
+        errorType: cluster.errorType,
+        occurrences: cluster.occurrences ?? 0,
+        ageDays: Math.max(0, Math.floor((now - new Date(cluster.createdAt).getTime()) / DAY_MS)),
+        firstSeenAt: cluster.createdAt,
+      }),
+    );
+
+  return {
+    totalOpen: open.length,
+    resolvedInPeriod,
+    byErrorType: [...byErrorType.entries()]
+      .map(([errorType, count]) => ({ errorType, count }))
+      .sort((a, b) => b.count - a.count),
+    clusters,
+  };
+}

--- a/application/shared/handlers/analytics/common.ts
+++ b/application/shared/handlers/analytics/common.ts
@@ -1,0 +1,168 @@
+import { and, eq, gte, inArray } from 'drizzle-orm';
+import { projects, testRuns, projectTags, tags } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsTagInfo } from '../../analytics/types';
+
+export type ProjectAccess = 'all' | Set<number>;
+
+export const TERMINAL_RUN_STATUSES = ['passed', 'failed', 'timedout', 'interrupted'];
+export const FAILING_RUN_STATUSES = ['failed', 'timedout', 'interrupted'];
+
+/**
+ * Intersect the requested project filter with the caller's access scope.
+ * Returns `'all'` (no restriction) or the allowed project id list (possibly empty).
+ */
+export function resolveAllowedProjects(scope: AnalyticsScope, access: ProjectAccess): 'all' | number[] {
+  if (!scope.projectIds || scope.projectIds.length === 0) {
+    return access === 'all' ? 'all' : [...access];
+  }
+  if (access === 'all') return scope.projectIds;
+  return scope.projectIds.filter((id) => access.has(id));
+}
+
+export interface ScopedProject {
+  id: number;
+  name: string;
+  label: string | null;
+}
+
+export async function fetchScopedProjects(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess,
+): Promise<ScopedProject[]> {
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return [];
+
+  const rows: any[] = await db
+    .select({ id: projects.id, name: projects.name, label: projects.label })
+    .from(projects)
+    .where(allowed === 'all' ? undefined : inArray(projects.id, allowed));
+  return rows;
+}
+
+export async function fetchTagsByProject(db: DrizzleDB, projectIds: number[]): Promise<Map<number, AnalyticsTagInfo[]>> {
+  const byProject = new Map<number, AnalyticsTagInfo[]>();
+  if (projectIds.length === 0) return byProject;
+
+  const rows: any[] = await db
+    .select({ projectId: projectTags.projectId, id: tags.id, text: tags.text, color: tags.color })
+    .from(projectTags)
+    .innerJoin(tags, eq(projectTags.tagId, tags.id))
+    .where(inArray(projectTags.projectId, projectIds));
+
+  for (const row of rows) {
+    const list = byProject.get(row.projectId) ?? [];
+    list.push({ id: row.id, text: row.text, color: row.color });
+    byProject.set(row.projectId, list);
+  }
+  return byProject;
+}
+
+export interface ScopedRun {
+  id: number;
+  projectId: number;
+  status: string;
+  startTime: Date;
+  duration: number | null;
+  totalTests: number;
+  passedTests: number;
+  failedTests: number;
+  flakyTests: number;
+}
+
+/**
+ * Terminal runs matching the scope, starting `sinceDays` ago (ordered oldest →
+ * newest). Most widgets fetch twice the period so they can compare against the
+ * previous equal-length window.
+ */
+export async function fetchScopedRuns(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess,
+  sinceDays: number,
+): Promise<ScopedRun[]> {
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return [];
+
+  const conditions = [
+    gte(testRuns.startTime, new Date(Date.now() - sinceDays * DAY_MS)),
+    inArray(testRuns.status, TERMINAL_RUN_STATUSES),
+  ];
+  if (allowed !== 'all') conditions.push(inArray(testRuns.projectId, allowed));
+  if (scope.fullRunsOnly) conditions.push(eq(testRuns.isFullRun, 1));
+  if (scope.environment) conditions.push(eq(testRuns.environment, scope.environment));
+
+  const rows: any[] = await db
+    .select({
+      id: testRuns.id,
+      projectId: testRuns.projectId,
+      status: testRuns.status,
+      startTime: testRuns.startTime,
+      duration: testRuns.duration,
+      totalTests: testRuns.totalTests,
+      passedTests: testRuns.passedTests,
+      failedTests: testRuns.failedTests,
+      flakyTests: testRuns.flakyTests,
+    })
+    .from(testRuns)
+    .where(and(...conditions))
+    .orderBy(testRuns.startTime);
+  return rows;
+}
+
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function periodStart(days: number): number {
+  return Date.now() - days * DAY_MS;
+}
+
+/** ISO `YYYY-MM-DD` (UTC) for a date. */
+export function dayKey(date: Date | string | number): string {
+  return new Date(date).toISOString().slice(0, 10);
+}
+
+/**
+ * Fixed-size time buckets over the last `days` days, at most ~`maxBuckets`
+ * buckets so a year-long period still renders a readable series.
+ * Returns bucket start keys (oldest → newest) plus a lookup from timestamp.
+ */
+export function makeTimeBuckets(days: number, maxBuckets = 31) {
+  const bucketDays = Math.max(1, Math.ceil(days / maxBuckets));
+  const bucketMs = bucketDays * DAY_MS;
+  const end = Date.now();
+  const start = end - days * DAY_MS;
+  const keys: string[] = [];
+  for (let t = start; t < end; t += bucketMs) {
+    keys.push(dayKey(t));
+  }
+  return {
+    bucketDays,
+    keys,
+    keyFor(date: Date | string | number): string | null {
+      const ts = new Date(date).getTime();
+      if (ts < start || Number.isNaN(ts)) return null;
+      const index = Math.min(keys.length - 1, Math.floor((ts - start) / bucketMs));
+      return keys[index] ?? null;
+    },
+  };
+}
+
+/**
+ * Index of the first non-empty entry, so long periods ("All time") don't
+ * render years of empty leading buckets. Returns 0 when everything is empty.
+ */
+export function firstNonEmptyIndex<T>(items: T[], isEmpty: (item: T) => boolean): number {
+  const index = items.findIndex((item) => !isEmpty(item));
+  return index <= 0 ? 0 : index;
+}
+
+export function roundRate(passed: number, total: number): number | null {
+  if (total <= 0) return null;
+  return Math.round((passed / total) * 1000) / 10;
+}
+
+export function minutes(ms: number): number {
+  return Math.round((ms / 60000) * 10) / 10;
+}

--- a/application/shared/handlers/analytics/flaky-leaderboard.ts
+++ b/application/shared/handlers/analytics/flaky-leaderboard.ts
@@ -1,0 +1,52 @@
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsFlakyRow } from '../../analytics/types';
+import { getProjectFlakyTests } from '../projects';
+import { fetchScopedProjects, type ProjectAccess } from './common';
+
+const RUNS_PER_PROJECT = 50;
+const TOP_TESTS = 20;
+const MAX_PROJECTS = 50;
+
+/**
+ * The worst flaky tests across every project the caller can see, impact-sorted
+ * — reuses the per-project flakiness scoring so the numbers match the project
+ * pages exactly.
+ */
+export async function getAnalyticsFlakyLeaderboard(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsFlakyRow[]> {
+  const scopedProjects = (await fetchScopedProjects(db, scope, access)).slice(0, MAX_PROJECTS);
+
+  const perProject = await Promise.all(
+    scopedProjects.map(async (project) => {
+      const flaky = await getProjectFlakyTests(db, project.id, RUNS_PER_PROJECT, scope.environment ?? undefined);
+      return flaky.map(
+        (test): AnalyticsFlakyRow => ({
+          projectId: project.id,
+          projectName: project.name,
+          projectLabel: project.label,
+          testCaseId: test.testCaseId,
+          latestRunsCaseId: test.latestRunsCaseId,
+          title: test.title,
+          filePath: test.filePath,
+          totalRuns: test.totalRuns,
+          retryPassRuns: test.retryPassRuns,
+          alternations: test.alternations,
+          score: test.score,
+          rootCause: test.rootCause,
+          impact: test.impact,
+          wastedCiMinutes: test.wastedCiMinutes,
+          lastFlakeAt: test.lastFlakeAt,
+        }),
+      );
+    }),
+  );
+
+  return perProject
+    .flat()
+    .sort((a, b) => b.impact - a.impact || b.score - a.score)
+    .slice(0, TOP_TESTS);
+}

--- a/application/shared/handlers/analytics/index.ts
+++ b/application/shared/handlers/analytics/index.ts
@@ -1,0 +1,39 @@
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import { isAnalyticsWidgetId, type AnalyticsWidgetId } from '../../analytics/registry';
+import type { ProjectAccess } from './common';
+import { getAnalyticsPortfolio } from './portfolio';
+import { getAnalyticsPassRateHeatmap } from './pass-rate-heatmap';
+import { getAnalyticsCiTimeTrend } from './ci-time-trend';
+import { getAnalyticsWastedTime } from './wasted-time';
+import { getAnalyticsFlakyLeaderboard } from './flaky-leaderboard';
+import { getAnalyticsClusterLandscape } from './cluster-landscape';
+import { getAnalyticsInsights } from './insights';
+
+export { isAnalyticsWidgetId };
+export type { AnalyticsWidgetId, ProjectAccess };
+
+type AnalyticsWidgetHandler = (db: DrizzleDB, scope: AnalyticsScope, access: ProjectAccess) => Promise<unknown>;
+
+/**
+ * Widget id → handler. Keyed by the registry union, so forgetting a handler
+ * for a registered widget (or vice versa) is a compile error.
+ */
+const ANALYTICS_WIDGET_HANDLERS: Record<AnalyticsWidgetId, AnalyticsWidgetHandler> = {
+  insights: getAnalyticsInsights,
+  portfolio: getAnalyticsPortfolio,
+  'pass-rate-heatmap': getAnalyticsPassRateHeatmap,
+  'ci-time-trend': getAnalyticsCiTimeTrend,
+  'wasted-time': getAnalyticsWastedTime,
+  'flaky-leaderboard': getAnalyticsFlakyLeaderboard,
+  'cluster-landscape': getAnalyticsClusterLandscape,
+};
+
+export function runAnalyticsWidget(
+  db: DrizzleDB,
+  widget: AnalyticsWidgetId,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<unknown> {
+  return ANALYTICS_WIDGET_HANDLERS[widget](db, scope, access);
+}

--- a/application/shared/handlers/analytics/insights.ts
+++ b/application/shared/handlers/analytics/insights.ts
@@ -1,0 +1,31 @@
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsInsight } from '../../analytics/types';
+import { evaluateInsightRules } from '../../analytics/insight-rules';
+import { getAnalyticsPortfolio } from './portfolio';
+import { getAnalyticsCiTimeTrend } from './ci-time-trend';
+import { getAnalyticsWastedTime } from './wasted-time';
+import { getAnalyticsClusterLandscape } from './cluster-landscape';
+import { getAnalyticsFlakyLeaderboard } from './flaky-leaderboard';
+import type { ProjectAccess } from './common';
+
+/**
+ * Ranked, human-readable findings over the scoped data — computed by the pure
+ * rule registry in `shared/analytics/insight-rules.ts` from the other widgets'
+ * aggregates, so every insight is consistent with what the page displays.
+ */
+export async function getAnalyticsInsights(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsInsight[]> {
+  const [portfolio, ciTime, wastedTime, clusters, flakyTests] = await Promise.all([
+    getAnalyticsPortfolio(db, scope, access),
+    getAnalyticsCiTimeTrend(db, scope, access),
+    getAnalyticsWastedTime(db, scope, access),
+    getAnalyticsClusterLandscape(db, scope, access),
+    getAnalyticsFlakyLeaderboard(db, scope, access),
+  ]);
+
+  return evaluateInsightRules({ scope, portfolio, ciTime, wastedTime, clusters, flakyTests });
+}

--- a/application/shared/handlers/analytics/pass-rate-heatmap.ts
+++ b/application/shared/handlers/analytics/pass-rate-heatmap.ts
@@ -1,0 +1,71 @@
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsHeatmap } from '../../analytics/types';
+import {
+  fetchScopedProjects,
+  fetchScopedRuns,
+  firstNonEmptyIndex,
+  makeTimeBuckets,
+  roundRate,
+  type ProjectAccess,
+} from './common';
+
+/**
+ * Projects × time-buckets grid of pass rates — shows at a glance who degraded
+ * and when. Buckets grow with the period (daily up to a month, weekly beyond)
+ * so the grid stays readable.
+ */
+export async function getAnalyticsPassRateHeatmap(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsHeatmap> {
+  const scopedProjects = await fetchScopedProjects(db, scope, access);
+  const runs = await fetchScopedRuns(db, scope, access, scope.days);
+  const buckets = makeTimeBuckets(scope.days);
+
+  // passed/total per (project, bucket)
+  const totals = new Map<number, Map<string, { passed: number; total: number }>>();
+  for (const run of runs) {
+    const key = buckets.keyFor(run.startTime);
+    if (!key) continue;
+    let byBucket = totals.get(run.projectId);
+    if (!byBucket) {
+      byBucket = new Map();
+      totals.set(run.projectId, byBucket);
+    }
+    const cell = byBucket.get(key) ?? { passed: 0, total: 0 };
+    cell.passed += run.passedTests ?? 0;
+    cell.total += run.totalTests ?? 0;
+    byBucket.set(key, cell);
+  }
+
+  const rows = scopedProjects
+    .map((project) => {
+      const byBucket = totals.get(project.id);
+      return {
+        projectId: project.id,
+        name: project.name,
+        label: project.label,
+        cells: buckets.keys.map((key) => {
+          const cell = byBucket?.get(key);
+          return cell ? roundRate(cell.passed, cell.total) : null;
+        }),
+      };
+    })
+    // Projects with no runs in the period would render an all-gray row — drop them.
+    .filter((row) => row.cells.some((c) => c !== null))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Trim leading all-empty columns so "All time" starts at the first real data.
+  const firstDataIndex = firstNonEmptyIndex(
+    buckets.keys.map((_, index) => index),
+    (index) => rows.every((row) => row.cells[index] === null),
+  );
+
+  return {
+    buckets: buckets.keys.slice(firstDataIndex),
+    bucketDays: buckets.bucketDays,
+    rows: rows.map((row) => ({ ...row, cells: row.cells.slice(firstDataIndex) })),
+  };
+}

--- a/application/shared/handlers/analytics/portfolio.ts
+++ b/application/shared/handlers/analytics/portfolio.ts
@@ -1,0 +1,118 @@
+import { and, count, eq, inArray } from 'drizzle-orm';
+import { failureClusters } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsPortfolioRow } from '../../analytics/types';
+import {
+  fetchScopedProjects,
+  fetchScopedRuns,
+  fetchTagsByProject,
+  periodStart,
+  roundRate,
+  FAILING_RUN_STATUSES,
+  type ProjectAccess,
+  type ScopedRun,
+} from './common';
+
+const SPARKLINE_RUNS = 20;
+
+/**
+ * Per-project health over the period: pass rate (+ delta vs the previous
+ * equal-length period), flaky volume, open clusters, failing streak, and the
+ * recent-run bars — one row per project the caller can see.
+ */
+export async function getAnalyticsPortfolio(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsPortfolioRow[]> {
+  const scopedProjects = await fetchScopedProjects(db, scope, access);
+  if (scopedProjects.length === 0) return [];
+  const projectIds = scopedProjects.map((p) => p.id);
+
+  const [runs, tagsByProject, clusterRows] = await Promise.all([
+    fetchScopedRuns(db, scope, access, scope.days * 2),
+    fetchTagsByProject(db, projectIds),
+    db
+      .select({ projectId: failureClusters.projectId, openCount: count() })
+      .from(failureClusters)
+      .where(and(inArray(failureClusters.projectId, projectIds), eq(failureClusters.status, 'open')))
+      .groupBy(failureClusters.projectId) as Promise<any[]>,
+  ]);
+
+  const openClustersByProject = new Map<number, number>();
+  for (const row of clusterRows) openClustersByProject.set(row.projectId, Number(row.openCount));
+
+  const cutoff = periodStart(scope.days);
+  const currentByProject = new Map<number, ScopedRun[]>();
+  const previousByProject = new Map<number, ScopedRun[]>();
+  for (const run of runs) {
+    const target = run.startTime.getTime() >= cutoff ? currentByProject : previousByProject;
+    const list = target.get(run.projectId) ?? [];
+    list.push(run);
+    target.set(run.projectId, list);
+  }
+
+  const rows = scopedProjects.map((project): AnalyticsPortfolioRow => {
+    const current = currentByProject.get(project.id) ?? [];
+    const previous = previousByProject.get(project.id) ?? [];
+
+    const passRate = sumPassRate(current);
+    const prevPassRate = sumPassRate(previous);
+    const passRateDelta =
+      passRate !== null && prevPassRate !== null ? Math.round((passRate - prevPassRate) * 10) / 10 : null;
+
+    const durations = current.map((r) => r.duration).filter((d): d is number => d != null && d > 0);
+    const avgRunDurationMs =
+      durations.length > 0 ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length) : null;
+
+    let failingStreak = 0;
+    for (let i = current.length - 1; i >= 0; i--) {
+      if (!FAILING_RUN_STATUSES.includes(current[i]!.status)) break;
+      failingStreak++;
+    }
+
+    const latest = current.length > 0 ? current[current.length - 1]! : null;
+
+    return {
+      projectId: project.id,
+      name: project.name,
+      label: project.label,
+      tags: tagsByProject.get(project.id) ?? [],
+      runCount: current.length,
+      passRate,
+      passRateDelta,
+      flakyTests: current.reduce((sum, r) => sum + (r.flakyTests ?? 0), 0),
+      avgRunDurationMs,
+      openClusters: openClustersByProject.get(project.id) ?? 0,
+      failingStreak,
+      latestRun: latest ? { id: latest.id, status: latest.status, startTime: latest.startTime } : null,
+      recentRuns: current.slice(-SPARKLINE_RUNS).map((r) => ({
+        id: r.id,
+        status: r.status,
+        passedTests: r.passedTests ?? 0,
+        failedTests: r.failedTests ?? 0,
+        flakyTests: r.flakyTests ?? 0,
+        totalTests: r.totalTests ?? 0,
+        startTime: r.startTime,
+      })),
+    };
+  });
+
+  // Worst health first: failing streaks, then lowest pass rate; idle projects last.
+  return rows.sort((a, b) => {
+    if ((b.runCount === 0) !== (a.runCount === 0)) return a.runCount === 0 ? 1 : -1;
+    if (b.failingStreak !== a.failingStreak) return b.failingStreak - a.failingStreak;
+    return (a.passRate ?? 101) - (b.passRate ?? 101);
+  });
+}
+
+function sumPassRate(runs: ScopedRun[]): number | null {
+  let passed = 0;
+  let total = 0;
+  for (const run of runs) {
+    passed += run.passedTests ?? 0;
+    total += run.totalTests ?? 0;
+  }
+  return roundRate(passed, total);
+}

--- a/application/shared/handlers/analytics/wasted-time.ts
+++ b/application/shared/handlers/analytics/wasted-time.ts
@@ -1,0 +1,117 @@
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
+import { testRuns, testRunsCases } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsWastedTime } from '../../analytics/types';
+import {
+  fetchScopedProjects,
+  firstNonEmptyIndex,
+  makeTimeBuckets,
+  minutes,
+  periodStart,
+  resolveAllowedProjects,
+  TERMINAL_RUN_STATUSES,
+  type ProjectAccess,
+} from './common';
+
+const TOP_PROJECTS = 8;
+
+/**
+ * CI time that produced no signal: minutes spent inside wait steps plus
+ * minutes spent executing attempts that ended failed or timed out — the
+ * "money" argument for fixing slow waits and flaky tests.
+ */
+export async function getAnalyticsWastedTime(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsWastedTime> {
+  const buckets = makeTimeBuckets(scope.days);
+  const empty: AnalyticsWastedTime = {
+    points: buckets.keys.map((date) => ({ date, waitMinutes: 0, failedExecMinutes: 0 })),
+    bucketDays: buckets.bucketDays,
+    totalWaitMinutes: 0,
+    totalFailedExecMinutes: 0,
+    byProject: [],
+  };
+
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return empty;
+
+  const conditions = [
+    gte(testRuns.startTime, new Date(periodStart(scope.days))),
+    inArray(testRuns.status, TERMINAL_RUN_STATUSES),
+  ];
+  if (allowed !== 'all') conditions.push(inArray(testRuns.projectId, allowed));
+  if (scope.fullRunsOnly) conditions.push(eq(testRuns.isFullRun, 1));
+  if (scope.environment) conditions.push(eq(testRuns.environment, scope.environment));
+
+  // One aggregated row per run — cheap in SQL on both dialects, bucketed in JS.
+  const rows: any[] = await db
+    .select({
+      projectId: testRuns.projectId,
+      startTime: testRuns.startTime,
+      waitMs: sql<number>`COALESCE(SUM(COALESCE(${testRunsCases.wastedTimeMs}, 0)), 0)`,
+      failedMs: sql<number>`COALESCE(SUM(CASE WHEN ${testRunsCases.status} IN ('failed', 'timedout', 'timedOut') THEN COALESCE(${testRunsCases.duration}, 0) ELSE 0 END), 0)`,
+    })
+    .from(testRunsCases)
+    .innerJoin(testRuns, eq(testRunsCases.testRunId, testRuns.id))
+    .where(and(...conditions))
+    .groupBy(testRunsCases.testRunId, testRuns.projectId, testRuns.startTime);
+
+  if (rows.length === 0) return empty;
+
+  const byBucket = new Map<string, { waitMs: number; failedMs: number }>();
+  const byProject = new Map<number, { waitMs: number; failedMs: number }>();
+  let totalWaitMs = 0;
+  let totalFailedMs = 0;
+
+  for (const row of rows) {
+    const waitMs = Number(row.waitMs) || 0;
+    const failedMs = Number(row.failedMs) || 0;
+    totalWaitMs += waitMs;
+    totalFailedMs += failedMs;
+
+    const key = buckets.keyFor(row.startTime);
+    if (key) {
+      const bucket = byBucket.get(key) ?? { waitMs: 0, failedMs: 0 };
+      bucket.waitMs += waitMs;
+      bucket.failedMs += failedMs;
+      byBucket.set(key, bucket);
+    }
+
+    const project = byProject.get(row.projectId) ?? { waitMs: 0, failedMs: 0 };
+    project.waitMs += waitMs;
+    project.failedMs += failedMs;
+    byProject.set(row.projectId, project);
+  }
+
+  const scopedProjects = await fetchScopedProjects(db, scope, access);
+  const projectById = new Map(scopedProjects.map((p) => [p.id, p]));
+
+  const points = buckets.keys.map((date) => {
+    const bucket = byBucket.get(date);
+    return {
+      date,
+      waitMinutes: minutes(bucket?.waitMs ?? 0),
+      failedExecMinutes: minutes(bucket?.failedMs ?? 0),
+    };
+  });
+
+  return {
+    points: points.slice(firstNonEmptyIndex(points, (p) => p.waitMinutes === 0 && p.failedExecMinutes === 0)),
+    bucketDays: buckets.bucketDays,
+    totalWaitMinutes: minutes(totalWaitMs),
+    totalFailedExecMinutes: minutes(totalFailedMs),
+    byProject: [...byProject.entries()]
+      .map(([projectId, sums]) => ({
+        projectId,
+        name: projectById.get(projectId)?.name ?? `Project ${projectId}`,
+        label: projectById.get(projectId)?.label ?? null,
+        waitMinutes: minutes(sums.waitMs),
+        failedExecMinutes: minutes(sums.failedMs),
+      }))
+      .sort((a, b) => b.waitMinutes + b.failedExecMinutes - (a.waitMinutes + a.failedExecMinutes))
+      .slice(0, TOP_PROJECTS),
+  };
+}

--- a/application/shared/test-project-names.ts
+++ b/application/shared/test-project-names.ts
@@ -13,6 +13,7 @@
  */
 
 export const PROJECT = {
+  ANALYTICS_TEST: 'analytics-widgets-test',
   API_CREATED: 'api-created-project',
   API_KEY_SUBMIT: 'api-key-submit-test',
   AUTH_ROLE_CHECKS: 'auth-role-checks-test',

--- a/application/tests/analytics.spec.ts
+++ b/application/tests/analytics.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the cross-project analytics platform:
+ *   GET /api/analytics/:widget — generic widget dispatch (registry-driven)
+ *   /analytics                 — page with scope bar and widget grid
+ */
+import { test, expect } from './fixtures';
+import { PROJECT } from '#shared/test-project-names';
+
+test.describe.serial('Analytics API', () => {
+  let projectId: number;
+
+  test.beforeAll(async ({ request }) => {
+    const passing = await request.post('/api/test-runs/submit', {
+      data: {
+        projectName: PROJECT.ANALYTICS_TEST,
+        status: 'passed',
+        startTime: new Date(Date.now() - 60_000).toISOString(),
+        duration: 30_000,
+        totalTests: 2,
+        passedTests: 2,
+        failedTests: 0,
+        skippedTests: 0,
+        testCases: [
+          { title: 'stable test', status: 'passed', duration: 500, location: 'tests/a.spec.ts:1:1' },
+          { title: 'other test', status: 'passed', duration: 700, location: 'tests/a.spec.ts:9:1' },
+        ],
+      },
+    });
+    expect(passing.ok()).toBeTruthy();
+    projectId = (await passing.json()).projectId;
+
+    const failing = await request.post('/api/test-runs/submit', {
+      data: {
+        projectName: PROJECT.ANALYTICS_TEST,
+        status: 'failed',
+        startTime: new Date().toISOString(),
+        duration: 45_000,
+        totalTests: 2,
+        passedTests: 1,
+        failedTests: 1,
+        skippedTests: 0,
+        testCases: [
+          { title: 'stable test', status: 'passed', duration: 500, location: 'tests/a.spec.ts:1:1' },
+          {
+            title: 'other test',
+            status: 'failed',
+            duration: 900,
+            location: 'tests/a.spec.ts:9:1',
+            error: 'Error: expect(received).toBe(expected)',
+          },
+        ],
+      },
+    });
+    expect(failing.ok()).toBeTruthy();
+  });
+
+  test('GET /api/analytics/portfolio aggregates the project over the period', async ({ request }) => {
+    const response = await request.get('/api/analytics/portfolio?days=7');
+    expect(response.ok()).toBeTruthy();
+    const rows = await response.json();
+
+    const row = rows.find((r: { projectId: number }) => r.projectId === projectId);
+    expect(row).toBeTruthy();
+    expect(row.runCount).toBe(2);
+    expect(row.passRate).toBe(75); // 3 of 4 tests passed across both runs
+    expect(row.latestRun.status).toBe('failed');
+    expect(row.recentRuns).toHaveLength(2);
+  });
+
+  test('GET /api/analytics/ci-time-trend sums run minutes', async ({ request }) => {
+    const response = await request.get('/api/analytics/ci-time-trend?days=7&projects=' + projectId);
+    expect(response.ok()).toBeTruthy();
+    const trend = await response.json();
+    expect(trend.runCount).toBe(2);
+    expect(trend.totalMinutes).toBeCloseTo(1.3, 1); // 30s + 45s
+  });
+
+  test('scope filters apply: an environment with no runs empties the result', async ({ request }) => {
+    const response = await request.get('/api/analytics/portfolio?days=7&environment=nonexistent-env');
+    expect(response.ok()).toBeTruthy();
+    const rows = await response.json();
+    const row = rows.find((r: { projectId: number }) => r.projectId === projectId);
+    expect(row.runCount).toBe(0);
+  });
+
+  test('GET /api/analytics/:widget 404s on an unknown widget id', async ({ request }) => {
+    const response = await request.get('/api/analytics/not-a-widget');
+    expect(response.status()).toBe(404);
+  });
+
+  test('every registered widget responds', async ({ request }) => {
+    for (const widget of [
+      'insights',
+      'portfolio',
+      'pass-rate-heatmap',
+      'ci-time-trend',
+      'wasted-time',
+      'flaky-leaderboard',
+      'cluster-landscape',
+    ]) {
+      const response = await request.get(`/api/analytics/${widget}?days=7`);
+      expect(response.ok(), `widget ${widget} should respond`).toBeTruthy();
+    }
+  });
+});
+
+test.describe('Analytics page', () => {
+  test('renders every registered widget card', async ({ page }) => {
+    await page.goto('/analytics');
+
+    await expect(page.getByRole('heading', { name: 'Insights' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Portfolio health' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Pass rate heatmap' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^CI time/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Wasted CI time' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Flakiest tests' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Failure clusters' })).toBeVisible();
+  });
+
+  test('is reachable from the sidebar', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('navigation').getByRole('link', { name: 'Analytics' }).first().click();
+    await expect(page).toHaveURL(/\/analytics$/);
+    await expect(page.getByRole('heading', { name: 'Portfolio health' })).toBeVisible();
+  });
+});

--- a/application/tests/unit/analytics-handlers.test.ts
+++ b/application/tests/unit/analytics-handlers.test.ts
@@ -1,0 +1,338 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createClient } from '@libsql/client';
+import * as schema from '../../server/database/schema.sqlite';
+
+// The schema barrel (server/database/schema.ts) picks the PostgreSQL schema at
+// import time when PIWI_DATABASE_URL is set, so clear it before the handler
+// modules (which import the barrel) are loaded.
+delete process.env.PIWI_DATABASE_URL;
+const { runAnalyticsWidget, isAnalyticsWidgetId } = await import('../../shared/handlers/analytics');
+const { getAnalyticsPortfolio } = await import('../../shared/handlers/analytics/portfolio');
+const { getAnalyticsPassRateHeatmap } = await import('../../shared/handlers/analytics/pass-rate-heatmap');
+const { getAnalyticsCiTimeTrend } = await import('../../shared/handlers/analytics/ci-time-trend');
+const { getAnalyticsWastedTime } = await import('../../shared/handlers/analytics/wasted-time');
+const { getAnalyticsClusterLandscape } = await import('../../shared/handlers/analytics/cluster-landscape');
+const { evaluateInsightRules } = await import('../../shared/analytics/insight-rules');
+const { parseAnalyticsScope } = await import('../../shared/analytics/scope');
+const { ANALYTICS_WIDGETS } = await import('../../shared/analytics/registry');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS);
+
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+interface RunSeed {
+  projectId: number;
+  status?: string;
+  daysAgo: number;
+  duration?: number;
+  totalTests?: number;
+  passedTests?: number;
+  failedTests?: number;
+  flakyTests?: number;
+  isFullRun?: number;
+  environment?: string;
+}
+
+async function seedRun(seed: RunSeed): Promise<number> {
+  const inserted = await db
+    .insert(schema.testRuns)
+    .values({
+      projectId: seed.projectId,
+      status: seed.status ?? 'passed',
+      startTime: daysAgo(seed.daysAgo),
+      duration: seed.duration ?? 60_000,
+      totalTests: seed.totalTests ?? 10,
+      passedTests: seed.passedTests ?? 10,
+      failedTests: seed.failedTests ?? 0,
+      flakyTests: seed.flakyTests ?? 0,
+      isFullRun: seed.isFullRun ?? 1,
+      environment: seed.environment,
+    })
+    .returning({ id: schema.testRuns.id });
+  return inserted[0]!.id;
+}
+
+const DEFAULT_SCOPE = parseAnalyticsScope({ days: '30' });
+
+beforeAll(async () => {
+  db = drizzle(createClient({ url: ':memory:' }), { schema });
+  await migrate(db, {
+    migrationsFolder: fileURLToPath(new URL('../../server/database/migrations', import.meta.url)),
+  });
+
+  await db.insert(schema.projects).values([
+    { id: 1, name: 'checkout' },
+    { id: 2, name: 'search', label: 'Search suite' },
+    { id: 3, name: 'idle-project' },
+  ]);
+
+  // Project 1: previous period healthy (100%), current period degraded and
+  // ending on a 3-run failing streak.
+  await seedRun({ projectId: 1, daysAgo: 45, passedTests: 10 });
+  await seedRun({ projectId: 1, daysAgo: 40, passedTests: 10 });
+  await seedRun({ projectId: 1, daysAgo: 10, passedTests: 8, failedTests: 2, status: 'failed' });
+  const failingRunId = await seedRun({ projectId: 1, daysAgo: 5, passedTests: 7, failedTests: 3, status: 'failed' });
+  await seedRun({ projectId: 1, daysAgo: 2, passedTests: 7, failedTests: 3, status: 'failed' });
+
+  // Project 2: healthy in the current period, staging environment, one flaky run.
+  await seedRun({ projectId: 2, daysAgo: 8, environment: 'staging', flakyTests: 2 });
+  await seedRun({ projectId: 2, daysAgo: 3, environment: 'staging' });
+  // Partial run — must be excluded when fullRunsOnly (the default).
+  await seedRun({ projectId: 2, daysAgo: 1, isFullRun: 0, passedTests: 1, totalTests: 1 });
+  // Non-terminal run — never counted.
+  await seedRun({ projectId: 2, daysAgo: 1, status: 'running' });
+
+  // Wasted time on project 1's latest failing run.
+  await db.insert(schema.testCases).values({ id: 1, projectId: 1, filePath: 'checkout.spec.ts', title: 'pays' });
+  await db.insert(schema.testRunsCases).values([
+    { testRunId: failingRunId, testCaseId: 1, status: 'failed', duration: 120_000, wastedTimeMs: 60_000 },
+    { testRunId: failingRunId, testCaseId: 1, status: 'passed', duration: 30_000, retries: 1, wastedTimeMs: 0 },
+  ]);
+
+  // Clusters: one old open on project 1, one fresh open + one resolved on project 2.
+  await db.insert(schema.failureClusters).values([
+    {
+      projectId: 1,
+      fingerprint: 'fp-1',
+      signature: 'TimeoutError: locator.click',
+      errorType: 'timeout',
+      firstSeenRunId: 1,
+      lastSeenRunId: failingRunId,
+      status: 'open',
+      occurrences: 25,
+      createdAt: daysAgo(40),
+      updatedAt: daysAgo(2),
+    },
+    {
+      projectId: 2,
+      fingerprint: 'fp-2',
+      signature: 'expect(received).toBe',
+      errorType: 'assertion',
+      firstSeenRunId: 1,
+      lastSeenRunId: 1,
+      status: 'open',
+      occurrences: 3,
+      createdAt: daysAgo(3),
+      updatedAt: daysAgo(3),
+    },
+    {
+      projectId: 2,
+      fingerprint: 'fp-3',
+      signature: 'net::ERR_CONNECTION_REFUSED',
+      errorType: 'navigation',
+      firstSeenRunId: 1,
+      lastSeenRunId: 1,
+      status: 'resolved',
+      occurrences: 5,
+      createdAt: daysAgo(20),
+      updatedAt: daysAgo(4),
+    },
+  ]);
+});
+
+describe('analytics registry', () => {
+  test('recognizes registered widget ids and rejects unknown ones', () => {
+    for (const widget of ANALYTICS_WIDGETS) {
+      expect(isAnalyticsWidgetId(widget.id)).toBe(true);
+    }
+    expect(isAnalyticsWidgetId('nope')).toBe(false);
+    expect(isAnalyticsWidgetId(undefined)).toBe(false);
+  });
+
+  test('runAnalyticsWidget dispatches every registered widget', async () => {
+    for (const widget of ANALYTICS_WIDGETS) {
+      const result = await runAnalyticsWidget(db, widget.id, DEFAULT_SCOPE, 'all');
+      expect(result).toBeDefined();
+    }
+  });
+});
+
+describe('analytics scope parsing', () => {
+  test('applies defaults and clamps values', () => {
+    expect(parseAnalyticsScope(undefined)).toEqual({
+      days: 30,
+      projectIds: undefined,
+      environment: null,
+      fullRunsOnly: true,
+    });
+    expect(parseAnalyticsScope({ days: '99999' }).days).toBe(3650);
+    expect(parseAnalyticsScope(new URLSearchParams('days=7&projects=1,2&environment=staging&fullRunsOnly=false'))).toEqual({
+      days: 7,
+      projectIds: [1, 2],
+      environment: 'staging',
+      fullRunsOnly: false,
+    });
+  });
+});
+
+describe('getAnalyticsPortfolio', () => {
+  test('computes pass rate, delta vs previous period, and failing streak', async () => {
+    const rows = await getAnalyticsPortfolio(db, DEFAULT_SCOPE, 'all');
+    const checkout = rows.find((r) => r.projectId === 1)!;
+
+    // Current period: 22 passed / 30 total = 73.3%; previous period 100%.
+    expect(checkout.runCount).toBe(3);
+    expect(checkout.passRate).toBeCloseTo(73.3, 1);
+    expect(checkout.passRateDelta).toBeCloseTo(-26.7, 1);
+    expect(checkout.failingStreak).toBe(3);
+    expect(checkout.openClusters).toBe(1);
+    expect(checkout.latestRun?.status).toBe('failed');
+
+    // Worst health sorts first; the idle project sorts last.
+    expect(rows[0]!.projectId).toBe(1);
+    expect(rows[rows.length - 1]!.projectId).toBe(3);
+  });
+
+  test('excludes partial and non-terminal runs by default', async () => {
+    const rows = await getAnalyticsPortfolio(db, DEFAULT_SCOPE, 'all');
+    const search = rows.find((r) => r.projectId === 2)!;
+    expect(search.runCount).toBe(2);
+    expect(search.passRate).toBe(100);
+    expect(search.flakyTests).toBe(2);
+  });
+
+  test('includes partial runs when fullRunsOnly is off', async () => {
+    const rows = await getAnalyticsPortfolio(db, parseAnalyticsScope({ days: '30', fullRunsOnly: 'false' }), 'all');
+    const search = rows.find((r) => r.projectId === 2)!;
+    expect(search.runCount).toBe(3);
+  });
+
+  test('respects the access scope and the requested project filter', async () => {
+    const restricted = await getAnalyticsPortfolio(db, DEFAULT_SCOPE, new Set([2]));
+    expect(restricted.map((r) => r.projectId)).toEqual([2]);
+
+    // Requested projects outside the access scope are dropped.
+    const scope = parseAnalyticsScope({ days: '30', projects: '1,2' });
+    const intersected = await getAnalyticsPortfolio(db, scope, new Set([2]));
+    expect(intersected.map((r) => r.projectId)).toEqual([2]);
+  });
+
+  test('filters by environment', async () => {
+    const scope = parseAnalyticsScope({ days: '30', environment: 'staging' });
+    const rows = await getAnalyticsPortfolio(db, scope, 'all');
+    expect(rows.find((r) => r.projectId === 2)!.runCount).toBe(2);
+    expect(rows.find((r) => r.projectId === 1)!.runCount).toBe(0);
+  });
+});
+
+describe('getAnalyticsPassRateHeatmap', () => {
+  test('buckets pass rates per project and drops run-less projects', async () => {
+    const heatmap = await getAnalyticsPassRateHeatmap(db, DEFAULT_SCOPE, 'all');
+    expect(heatmap.bucketDays).toBe(1);
+    // Leading all-empty columns are trimmed: the oldest seeded run is 10 days old.
+    expect(heatmap.buckets.length).toBeLessThanOrEqual(30);
+    expect(heatmap.rows.some((r) => r.cells[0] !== null)).toBe(true);
+    expect(heatmap.rows.map((r) => r.projectId).sort()).toEqual([1, 2]);
+
+    const checkout = heatmap.rows.find((r) => r.projectId === 1)!;
+    const values = checkout.cells.filter((c) => c !== null);
+    expect(values).toHaveLength(3);
+    expect(values).toContain(70); // 7/10 on the latest failing runs
+  });
+
+  test('widens buckets for long periods', async () => {
+    const heatmap = await getAnalyticsPassRateHeatmap(db, parseAnalyticsScope({ days: '365' }), 'all');
+    expect(heatmap.bucketDays).toBeGreaterThan(1);
+    expect(heatmap.buckets.length).toBeLessThanOrEqual(32);
+  });
+});
+
+describe('getAnalyticsCiTimeTrend', () => {
+  test('sums minutes for the period and compares with the previous one', async () => {
+    const trend = await getAnalyticsCiTimeTrend(db, DEFAULT_SCOPE, 'all');
+    // 5 full terminal runs in the current period × 1 min each.
+    expect(trend.runCount).toBe(5);
+    expect(trend.totalMinutes).toBe(5);
+    expect(trend.prevTotalMinutes).toBe(2);
+    expect(trend.deltaPct).toBe(150);
+    expect(trend.avgRunMinutes).toBe(1);
+    expect(trend.points.reduce((sum, p) => sum + p.runCount, 0)).toBe(5);
+  });
+});
+
+describe('getAnalyticsWastedTime', () => {
+  test('aggregates wait time and failed-attempt time', async () => {
+    const wasted = await getAnalyticsWastedTime(db, DEFAULT_SCOPE, 'all');
+    expect(wasted.totalWaitMinutes).toBe(1); // 60s of wait steps
+    expect(wasted.totalFailedExecMinutes).toBe(2); // one 120s failed attempt
+    expect(wasted.byProject[0]!.projectId).toBe(1);
+    expect(wasted.points.reduce((sum, p) => sum + p.waitMinutes, 0)).toBe(1);
+  });
+
+  test('returns an empty shape when the access scope has no projects', async () => {
+    const wasted = await getAnalyticsWastedTime(db, DEFAULT_SCOPE, new Set<number>());
+    expect(wasted.totalWaitMinutes).toBe(0);
+    expect(wasted.byProject).toEqual([]);
+  });
+});
+
+describe('getAnalyticsClusterLandscape', () => {
+  test('counts open clusters, resolved-in-period, and error-type mix', async () => {
+    const landscape = await getAnalyticsClusterLandscape(db, DEFAULT_SCOPE, 'all');
+    expect(landscape.totalOpen).toBe(2);
+    expect(landscape.resolvedInPeriod).toBe(1);
+    expect(landscape.byErrorType).toEqual([
+      { errorType: 'timeout', count: 1 },
+      { errorType: 'assertion', count: 1 },
+    ]);
+
+    const top = landscape.clusters[0]!;
+    expect(top.occurrences).toBe(25);
+    expect(top.ageDays).toBeGreaterThanOrEqual(39);
+    expect(top.projectName).toBe('checkout');
+  });
+
+  test('respects the access scope', async () => {
+    const landscape = await getAnalyticsClusterLandscape(db, DEFAULT_SCOPE, new Set([2]));
+    expect(landscape.totalOpen).toBe(1);
+    expect(landscape.clusters[0]!.projectId).toBe(2);
+  });
+});
+
+describe('insight rules', () => {
+  test('fires on the seeded data through the full pipeline', async () => {
+    const insights = (await runAnalyticsWidget(db, 'insights', DEFAULT_SCOPE, 'all')) as Array<{
+      ruleId: string;
+      severity: string;
+    }>;
+    const ruleIds = insights.map((i) => i.ruleId);
+    expect(ruleIds).toContain('failing-streak');
+    expect(ruleIds).toContain('pass-rate-drop');
+    expect(ruleIds).toContain('stale-cluster');
+    // Critical findings sort before informational ones.
+    const severities = insights.map((i) => i.severity);
+    expect(severities.indexOf('critical')).toBe(0);
+  });
+
+  test('rules are pure and independently evaluable', () => {
+    const insights = evaluateInsightRules({
+      scope: DEFAULT_SCOPE,
+      portfolio: [],
+      ciTime: {
+        points: [],
+        bucketDays: 1,
+        totalMinutes: 100,
+        runCount: 10,
+        prevTotalMinutes: 50,
+        deltaPct: 100,
+        avgRunMinutes: 10,
+      },
+      wastedTime: {
+        points: [],
+        bucketDays: 1,
+        totalWaitMinutes: 0,
+        totalFailedExecMinutes: 0,
+        byProject: [],
+      },
+      clusters: { totalOpen: 0, resolvedInPeriod: 0, byErrorType: [], clusters: [] },
+      flakyTests: [],
+    });
+    expect(insights).toHaveLength(1);
+    expect(insights[0]!.ruleId).toBe('ci-time-growth');
+    expect(insights[0]!.severity).toBe('warning');
+  });
+});

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -97,6 +97,19 @@ Network analysis and Web Vitals require the [capture fixtures](./capture-fixture
 
 A project-level overview groups test cases by spec file and colors each by pass rate, so an unhealthy area of the suite jumps out. Cells link straight to the filtered test-case list.
 
+## Cross-project analytics
+
+Everything above is scoped to one project. The **Analytics** page (`/analytics`) lifts the same signals to the whole portfolio over a time window you choose (last 7 / 30 / 90 days, last year, or all time — plus an optional environment and a full-runs-only toggle). It answers the higher-level questions a single project page can't:
+
+- **Portfolio health** — every project's pass rate with its change vs the previous period, flaky volume, open failure clusters, and latest run, sorted worst-first.
+- **Pass rate heatmap** — projects × time, colored by pass rate, so you can see who degraded and when.
+- **CI time** and **Wasted CI time** — how many CI minutes your runs consume, and how many of those produce no signal (wait steps + failed attempts).
+- **Flakiest tests** — the global flaky leaderboard across all projects, using the [impact ranking](#impact-ranking) above.
+- **Failure clusters** — open root causes across all projects, by age and occurrences.
+- **Insights** — an auto-generated, severity-ranked feed of the findings that matter (pass-rate drops, failing streaks, stale clusters, wasted time), each linking to the source.
+
+Each widget is served by `GET /api/analytics/:widget` and computed by a shared handler in `shared/handlers/analytics/`, so the same numbers back the dashboard, the demo, and any future API consumer.
+
 ## See also
 
 - [UI overview](./ui-overview) — where each of these views lives in the dashboard

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -24,6 +24,7 @@ The sidebar gives access to the top-level sections:
 | Section | Path | Purpose |
 |---------|------|---------|
 | Home | `/` | Aggregate stats and activity across all projects |
+| Analytics | `/analytics` | Cross-project trends, portfolio health, and insights over a chosen time window |
 | Projects | `/projects` | Full project listing with search and tag filters |
 | Settings | `/settings` | Configuration — general, account, users, storage, tags, wasted time, AI, notifications |
 | API docs | `/docs` | Self-contained OpenAPI 3.1 reference (no external CDN) — browse endpoints and schemas, try requests live, copy cURL / fetch snippets |
@@ -43,6 +44,20 @@ Everything else is reached by drilling into a project, run, or test case:
 ## Home
 
 A quick health check across all projects: **stats cards** (projects, runs, active/passing projects, flaky count, slowest project), a **test-results trend chart** (pass/fail/skip/flaky over time), **recent projects**, and a getting-started snippet for teams that haven't wired up the reporter yet.
+
+## Analytics
+
+A cross-project decision view — where Home answers *"what's happening now"*, Analytics answers *"across projects, over time"*. A **scope bar** at the top sets the period (last 7 / 30 / 90 days, last year, or all time), an optional environment, and a full-runs-only toggle; every widget re-aggregates against that scope. The widgets:
+
+- **Insights** — auto-generated, severity-ranked findings over the period (pass-rate drops, failing streaks, stale failure clusters, wasted CI time, CI-time growth). Each links straight to the project, run, cluster, or test case it's about.
+- **Portfolio health** — every project's pass rate (with its change vs the previous period), flaky volume, open failure clusters, average run duration, and latest run, in one sortable table with trend bars. Worst health sorts first.
+- **Pass rate heatmap** — a projects × time grid colored by daily (or, for longer periods, weekly) pass rate, so a project that degraded — and when — jumps out.
+- **CI time** — total CI minutes your runs consumed over the period, with the growth vs the previous period.
+- **Wasted CI time** — minutes that produced no signal: time inside wait steps plus time executing attempts that ended failed or timed out, split by project.
+- **Flakiest tests** — the worst flaky tests across all projects, using the same scoring as each project's Flaky tests tab, ranked by wasted-CI impact.
+- **Failure clusters** — open root causes across all projects, with age, occurrences, and error-type mix; the oldest unresolved cluster is highlighted.
+
+The analytics surface is **widget-driven**: each widget is a registry entry (`shared/analytics/registry.ts`) backed by a shared handler (`shared/handlers/analytics/`) and served by one generic endpoint, `GET /api/analytics/:widget`. See [Flaky tests & analytics](./flaky-tests).
 
 ## Projects
 


### PR DESCRIPTION
Introduce a new `/analytics` page that aggregates the existing run,
flakiness, cluster and CI-time data across all projects over a chosen
time window — a higher-level decision view alongside the per-project
pages.

The surface is widget-driven and extensible: each widget is a registry
entry (shared/analytics/registry.ts) backed by a shared handler
(shared/handlers/analytics/) and served by one generic endpoint,
GET /api/analytics/:widget, mirrored in the demo router with a single
route. v1 ships seven widgets — insights feed, portfolio scorecard,
pass-rate heatmap, CI-time and wasted-time trends, global flaky
leaderboard, and failure-cluster landscape — plus a rule-based insights
engine (shared/analytics/insight-rules.ts) whose findings deep-link to
the source page.

Includes unit tests for the handlers and insight rules, a functional
spec for the endpoints and page, help topics, and docs.