### PR TITLE
feat(demo): rebase seed timestamps to load time

### DIFF
--- a/application/app/components/demo/DemoBanner.vue
+++ b/application/app/components/demo/DemoBanner.vue
@@ -31,6 +31,7 @@ if (config.public.demoMode) {
         </span>
         <DemoUserSwitcher />
         <DemoSimulator />
+        <DemoResetButton />
       </div>
     </div>
   </Teleport>

--- a/application/app/components/demo/DemoResetButton.vue
+++ b/application/app/components/demo/DemoResetButton.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+/**
+ * Reset control for the demo banner: wipes the in-browser database and reloads
+ * with fresh sample data dated to the current moment. Guarded by a small
+ * confirmation popover since it discards any changes made this session.
+ */
+const { isResetting, resetDemo } = useDemoReset();
+const confirmOpen = ref(false);
+
+function confirmReset() {
+  confirmOpen.value = false;
+  resetDemo();
+}
+</script>
+
+<template>
+  <UPopover v-model:open="confirmOpen">
+    <UButton
+      size="xs"
+      color="warning"
+      variant="outline"
+      icon="i-lucide-refresh-cw"
+      label="Reset data"
+      :loading="isResetting"
+    />
+
+    <template #content>
+      <div class="p-3 w-72 flex flex-col gap-3">
+        <div class="flex flex-col gap-1">
+          <p class="text-sm font-medium text-highlighted">Reset demo data?</p>
+          <p class="text-xs text-muted">
+            Wipes the in-browser database and reloads with fresh sample data dated to now. Any changes made this session
+            will be lost.
+          </p>
+        </div>
+        <div class="flex justify-end gap-2">
+          <UButton size="xs" color="neutral" variant="ghost" label="Cancel" @click="confirmOpen = false" />
+          <UButton
+            size="xs"
+            color="error"
+            variant="solid"
+            icon="i-lucide-refresh-cw"
+            label="Reset"
+            :loading="isResetting"
+            @click="confirmReset"
+          />
+        </div>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/application/app/composables/useDemoReset.ts
+++ b/application/app/composables/useDemoReset.ts
@@ -1,0 +1,39 @@
+import { ref } from 'vue';
+
+/**
+ * Shared "reset the demo database" action, used by the demo banner button and
+ * the settings page. Wipes the in-browser SQLite DB and reloads: the next load
+ * re-seeds from scratch, and because the seed rebases every timestamp to the
+ * current moment, the fresh data is always dated relative to now.
+ */
+export function useDemoReset() {
+  const isResetting = ref(false);
+  const toast = useToast();
+
+  async function resetDemo() {
+    if (isResetting.value) return;
+    isResetting.value = true;
+    try {
+      const { resetDemoDb } = await import('~/demo/db.client');
+      await resetDemoDb();
+      toast.add({
+        title: 'Demo reset',
+        description: 'Reloading with fresh sample data dated to now.',
+        icon: 'i-lucide-refresh-cw',
+        color: 'success',
+      });
+      // Brief delay so the success toast is visible before the reload clears the page.
+      setTimeout(() => window.location.reload(), 800);
+    } catch (e) {
+      toast.add({
+        title: 'Reset failed',
+        description: String(e),
+        icon: 'i-lucide-x-circle',
+        color: 'error',
+      });
+      isResetting.value = false;
+    }
+  }
+
+  return { isResetting, resetDemo };
+}

--- a/application/app/pages/settings/index.vue
+++ b/application/app/pages/settings/index.vue
@@ -1,32 +1,7 @@
 <script setup lang="ts">
 const runtimeConfig = useRuntimeConfig();
 const isDemoMode = runtimeConfig.public.demoMode;
-const isResetting = ref(false);
-const toast = useToast();
-
-async function resetDemo() {
-  isResetting.value = true;
-  try {
-    const { resetDemoDb } = await import('~/demo/db.client');
-    await resetDemoDb();
-    toast.add({
-      title: 'Demo reset',
-      description: 'The demo database has been reset to its initial state.',
-      icon: 'i-lucide-refresh-cw',
-      color: 'success',
-    });
-    // Brief delay so the success toast is visible before the reload clears the page
-    setTimeout(() => window.location.reload(), 800);
-  } catch (e) {
-    toast.add({
-      title: 'Reset failed',
-      description: String(e),
-      icon: 'i-lucide-x-circle',
-      color: 'error',
-    });
-    isResetting.value = false;
-  }
-}
+const { isResetting, resetDemo } = useDemoReset();
 </script>
 
 <template>
@@ -48,8 +23,8 @@ async function resetDemo() {
       <div>
         <p class="font-medium text-sm">Reset demo data</p>
         <p class="text-sm text-muted">
-          Wipe the in-browser database and reload with the original seed data. All changes made during this demo session
-          will be lost.
+          Wipe the in-browser database and reload with fresh sample data dated to the current moment. All changes made
+          during this demo session will be lost.
         </p>
       </div>
     </div>

--- a/application/public/demo/seed.version.json
+++ b/application/public/demo/seed.version.json
@@ -1,4 +1,4 @@
 {
-  "hash": "7627425edace61e124efec59cef0b6694881f14f9f56eb8c2a9e90a2b58d7dce",
-  "generatedAt": "2026-07-18T15:31:06.819Z"
+  "hash": "2de9ded0ac2c3501a8bc8ab42d6320fdb0662045bd2f3ca87e7f6114567c4dc2",
+  "generatedAt": "2026-07-18T15:55:59.398Z"
 }

--- a/application/scripts/generate-demo-seed.mjs
+++ b/application/scripts/generate-demo-seed.mjs
@@ -1406,8 +1406,9 @@ const ENTITY_LINKS = [
     metadata: null,
     unfurled_at: null,
     created_by: null,
-    created_at: ts('2025-04-25T08:30:00'),
-    updated_at: ts('2025-04-25T08:30:00'),
+    // entity_links.created_at/updated_at are timestamp_ms columns — store ms.
+    created_at: ts('2025-04-25T08:30:00') * 1000,
+    updated_at: ts('2025-04-25T08:30:00') * 1000,
   },
   {
     id: 2,
@@ -1423,8 +1424,8 @@ const ENTITY_LINKS = [
     metadata: null,
     unfurled_at: null,
     created_by: null,
-    created_at: ts('2025-04-24T10:00:00'),
-    updated_at: ts('2025-04-24T10:00:00'),
+    created_at: ts('2025-04-24T10:00:00') * 1000,
+    updated_at: ts('2025-04-24T10:00:00') * 1000,
   },
   {
     id: 3,
@@ -1440,8 +1441,8 @@ const ENTITY_LINKS = [
     metadata: null,
     unfurled_at: null,
     created_by: null,
-    created_at: ts('2025-04-25T09:00:00'),
-    updated_at: ts('2025-04-25T09:00:00'),
+    created_at: ts('2025-04-25T09:00:00') * 1000,
+    updated_at: ts('2025-04-25T09:00:00') * 1000,
   },
 ];
 
@@ -2017,6 +2018,107 @@ const LOCATOR_SNAPSHOTS = [
   },
 ];
 
+// ── Load-time timestamp rebase ─────────────────────────────────────────────
+// Every timestamp above is anchored to a fixed generation-time window, so a
+// committed seed would show runs that drift ever further into the past. To keep
+// the demo feeling live, the seed shifts every timestamp forward when it runs —
+// the first time a visitor opens the demo AND every time they reset the data —
+// so the newest run always lands near "now". SQLite evaluates
+// `strftime('%s','now')` at seed-run time, so the offset is computed relative to
+// the actual moment of the visit, not to when the seed file was built.
+//
+// `ANCHOR_SEC` is the newest timestamp in the dataset (in seconds). Mapping it
+// to the current time and shifting everything else by the same delta keeps the
+// data's internal spacing intact and guarantees nothing lands in the future.
+function collectAnchorSec() {
+  let max = 0;
+  // Fold a candidate timestamp into the running max, normalizing to seconds.
+  const bump = (v, unit) => {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return;
+    const s = unit === 'ms' ? Math.floor(v / 1000) : v;
+    if (s > max) max = s;
+  };
+
+  // Tables whose created_at/updated_at are second-precision.
+  for (const rows of [TAGS, PROJECTS, USERS, TEST_SUITES, TEST_CASES, FAILURE_CLUSTERS, FAILURE_DIAGNOSES]) {
+    for (const r of rows) {
+      bump(r.created_at, 's');
+      bump(r.updated_at, 's');
+    }
+  }
+  for (const r of FAILURE_DIAGNOSIS_VERSIONS) bump(r.created_at, 's');
+  for (const r of TEST_RUNS) {
+    bump(r.start_time, 's');
+    bump(r.created_at, 's');
+    bump(r.updated_at, 's');
+  }
+  for (const r of REPORTS) bump(r.created_at, 's');
+  for (const r of ATTACHMENTS) bump(r.created_at, 's');
+
+  // Millisecond-precision columns.
+  for (const r of PROJECT_ASSIGNMENTS) bump(r.created_at, 'ms');
+  for (const r of LOCATOR_SNAPSHOTS) bump(r.last_seen_at, 'ms');
+  for (const r of ENTITY_LINKS) {
+    bump(r.created_at, 'ms');
+    bump(r.updated_at, 'ms');
+  }
+  for (const r of TEST_RUNS_CASES) {
+    bump(r.started_at, 'ms');
+    bump(r.created_at, 'ms');
+    for (const e of r.step_events || []) bump(e.startedAt, 'ms');
+    for (const e of r.console_logs || []) bump(e.timestamp, 'ms');
+  }
+  for (const r of NETWORK_REQUESTS) {
+    for (const e of r.server_logs || []) bump(e.timestamp, 'ms');
+  }
+  return max;
+}
+
+const ANCHOR_SEC = collectAnchorSec();
+// Delta between load time and the seed's anchor, computed by SQLite when the
+// seed runs. Referenced from a temp table so every statement shares one value
+// (a second-precision drift between statements would otherwise desync the ms
+// columns from their JSON-embedded counterparts and skew the timeline).
+const D = '(SELECT delta_sec FROM _rebase)';
+const D_MS = `(SELECT delta_sec FROM _rebase) * 1000`;
+
+// Shift a JSON array column's per-element ms timestamp (`$.field`) in place,
+// preserving element order (json_each iterates in array order).
+const shiftJsonMs = (table, column, field) =>
+  `UPDATE ${table} SET ${column} = (SELECT json_group_array(json_set(value, '$.${field}', ` +
+  `json_extract(value, '$.${field}') + ${D_MS})) FROM json_each(${table}.${column})) ` +
+  `WHERE ${column} IS NOT NULL AND json_valid(${column});`;
+
+const REBASE_SQL = [
+  '-- ── Rebase every timestamp to load time (see generator for rationale) ──────',
+  `CREATE TEMP TABLE _rebase AS SELECT (CAST(strftime('%s', 'now') AS INTEGER) - ${ANCHOR_SEC}) AS delta_sec;`,
+  '',
+  '-- Second-precision timestamp columns',
+  `UPDATE tags SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE projects SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE users SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE test_suites SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE test_cases SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE test_runs SET start_time = start_time + ${D}, created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE files SET created_at = created_at + ${D};`,
+  `UPDATE failure_clusters SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE failure_diagnoses SET created_at = created_at + ${D}, updated_at = updated_at + ${D};`,
+  `UPDATE failure_diagnosis_versions SET created_at = created_at + ${D};`,
+  '',
+  '-- Millisecond timestamp columns',
+  `UPDATE test_runs_cases SET started_at = started_at + ${D_MS}, created_at = created_at + ${D_MS};`,
+  `UPDATE project_assignments SET created_at = created_at + ${D_MS};`,
+  `UPDATE entity_links SET created_at = created_at + ${D_MS}, updated_at = updated_at + ${D_MS};`,
+  `UPDATE locator_snapshots SET last_seen_at = last_seen_at + ${D_MS};`,
+  '',
+  '-- Millisecond timestamps embedded in JSON columns',
+  shiftJsonMs('test_runs_cases', 'step_events', 'startedAt'),
+  shiftJsonMs('test_runs_cases', 'console_logs', 'timestamp'),
+  shiftJsonMs('network_requests', 'server_logs', 'timestamp'),
+  '',
+  'DROP TABLE _rebase;',
+];
+
 // ── Assemble SQL ───────────────────────────────────────────────────────────
 const lines = [
   '-- Piwi Dashboard demo seed',
@@ -2079,6 +2181,8 @@ const lines = [
   '',
   '-- Locator healing snapshots (references test_cases)',
   insert('locator_snapshots', LOCATOR_SNAPSHOTS),
+  '',
+  ...REBASE_SQL,
   '',
   'COMMIT;',
 ];


### PR DESCRIPTION
## What & why

The demo seed data was anchored to fixed timestamps, causing the sample data to drift further into the past with each passing day. This change makes the demo feel "live" by rebasing all timestamps to the current moment whenever the seed runs—both on initial load and when users reset the data.

**Key changes:**

1. **Fixed entity_links timestamps**: Converted `created_at` and `updated_at` from seconds to milliseconds (multiplied by 1000) to match the column type.

2. **Added timestamp rebasing logic**: Implemented `collectAnchorSec()` to find the newest timestamp in the entire dataset, then generates SQL that:
   - Computes a delta between the current time and the seed's anchor timestamp
   - Updates all second-precision timestamp columns (tags, projects, users, test_suites, test_cases, test_runs, etc.)
   - Updates all millisecond-precision columns (test_runs_cases, project_assignments, entity_links, locator_snapshots)
   - Shifts millisecond timestamps embedded in JSON arrays (step_events, console_logs, server_logs)

3. **Added demo reset UI**: Created `DemoResetButton.vue` component with confirmation popover and integrated it into the demo banner, allowing users to reset the database and reload with fresh data dated to now.

4. **Extracted reset logic**: Moved the reset functionality into a reusable `useDemoReset()` composable, shared by both the banner button and settings page.

5. **Updated messaging**: Changed descriptions to clarify that reset data is "dated to the current moment" rather than "original seed data."

The rebasing preserves the internal spacing of all timestamps, ensuring the data's temporal relationships remain intact while keeping everything relative to the current time.

## How was it tested?

- Verified seed generation completes successfully with new rebasing SQL
- Confirmed timestamp calculations are correct (anchor detection, delta computation)
- Tested reset button UI with confirmation popover
- Existing demo functionality remains unaffected

## Checklist

- [x] PR title follows Conventional Commits (`feat(demo): ...`)
- [x] No new tests required (seed generation is deterministic, UI is straightforward)
- [x] User-facing messaging updated in settings page and reset button

https://claude.ai/code/session_01UQKpriCznDthaHb7FvHefz