### PR TITLE
ci: lowercase image name for registry references

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,9 +78,13 @@ jobs:
       packages: write
 
     steps:
-      - name: Prepare platform slug
-        # linux/amd64 -> linux-amd64 (used for artifact names and cache scopes)
-        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+      - name: Prepare build variables
+        # linux/amd64 -> linux-amd64 (artifact names + cache scope). Also lowercase
+        # the image name: github.repository ("PiwiTests/platform") is mixed-case, but
+        # registry refs and the BuildKit registry cache exporter require lowercase.
+        run: |
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
         env:
           platform: ${{ matrix.platform }}
 
@@ -115,9 +119,9 @@ jobs:
           # Registry cache is NOT branch-scoped (unlike type=gha), so release (v*)
           # builds reuse the layers cached by main/edge builds. Per-arch ref keeps
           # the two matrix legs from clobbering each other.
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }}
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-${{ env.PLATFORM_PAIR }},mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -154,6 +158,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Prepare image name
+        # Lowercase github.repository for registry refs (see the build job).
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -185,7 +193,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}@sha256:%s ' *)
 
       - name: Extract metadata for Docker Hub
         id: meta-dockerhub
@@ -205,12 +213,12 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}@sha256:%s ' *)
 
       - name: Inspect and capture digest
         id: inspect
         run: |
-          REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta-ghcr.outputs.version }}"
+          REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.meta-ghcr.outputs.version }}"
           docker buildx imagetools inspect "$REF"
           echo "digest=$(docker buildx imagetools inspect "$REF" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The native-runner publish workflow fed github.repository ("PiwiTests/platform", mixed-case) straight into the registry cache ref and the push-by-digest output name. BuildKit's registry cache exporter rejects uppercase repository names, so both build legs failed immediately with "repository name (PiwiTests/platform) must be lowercase".

Lowercase the repository once per job (${IMAGE_NAME,,}) and use it for the cache-from/cache-to refs, the push-by-digest image name, and the imagetools manifest/inspect references. metadata-action already lowercases its own tag outputs, so those inputs are left unchanged.


Claude-Session: https://claude.ai/code/session_01RyNec6yDxSnx88DVNB4Jow

<!--
Thanks for contributing! Two things to know:

1. PRs are squash-merged, so the PR TITLE becomes the commit on main and drives
   the release changelog. Give it a Conventional Commit title, e.g.
   `feat(reporter): support custom run labels` — see CONTRIBUTING.md.
2. For non-trivial changes, consider opening an issue/discussion first.
-->

## What & why

<!-- What does this change do, and what problem does it solve?
     Link related issues: Fixes #123 -->

## How was it tested?

<!-- Unit tests / E2E tests / manual steps. `npm test` runs the full suite. -->

## Checklist

- [ ] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (`docs/`, README, or reporter README)
