### PR TITLE
feat(analytics): improve pass rate heatmap axis labels

### DIFF
--- a/application/app/components/analytics/PassRateHeatmap.vue
+++ b/application/app/components/analytics/PassRateHeatmap.vue
@@ -38,6 +38,45 @@ const subtitle = computed(() => {
   const bucketDays = heatmap.value?.bucketDays ?? 1;
   return bucketDays > 1 ? `One cell = ${bucketDays} days` : 'One cell = one day';
 });
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/** Long periods cross calendar years — label those ticks with the year, not the day. */
+const axisSpansYears = computed(() => {
+  const buckets = heatmap.value?.buckets ?? [];
+  return buckets.length > 1 && buckets[0]!.slice(0, 4) !== buckets[buckets.length - 1]!.slice(0, 4);
+});
+
+function formatBucket(iso: string): string {
+  const [year, month, day] = iso.split('-');
+  const monthName = MONTHS[Number(month) - 1];
+  return axisSpansYears.value ? `${monthName} ${year}` : `${monthName} ${Number(day)}`;
+}
+
+/**
+ * Evenly-spaced date ticks aligned to the cells they sit under, so the axis
+ * spans the whole selected period and you can read what each cell covers —
+ * instead of only labelling the two endpoints.
+ */
+const axisTicks = computed(() => {
+  const buckets = heatmap.value?.buckets ?? [];
+  const count = buckets.length;
+  if (count === 0) return [] as Array<{ index: number; label: string; left: number; transform: string }>;
+
+  const tickCount = Math.min(axisSpansYears.value ? 4 : 5, count);
+  const seen = new Set<number>();
+  const ticks: Array<{ index: number; label: string; left: number; transform: string }> = [];
+  for (let i = 0; i < tickCount; i++) {
+    const index = tickCount === 1 ? 0 : Math.round((i * (count - 1)) / (tickCount - 1));
+    if (seen.has(index)) continue;
+    seen.add(index);
+    // Pin the endpoints to the edges; center interior ticks over their cell.
+    const left = index === 0 ? 0 : index === count - 1 ? 100 : ((index + 0.5) / count) * 100;
+    const transform = index === 0 ? 'translateX(0)' : index === count - 1 ? 'translateX(-100%)' : 'translateX(-50%)';
+    ticks.push({ index, label: formatBucket(buckets[index]!), left, transform });
+  }
+  return ticks;
+});
 </script>
 
 <template>
