### PR TITLE
fix(app): show a loading state on the project Performance tab

### DIFF
--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -947,7 +947,7 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
             </div>
 
             <ChartCard title="Performance trend" subtitle="Duration metrics over time" help="project.performance">
-              <LoadingState v-if="performanceInitialLoading" text="Loading performance trend…" />
+              <LoadingState v-if="performanceInitialLoading" text="Loading chart…" />
               <PerformanceTrendChart
                 v-else
                 :data="performanceData || []"
@@ -965,7 +965,7 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
                 <p class="text-sm text-gray-600 mt-1">Top 20 slowest test cases across recent runs</p>
               </template>
 
-              <LoadingState v-if="slowTestsLoading && slowTests === null" text="Loading slowest tests…" />
+              <LoadingState v-if="slowTestsLoading && slowTests === null" text="Loading…" />
 
               <UTable
                 v-else-if="slowTests && slowTests.length > 0"

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -417,13 +417,25 @@ const performanceQueryParams = computed(() => {
 
 // Only fetch when the trends tab is active; re-fetch when date filters change
 const performanceData = ref<PerformanceTrendPoint[] | null>(null);
+const performanceLoading = ref(false);
 const slowTests = ref<SlowTest[] | null>(null);
 const slowTestsError = ref(false);
+const slowTestsLoading = ref(false);
+
+// Show a loading state — not the chart's "no data" empty message — until the first
+// fetch settles. Without this, a refresh on ?tab=performance renders the empty state
+// while the async fetch is still in flight, so the tab reads as if it loaded broken.
+const performanceInitialLoading = computed(() => performanceLoading.value && performanceData.value === null);
 
 watch(
   [activeTab, performanceQueryParams, fullRunsOnly],
   async ([tab, params]) => {
     if (tab !== 'performance') return;
+    performanceLoading.value = true;
+    if (!slowTests.value) slowTestsLoading.value = true;
+    // The fetch result isn't awaited into the SSR render, so skip the wasted server
+    // round-trip; the immediate run on the client performs it (SSR still shows the loader).
+    if (import.meta.server) return;
     const qs = new URLSearchParams(params as Record<string, string>).toString();
     const fullParam = fullRunsOnly.value ? `${qs ? '&' : ''}fullRunsOnly=true` : '';
     const queryString = qs || fullParam ? `?${qs}${fullParam}` : '';
@@ -433,13 +445,15 @@ watch(
       console.warn('[PerformanceTab] Failed to fetch performance trend:', err);
       return null;
     });
-    if (!slowTests.value) {
+    performanceLoading.value = false;
+    if (slowTestsLoading.value) {
       slowTestsError.value = false;
       slowTests.value = await $fetch<SlowTest[]>(`/api/projects/${projectId}/slow-tests`).catch((err) => {
         slowTestsError.value = true;
         console.warn('[PerformanceTab] Failed to fetch slow tests:', err);
         return null;
       });
+      slowTestsLoading.value = false;
     }
   },
   { immediate: true },
@@ -933,7 +947,9 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
             </div>
 
             <ChartCard title="Performance trend" subtitle="Duration metrics over time" help="project.performance">
+              <LoadingState v-if="performanceInitialLoading" text="Loading performance trend…" />
               <PerformanceTrendChart
+                v-else
                 :data="performanceData || []"
                 :height="350"
                 :markers="visibleMarkers"
@@ -949,8 +965,10 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
                 <p class="text-sm text-gray-600 mt-1">Top 20 slowest test cases across recent runs</p>
               </template>
 
+              <LoadingState v-if="slowTestsLoading && slowTests === null" text="Loading slowest tests…" />
+
               <UTable
-                v-if="slowTests && slowTests.length > 0"
+                v-else-if="slowTests && slowTests.length > 0"
                 :data="slowTests"
                 :columns="slowTestsColumns"
                 :ui="{
@@ -980,6 +998,10 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
                   <span v-else class="text-gray-500">&mdash; Stable</span>
                 </template>
               </UTable>
+
+              <div v-else-if="slowTestsError" class="text-center py-8 text-red-500">
+                Couldn't load the slowest tests — try refreshing.
+              </div>
 
               <div v-else class="text-center py-8 text-gray-500">No slow test data available yet.</div>
             </UCard>


### PR DESCRIPTION
Refreshing a project on ?tab=performance rendered the chart's "No performance data available" empty state (and "No slow test data available yet") while the tab's data was still being fetched, so the tab looked like it had loaded broken.

The data loads from a `watch([activeTab, …], …, { immediate: true })`. That fires on tab *change* (clicking in looked fine), but on a refresh its initial run raced the first render: `performanceData` was still null, so the chart was handed `[]` and showed its empty message.

Distinguish loading from empty — track `performanceLoading`/`slowTestsLoading` and render `<LoadingState>` until the first fetch settles, with an explicit error branch for the slow-tests table. Also skip the immediate run's fetch on the server (its result isn't awaited into the SSR render anyway), so SSR shows the loader and the client performs the fetch.


Claude-Session: https://claude.ai/code/session_01KMeKiYa5F1adsaaLiqnaeM

<!--
Thanks for contributing! Two things to know:

1. PRs are squash-merged, so the PR TITLE becomes the commit on main and drives
   the release changelog. Give it a Conventional Commit title, e.g.
   `feat(reporter): support custom run labels` — see CONTRIBUTING.md.
2. For non-trivial changes, consider opening an issue/discussion first.
-->

## What & why

<!-- What does this change do, and what problem does it solve?
     Link related issues: Fixes #123 -->

## How was it tested?

<!-- Unit tests / E2E tests / manual steps. `npm test` runs the full suite. -->

## Checklist

- [ ] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (`docs/`, README, or reporter README)
