### PR TITLE
refactor: reorganize test status grid and improve formatting

### DIFF
--- a/application/app/components/analytics/BrowserMatrix.vue
+++ b/application/app/components/analytics/BrowserMatrix.vue
@@ -48,7 +48,11 @@ function cellClass(rate: number | null): string {
         <tbody>
           <tr v-for="row in matrix.rows" :key="row.projectId">
             <td class="pr-2 max-w-[12rem]">
-              <NuxtLink :to="`/projects/${row.projectId}`" class="truncate hover:text-primary block" :title="row.label || row.name">
+              <NuxtLink
+                :to="`/projects/${row.projectId}`"
+                class="truncate hover:text-primary block"
+                :title="row.label || row.name"
+              >
                 {{ row.label || row.name }}
               </NuxtLink>
             </td>

--- a/application/app/components/analytics/SlowEndpointsTable.vue
+++ b/application/app/components/analytics/SlowEndpointsTable.vue
@@ -62,9 +62,13 @@ function methodColor(method: string): 'success' | 'info' | 'warning' | 'error' |
             <code class="text-xs truncate">{{ ep.route }}</code>
           </div>
           <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-            <span>p90 <span class="tabular-nums font-medium" :class="latencyClass(ep.p90Ms)">{{ ep.p90Ms }} ms</span></span>
+            <span
+              >p90 <span class="tabular-nums font-medium" :class="latencyClass(ep.p90Ms)">{{ ep.p90Ms }} ms</span></span
+            >
             <span>{{ ep.requests }} reqs · {{ ep.projectCount }} proj</span>
-            <span v-if="ep.errorRate > 0" class="text-red-600 dark:text-red-400 tabular-nums">{{ ep.errorRate }}% err</span>
+            <span v-if="ep.errorRate > 0" class="text-red-600 dark:text-red-400 tabular-nums"
+              >{{ ep.errorRate }}% err</span
+            >
           </div>
         </div>
       </div>
@@ -74,7 +78,9 @@ function methodColor(method: string): 'success' | 'info' | 'warning' | 'error' |
         <TableScroller min-width="44rem">
           <table class="w-full text-sm">
             <thead>
-              <tr class="text-left text-xs text-gray-500 uppercase tracking-wider border-b border-gray-200 dark:border-gray-800">
+              <tr
+                class="text-left text-xs text-gray-500 uppercase tracking-wider border-b border-gray-200 dark:border-gray-800"
+              >
                 <th class="py-2 pr-4 font-medium">Endpoint</th>
                 <th class="py-2 pr-4 font-medium text-right">Requests</th>
                 <th class="py-2 pr-4 font-medium text-right">p50</th>
@@ -94,7 +100,9 @@ function methodColor(method: string): 'success' | 'info' | 'warning' | 'error' |
                 </td>
                 <td class="py-2.5 pr-4 text-right tabular-nums">{{ ep.requests }}</td>
                 <td class="py-2.5 pr-4 text-right tabular-nums text-gray-500">{{ ep.p50Ms }} ms</td>
-                <td class="py-2.5 pr-4 text-right tabular-nums font-medium" :class="latencyClass(ep.p90Ms)">{{ ep.p90Ms }} ms</td>
+                <td class="py-2.5 pr-4 text-right tabular-nums font-medium" :class="latencyClass(ep.p90Ms)">
+                  {{ ep.p90Ms }} ms
+                </td>
                 <td class="py-2.5 pr-4 text-right tabular-nums text-gray-500">{{ ep.maxMs }} ms</td>
                 <td
                   class="py-2.5 pr-4 text-right tabular-nums"

--- a/application/app/components/run/RunSummary.vue
+++ b/application/app/components/run/RunSummary.vue
@@ -353,7 +353,7 @@ function onLabelKeydown(e: KeyboardEvent) {
               </div>
             </div>
 
-            <div class="grid grid-cols-3 sm:grid-cols-6 gap-2">
+            <div class="grid grid-cols-3 sm:grid-cols-5 gap-2">
               <button
                 class="rounded-lg p-3 text-left w-full transition-colors cursor-pointer"
                 :class="
@@ -368,20 +368,40 @@ function onLabelKeydown(e: KeyboardEvent) {
                   {{ displayProgress?.totalTests ?? testRun?.totalTests ?? 0 }}
                 </p>
               </button>
-              <button
-                class="rounded-lg p-3 text-left w-full transition-colors cursor-pointer"
-                :class="
-                  activeFilter === 'passed'
-                    ? 'bg-green-100 dark:bg-green-900/30 ring-2 ring-green-400 dark:ring-green-600'
-                    : 'bg-green-50 dark:bg-green-900/20 hover:bg-green-100 dark:hover:bg-green-900/30'
-                "
-                @click="emit('filter-status', 'passed')"
-              >
-                <p class="text-xs font-medium text-green-700 dark:text-green-400 uppercase tracking-wider">Passed</p>
-                <p class="text-xl font-bold mt-0.5 text-green-600 dark:text-green-400">
-                  {{ displayProgress?.passedTests ?? testRun?.passedTests ?? 0 }}
-                </p>
-              </button>
+              <!-- Passed cell hosts the flaky count as a corner badge: flaky tests are
+                   a subset of passed (they passed on retry), so they live "inside" Passed
+                   instead of taking their own column. Sibling buttons (not nested) keep the
+                   markup valid while giving each its own filter click + active highlight. -->
+              <div class="relative">
+                <button
+                  class="rounded-lg p-3 text-left w-full h-full transition-colors cursor-pointer"
+                  :class="
+                    activeFilter === 'passed'
+                      ? 'bg-green-100 dark:bg-green-900/30 ring-2 ring-green-400 dark:ring-green-600'
+                      : 'bg-green-50 dark:bg-green-900/20 hover:bg-green-100 dark:hover:bg-green-900/30'
+                  "
+                  @click="emit('filter-status', 'passed')"
+                >
+                  <p class="text-xs font-medium text-green-700 dark:text-green-400 uppercase tracking-wider">Passed</p>
+                  <p class="text-xl font-bold mt-0.5 text-green-600 dark:text-green-400">
+                    {{ displayProgress?.passedTests ?? testRun?.passedTests ?? 0 }}
+                  </p>
+                </button>
+                <button
+                  v-if="(testRun?.flakyTests ?? 0) > 0"
+                  class="absolute top-1.5 right-1.5 inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-semibold leading-none tabular-nums transition-colors cursor-pointer"
+                  :class="
+                    activeFilter === 'flaky'
+                      ? 'bg-orange-200 dark:bg-orange-800/60 text-orange-800 dark:text-orange-200 ring-2 ring-orange-400 dark:ring-orange-600'
+                      : 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300 hover:bg-orange-200 dark:hover:bg-orange-800/60'
+                  "
+                  title="Flaky — passed only after a retry (a subset of passed). Click to filter."
+                  @click="emit('filter-status', 'flaky')"
+                >
+                  <UIcon name="i-lucide-shuffle" class="size-3" />
+                  {{ testRun?.flakyTests ?? 0 }}
+                </button>
+              </div>
               <button
                 class="rounded-lg p-3 text-left w-full transition-colors cursor-pointer"
                 :class="
@@ -425,20 +445,6 @@ function onLabelKeydown(e: KeyboardEvent) {
                 </p>
                 <p class="text-xl font-bold mt-0.5 text-amber-600 dark:text-amber-400">
                   {{ testRun?.didNotRunTests ?? 0 }}
-                </p>
-              </button>
-              <button
-                class="rounded-lg p-3 text-left w-full transition-colors cursor-pointer"
-                :class="
-                  activeFilter === 'flaky'
-                    ? 'bg-orange-100 dark:bg-orange-900/30 ring-2 ring-orange-400 dark:ring-orange-600'
-                    : 'bg-orange-50 dark:bg-orange-900/20 hover:bg-orange-100 dark:hover:bg-orange-900/30'
-                "
-                @click="emit('filter-status', 'flaky')"
-              >
-                <p class="text-xs font-medium text-orange-700 dark:text-orange-400 uppercase tracking-wider">Flaky</p>
-                <p class="text-xl font-bold mt-0.5 text-orange-600 dark:text-orange-400">
-                  {{ testRun?.flakyTests ?? 0 }}
                 </p>
               </button>
             </div>

--- a/application/app/components/test-case/TestCaseNetworkRequests.vue
+++ b/application/app/components/test-case/TestCaseNetworkRequests.vue
@@ -346,8 +346,7 @@ function rowAccent(r: DecoratedRequest): string {
               <pre
                 v-if="stackOpen.has(`${req._index}:${li}`)"
                 class="mt-1 whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed text-gray-500 dark:text-gray-400 max-h-48 overflow-y-auto"
-                >{{ log.stack }}</pre
-              >
+                >{{ log.stack }}</pre>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What & why

This PR makes two main changes:

1. **Reorganize flaky test display in RunSummary**: Moves the flaky test count from a standalone grid column into a corner badge overlay on the "Passed" button. This better reflects the semantic relationship—flaky tests are a subset of passed tests (they passed on retry), so nesting them visually within the Passed cell is more intuitive. The grid is reduced from 6 to 5 columns on small screens to accommodate this change.

2. **Code formatting improvements**: Applies consistent line-wrapping and formatting across multiple Vue components (SlowEndpointsTable, BrowserMatrix, TestCaseNetworkRequests) for better readability and maintainability.

## How was it tested?

- Visual inspection of the grid layout change and badge positioning
- Existing component tests should continue to pass as the functionality remains the same, only the visual presentation has changed

## Checklist

- [x] PR title follows Conventional Commits
- [x] No new tests needed (refactor of existing UI layout)
- [x] No user-facing documentation changes required

https://claude.ai/code/session_01KUejYK3DGsfwfcf7G6XGnH