@@ -51,13 +90,13 @@ const subtitle = computed(() => {
       </template>
     </ErrorState>
     <EmptyState v-else-if="!heatmap || heatmap.rows.length === 0" text="No runs in this period." />
-    <TableScroller v-else min-width="40rem">
+    <TableScroller v-else min-width="22rem">
       <div class="space-y-1">
         <div
           v-for="row in heatmap.rows"
           :key="row.projectId"
           class="grid items-center gap-2"
-          style="grid-template-columns: 10rem 1fr"
+          style="grid-template-columns: 8rem 1fr"
         >
           <NuxtLink
             :to="`/projects/${row.projectId}`"
@@ -76,11 +115,17 @@ const subtitle = computed(() => {
             />
           </div>
         </div>
-        <div class="grid gap-2" style="grid-template-columns: 10rem 1fr">
+        <div class="grid gap-2" style="grid-template-columns: 8rem 1fr">
           <span />
-          <div class="flex justify-between text-xs text-gray-400">
-            <span>{{ heatmap.buckets[0] }}</span>
-            <span>{{ heatmap.buckets[heatmap.buckets.length - 1] }}</span>
+          <div class="relative h-4">
+            <span
+              v-for="tick in axisTicks"
+              :key="tick.index"
+              class="absolute top-0 text-xs text-gray-400 whitespace-nowrap"
+              :style="{ left: `${tick.left}%`, transform: tick.transform }"
+            >
+              {{ tick.label }}
+            </span>
           </div>
         </div>
         <ChartLegend :items="legendItems" dense />

--- a/application/shared/analytics/registry.ts
+++ b/application/shared/analytics/registry.ts
@@ -23,18 +23,18 @@ export const ANALYTICS_WIDGETS = [
     id: 'insights',
     title: 'Insights',
     icon: 'i-lucide-lightbulb',
-    size: 'full',
-  },
-  {
-    id: 'portfolio',
-    title: 'Portfolio health',
-    icon: 'i-lucide-table-properties',
-    size: 'full',
+    size: 'half',
   },
   {
     id: 'pass-rate-heatmap',
     title: 'Pass rate heatmap',
     icon: 'i-lucide-grid-3x3',
+    size: 'half',
+  },
+  {
+    id: 'portfolio',
+    title: 'Portfolio health',
+    icon: 'i-lucide-table-properties',
     size: 'full',
   },
   {

--- a/application/shared/handlers/analytics/pass-rate-heatmap.ts
+++ b/application/shared/handlers/analytics/pass-rate-heatmap.ts
@@ -1,5 +1,5 @@
 import type { DrizzleDB } from '../db';
-import type { AnalyticsScope } from '../../analytics/scope';
+import { MAX_ANALYTICS_DAYS, type AnalyticsScope } from '../../analytics/scope';
 import type { AnalyticsHeatmap } from '../../analytics/types';
 import {
   fetchScopedProjects,
@@ -57,11 +57,17 @@ export async function getAnalyticsPassRateHeatmap(
     .filter((row) => row.cells.some((c) => c !== null))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  // Trim leading all-empty columns so "All time" starts at the first real data.
-  const firstDataIndex = firstNonEmptyIndex(
-    buckets.keys.map((_, index) => index),
-    (index) => rows.every((row) => row.cells[index] === null),
-  );
+  // Bounded periods render the whole window the user selected, so the axis
+  // always spans the full period. Only the unbounded "All time" window trims its
+  // leading all-empty columns — otherwise it would show years of blank buckets
+  // before the first real data.
+  const firstDataIndex =
+    scope.days >= MAX_ANALYTICS_DAYS
+      ? firstNonEmptyIndex(
+          buckets.keys.map((_, index) => index),
+          (index) => rows.every((row) => row.cells[index] === null),
+        )
+      : 0;
 
   return {
     buckets: buckets.keys.slice(firstDataIndex),

--- a/application/tests/unit/analytics-handlers.test.ts
+++ b/application/tests/unit/analytics-handlers.test.ts
@@ -19,7 +19,7 @@ const { getAnalyticsRegressionVelocity } = await import('../../shared/handlers/a
 const { getAnalyticsBrowserMatrix } = await import('../../shared/handlers/analytics/browser-matrix');
 const { getAnalyticsSlowEndpoints } = await import('../../shared/handlers/analytics/slow-endpoints');
 const { evaluateInsightRules } = await import('../../shared/analytics/insight-rules');
-const { parseAnalyticsScope } = await import('../../shared/analytics/scope');
+const { parseAnalyticsScope, MAX_ANALYTICS_DAYS } = await import('../../shared/analytics/scope');
 const { ANALYTICS_WIDGETS } = await import('../../shared/analytics/registry');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -273,12 +273,12 @@ describe('getAnalyticsPortfolio', () => {
 });
 
 describe('getAnalyticsPassRateHeatmap', () => {
-  test('buckets pass rates per project and drops run-less projects', async () => {
+  test('buckets pass rates over the full selected window and drops run-less projects', async () => {
     const heatmap = await getAnalyticsPassRateHeatmap(db, DEFAULT_SCOPE, 'all');
     expect(heatmap.bucketDays).toBe(1);
-    // Leading all-empty columns are trimmed: the oldest seeded run is 10 days old.
-    expect(heatmap.buckets.length).toBeLessThanOrEqual(30);
-    expect(heatmap.rows.some((r) => r.cells[0] !== null)).toBe(true);
+    // Bounded periods render the whole window, so the axis always spans the full
+    // 30 days the user selected — even though the oldest seeded run is 10 days old.
+    expect(heatmap.buckets.length).toBe(30);
     expect(heatmap.rows.map((r) => r.projectId).sort()).toEqual([1, 2]);
 
     const checkout = heatmap.rows.find((r) => r.projectId === 1)!;
@@ -291,6 +291,17 @@ describe('getAnalyticsPassRateHeatmap', () => {
     const heatmap = await getAnalyticsPassRateHeatmap(db, parseAnalyticsScope({ days: '365' }), 'all');
     expect(heatmap.bucketDays).toBeGreaterThan(1);
     expect(heatmap.buckets.length).toBeLessThanOrEqual(32);
+  });
+
+  test('trims leading empty buckets only for the unbounded All time window', async () => {
+    const heatmap = await getAnalyticsPassRateHeatmap(
+      db,
+      parseAnalyticsScope({ days: String(MAX_ANALYTICS_DAYS) }),
+      'all',
+    );
+    // All seeded runs are recent, so the years of leading blank buckets are
+    // dropped and the first rendered column already carries data.
+    expect(heatmap.rows.some((r) => r.cells[0] !== null)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What & why

Improves the pass rate heatmap visualization with better date axis labeling:

1. **Evenly-spaced axis ticks**: Replaces the simple start/end date labels with 4-5 evenly-distributed date ticks that align with the cells they represent, making it easier to read what each cell covers across the full selected period.

2. **Smart date formatting**: Formats dates based on the time span:
   - For periods spanning multiple years: shows "Month Year" (e.g., "Jan 2024")
   - For single-year periods: shows "Month Day" (e.g., "Jan 15")

3. **Bounded vs unbounded period handling**: 
   - Bounded periods (e.g., "Last 30 days") now render the entire selected window, so the axis always spans the full period the user chose
   - Only the unbounded "All time" window trims leading empty buckets to avoid showing years of blank data before the first real data point

4. **Layout improvements**: Reduces the fixed project name column width from 10rem to 8rem and minimum table width from 40rem to 22rem to better accommodate the improved axis.

5. **Widget reordering**: Moves the pass rate heatmap widget to appear alongside insights (both "half" size) before the portfolio health widget.

## How was it tested?

- Updated unit tests in `analytics-handlers.test.ts` to reflect the new behavior where bounded periods render the full selected window
- Added new test case for the unbounded "All time" window to verify leading empty buckets are still trimmed in that case
- Existing test coverage validates the bucketing logic and project filtering

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added/updated for behavior changes
- [ ] Docs updated (N/A - internal analytics UI improvement)

https://claude.ai/code/session_01F1SS5RNKsuKXeeh8jt6LVn