### PR TITLE
feat: add @piwitests/server npm package to run the dashboard server

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,53 @@ jobs:
           echo "npm install @piwitests/reporter" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+  # Publish @piwitests/server: the dashboard server as an npm package (npx @piwitests/server).
+  # Kept as its own job so the heavy Nuxt build doesn't gate the reporter publish above.
+  # The bundled Nitro node-server output is built here and copied in by the package's
+  # `prepack` step (scripts/copy-output.mjs) at publish time.
+  publish-npm-server:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application (node-server preset)
+        run: npm run app:build --workspace=application
+        env:
+          NITRO_PRESET: node-server
+
+      - name: Publish to npm
+        run: npm publish --workspace @piwitests/server --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "## NPM Package Published :package:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Package**: \`@piwitests/server\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Run" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "npx @piwitests/server" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
   # Build each architecture on its own NATIVE runner and push it by digest.
   # Building linux/arm64 on a native arm runner (instead of QEMU emulation on an
   # amd64 runner) is the main speed-up: the heavy npm ci + nuxt build no longer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ application/            — Nuxt 4 dashboard app
 application/shared/     — Shared types, constants & utilities (import via `#shared/...`, not relative paths or `~~/shared/...`)
 application/tests/      — Functional tests (Playwright)
 packages/core/          — `@piwitests/core`: pure logic shared by the app AND the reporter (bundled into the reporter — see below)
