### PR TITLE
feat(reporter): publish the dashboard run URL to CI runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ Nuxt file-based routing:
   - `files/` — `file-handler.ts`, `compression.ts`
   - `capture/` — `capture-fixtures.ts` (Playwright fixtures for network/web-vitals/console/locator capture; runs in the worker), `locator-healing.ts` (re-exports the pure generation/scoring/types from `@piwitests/core`, and keeps the reporter-only runtime: `captureCallerLocation`, snapshot dedupe, the fixture-proxy method surface, and `suggestLocatorsFromAria`'s same-style rendering), `attachments.ts` (the `piwi-*` attachment names)
   - `config/env.ts` — `PIWI_ENV_KEYS`, `resolveOptions`, `applyOptionsToEnv` (the `PIWI_*` ↔ option map)
-  - `support/` — `logger.ts` (`Logger`), `errors.ts` (`errorMessage`), `instance-id.ts`, `setup-file.ts`, `source-snippet.ts`, `cli-filters.ts`, `worker-index.ts`, `ci.ts`, `limiter.ts`
+  - `support/` — `logger.ts` (`Logger`), `errors.ts` (`errorMessage`), `instance-id.ts`, `setup-file.ts`, `source-snippet.ts`, `cli-filters.ts`, `worker-index.ts`, `ci.ts`, `run-url.ts`, `ci-output.ts` (`emitRunOutputs`: surfaces the dashboard run URL to CI after submit — universal JSON `outputFile`, GitHub Actions `$GITHUB_OUTPUT`/step-summary/annotation, GitLab dotenv report), `limiter.ts`
 - **`reporter/src/types/`** — `wire.ts` (EXTERNAL server contract; leaf shapes re-exported from `@piwitests/core/wire`, the per-case `WireTestCase`/stream union kept here and pinned to the server payloads by `wire-shared-drift.test.ts`) and `collected.ts` (INTERNAL in-process model); `reporter/src/types.ts` is a barrel over both
 - `reporter/package.json` — NPM package
 - Source is TypeScript (`.ts` in `src/`); compile with `npm run reporter:build` to produce `.js` + `.d.ts` in `dist/`

--- a/reporter/ARCHITECTURE.md
+++ b/reporter/ARCHITECTURE.md
@@ -77,8 +77,8 @@ src/
     files/      file-handler, compression
     capture/    capture-fixtures, locator-healing, attachments   ← runs in the worker
     config/     env (PIWI_* ↔ options)
-    support/    logger, limiter, ci, instance-id, cli-filters, setup-file,
-                source-snippet, worker-index, errors
+    support/    logger, limiter, ci, ci-output, run-url, instance-id,
+                cli-filters, setup-file, source-snippet, worker-index, errors
   types/
     wire.ts        EXTERNAL server contract
     collected.ts   INTERNAL in-process model

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -92,6 +92,7 @@ export default defineConfig({
 | `collectScmInfo`            | boolean  | `true`                    | Auto-collect git commit, branch, author                                |
 | `collectCiInfo`             | boolean  | `true`                    | Auto-collect CI environment info                                       |
 | `collectPerformanceMetrics` | boolean  | `true`                    | Collect step timings, network requests and web vitals from the fixture |
+| `outputFile`                | string   | —                         | Write a JSON file with the run URL/id/status so CI can consume it (see below) |
 | `apiKey`                    | string   | —                         | API key for authentication (preferred for CI)                          |
 | `username`                  | string   | —                         | Username for dashboard login (use `apiKey` instead when possible)      |
 | `password`                  | string   | —                         | Password for dashboard login (used with `username`)                    |
@@ -208,6 +209,51 @@ When `collectCiInfo` is enabled (default), the reporter auto-detects:
 - **CircleCI** — build number/URL, job name, workflow
 - **Travis CI** — build number/URL, job number
 - **Azure Pipelines** — build number, build ID/URL, job name
+
+## Publishing the run URL to CI
+
+After a run is submitted, the reporter surfaces the dashboard run URL so a later
+CI step (a custom email, a Slack message, a deploy gate) can pick it up without
+scraping the log. The URL is always printed as `View run: <url>`, and in
+addition:
+
+- **Any CI — JSON output file.** Set `outputFile` (or `PIWI_OUTPUT_FILE`) and the
+  reporter writes a small JSON file when the run lands:
+
+  ```json
+  { "runUrl": "https://piwi.example.com/test-runs/1234", "runId": 1234, "projectId": 5, "projectName": "checkout", "status": "passed", "ciBuildUrl": "https://ci.example.com/build/9" }
+  ```
+
+  Read it from any pipeline, e.g. `node -e "console.log(require('./piwi-run.json').runUrl)"`
+  (portable) or `cat piwi-run.json` and parse it in your email step. In Jenkins,
+  `def run = readJSON file: 'piwi-run.json'` then use `run.runUrl`.
+
+- **GitHub Actions (automatic).** When `GITHUB_ACTIONS` is set, the reporter
+  appends step outputs to `$GITHUB_OUTPUT` (`piwi_run_url`, `piwi_run_id`,
+  `piwi_project_id`, `piwi_run_status`), writes a markdown link to the job
+  summary, and prints a `::notice::` annotation. Give the test step an `id` and a
+  downstream step can read it:
+
+  ```yaml
+  - id: tests
+    run: npx playwright test
+  - run: echo "Results at ${{ steps.tests.outputs.piwi_run_url }}"
+  ```
+
+- **GitLab CI (automatic).** When `GITLAB_CI` is set, the reporter writes a
+  dotenv report (`piwi.env` by default, override with `PIWI_DOTENV_FILE`).
+  Declare it so later jobs inherit `$PIWI_RUN_URL`:
+
+  ```yaml
+  test:
+    script: npx playwright test
+    artifacts:
+      reports:
+        dotenv: piwi.env
+  email:
+    needs: [test]
+    script: ./send-email.sh "$PIWI_RUN_URL"
+  ```
 
 ## How It Works
 

--- a/reporter/src/internal/config/env.ts
+++ b/reporter/src/internal/config/env.ts
@@ -49,6 +49,7 @@ export const PIWI_ENV_KEYS = {
   capturePageState: 'PIWI_CAPTURE_PAGE_STATE',
   inspectOnFailure: 'PIWI_INSPECT_ON_FAIL',
   pickLocatorOnFailure: 'PIWI_PICK_LOCATOR_ON_FAIL',
+  outputFile: 'PIWI_OUTPUT_FILE',
 } as const;
 
 function readBool(val: string | undefined): boolean | undefined {
@@ -96,6 +97,7 @@ const ENV_FALLBACK_SPECS: ReadonlyArray<{
   { option: 'capturePageState', env: PIWI_ENV_KEYS.capturePageState, kind: 'bool' },
   { option: 'inspectOnFailure', env: PIWI_ENV_KEYS.inspectOnFailure, kind: 'bool' },
   { option: 'pickLocatorOnFailure', env: PIWI_ENV_KEYS.pickLocatorOnFailure, kind: 'bool' },
+  { option: 'outputFile', env: PIWI_ENV_KEYS.outputFile, kind: 'string' },
 ];
 
 /**

--- a/reporter/src/internal/submit/run-submitter.ts
+++ b/reporter/src/internal/submit/run-submitter.ts
@@ -10,7 +10,19 @@ import { Logger } from '../support/logger.js';
 import { computePerformanceSummary } from '../collect/step-analyzer.js';
 import { resolveOverallStatus, serializeRun } from './serializer.js';
 import { runUrl } from '../support/run-url.js';
+import { emitRunOutputs, ciBuildUrlFromMetadata, type RunOutput } from '../support/ci-output.js';
 import type { CollectedTestCase, SetupStep, FilterDetails } from '../../types.js';
+
+/**
+ * Result of one rung of the submit ladder. `done` stops the ladder (the run
+ * landed, or the last rung was reached); `output` carries the run identity to
+ * surface to CI, and is `null` when a rung failed or the server returned no run
+ * id.
+ */
+interface SubmitOutcome {
+  done: boolean;
+  output: RunOutput | null;
+}
 
 /**
  * Snapshot of everything the reporter has collected by `onEnd`, handed off to
@@ -98,15 +110,39 @@ export class RunSubmitter {
       throw error;
     }
 
+    let outcome: SubmitOutcome = { done: false, output: null };
+
     if (sm?.enabled && sm?.runId != null) {
-      if (await this.tryFinishStreaming(run, overallStatus, duration, auth)) return;
+      outcome = await this.tryFinishStreaming(run, overallStatus, duration, auth);
     }
 
-    if (this.hasReports(run) || run.options.uploadTraces) {
-      if (await this.tryUploadWithFiles(run, overallStatus, duration, auth)) return;
+    if (!outcome.done && (this.hasReports(run) || run.options.uploadTraces)) {
+      outcome = await this.tryUploadWithFiles(run, overallStatus, duration, auth);
     }
 
-    await this.tryUploadJSON(run, overallStatus, duration, auth);
+    if (!outcome.done) {
+      outcome = await this.tryUploadJSON(run, overallStatus, duration, auth);
+    }
+
+    if (outcome.output) emitRunOutputs(outcome.output, this.logger, run.options.outputFile);
+  }
+
+  /** Assemble a CI-facing run output, or `null` when the server returned no run id. */
+  private buildOutput(
+    runId: number | string | undefined,
+    projectId: number | string | undefined,
+    run: CollectedRun,
+    status: string,
+  ): RunOutput | null {
+    if (runId == null) return null;
+    return {
+      runUrl: runUrl(this.httpClient.baseUrl, runId),
+      runId,
+      projectId,
+      projectName: run.options.projectName!,
+      status,
+      ciBuildUrl: ciBuildUrlFromMetadata(run.metadata),
+    };
   }
 
   private hasReports(run: CollectedRun): boolean {
@@ -153,7 +189,7 @@ export class RunSubmitter {
     overallStatus: string,
     duration: number,
     auth: string | null,
-  ): Promise<boolean> {
+  ): Promise<SubmitOutcome> {
     const sm = this.streamManager!;
     try {
       const flakyTests = run.testCases.filter((tc) => tc.status === 'passed' && (tc.retries || 0) > 0).length;
@@ -190,9 +226,6 @@ export class RunSubmitter {
       await this.httpClient.postJSON(`/api/test-runs/${sm.runId}/finish`, finishBody, auth);
 
       this.logger.info(`Successfully finalized streaming run #${sm.runId}`);
-      if (run.options.serverUrl) {
-        this.logger.info(`View run: ${runUrl(run.options.serverUrl, sm.runId!)}`);
-      }
       this.recovery.clear();
 
       if (this.hasReports(run)) {
@@ -208,11 +241,11 @@ export class RunSubmitter {
           this.logger.warn(`Failed to upload reports for streaming run: ${errorMessage(error)}`);
         }
       }
-      return true;
+      return { done: true, output: this.buildOutput(sm.runId!, undefined, run, overallStatus) };
     } catch (error) {
       this.logger.warn(`Failed to finalize streaming run: ${errorMessage(error)}`);
       this.logger.info('Falling back to batch upload...');
-      return false;
+      return { done: false, output: null };
     }
   }
 
@@ -221,15 +254,15 @@ export class RunSubmitter {
     overallStatus: string,
     duration: number,
     auth: string | null,
-  ): Promise<boolean> {
+  ): Promise<SubmitOutcome> {
     try {
-      await this.uploader.uploadWithFiles(
+      const response = await this.uploader.uploadWithFiles(
         this.buildRunPayload(run, overallStatus, duration),
         this.reportOptions(run),
         auth,
       );
       this.recovery.clear();
-      return true;
+      return { done: true, output: this.buildOutput(response?.testRunId, response?.projectId, run, overallStatus) };
     } catch (error) {
       if (error instanceof HttpError && error.status === 401 && !auth) {
         this.logAuthRequired(run.options.serverUrl);
@@ -237,7 +270,7 @@ export class RunSubmitter {
       }
       this.logger.warn(`Failed to upload with files: ${errorMessage(error)}`);
       this.logger.info('Falling back to JSON upload...');
-      return false;
+      return { done: false, output: null };
     }
   }
 
@@ -246,11 +279,12 @@ export class RunSubmitter {
     overallStatus: string,
     duration: number,
     auth: string | null,
-  ): Promise<void> {
+  ): Promise<SubmitOutcome> {
     const payload = this.buildRunPayload(run, overallStatus, duration);
     try {
-      await this.uploader.uploadJSON(payload, auth);
+      const response = await this.uploader.uploadJSON(payload, auth);
       this.recovery.clear();
+      return { done: true, output: this.buildOutput(response?.testRunId, response?.projectId, run, overallStatus) };
     } catch (error) {
       // If the server returned 401 and no auth was configured, this is a
       // configuration error — throw so the caller knows it's fatal.
@@ -266,6 +300,8 @@ export class RunSubmitter {
       // Save the wire-serialized form so the recovery file matches the
       // original submit payload (no raw attachments / internal fields).
       this.recovery.save(serializeRun(payload, { includeTestCases: true }));
+      // The ladder is exhausted; nothing to surface to CI.
+      return { done: true, output: null };
     }
   }
 

--- a/reporter/src/internal/submit/uploader.ts
+++ b/reporter/src/internal/submit/uploader.ts
@@ -6,7 +6,6 @@ import { HttpError } from '../transport/http-client.js';
 import type { FileHandler } from '../files/file-handler.js';
 import { Logger } from '../support/logger.js';
 import { serializeRun, toWireTestCase } from './serializer.js';
-import { runUrl } from '../support/run-url.js';
 import type { CollectedTestCase, TraceHashInfo, FilterDetails } from '../../types.js';
 
 /** Payload for a batch test-run submission */
@@ -90,7 +89,6 @@ export class Uploader {
     this.logger.info(`Successfully uploaded test results`);
     if (response.testRunId) {
       this.logger.info(`Test Run ID: ${response.testRunId}, Project ID: ${response.projectId}`);
-      this.logger.info(`View run: ${runUrl(this.httpClient.baseUrl, response.testRunId)}`);
     }
     return response;
   }
@@ -109,7 +107,6 @@ export class Uploader {
     this.logger.info(`Successfully uploaded test results with files`);
     if (response.testRunId) {
       this.logger.info(`Test Run ID: ${response.testRunId}, Project ID: ${response.projectId}`);
-      this.logger.info(`View run: ${runUrl(this.httpClient.baseUrl, response.testRunId)}`);
     }
     if (response.reports) {
       for (const r of response.reports) this.logger.info(`${r.label}: ${r.path}`);

--- a/reporter/src/internal/support/ci-output.ts
+++ b/reporter/src/internal/support/ci-output.ts
@@ -1,0 +1,141 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Logger } from './logger.js';
+import { errorMessage } from './errors.js';
+
+/**
+ * The facts about a just-submitted run that CI pipelines want to consume: the
+ * clickable dashboard URL plus the identifiers and status behind it. Produced by
+ * the submit ladder once a run lands, and rendered into CI-native channels by
+ * `emitRunOutputs`.
+ */
+export interface RunOutput {
+  /** Clickable dashboard URL for the run (`<serverUrl>/test-runs/<id>`). */
+  runUrl: string;
+  /** Dashboard run id. */
+  runId: number | string;
+  /** Dashboard project id, when the submit response carried one. */
+  projectId?: number | string | null;
+  /** Project name the run was reported under. */
+  projectName: string;
+  /** Overall run status (`"passed"` / `"failed"`). */
+  status: string;
+  /** Link back to the CI build/job that produced the run, when detected. */
+  ciBuildUrl?: string | null;
+}
+
+/**
+ * Surface the dashboard run URL wherever a CI pipeline can pick it up, so a
+ * downstream step (a custom email, a Slack post, a deploy gate) can consume it
+ * without scraping the reporter's stdout.
+ *
+ * Layered, best-effort — a failure in any channel is logged and swallowed so it
+ * never fails the run:
+ *  1. Always logs `View run: <url>` for a human reading the CI log.
+ *  2. `outputFile` (opt-in): a portable JSON file every CI can read
+ *     (`cat piwi-run.json`, Jenkins `readJSON`, etc.).
+ *  3. GitHub Actions (auto): step outputs on `$GITHUB_OUTPUT`
+ *     (`steps.<id>.outputs.piwi_run_url`), a markdown link on
+ *     `$GITHUB_STEP_SUMMARY`, and a `::notice::` workflow annotation.
+ *  4. GitLab CI (auto): a dotenv report file (default `piwi.env`) to be wired as
+ *     `artifacts:reports:dotenv:` so later jobs inherit `$PIWI_RUN_URL`.
+ */
+export function emitRunOutputs(
+  output: RunOutput,
+  logger: Logger,
+  outputFile?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  logger.info(`View run: ${output.runUrl}`);
+
+  if (outputFile) writeOutputFile(outputFile, output, logger);
+  if (env.GITHUB_ACTIONS) emitGitHubActions(output, env, logger);
+  if (env.GITLAB_CI) emitGitLabDotenv(output, env, logger);
+}
+
+/** Portable machine-readable output: a JSON file readable by any CI system. */
+function writeOutputFile(file: string, output: RunOutput, logger: Logger): void {
+  try {
+    const dir = path.dirname(file);
+    if (dir && dir !== '.') fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify(
+        {
+          runUrl: output.runUrl,
+          runId: output.runId,
+          projectId: output.projectId ?? null,
+          projectName: output.projectName,
+          status: output.status,
+          ciBuildUrl: output.ciBuildUrl ?? null,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    logger.info(`Wrote run output to ${file}`);
+  } catch (error) {
+    logger.warn(`Failed to write run output file '${file}': ${errorMessage(error)}`);
+  }
+}
+
+/** GitHub Actions: step outputs, a job-summary link, and a workflow annotation. */
+function emitGitHubActions(output: RunOutput, env: NodeJS.ProcessEnv, logger: Logger): void {
+  const pairs: Array<[string, string]> = [
+    ['piwi_run_url', output.runUrl],
+    ['piwi_run_id', String(output.runId)],
+    ['piwi_run_status', output.status],
+  ];
+  if (output.projectId != null) pairs.push(['piwi_project_id', String(output.projectId)]);
+
+  // Values are single-line (URL / id / status), so the plain `key=value` form is
+  // safe — no heredoc delimiter needed.
+  if (env.GITHUB_OUTPUT) {
+    appendFileLines(
+      env.GITHUB_OUTPUT,
+      pairs.map(([k, v]) => `${k}=${v}`),
+      logger,
+      'step output',
+    );
+  }
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendFileLines(
+      env.GITHUB_STEP_SUMMARY,
+      ['### Piwi test run', '', `[View run](${output.runUrl}) — **${output.status}**`, ''],
+      logger,
+      'step summary',
+    );
+  }
+  // A workflow annotation must be a bare stdout line (no logger prefix).
+  process.stdout.write(`::notice title=Piwi test run::${output.runUrl}\n`);
+}
+
+/** GitLab CI: a dotenv report file so later jobs inherit the run URL as a variable. */
+function emitGitLabDotenv(output: RunOutput, env: NodeJS.ProcessEnv, logger: Logger): void {
+  const file = env.PIWI_DOTENV_FILE || 'piwi.env';
+  const lines = [`PIWI_RUN_URL=${output.runUrl}`, `PIWI_RUN_ID=${output.runId}`, `PIWI_RUN_STATUS=${output.status}`];
+  if (output.projectId != null) lines.push(`PIWI_PROJECT_ID=${output.projectId}`);
+  if (output.ciBuildUrl) lines.push(`PIWI_CI_BUILD_URL=${output.ciBuildUrl}`);
+  try {
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+    logger.info(`Wrote GitLab dotenv report to ${file} (declare it as artifacts:reports:dotenv)`);
+  } catch (error) {
+    logger.warn(`Failed to write GitLab dotenv file '${file}': ${errorMessage(error)}`);
+  }
+}
+
+/** Append newline-terminated lines to a file, swallowing (but logging) failures. */
+function appendFileLines(file: string, lines: string[], logger: Logger, label: string): void {
+  try {
+    fs.appendFileSync(file, lines.join('\n') + '\n');
+  } catch (error) {
+    logger.warn(`Failed to write GitHub Actions ${label}: ${errorMessage(error)}`);
+  }
+}
+
+/** Pick the most specific CI build/job URL from collected CI metadata, if any. */
+export function ciBuildUrlFromMetadata(metadata: Record<string, any> | undefined): string | undefined {
+  const ci = metadata?.ci;
+  if (!ci) return undefined;
+  return ci.buildUrl || ci.pipelineUrl || ci.jobUrl || undefined;
+}

--- a/reporter/src/public/options.ts
+++ b/reporter/src/public/options.ts
@@ -103,6 +103,15 @@ export interface PiwiDashboardOptions extends PlaywrightTestConfig {
   tags?: string[];
   /** Additional custom metadata as key-value pairs */
   customData?: Record<string, unknown>;
+  /**
+   * Write a JSON file with the submitted run's dashboard URL, id, project id and
+   * status after the run lands, so a CI pipeline can consume it (e.g. feed the
+   * run URL into a custom email step). Any CI can read the file. GitHub Actions
+   * step outputs / job summary and GitLab dotenv reports are emitted
+   * automatically when running under those systems, regardless of this option.
+   * Can also be set with `PIWI_OUTPUT_FILE`.
+   */
+  outputFile?: string;
   /** Enable verbose logging for debugging. Defaults to `false`. */
   verbose?: boolean;
 }

--- a/reporter/tests/ci-output.spec.ts
+++ b/reporter/tests/ci-output.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { emitRunOutputs, ciBuildUrlFromMetadata, type RunOutput } from '../src/internal/support/ci-output.js';
+import { Logger } from '../src/internal/support/logger.js';
+
+const OUTPUT: RunOutput = {
+  runUrl: 'https://dash.example.com/test-runs/42',
+  runId: 42,
+  projectId: 7,
+  projectName: 'checkout',
+  status: 'passed',
+  ciBuildUrl: 'https://ci.example.com/build/9',
+};
+
+let tmpDir: string;
+const silentLogger = new Logger(false);
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'piwi-ci-output-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('emitRunOutputs — universal output file', () => {
+  it('writes a JSON file with the run identity when outputFile is set', () => {
+    const file = path.join(tmpDir, 'nested', 'piwi-run.json');
+    emitRunOutputs(OUTPUT, silentLogger, file, {});
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(parsed).toEqual({
+      runUrl: OUTPUT.runUrl,
+      runId: 42,
+      projectId: 7,
+      projectName: 'checkout',
+      status: 'passed',
+      ciBuildUrl: 'https://ci.example.com/build/9',
+    });
+  });
+
+  it('does not write a file when outputFile is not set', () => {
+    emitRunOutputs(OUTPUT, silentLogger, undefined, {});
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('never throws when the output file path is unwritable', () => {
+    const badPath = path.join(tmpDir, 'a-file');
+    fs.writeFileSync(badPath, 'x');
+    // Treating an existing file as a directory parent must be swallowed.
+    expect(() => emitRunOutputs(OUTPUT, silentLogger, path.join(badPath, 'child.json'), {})).not.toThrow();
+  });
+});
+
+describe('emitRunOutputs — GitHub Actions', () => {
+  it('appends step outputs and a job-summary link, and prints an annotation', () => {
+    const outputFile = path.join(tmpDir, 'gh-output');
+    const summaryFile = path.join(tmpDir, 'gh-summary');
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    emitRunOutputs(OUTPUT, silentLogger, undefined, {
+      GITHUB_ACTIONS: 'true',
+      GITHUB_OUTPUT: outputFile,
+      GITHUB_STEP_SUMMARY: summaryFile,
+    });
+
+    const outputs = fs.readFileSync(outputFile, 'utf8');
+    expect(outputs).toContain('piwi_run_url=https://dash.example.com/test-runs/42');
+    expect(outputs).toContain('piwi_run_id=42');
+    expect(outputs).toContain('piwi_run_status=passed');
+    expect(outputs).toContain('piwi_project_id=7');
+
+    const summary = fs.readFileSync(summaryFile, 'utf8');
+    expect(summary).toContain('[View run](https://dash.example.com/test-runs/42)');
+    expect(summary).toContain('**passed**');
+
+    expect(stdout).toHaveBeenCalledWith('::notice title=Piwi test run::https://dash.example.com/test-runs/42\n');
+  });
+
+  it('still prints the annotation when GITHUB_OUTPUT/SUMMARY files are absent', () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    emitRunOutputs(OUTPUT, silentLogger, undefined, { GITHUB_ACTIONS: 'true' });
+    expect(stdout).toHaveBeenCalledWith('::notice title=Piwi test run::https://dash.example.com/test-runs/42\n');
+  });
+});
+
+describe('emitRunOutputs — GitLab CI', () => {
+  it('writes a dotenv report at the default path', () => {
+    const cwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      emitRunOutputs(OUTPUT, silentLogger, undefined, { GITLAB_CI: 'true' });
+      const dotenv = fs.readFileSync(path.join(tmpDir, 'piwi.env'), 'utf8');
+      expect(dotenv).toContain('PIWI_RUN_URL=https://dash.example.com/test-runs/42');
+      expect(dotenv).toContain('PIWI_RUN_ID=42');
+      expect(dotenv).toContain('PIWI_RUN_STATUS=passed');
+      expect(dotenv).toContain('PIWI_PROJECT_ID=7');
+      expect(dotenv).toContain('PIWI_CI_BUILD_URL=https://ci.example.com/build/9');
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it('honors PIWI_DOTENV_FILE for the dotenv path', () => {
+    const file = path.join(tmpDir, 'custom.env');
+    emitRunOutputs(OUTPUT, silentLogger, undefined, { GITLAB_CI: 'true', PIWI_DOTENV_FILE: file });
+    expect(fs.readFileSync(file, 'utf8')).toContain('PIWI_RUN_URL=https://dash.example.com/test-runs/42');
+  });
+});
+
+describe('ciBuildUrlFromMetadata', () => {
+  it('prefers buildUrl, then pipelineUrl, then jobUrl', () => {
+    expect(ciBuildUrlFromMetadata({ ci: { buildUrl: 'b', pipelineUrl: 'p', jobUrl: 'j' } })).toBe('b');
+    expect(ciBuildUrlFromMetadata({ ci: { pipelineUrl: 'p', jobUrl: 'j' } })).toBe('p');
+    expect(ciBuildUrlFromMetadata({ ci: { jobUrl: 'j' } })).toBe('j');
+  });
+
+  it('returns undefined when there is no CI metadata', () => {
+    expect(ciBuildUrlFromMetadata(undefined)).toBeUndefined();
+    expect(ciBuildUrlFromMetadata({})).toBeUndefined();
+    expect(ciBuildUrlFromMetadata({ ci: {} })).toBeUndefined();
+  });
+});

--- a/reporter/tests/config.spec.ts
+++ b/reporter/tests/config.spec.ts
@@ -17,6 +17,7 @@ const PIWI_KEYS = [
   'PIWI_LIVE_FILE_UPLOADS',
   'PIWI_UPLOAD_TRACES',
   'PIWI_UPLOAD_REPORT',
+  'PIWI_OUTPUT_FILE',
 ];
 
 const SAVED_ENV: Record<string, string | undefined> = {};
@@ -139,5 +140,11 @@ describe('resolveOptions', () => {
     process.env.PIWI_VERBOSE = 'false';
     const opts = resolveOptions({});
     expect(opts.verbose).toBe(false);
+  });
+
+  it('reads PIWI_OUTPUT_FILE from env, and a user option wins over it', () => {
+    process.env.PIWI_OUTPUT_FILE = 'piwi-run.json';
+    expect(resolveOptions({}).outputFile).toBe('piwi-run.json');
+    expect(resolveOptions({ outputFile: 'explicit.json' }).outputFile).toBe('explicit.json');
   });
 });

--- a/reporter/tests/submit-ladder.spec.ts
+++ b/reporter/tests/submit-ladder.spec.ts
@@ -140,6 +140,38 @@ describe('PiwiDashboardReporter submit/fallback ladder', () => {
     expect('_filesUploaded' in submitBody.testCases[0]).toBe(false);
   });
 
+  it('writes the CI output file with the submitted run identity', async () => {
+    server = await startServer((req, res) => {
+      if (req.url === '/api/test-runs/submit') {
+        jsonRes(res, 200, { testRunId: 99, projectId: 5 });
+      } else {
+        textRes(res, 404, 'nope');
+      }
+    });
+
+    const outputFile = path.join(os.tmpdir(), `piwi-run-${process.pid}.json`);
+    try {
+      const reporter = new PiwiDashboardReporter({
+        serverUrl: server.url,
+        projectName,
+        streaming: false,
+        uploadReport: false,
+        uploadTraces: false,
+        liveFileUploads: false,
+        outputFile,
+      });
+      await runOneTest(reporter, 'output-file-test');
+
+      const parsed = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+      expect(parsed.runId).toBe(99);
+      expect(parsed.projectId).toBe(5);
+      expect(parsed.status).toBe('passed');
+      expect(parsed.runUrl).toBe(`${server.url}/test-runs/99`);
+    } finally {
+      fs.rmSync(outputFile, { force: true });
+    }
+  });
+
   it('streaming disabled, uploadReport=true: multipart /upload only (no /submit)', async () => {
     server = await startServer((req, res) => {
       if (req.url === '/api/test-runs/upload') {


### PR DESCRIPTION
Surface the submitted run's dashboard URL wherever a CI pipeline can pick it
up, so a downstream step (a custom email, a Slack post, a deploy gate) can
consume it without scraping stdout.

- New `emitRunOutputs` in `support/ci-output.ts`, called once by the submit
  ladder after any rung lands:
  - `outputFile` option / `PIWI_OUTPUT_FILE`: a portable JSON file with
    runUrl/runId/projectId/status/ciBuildUrl that any CI can read.
  - GitHub Actions (auto): step outputs on `$GITHUB_OUTPUT`, a job-summary
    link, and a `::notice::` annotation.
  - GitLab CI (auto): a dotenv report (`piwi.env`, override with
    `PIWI_DOTENV_FILE`) to wire as `artifacts:reports:dotenv`.
- Thread the submit response through the ladder as a `RunOutput`, replacing
  the three scattered `View run:` log lines with one emit path. Every channel
  is best-effort — failures are logged, never thrown.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G5DtwhCUsAS2afevfm5NX2