### PR TITLE
fix(docs): keep the docs build independent of the app install state

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,6 +13,14 @@ export default defineConfig({
   // Ollama base URLs) are intentionally unreachable localhost URLs.
   ignoreDeadLinks: [/^https?:\/\/localhost/],
   vite: {
+    // The #shared modules imported below live outside the docs root, and their
+    // nearest tsconfig (application/tsconfig.json) references Nuxt-generated
+    // .nuxt/tsconfig.*.json files that only exist after the app has been
+    // installed. Inline an empty tsconfig so the docs build never reads
+    // on-disk tsconfigs and stays independent of the app's install state.
+    esbuild: {
+      tsconfigRaw: '{}',
+    },
     resolve: {
       alias: {
         // The env-var registry and format emitters are imported straight from


### PR DESCRIPTION
## What & why

Fixes the failing **Deploy Docs & Demo** run ([29688995843](https://github.com/PiwiTests/platform/actions/runs/29688995843/job/88198262279)) after #288.

The `#shared` modules imported by the configuration generator live under `application/`, whose nearest `tsconfig.json` references the Nuxt-generated `.nuxt/tsconfig.*.json` files. The Pages workflow builds the docs **before** any application install, so Vite/esbuild's tsconfig discovery hit `ENOENT: application/.nuxt/tsconfig.app.json` and failed the deploy (it passed in PR CI only because the app was installed there first).

The fix inlines an empty tsconfig for the docs build (`vite.esbuild.tsconfigRaw: '{}'`), so it never reads on-disk tsconfigs and stays independent of the app's install state — the right property for this build anyway, since the shared modules it imports are deliberately dependency-free.

## How was it tested?

Reproduced the runner's exact condition locally by removing `application/.nuxt`: `npm run docs:build` failed with the same `ENOENT`; with the fix it builds green with `.nuxt` still absent, and again with it present.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — build-config-only change, verified by reproducing the failing build locally
- [x] Docs updated if user-facing — not user-facing (build configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaqSa964D2s5EJU3Yc7wjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaqSa964D2s5EJU3Yc7wjS)_