+packages/server/        — `@piwitests/server`: published npm run-option for the server (bundles the app's built `.output/` + a `bin` launcher; `npx @piwitests/server`)
 plans/                  — Design docs, audit plans & roadmap (see below)
 reporter/               — Custom Playwright reporter package (TypeScript → bundled JS via tsup)
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@piwitests/reporter"><img src="https://img.shields.io/npm/v/@piwitests/reporter?logo=npm&labelColor=020420&color=CB3837" alt="npm"></a>
+  <a href="https://www.npmjs.com/package/@piwitests/reporter"><img src="https://img.shields.io/npm/v/@piwitests/reporter?logo=npm&label=reporter&labelColor=020420&color=CB3837" alt="npm reporter"></a>
+  <a href="https://www.npmjs.com/package/@piwitests/server"><img src="https://img.shields.io/npm/v/@piwitests/server?logo=npm&label=server&labelColor=020420&color=CB3837" alt="npm server"></a>
   <a href="https://hub.docker.com/r/phenx/piwitests-server"><img src="https://img.shields.io/docker/v/phenx/piwitests-server?logo=docker&labelColor=020420&color=2496ED" alt="Docker"></a>
   <a href="https://github.com/PiwiTests/platform/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/PiwiTests/platform/ci.yml?branch=main&logo=githubactions&logoColor=white&labelColor=020420&label=CI" alt="CI status"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?labelColor=020420" alt="MIT license"></a>
@@ -77,6 +78,14 @@ docker run -p 3000:3000 -v ${PWD}/.data:/app/.data phenx/piwitests-server:latest
 ```
 
 Visit `http://localhost:3000`. A [`docker-compose.yml`](./docker-compose.yml) is also included.
+
+Prefer no Docker? With **Node.js 24+** you can run the server straight from npm — it creates its `.data/` in the current directory:
+
+```bash
+npx @piwitests/server
+```
+
+Docker stays the recommended path for production; see the [deployment guide](https://piwitests.github.io/deployment) for both.
 
 > **Linux hosts:** the container runs as non-root UID 1001, so without the `chown` above, Docker auto-creates `.data` owned by `root` and the container can't write to it. Windows and macOS (Docker Desktop) don't need this step. See [Troubleshooting](./DOCKER.md#troubleshooting) if you hit a permission error.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -212,6 +212,42 @@ spec:
   type: LoadBalancer
 ```
 
+## npm / npx (quick local run)
+
+For a quick local run without Docker, the server is published to npm as
+[`@piwitests/server`](https://www.npmjs.com/package/@piwitests/server). It bundles the
+prebuilt server and needs only **Node.js 24+**:
+
+```bash
+npx @piwitests/server
+```
+
+The dashboard will be available at `http://localhost:3000`.
+
+The server creates a `.data/` directory **in the current working directory** for the
+SQLite database (`.data/piwi.db`) and file storage (`.data/storage/`) — the same data
+layout the Docker image mounts at `/app/.data`. Run the command from the same directory
+each time to keep your data.
+
+Configuration uses the same environment variables as the Docker image (see the table
+above and the [configuration reference](/configuration)). For example, to change the port:
+
+::: code-group
+
+```bash [Linux / macOS]
+PORT=8080 npx @piwitests/server
+```
+
+```powershell [Windows (PowerShell)]
+$env:PORT='8080'; npx @piwitests/server
+```
+
+:::
+
+> **Docker remains the recommended path for production** — it ships a pinned Node runtime,
+> runs as a non-root user, and isolates the environment. The npm package is best for a
+> quick local trial or environments where Docker isn't available.
+
 ## Production build from source
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.14.0",
       "workspaces": [
         "packages/core",
+        "packages/server",
         "application",
         "reporter",
         "integrations/nitro"
@@ -29,7 +30,7 @@
     },
     "application": {
       "name": "@piwitests/dashboard",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -170,7 +171,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -3784,9 +3785,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3802,9 +3800,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3822,9 +3817,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3840,9 +3832,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3860,9 +3849,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3878,9 +3864,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3898,9 +3881,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3917,9 +3897,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3935,9 +3912,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3961,9 +3935,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3985,9 +3956,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4011,9 +3979,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4035,9 +4000,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4061,9 +4023,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4086,9 +4045,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4110,9 +4066,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -7262,9 +7215,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7282,9 +7232,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7302,9 +7249,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7322,9 +7266,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7342,9 +7283,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7362,9 +7300,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7382,9 +7317,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7402,9 +7334,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7601,9 +7530,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7619,9 +7545,6 @@
       "integrity": "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7639,9 +7562,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7657,9 +7577,6 @@
       "integrity": "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -7677,9 +7594,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7695,9 +7609,6 @@
       "integrity": "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -7715,9 +7626,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7733,9 +7641,6 @@
       "integrity": "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8154,6 +8059,10 @@
     },
     "node_modules/@piwitests/reporter": {
       "resolved": "reporter",
+      "link": true
+    },
+    "node_modules/@piwitests/server": {
+      "resolved": "packages/server",
       "link": true
     },
     "node_modules/@pkgjs/parseargs": {
@@ -9363,9 +9272,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9381,9 +9287,6 @@
       "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9401,9 +9304,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9419,9 +9319,6 @@
       "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -26368,11 +26265,26 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.12.0"
+      "version": "0.14.0"
+    },
+    "packages/server": {
+      "name": "@piwitests/server",
+      "version": "0.14.0",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/client": "0.17.4",
+        "sharp": "0.35.3"
+      },
+      "bin": {
+        "piwi-server": "bin/piwi-server.mjs"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
     },
     "reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "workspaces": [
     "packages/core",
+    "packages/server",
     "application",
     "reporter",
     "integrations/nitro"

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,0 +1,7 @@
+# Built server output copied in by prepack (scripts/copy-output.mjs) at publish time.
+.output/
+
+# The root .gitignore ignores every `bin/` dir (build output); this package's bin/
+# holds the committed launcher, so re-include it.
+!/bin/
+!/bin/**

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,77 @@
+# @piwitests/server
+
+Run the self-hosted [Piwi Dashboard](https://piwitests.github.io) server — a permanent
+home for your Playwright test results — with a single command, no Docker required.
+
+> **Docker is the recommended way to run Piwi in production** (pinned runtime, isolated
+> environment): see the [deployment guide](https://piwitests.github.io/deployment). This
+> npm package is a low-friction path for a quick local run or environments where Docker
+> isn't available.
+
+## Requirements
+
+- Node.js **24+**
+
+## Quick start
+
+```bash
+npx @piwitests/server
+```
+
+Then open `http://localhost:3000`.
+
+The server creates a `.data/` directory **in your current working directory** to hold the
+SQLite database (`.data/piwi.db`) and file storage (`.data/storage/` — HTML reports,
+traces, attachments). Run the command from the same directory each time to keep your data,
+or install it as a dependency and add a script:
+
+```bash
+npm install @piwitests/server
+```
+
+```json
+{
+  "scripts": {
+    "piwi": "piwi-server"
+  }
+}
+```
+
+## Configuration
+
+All configuration is via environment variables (same as the Docker image). Common ones:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | Port to listen on |
+| `PIWI_SECRET_KEY` | — | Master key for encrypting secrets stored in the database (AI API keys, SCM tokens). Recommended in any real deployment. Generate with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`. |
+| `PIWI_AUTH_ENABLED` | — | Enable authentication (multi-user) |
+| `PIWI_AUTH_SECRET` | — | Secret for encrypting session cookies (required when auth is enabled) |
+| `PIWI_DATABASE_URL` | — | PostgreSQL connection string (e.g. `postgresql://user:pass@host:5432/db`). When set, PostgreSQL is used instead of SQLite. |
+| `PIWI_DATABASE_PATH` | `.data/piwi.db` | SQLite database path (ignored when `PIWI_DATABASE_URL` is set) |
+| `PIWI_STORAGE_TYPE` | `local` | Storage backend (`local` or `s3`) |
+
+See the [configuration reference](https://piwitests.github.io/configuration) for the full
+list.
+
+Set variables the usual way for your shell — for example, on a different port:
+
+```bash
+# Linux / macOS
+PORT=8080 npx @piwitests/server
+```
+
+```powershell
+# Windows (PowerShell)
+$env:PORT='8080'; npx @piwitests/server
+```
+
+## Sending results
+
+Add the [`@piwitests/reporter`](https://www.npmjs.com/package/@piwitests/reporter) to your
+Playwright project and point it at this server — see the
+[getting started guide](https://piwitests.github.io/getting-started).
+
+## License
+
+MIT

--- a/packages/server/bin/piwi-server.mjs
+++ b/packages/server/bin/piwi-server.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Launcher for the Piwi Dashboard server. Resolves the bundled Nitro node-server
+// output relative to this package (so hoisted native deps resolve) and imports it.
+// The working directory is left untouched — the server creates its `.data/` (SQLite
+// database + file storage) relative to wherever you run this command.
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const entry = resolve(here, '../.output/server/index.mjs')
+
+if (!existsSync(entry)) {
+  console.error(
+    '[piwi-server] Bundled server output not found at .output/server/index.mjs.\n' +
+      'This package must be installed from npm (the prebuilt output ships inside it).',
+  )
+  process.exit(1)
+}
+
+const port = process.env.PORT || process.env.NITRO_PORT || '3000'
+console.log(`Starting Piwi Dashboard on http://localhost:${port}`)
+console.log(`Data (SQLite database + file storage) will be stored in ${resolve(process.cwd(), '.data')}`)
+
+await import(entry)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@piwitests/server",
+  "version": "0.14.0",
+  "description": "Self-hosted Piwi Dashboard server — run with npx @piwitests/server",
+  "type": "module",
+  "bin": {
+    "piwi-server": "bin/piwi-server.mjs"
+  },
+  "files": [
+    ".output/",
+    "bin/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PiwiTests/platform"
+  },
+  "homepage": "https://piwitests.github.io",
+  "bugs": {
+    "url": "https://github.com/PiwiTests/platform/issues"
+  },
+  "author": "piwitests",
+  "license": "MIT",
+  "keywords": [
+    "playwright",
+    "dashboard",
+    "test-results",
+    "self-hosted"
+  ],
+  "scripts": {
+    "prepack": "node scripts/copy-output.mjs"
+  },
+  "dependencies": {
+    "@libsql/client": "0.17.4",
+    "sharp": "0.35.3"
+  }
+}

--- a/packages/server/scripts/copy-output.mjs
+++ b/packages/server/scripts/copy-output.mjs
@@ -1,0 +1,64 @@
+// prepack step: copy the application's freshly built Nitro output into this package
+// so it ships inside the published tarball (`files: [".output/"]`). The build artifact
+// is intentionally not committed to git — CI runs `npm run app:build --workspace=application`
+// (with NITRO_PRESET=node-server) before packing.
+//
+// The build bundles a `node_modules` into `.output/server/` (Nitro's noExternals does
+// not fully inline it — the runtime still resolves deps like drizzle-orm from there).
+// Those pure-JS deps are cross-platform and ship as-is. The one exception is the native
+// modules (sharp, libsql): the bundled copies are the BUILD machine's platform binaries
+// (e.g. linux-x64-glibc), which would be wrong for a macOS / Windows / arm / musl user.
+// We strip those platform-specific binary sub-packages here and declare `sharp` +
+// `@libsql/client` as real dependencies in package.json, so npm installs the correct
+// per-platform binaries at install time (the bundled JS wrappers resolve them from the
+// hoisted top-level node_modules). This mirrors the Dockerfile's runtime install.
+import { cpSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const source = resolve(here, '../../../application/.output')
+const target = resolve(here, '../.output')
+
+if (!existsSync(source)) {
+  console.error(
+    `[copy-output] Application build output not found at ${source}.\n` +
+      'Build it first: NITRO_PRESET=node-server npm run app:build --workspace=application',
+  )
+  process.exit(1)
+}
+
+rmSync(target, { recursive: true, force: true })
+cpSync(source, target, { recursive: true })
+console.log(`[copy-output] Copied ${source} -> ${target}`)
+
+// Strip platform-locked native binaries so npm reinstalls the correct ones per platform.
+const serverModules = join(target, 'server/node_modules')
+const stripDirs = []
+
+// sharp: every @img/sharp-<platform>* and @img/sharp-libvips-<platform>* except the
+// cross-platform wasm fallback (@img/sharp-wasm32) and shared helper (@img/colour).
+const imgDir = join(serverModules, '@img')
+if (existsSync(imgDir)) {
+  for (const entry of readdirSync(imgDir)) {
+    if (entry.startsWith('sharp-') && entry !== 'sharp-wasm32') {
+      stripDirs.push(join(imgDir, entry))
+    }
+  }
+}
+
+// libsql: every @libsql/<platform> native binary (e.g. linux-x64-gnu, darwin-arm64).
+const libsqlDir = join(serverModules, '@libsql')
+if (existsSync(libsqlDir)) {
+  const KEEP = new Set(['client', 'core', 'hrana-client', 'isomorphic-ws'])
+  for (const entry of readdirSync(libsqlDir)) {
+    if (!KEEP.has(entry)) {
+      stripDirs.push(join(libsqlDir, entry))
+    }
+  }
+}
+
+for (const dir of stripDirs) {
+  rmSync(dir, { recursive: true, force: true })
+  console.log(`[copy-output] Stripped platform binary: ${dir.slice(target.length + 1)}`)
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "packages/core/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "packages/server/package.json", "jsonpath": "$.version" },
         { "type": "json", "path": "application/package.json", "jsonpath": "$.version" },
         { "type": "json", "path": "reporter/package.json", "jsonpath": "$.version" },
         { "type": "json", "path": "integrations/nitro/package.json", "jsonpath": "$.version" },


### PR DESCRIPTION
Adds a second way to run the Piwi Dashboard server alongside the Docker
image: `npx @piwitests/server`. Docker stays the recommended production
path; the npm package is a low-friction local/no-Docker option for the
Node/npm audience that already installs @piwitests/reporter.

The new `packages/server` workspace bundles the app's prebuilt Nitro
node-server output (`.output/`, migrations included) plus a thin bin
launcher. Its prepack step copies the freshly built output in and strips
the build machine's platform-locked native binaries (sharp, libsql), so
npm reinstalls the correct per-platform binaries at install time via the
declared `sharp`/`@libsql/client` dependencies — mirroring the Dockerfile.

Publishing reuses the existing release machinery: a new tag-only
`publish-npm-server` job in publish.yml builds the app and publishes at
the same lockstep version, and release-please bumps the new package.json.
Docs (deployment guide, README, AGENTS) document the npm run option.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019e6VhU3Gx42Gk2bM7BBLbQ