### PR TITLE
feat(app): add regression, browser, and endpoint analytics widgets

### DIFF
--- a/application/app/components/analytics/BrowserMatrix.vue
+++ b/application/app/components/analytics/BrowserMatrix.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import type { AnalyticsBrowserMatrix } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: matrix,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsBrowserMatrix>('browser-matrix', () => props.query);
+
+function cellClass(rate: number | null): string {
+  if (rate === null) return 'bg-gray-100 dark:bg-gray-800 text-gray-400';
+  if (rate >= 99.5) return 'bg-green-500/85 text-white';
+  if (rate >= 90) return 'bg-green-500/45';
+  if (rate >= 75) return 'bg-amber-500/50';
+  if (rate >= 50) return 'bg-orange-500/60';
+  return 'bg-red-500/70 text-white';
+}
+</script>
+
+<template>
+  <SectionCard icon="i-lucide-monitor-smartphone" title="Browser matrix" help="analytics.browser-matrix">
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load the browser matrix: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!matrix || matrix.rows.length === 0" text="No runs with browser data in this period." />
+    <TableScroller v-else min-width="30rem">
+      <table class="w-full text-sm border-separate border-spacing-1">
+        <thead>
+          <tr>
+            <th class="text-left text-xs text-gray-500 uppercase tracking-wider font-medium pr-2">Project</th>
+            <th
+              v-for="browser in matrix.browsers"
+              :key="browser"
+              class="text-xs text-gray-500 uppercase tracking-wider font-medium px-1 text-center"
+            >
+              {{ browser }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in matrix.rows" :key="row.projectId">
+            <td class="pr-2 max-w-[12rem]">
+              <NuxtLink :to="`/projects/${row.projectId}`" class="truncate hover:text-primary block" :title="row.label || row.name">
+                {{ row.label || row.name }}
+              </NuxtLink>
+            </td>
+            <td
+              v-for="(rate, index) in row.cells"
+              :key="index"
+              class="text-center tabular-nums rounded-md px-2 py-1.5 font-medium"
+              :class="cellClass(rate)"
+              :title="`${row.label || row.name} · ${matrix.browsers[index]}: ${rate !== null ? `${rate}% passed` : 'no tests'}`"
+            >
+              {{ rate !== null ? `${Math.round(rate)}%` : '—' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </TableScroller>
+  </SectionCard>
+</template>

--- a/application/app/components/analytics/RegressionVelocityChart.vue
+++ b/application/app/components/analytics/RegressionVelocityChart.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { VisXYContainer, VisStackedBar, VisAxis } from '@unovis/vue';
+import type { AnalyticsRegressionVelocity } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: velocity,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsRegressionVelocity>('regression-velocity', () => props.query);
+
+type DataPoint = { date: Date; regressions: number; newFlaky: number };
+
+const chartData = computed<DataPoint[]>(
+  () =>
+    velocity.value?.points.map((p) => ({
+      date: new Date(p.date),
+      regressions: p.regressions,
+      newFlaky: p.newFlaky,
+    })) ?? [],
+);
+
+const hasData = computed(() => chartData.value.some((p) => p.regressions > 0 || p.newFlaky > 0));
+
+const x = (d: DataPoint) => d.date;
+const barColors = ['rgb(239, 68, 68)', 'rgb(147, 51, 234)'] as const;
+
+const legendItems = [
+  { color: barColors[0], label: 'New regressions' },
+  { color: barColors[1], label: 'Newly flaky' },
+];
+
+const deltaBadge = computed(() => {
+  if (!velocity.value || velocity.value.deltaPct === null) return null;
+  const pct = velocity.value.deltaPct;
+  return {
+    label: `${pct > 0 ? '+' : ''}${pct}% vs previous period`,
+    // Fewer regressions is good, more is bad.
+    class: pct > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400',
+  };
+});
+
+const subtitle = computed(() => {
+  if (!velocity.value) return undefined;
+  return `${velocity.value.totalRegressions} new regressions, ${velocity.value.totalNewFlaky} newly flaky`;
+});
+</script>
+
+<template>
+  <ChartCard
+    icon="i-lucide-git-pull-request-arrow"
+    title="Regression velocity"
+    :subtitle="subtitle"
+    help="analytics.regression-velocity"
+  >
+    <template #legend>
+      <ChartLegend :items="legendItems" dense />
+    </template>
+    <template #actions>
+      <span v-if="deltaBadge" class="text-xs font-medium tabular-nums" :class="deltaBadge.class">
+        {{ deltaBadge.label }}
+      </span>
+    </template>
+
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load regression velocity: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState v-else-if="!hasData" icon="i-lucide-shield-check" text="No new regressions in this period." />
+    <div v-else class="w-full">
+      <VisXYContainer :data="chartData" :height="220" :padding="{ top: 10, right: 10, bottom: 0, left: 0 }">
+        <VisStackedBar
+          :x="x"
+          :y="[(d: DataPoint) => d.regressions, (d: DataPoint) => d.newFlaky]"
+          :color="barColors"
+          :rounded-corners="2"
+        />
+        <VisAxis
+          type="x"
+          :tick-format="(d: Date) => new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })"
+        />
+        <VisAxis type="y" label="Count" :tick-format="(d: number) => d.toString()" />
+      </VisXYContainer>
+    </div>
+  </ChartCard>
+</template>

--- a/application/app/components/analytics/SlowEndpointsTable.vue
+++ b/application/app/components/analytics/SlowEndpointsTable.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import type { AnalyticsSlowEndpoints } from '#shared/analytics/types';
+
+const props = defineProps<{ query: Record<string, string> }>();
+
+const {
+  data: slow,
+  pending,
+  error,
+  refresh,
+} = await useAnalyticsWidget<AnalyticsSlowEndpoints>('slow-endpoints', () => props.query);
+
+function latencyClass(ms: number): string {
+  if (ms >= 1000) return 'text-red-600 dark:text-red-400';
+  if (ms >= 500) return 'text-amber-600 dark:text-amber-400';
+  return 'text-gray-600 dark:text-gray-300';
+}
+
+function methodColor(method: string): 'success' | 'info' | 'warning' | 'error' | 'neutral' {
+  const map: Record<string, 'success' | 'info' | 'warning' | 'error' | 'neutral'> = {
+    GET: 'info',
+    POST: 'success',
+    PUT: 'warning',
+    PATCH: 'warning',
+    DELETE: 'error',
+  };
+  return map[method.toUpperCase()] ?? 'neutral';
+}
+</script>
+
+<template>
+  <SectionCard
+    icon="i-lucide-gauge"
+    title="Slow endpoints"
+    :count="slow?.endpoints.length || undefined"
+    subtitle="Backend calls across all projects, slowest first"
+    help="analytics.slow-endpoints"
+  >
+    <LoadingState v-if="pending" />
+    <ErrorState v-else-if="error" :text="`Couldn't load slow endpoints: ${errorMessage(error)}`">
+      <template #action>
+        <UButton size="sm" color="neutral" variant="outline" icon="i-lucide-refresh-cw" @click="refresh()">
+          Retry
+        </UButton>
+      </template>
+    </ErrorState>
+    <EmptyState
+      v-else-if="!slow || slow.endpoints.length === 0"
+      icon="i-lucide-network"
+      text="No network requests captured in this period."
+    />
+    <template v-else>
+      <!-- Mobile: card list -->
+      <div class="md:hidden space-y-3">
+        <div
+          v-for="ep in slow.endpoints"
+          :key="`${ep.method} ${ep.route}`"
+          class="rounded-lg border border-gray-200 dark:border-gray-800 p-3 space-y-1.5"
+        >
+          <div class="flex items-center gap-2 min-w-0">
+            <UBadge :color="methodColor(ep.method)" variant="subtle" size="sm">{{ ep.method }}</UBadge>
+            <code class="text-xs truncate">{{ ep.route }}</code>
+          </div>
+          <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <span>p90 <span class="tabular-nums font-medium" :class="latencyClass(ep.p90Ms)">{{ ep.p90Ms }} ms</span></span>
+            <span>{{ ep.requests }} reqs · {{ ep.projectCount }} proj</span>
+            <span v-if="ep.errorRate > 0" class="text-red-600 dark:text-red-400 tabular-nums">{{ ep.errorRate }}% err</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Desktop: table -->
+      <div class="hidden md:block">
+        <TableScroller min-width="44rem">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs text-gray-500 uppercase tracking-wider border-b border-gray-200 dark:border-gray-800">
+                <th class="py-2 pr-4 font-medium">Endpoint</th>
+                <th class="py-2 pr-4 font-medium text-right">Requests</th>
+                <th class="py-2 pr-4 font-medium text-right">p50</th>
+                <th class="py-2 pr-4 font-medium text-right">p90</th>
+                <th class="py-2 pr-4 font-medium text-right">Max</th>
+                <th class="py-2 pr-4 font-medium text-right">Errors</th>
+                <th class="py-2 font-medium text-right">Projects</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+              <tr v-for="ep in slow.endpoints" :key="`${ep.method} ${ep.route}`">
+                <td class="py-2.5 pr-4">
+                  <div class="flex items-center gap-2 min-w-0">
+                    <UBadge :color="methodColor(ep.method)" variant="subtle" size="sm">{{ ep.method }}</UBadge>
+                    <code class="text-xs truncate max-w-[22rem]" :title="ep.route">{{ ep.route }}</code>
+                  </div>
+                </td>
+                <td class="py-2.5 pr-4 text-right tabular-nums">{{ ep.requests }}</td>
+                <td class="py-2.5 pr-4 text-right tabular-nums text-gray-500">{{ ep.p50Ms }} ms</td>
+                <td class="py-2.5 pr-4 text-right tabular-nums font-medium" :class="latencyClass(ep.p90Ms)">{{ ep.p90Ms }} ms</td>
+                <td class="py-2.5 pr-4 text-right tabular-nums text-gray-500">{{ ep.maxMs }} ms</td>
+                <td
+                  class="py-2.5 pr-4 text-right tabular-nums"
+                  :class="ep.errorRate > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-400'"
+                >
+                  {{ ep.errorRate }}%
+                </td>
+                <td class="py-2.5 text-right tabular-nums">{{ ep.projectCount }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </TableScroller>
+      </div>
+    </template>
+  </SectionCard>
+</template>

--- a/application/app/pages/analytics.vue
+++ b/application/app/pages/analytics.vue
@@ -10,6 +10,9 @@ import {
   WastedTimeChart,
   GlobalFlakyLeaderboard,
   ClusterLandscape,
+  RegressionVelocityChart,
+  BrowserMatrix,
+  SlowEndpointsTable,
 } from '#components';
 
 useHead({ title: 'Analytics - Piwi Dashboard' });
@@ -43,6 +46,9 @@ const WIDGET_COMPONENTS: Record<AnalyticsWidgetId, Component> = {
   'wasted-time': WastedTimeChart,
   'flaky-leaderboard': GlobalFlakyLeaderboard,
   'cluster-landscape': ClusterLandscape,
+  'regression-velocity': RegressionVelocityChart,
+  'browser-matrix': BrowserMatrix,
+  'slow-endpoints': SlowEndpointsTable,
 };
 </script>
 

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -88,6 +88,20 @@ export const HELP_TOPICS = {
     text: 'Open failure clusters across all projects — the biggest and oldest unresolved root causes. Clusters outlive run retention, so this works on long horizons.',
     doc: 'failure-clustering',
   },
+  'analytics.regression-velocity': {
+    title: 'Regression velocity',
+    text: 'How much new breakage each period introduces: tests that passed in a baseline and now fail (regressions), plus tests that turned flaky. Rising bars mean quality debt is accumulating.',
+    doc: 'flaky-tests#regression-signals',
+  },
+  'analytics.browser-matrix': {
+    title: 'Browser matrix',
+    text: 'Pass rate per project × browser, so a suite that is green on one browser but failing on another (a browser-specific bug) stands out immediately.',
+  },
+  'analytics.slow-endpoints': {
+    title: 'Slow endpoints',
+    text: 'Backend calls captured during tests, aggregated across all projects by route: p50/p90 latency, error rate, and how many projects hit each one — a shared endpoint regressing shows up here first.',
+    doc: 'capture-fixtures',
+  },
 
   // ── Projects list ─────────────────────────────────────────────────────
   'projects.tag-filter': {

--- a/application/shared/analytics/insight-rules.ts
+++ b/application/shared/analytics/insight-rules.ts
@@ -10,6 +10,8 @@ import type {
   AnalyticsFlakyRow,
   AnalyticsInsight,
   AnalyticsPortfolioRow,
+  AnalyticsRegressionVelocity,
+  AnalyticsSlowEndpoints,
   AnalyticsWastedTime,
 } from './types';
 import type { AnalyticsScope } from './scope';
@@ -21,6 +23,8 @@ export interface InsightContext {
   wastedTime: AnalyticsWastedTime;
   clusters: AnalyticsClusterLandscape;
   flakyTests: AnalyticsFlakyRow[];
+  regressionVelocity: AnalyticsRegressionVelocity;
+  slowEndpoints: AnalyticsSlowEndpoints;
 }
 
 export interface InsightRule {
@@ -160,11 +164,46 @@ const topFlakyImpact: InsightRule = {
       })),
 };
 
+const regressionSurge: InsightRule = {
+  id: 'regression-surge',
+  evaluate: ({ regressionVelocity, scope }) => {
+    const { totalRegressions, prevRegressions, deltaPct } = regressionVelocity;
+    if (totalRegressions < 5 || deltaPct === null || deltaPct < 50) return [];
+    return [
+      {
+        id: 'regression-surge',
+        ruleId: 'regression-surge',
+        severity: deltaPct >= 100 ? 'warning' : 'info',
+        message: `New regressions rose ${deltaPct}% vs the previous ${scope.days} days`,
+        detail: `${totalRegressions} this period, up from ${prevRegressions}.`,
+      },
+    ];
+  },
+};
+
+const slowSharedEndpoint: InsightRule = {
+  id: 'slow-shared-endpoint',
+  evaluate: ({ slowEndpoints }) =>
+    slowEndpoints.endpoints
+      // A slow call hit by several projects points at a shared backend, not one flaky test.
+      .filter((ep) => ep.projectCount >= 2 && ep.p90Ms >= 1000)
+      .slice(0, 2)
+      .map((ep) => ({
+        id: `slow-shared-endpoint:${ep.method}:${ep.route}`,
+        ruleId: 'slow-shared-endpoint',
+        severity: 'warning' as const,
+        message: `${ep.method} ${ep.route} is slow (p90 ${ep.p90Ms} ms) across ${ep.projectCount} projects`,
+        detail: `${ep.requests} requests this period${ep.errorRate > 0 ? ` · ${ep.errorRate}% errored` : ''}.`,
+      })),
+};
+
 export const INSIGHT_RULES: InsightRule[] = [
   failingStreak,
   passRateDrop,
   staleCluster,
   topFlakyImpact,
+  regressionSurge,
+  slowSharedEndpoint,
   wastedCiTime,
   ciTimeGrowth,
   passRateRecovery,

--- a/application/shared/analytics/registry.ts
+++ b/application/shared/analytics/registry.ts
@@ -61,6 +61,24 @@ export const ANALYTICS_WIDGETS = [
     icon: 'i-lucide-layers',
     size: 'half',
   },
+  {
+    id: 'regression-velocity',
+    title: 'Regression velocity',
+    icon: 'i-lucide-git-pull-request-arrow',
+    size: 'half',
+  },
+  {
+    id: 'browser-matrix',
+    title: 'Browser matrix',
+    icon: 'i-lucide-monitor-smartphone',
+    size: 'half',
+  },
+  {
+    id: 'slow-endpoints',
+    title: 'Slow endpoints',
+    icon: 'i-lucide-gauge',
+    size: 'full',
+  },
 ] as const satisfies readonly AnalyticsWidgetMeta[];
 
 export type AnalyticsWidgetId = (typeof ANALYTICS_WIDGETS)[number]['id'];

--- a/application/shared/analytics/types.ts
+++ b/application/shared/analytics/types.ts
@@ -150,6 +150,61 @@ export interface AnalyticsClusterLandscape {
   clusters: AnalyticsClusterRow[];
 }
 
+// ── Regression velocity ──────────────────────────────────────────────────────
+
+export interface AnalyticsRegressionPoint {
+  /** Bucket start date (ISO `YYYY-MM-DD`). */
+  date: string;
+  /** Executions first failing this period (`isNewRegression`). */
+  regressions: number;
+  /** Executions newly flaky this period (`isNewFlaky`). */
+  newFlaky: number;
+}
+
+export interface AnalyticsRegressionVelocity {
+  points: AnalyticsRegressionPoint[];
+  bucketDays: number;
+  totalRegressions: number;
+  totalNewFlaky: number;
+  /** Regressions in the previous equal-length period. Null without a baseline. */
+  prevRegressions: number | null;
+  deltaPct: number | null;
+}
+
+// ── Browser matrix ───────────────────────────────────────────────────────────
+
+export interface AnalyticsBrowserMatrix {
+  /** Browser identities present in the period (column order). */
+  browsers: string[];
+  rows: Array<{
+    projectId: number;
+    name: string;
+    label: string | null;
+    /** Pass rate (0–100) per browser; null = the project ran no tests on it. */
+    cells: Array<number | null>;
+  }>;
+}
+
+// ── Slow endpoints ───────────────────────────────────────────────────────────
+
+export interface AnalyticsSlowEndpointRow {
+  method: string;
+  route: string;
+  requests: number;
+  p50Ms: number;
+  p90Ms: number;
+  maxMs: number;
+  /** Share of requests with a 4xx/5xx status, 0–100. */
+  errorRate: number;
+  /** Distinct projects that hit this endpoint (shared-backend signal). */
+  projectCount: number;
+}
+
+export interface AnalyticsSlowEndpoints {
+  endpoints: AnalyticsSlowEndpointRow[];
+  totalRequests: number;
+}
+
 // ── Insights feed ────────────────────────────────────────────────────────────
 
 export type AnalyticsInsightSeverity = 'critical' | 'warning' | 'info' | 'positive';

--- a/application/shared/handlers/analytics/browser-matrix.ts
+++ b/application/shared/handlers/analytics/browser-matrix.ts
@@ -1,0 +1,84 @@
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
+import { testRuns, testRunsCases } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsBrowserMatrix } from '../../analytics/types';
+import {
+  fetchScopedProjects,
+  periodStart,
+  resolveAllowedProjects,
+  roundRate,
+  TERMINAL_RUN_STATUSES,
+  type ProjectAccess,
+} from './common';
+
+/**
+ * Pass rate per browser × project — surfaces browser-specific rot (a suite
+ * that's green on Chromium but red on WebKit). Uses the scalar `browserName`
+ * column on `test_runs_cases`.
+ */
+export async function getAnalyticsBrowserMatrix(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsBrowserMatrix> {
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return { browsers: [], rows: [] };
+
+  const conditions = [
+    gte(testRuns.startTime, new Date(periodStart(scope.days))),
+    inArray(testRuns.status, TERMINAL_RUN_STATUSES),
+  ];
+  if (allowed !== 'all') conditions.push(inArray(testRuns.projectId, allowed));
+  if (scope.fullRunsOnly) conditions.push(eq(testRuns.isFullRun, 1));
+  if (scope.environment) conditions.push(eq(testRuns.environment, scope.environment));
+
+  const rows: any[] = await db
+    .select({
+      projectId: testRuns.projectId,
+      browserName: testRunsCases.browserName,
+      passed: sql<number>`COALESCE(SUM(CASE WHEN ${testRunsCases.status} = 'passed' THEN 1 ELSE 0 END), 0)`,
+      total: sql<number>`COUNT(*)`,
+    })
+    .from(testRunsCases)
+    .innerJoin(testRuns, eq(testRunsCases.testRunId, testRuns.id))
+    .where(and(...conditions))
+    .groupBy(testRuns.projectId, testRunsCases.browserName);
+
+  // Aggregate into a project × browser grid.
+  const browserSet = new Set<string>();
+  const byProject = new Map<number, Map<string, { passed: number; total: number }>>();
+  for (const row of rows) {
+    const browser = (row.browserName as string | null) || 'unknown';
+    browserSet.add(browser);
+    let byBrowser = byProject.get(row.projectId);
+    if (!byBrowser) {
+      byBrowser = new Map();
+      byProject.set(row.projectId, byBrowser);
+    }
+    byBrowser.set(browser, { passed: Number(row.passed) || 0, total: Number(row.total) || 0 });
+  }
+
+  const browsers = [...browserSet].sort();
+  if (browsers.length === 0) return { browsers: [], rows: [] };
+
+  const scopedProjects = await fetchScopedProjects(db, scope, access);
+
+  const matrixRows = scopedProjects
+    .filter((project) => byProject.has(project.id))
+    .map((project) => {
+      const byBrowser = byProject.get(project.id)!;
+      return {
+        projectId: project.id,
+        name: project.name,
+        label: project.label,
+        cells: browsers.map((browser) => {
+          const cell = byBrowser.get(browser);
+          return cell ? roundRate(cell.passed, cell.total) : null;
+        }),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { browsers, rows: matrixRows };
+}

--- a/application/shared/handlers/analytics/index.ts
+++ b/application/shared/handlers/analytics/index.ts
@@ -8,6 +8,9 @@ import { getAnalyticsCiTimeTrend } from './ci-time-trend';
 import { getAnalyticsWastedTime } from './wasted-time';
 import { getAnalyticsFlakyLeaderboard } from './flaky-leaderboard';
 import { getAnalyticsClusterLandscape } from './cluster-landscape';
+import { getAnalyticsRegressionVelocity } from './regression-velocity';
+import { getAnalyticsBrowserMatrix } from './browser-matrix';
+import { getAnalyticsSlowEndpoints } from './slow-endpoints';
 import { getAnalyticsInsights } from './insights';
 
 export { isAnalyticsWidgetId };
@@ -27,6 +30,9 @@ const ANALYTICS_WIDGET_HANDLERS: Record<AnalyticsWidgetId, AnalyticsWidgetHandle
   'wasted-time': getAnalyticsWastedTime,
   'flaky-leaderboard': getAnalyticsFlakyLeaderboard,
   'cluster-landscape': getAnalyticsClusterLandscape,
+  'regression-velocity': getAnalyticsRegressionVelocity,
+  'browser-matrix': getAnalyticsBrowserMatrix,
+  'slow-endpoints': getAnalyticsSlowEndpoints,
 };
 
 export function runAnalyticsWidget(

--- a/application/shared/handlers/analytics/insights.ts
+++ b/application/shared/handlers/analytics/insights.ts
@@ -7,6 +7,8 @@ import { getAnalyticsCiTimeTrend } from './ci-time-trend';
 import { getAnalyticsWastedTime } from './wasted-time';
 import { getAnalyticsClusterLandscape } from './cluster-landscape';
 import { getAnalyticsFlakyLeaderboard } from './flaky-leaderboard';
+import { getAnalyticsRegressionVelocity } from './regression-velocity';
+import { getAnalyticsSlowEndpoints } from './slow-endpoints';
 import type { ProjectAccess } from './common';
 
 /**
@@ -19,13 +21,24 @@ export async function getAnalyticsInsights(
   scope: AnalyticsScope,
   access: ProjectAccess = 'all',
 ): Promise<AnalyticsInsight[]> {
-  const [portfolio, ciTime, wastedTime, clusters, flakyTests] = await Promise.all([
+  const [portfolio, ciTime, wastedTime, clusters, flakyTests, regressionVelocity, slowEndpoints] = await Promise.all([
     getAnalyticsPortfolio(db, scope, access),
     getAnalyticsCiTimeTrend(db, scope, access),
     getAnalyticsWastedTime(db, scope, access),
     getAnalyticsClusterLandscape(db, scope, access),
     getAnalyticsFlakyLeaderboard(db, scope, access),
+    getAnalyticsRegressionVelocity(db, scope, access),
+    getAnalyticsSlowEndpoints(db, scope, access),
   ]);
 
-  return evaluateInsightRules({ scope, portfolio, ciTime, wastedTime, clusters, flakyTests });
+  return evaluateInsightRules({
+    scope,
+    portfolio,
+    ciTime,
+    wastedTime,
+    clusters,
+    flakyTests,
+    regressionVelocity,
+    slowEndpoints,
+  });
 }

--- a/application/shared/handlers/analytics/regression-velocity.ts
+++ b/application/shared/handlers/analytics/regression-velocity.ts
@@ -1,0 +1,101 @@
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
+import { testRuns, testRunsCases } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsRegressionVelocity } from '../../analytics/types';
+import {
+  firstNonEmptyIndex,
+  makeTimeBuckets,
+  periodStart,
+  resolveAllowedProjects,
+  TERMINAL_RUN_STATUSES,
+  type ProjectAccess,
+} from './common';
+
+/**
+ * New regressions and newly-flaky tests introduced over time — a burn-up of
+ * quality debt. Both signals are precomputed columns on `test_runs_cases`
+ * (`isNewRegression`/`isNewFlaky`), so this is cheap SQL.
+ */
+export async function getAnalyticsRegressionVelocity(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsRegressionVelocity> {
+  const buckets = makeTimeBuckets(scope.days);
+  const empty: AnalyticsRegressionVelocity = {
+    points: buckets.keys.map((date) => ({ date, regressions: 0, newFlaky: 0 })),
+    bucketDays: buckets.bucketDays,
+    totalRegressions: 0,
+    totalNewFlaky: 0,
+    prevRegressions: null,
+    deltaPct: null,
+  };
+
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return empty;
+
+  const conditions = [
+    gte(testRuns.startTime, new Date(periodStart(scope.days * 2))),
+    inArray(testRuns.status, TERMINAL_RUN_STATUSES),
+  ];
+  if (allowed !== 'all') conditions.push(inArray(testRuns.projectId, allowed));
+  if (scope.fullRunsOnly) conditions.push(eq(testRuns.isFullRun, 1));
+  if (scope.environment) conditions.push(eq(testRuns.environment, scope.environment));
+
+  // One aggregated row per run; bucketed and split into current/previous in JS.
+  const rows: any[] = await db
+    .select({
+      startTime: testRuns.startTime,
+      regressions: sql<number>`COALESCE(SUM(CASE WHEN ${testRunsCases.isNewRegression} = 1 THEN 1 ELSE 0 END), 0)`,
+      newFlaky: sql<number>`COALESCE(SUM(CASE WHEN ${testRunsCases.isNewFlaky} = 1 THEN 1 ELSE 0 END), 0)`,
+    })
+    .from(testRunsCases)
+    .innerJoin(testRuns, eq(testRunsCases.testRunId, testRuns.id))
+    .where(and(...conditions))
+    .groupBy(testRunsCases.testRunId, testRuns.startTime);
+
+  const cutoff = periodStart(scope.days);
+  const byBucket = new Map<string, { regressions: number; newFlaky: number }>();
+  let totalRegressions = 0;
+  let totalNewFlaky = 0;
+  let prevRegressions = 0;
+  let hasPrevious = false;
+
+  for (const row of rows) {
+    const regressions = Number(row.regressions) || 0;
+    const newFlaky = Number(row.newFlaky) || 0;
+    if (row.startTime.getTime() < cutoff) {
+      hasPrevious = true;
+      prevRegressions += regressions;
+      continue;
+    }
+    totalRegressions += regressions;
+    totalNewFlaky += newFlaky;
+    const key = buckets.keyFor(row.startTime);
+    if (!key) continue;
+    const bucket = byBucket.get(key) ?? { regressions: 0, newFlaky: 0 };
+    bucket.regressions += regressions;
+    bucket.newFlaky += newFlaky;
+    byBucket.set(key, bucket);
+  }
+
+  const points = buckets.keys.map((date) => {
+    const bucket = byBucket.get(date);
+    return { date, regressions: bucket?.regressions ?? 0, newFlaky: bucket?.newFlaky ?? 0 };
+  });
+
+  const deltaPct =
+    hasPrevious && prevRegressions > 0
+      ? Math.round(((totalRegressions - prevRegressions) / prevRegressions) * 1000) / 10
+      : null;
+
+  return {
+    points: points.slice(firstNonEmptyIndex(points, (p) => p.regressions === 0 && p.newFlaky === 0)),
+    bucketDays: buckets.bucketDays,
+    totalRegressions,
+    totalNewFlaky,
+    prevRegressions: hasPrevious ? prevRegressions : null,
+    deltaPct,
+  };
+}

--- a/application/shared/handlers/analytics/slow-endpoints.ts
+++ b/application/shared/handlers/analytics/slow-endpoints.ts
@@ -1,0 +1,89 @@
+import { and, eq, gte, inArray, isNotNull } from 'drizzle-orm';
+import { networkRequests, testRuns } from '../../../server/database/schema';
+import type { DrizzleDB } from '../db';
+import type { AnalyticsScope } from '../../analytics/scope';
+import type { AnalyticsSlowEndpoints, AnalyticsSlowEndpointRow } from '../../analytics/types';
+import { percentile } from '../../utils/stats';
+import { periodStart, resolveAllowedProjects, TERMINAL_RUN_STATUSES, type ProjectAccess } from './common';
+
+const TOP_ENDPOINTS = 20;
+const MIN_REQUESTS = 3;
+
+/**
+ * Backend endpoints aggregated across every project's network captures —
+ * p50/p90 latency, error rate, and how many projects hit each route. A shared
+ * endpoint regressing shows up here before it's obvious in any single suite.
+ * `network_requests` is fully relational, so grouping by route is cheap.
+ */
+export async function getAnalyticsSlowEndpoints(
+  db: DrizzleDB,
+  scope: AnalyticsScope,
+  access: ProjectAccess = 'all',
+): Promise<AnalyticsSlowEndpoints> {
+  const allowed = resolveAllowedProjects(scope, access);
+  if (allowed !== 'all' && allowed.length === 0) return { endpoints: [], totalRequests: 0 };
+
+  const conditions = [
+    gte(testRuns.startTime, new Date(periodStart(scope.days))),
+    inArray(testRuns.status, TERMINAL_RUN_STATUSES),
+    isNotNull(networkRequests.duration),
+  ];
+  if (allowed !== 'all') conditions.push(inArray(testRuns.projectId, allowed));
+  if (scope.fullRunsOnly) conditions.push(eq(testRuns.isFullRun, 1));
+  if (scope.environment) conditions.push(eq(testRuns.environment, scope.environment));
+
+  const rows: any[] = await db
+    .select({
+      projectId: testRuns.projectId,
+      method: networkRequests.method,
+      route: networkRequests.normalizedUrl,
+      status: networkRequests.status,
+      duration: networkRequests.duration,
+    })
+    .from(networkRequests)
+    .innerJoin(testRuns, eq(networkRequests.testRunId, testRuns.id))
+    .where(and(...conditions));
+
+  interface Group {
+    durations: number[];
+    errors: number;
+    projects: Set<number>;
+  }
+  const groups = new Map<string, Group>();
+  for (const row of rows) {
+    const route = (row.route as string | null) || row.url || 'unknown';
+    const key = `${row.method} ${route}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = { durations: [], errors: 0, projects: new Set() };
+      groups.set(key, group);
+    }
+    group.durations.push(row.duration as number);
+    if ((row.status as number) >= 400) group.errors++;
+    group.projects.add(row.projectId);
+  }
+
+  const endpoints: AnalyticsSlowEndpointRow[] = [];
+  for (const [key, group] of groups) {
+    if (group.durations.length < MIN_REQUESTS) continue;
+    const spaceIndex = key.indexOf(' ');
+    const sorted = group.durations.slice().sort((a, b) => a - b);
+    endpoints.push({
+      method: key.slice(0, spaceIndex),
+      route: key.slice(spaceIndex + 1),
+      requests: group.durations.length,
+      p50Ms: percentile(sorted, 50),
+      p90Ms: percentile(sorted, 90),
+      maxMs: sorted[sorted.length - 1] ?? 0,
+      errorRate: Math.round((group.errors / group.durations.length) * 1000) / 10,
+      projectCount: group.projects.size,
+    });
+  }
+
+  endpoints.sort((a, b) => b.p90Ms - a.p90Ms || b.requests - a.requests);
+
+  return {
+    endpoints: endpoints.slice(0, TOP_ENDPOINTS),
+    totalRequests: rows.length,
+  };
+}

--- a/application/tests/analytics.spec.ts
+++ b/application/tests/analytics.spec.ts
@@ -5,6 +5,7 @@
  */
 import { test, expect } from './fixtures';
 import { PROJECT } from '#shared/test-project-names';
+import { ANALYTICS_WIDGETS } from '#shared/analytics/registry';
 
 test.describe.serial('Analytics API', () => {
   let projectId: number;
@@ -89,17 +90,10 @@ test.describe.serial('Analytics API', () => {
   });
 
   test('every registered widget responds', async ({ request }) => {
-    for (const widget of [
-      'insights',
-      'portfolio',
-      'pass-rate-heatmap',
-      'ci-time-trend',
-      'wasted-time',
-      'flaky-leaderboard',
-      'cluster-landscape',
-    ]) {
-      const response = await request.get(`/api/analytics/${widget}?days=7`);
-      expect(response.ok(), `widget ${widget} should respond`).toBeTruthy();
+    // Driven by the registry so a newly added widget is covered automatically.
+    for (const widget of ANALYTICS_WIDGETS) {
+      const response = await request.get(`/api/analytics/${widget.id}?days=7`);
+      expect(response.ok(), `widget ${widget.id} should respond`).toBeTruthy();
     }
   });
 });
@@ -115,6 +109,9 @@ test.describe('Analytics page', () => {
     await expect(page.getByRole('heading', { name: 'Wasted CI time' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Flakiest tests' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Failure clusters' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Regression velocity' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Browser matrix' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Slow endpoints' })).toBeVisible();
   });
 
   test('is reachable from the sidebar', async ({ page }) => {

--- a/application/tests/unit/analytics-handlers.test.ts
+++ b/application/tests/unit/analytics-handlers.test.ts
@@ -15,6 +15,9 @@ const { getAnalyticsPassRateHeatmap } = await import('../../shared/handlers/anal
 const { getAnalyticsCiTimeTrend } = await import('../../shared/handlers/analytics/ci-time-trend');
 const { getAnalyticsWastedTime } = await import('../../shared/handlers/analytics/wasted-time');
 const { getAnalyticsClusterLandscape } = await import('../../shared/handlers/analytics/cluster-landscape');
+const { getAnalyticsRegressionVelocity } = await import('../../shared/handlers/analytics/regression-velocity');
+const { getAnalyticsBrowserMatrix } = await import('../../shared/handlers/analytics/browser-matrix');
+const { getAnalyticsSlowEndpoints } = await import('../../shared/handlers/analytics/slow-endpoints');
 const { evaluateInsightRules } = await import('../../shared/analytics/insight-rules');
 const { parseAnalyticsScope } = await import('../../shared/analytics/scope');
 const { ANALYTICS_WIDGETS } = await import('../../shared/analytics/registry');
@@ -86,11 +89,59 @@ beforeAll(async () => {
   // Non-terminal run — never counted.
   await seedRun({ projectId: 2, daysAgo: 1, status: 'running' });
 
-  // Wasted time on project 1's latest failing run.
+  // Wasted time + regression signals + browser split on project 1's latest failing run.
   await db.insert(schema.testCases).values({ id: 1, projectId: 1, filePath: 'checkout.spec.ts', title: 'pays' });
-  await db.insert(schema.testRunsCases).values([
-    { testRunId: failingRunId, testCaseId: 1, status: 'failed', duration: 120_000, wastedTimeMs: 60_000 },
-    { testRunId: failingRunId, testCaseId: 1, status: 'passed', duration: 30_000, retries: 1, wastedTimeMs: 0 },
+  const insertedCases = await db
+    .insert(schema.testRunsCases)
+    .values([
+      {
+        testRunId: failingRunId,
+        testCaseId: 1,
+        status: 'failed',
+        duration: 120_000,
+        wastedTimeMs: 60_000,
+        browserName: 'chromium',
+        isNewRegression: 1,
+      },
+      {
+        testRunId: failingRunId,
+        testCaseId: 1,
+        status: 'passed',
+        duration: 30_000,
+        retries: 1,
+        wastedTimeMs: 0,
+        browserName: 'webkit',
+        isNewFlaky: 1,
+      },
+    ])
+    .returning({ id: schema.testRunsCases.id });
+
+  // Network requests captured on those executions — one slow shared endpoint.
+  await db.insert(schema.networkRequests).values([
+    {
+      testRunsCaseId: insertedCases[0]!.id,
+      testRunId: failingRunId,
+      method: 'GET',
+      normalizedUrl: '/api/cart',
+      status: 200,
+      duration: 1500,
+    },
+    {
+      testRunsCaseId: insertedCases[0]!.id,
+      testRunId: failingRunId,
+      method: 'GET',
+      normalizedUrl: '/api/cart',
+      status: 500,
+      duration: 2500,
+    },
+    {
+      testRunsCaseId: insertedCases[1]!.id,
+      testRunId: failingRunId,
+      method: 'GET',
+      normalizedUrl: '/api/cart',
+      status: 200,
+      duration: 1800,
+    },
   ]);
 
   // Clusters: one old open on project 1, one fresh open + one resolved on project 2.
@@ -332,9 +383,103 @@ describe('insight rules', () => {
       },
       clusters: { totalOpen: 0, resolvedInPeriod: 0, byErrorType: [], clusters: [] },
       flakyTests: [],
+      regressionVelocity: {
+        points: [],
+        bucketDays: 1,
+        totalRegressions: 0,
+        totalNewFlaky: 0,
+        prevRegressions: null,
+        deltaPct: null,
+      },
+      slowEndpoints: { endpoints: [], totalRequests: 0 },
     });
     expect(insights).toHaveLength(1);
     expect(insights[0]!.ruleId).toBe('ci-time-growth');
     expect(insights[0]!.severity).toBe('warning');
+  });
+
+  test('regression-surge and slow-shared-endpoint rules fire on their inputs', () => {
+    const insights = evaluateInsightRules({
+      scope: DEFAULT_SCOPE,
+      portfolio: [],
+      ciTime: {
+        points: [],
+        bucketDays: 1,
+        totalMinutes: 0,
+        runCount: 0,
+        prevTotalMinutes: null,
+        deltaPct: null,
+        avgRunMinutes: null,
+      },
+      wastedTime: { points: [], bucketDays: 1, totalWaitMinutes: 0, totalFailedExecMinutes: 0, byProject: [] },
+      clusters: { totalOpen: 0, resolvedInPeriod: 0, byErrorType: [], clusters: [] },
+      flakyTests: [],
+      regressionVelocity: {
+        points: [],
+        bucketDays: 1,
+        totalRegressions: 12,
+        totalNewFlaky: 3,
+        prevRegressions: 4,
+        deltaPct: 200,
+      },
+      slowEndpoints: {
+        endpoints: [
+          {
+            method: 'GET',
+            route: '/api/cart',
+            requests: 40,
+            p50Ms: 900,
+            p90Ms: 1800,
+            maxMs: 2500,
+            errorRate: 12.5,
+            projectCount: 3,
+          },
+        ],
+        totalRequests: 40,
+      },
+    });
+    const ruleIds = insights.map((i) => i.ruleId);
+    expect(ruleIds).toContain('regression-surge');
+    expect(ruleIds).toContain('slow-shared-endpoint');
+  });
+});
+
+describe('getAnalyticsRegressionVelocity', () => {
+  test('counts new regressions and newly-flaky executions', async () => {
+    const velocity = await getAnalyticsRegressionVelocity(db, DEFAULT_SCOPE, 'all');
+    expect(velocity.totalRegressions).toBe(1);
+    expect(velocity.totalNewFlaky).toBe(1);
+    expect(velocity.points.some((p) => p.regressions > 0)).toBe(true);
+  });
+});
+
+describe('getAnalyticsBrowserMatrix', () => {
+  test('builds a project × browser pass-rate grid', async () => {
+    const matrix = await getAnalyticsBrowserMatrix(db, DEFAULT_SCOPE, 'all');
+    expect(matrix.browsers).toEqual(['chromium', 'webkit']);
+    const checkout = matrix.rows.find((r) => r.projectId === 1)!;
+    const chromiumRate = checkout.cells[matrix.browsers.indexOf('chromium')];
+    const webkitRate = checkout.cells[matrix.browsers.indexOf('webkit')];
+    expect(chromiumRate).toBe(0); // the one chromium execution failed
+    expect(webkitRate).toBe(100); // the one webkit execution passed
+  });
+});
+
+describe('getAnalyticsSlowEndpoints', () => {
+  test('aggregates network requests by route with percentiles and error rate', async () => {
+    const slow = await getAnalyticsSlowEndpoints(db, DEFAULT_SCOPE, 'all');
+    expect(slow.totalRequests).toBe(3);
+    const cart = slow.endpoints.find((e) => e.route === '/api/cart')!;
+    expect(cart.method).toBe('GET');
+    expect(cart.requests).toBe(3);
+    expect(cart.maxMs).toBe(2500);
+    expect(cart.errorRate).toBeCloseTo(33.3, 1); // 1 of 3 was a 500
+    expect(cart.projectCount).toBe(1);
+  });
+
+  test('respects the access scope', async () => {
+    const slow = await getAnalyticsSlowEndpoints(db, DEFAULT_SCOPE, new Set([2]));
+    expect(slow.totalRequests).toBe(0);
+    expect(slow.endpoints).toEqual([]);
   });
 });

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -106,7 +106,10 @@ Everything above is scoped to one project. The **Analytics** page (`/analytics`)
 - **CI time** and **Wasted CI time** — how many CI minutes your runs consume, and how many of those produce no signal (wait steps + failed attempts).
 - **Flakiest tests** — the global flaky leaderboard across all projects, using the [impact ranking](#impact-ranking) above.
 - **Failure clusters** — open root causes across all projects, by age and occurrences.
-- **Insights** — an auto-generated, severity-ranked feed of the findings that matter (pass-rate drops, failing streaks, stale clusters, wasted time), each linking to the source.
+- **Regression velocity** — new regressions and newly-flaky tests introduced per period (see [Regression signals](#regression-signals)), so you can see whether quality debt is growing or shrinking.
+- **Browser matrix** — pass rate per project × browser, to catch browser-specific breakage.
+- **Slow endpoints** — the backend calls captured during tests, aggregated across all projects by route (p50/p90 latency, error rate, projects affected).
+- **Insights** — an auto-generated, severity-ranked feed of the findings that matter (pass-rate drops, failing streaks, stale clusters, wasted time, regression surges, slow shared endpoints), each linking to the source.
 
 Each widget is served by `GET /api/analytics/:widget` and computed by a shared handler in `shared/handlers/analytics/`, so the same numbers back the dashboard, the demo, and any future API consumer.
 

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -56,6 +56,9 @@ A cross-project decision view — where Home answers *"what's happening now"*, A
 - **Wasted CI time** — minutes that produced no signal: time inside wait steps plus time executing attempts that ended failed or timed out, split by project.
 - **Flakiest tests** — the worst flaky tests across all projects, using the same scoring as each project's Flaky tests tab, ranked by wasted-CI impact.
 - **Failure clusters** — open root causes across all projects, with age, occurrences, and error-type mix; the oldest unresolved cluster is highlighted.
+- **Regression velocity** — new regressions (tests that passed in a baseline and now fail) and newly-flaky tests introduced per period, as a stacked bar with the change vs the previous period. Rising bars mean quality debt is accumulating.
+- **Browser matrix** — pass rate per project × browser, so a suite that's green on one browser but failing on another stands out at a glance.
+- **Slow endpoints** — backend calls captured during tests, aggregated across all projects by route: p50/p90 latency, error rate, and how many projects hit each one, so a shared endpoint regressing surfaces before it's obvious in any single suite.
 
 The analytics surface is **widget-driven**: each widget is a registry entry (`shared/analytics/registry.ts`) backed by a shared handler (`shared/handlers/analytics/`) and served by one generic endpoint, `GET /api/analytics/:widget`. See [Flaky tests & analytics](./flaky-tests).
 


### PR DESCRIPTION
## What & why

Follow-up to the cross-project analytics dashboard (#269), extending it with three more widgets so the portfolio view answers more of the "across projects, over time" questions. Each widget was added the **extensible way** the platform was designed for — a registry entry, a shared handler, and a component — with **no change to the generic `GET /api/analytics/:widget` route or its demo mirror**. That the diff touches no routing code is the point: it demonstrates the registry works as intended.

New widgets:
- **Regression velocity** — new regressions (passed in a baseline, now failing) and newly-flaky tests introduced per period, from the existing `isNewRegression`/`isNewFlaky` columns, as a stacked bar with the change vs the previous equal-length period. Rising bars mean quality debt is accumulating.
- **Browser matrix** — pass rate per project × browser (scalar `browserName` column), so a suite that's green on one browser but red on another stands out at a glance.
- **Slow endpoints** — captured network requests aggregated across all projects by route (`normalized_url`): p50/p90/max latency, error rate, and how many projects hit each one. A shared backend regressing shows up here before it's obvious in any single suite.

Also adds two insight rules — **regression surge** and **slow shared endpoint** — that plug into the existing rule registry and feed the Insights widget.

All aggregation lives in `shared/handlers/analytics/`, so the same numbers back the server, the demo, and any future API consumer.

## How was it tested?

- **Unit** (`tests/unit/analytics-handlers.test.ts`): new cases for the three handlers (regression counts, project × browser grid, endpoint percentiles + error rate + access scoping) and the two new insight rules; the registry-dispatch test auto-covers the new widget ids. 22 pass.
- **Functional** (`tests/analytics.spec.ts`): the "every registered widget responds" test is now registry-driven (so new widgets are covered automatically) and the page test asserts the three new cards render. 7 pass.
- **Manual**: drove `/analytics` in a browser against seeded data — all three widgets render correctly, including the cross-project "N projects" aggregation on slow endpoints.
- `nuxt typecheck` and `oxlint` clean.

Note: in the bundled demo/dev seed the browser matrix shows a single "unknown" column because the seed doesn't populate the scalar `browserName`; the handler is correct and unit-tested with real browser data. Enriching the seed is a good follow-up.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated (`docs/ui-overview.md`, `docs/flaky-tests.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0118sVBbKxQW4PCzoHHJvHQR)_