### PR TITLE
feat(ui): add project filter and reduce padding on analytics page

### DIFF
--- a/application/app/components/analytics/AnalyticsScopeBar.vue
+++ b/application/app/components/analytics/AnalyticsScopeBar.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { MAX_ANALYTICS_DAYS } from '#shared/analytics/scope';
-import type { AnalyticsScopeState } from '~/composables/useAnalyticsScope';
+import { DEFAULT_ANALYTICS_SCOPE_STATE, type AnalyticsScopeState } from '~/composables/useAnalyticsScope';
+import type { ProjectMenuItem } from '~~/types/api';
 
 const props = defineProps<{
   modelValue: AnalyticsScopeState;
+  availableProjects: ProjectMenuItem[];
   availableEnvironments: string[];
 }>();
 
@@ -24,6 +26,17 @@ const days = computed({
   set: (val: number) => emit('update:modelValue', { ...props.modelValue, days: val }),
 });
 
+const projectItems = computed(() => props.availableProjects.map((p) => ({ label: p.label || p.name, value: p.id })));
+
+const projectIds = computed({
+  get: () => props.modelValue.projectIds,
+  set: (val: number[]) => emit('update:modelValue', { ...props.modelValue, projectIds: val }),
+});
+
+function projectLabel(id: number) {
+  return projectItems.value.find((item) => item.value === id)?.label ?? `#${id}`;
+}
+
 const ENV_ALL = 'All environments';
 
 const environment = computed({
@@ -37,11 +50,50 @@ const fullRunsOnly = computed({
   get: () => props.modelValue.fullRunsOnly,
   set: (val: boolean) => emit('update:modelValue', { ...props.modelValue, fullRunsOnly: val }),
 });
+
+const isDefault = computed(
+  () =>
+    props.modelValue.days === DEFAULT_ANALYTICS_SCOPE_STATE.days &&
+    props.modelValue.projectIds.length === 0 &&
+    props.modelValue.environment === null &&
+    props.modelValue.fullRunsOnly === DEFAULT_ANALYTICS_SCOPE_STATE.fullRunsOnly,
+);
+
+function reset() {
+  emit('update:modelValue', { ...DEFAULT_ANALYTICS_SCOPE_STATE });
+}
 </script>
 
 <template>
   <div class="flex items-center gap-3 flex-wrap">
     <USelect v-model="days" :items="PERIOD_ITEMS" size="sm" class="min-w-[140px]" icon="i-lucide-calendar-range" />
+
+    <USelectMenu
+      v-if="projectItems.length > 0"
+      v-model="projectIds"
+      :items="projectItems"
+      value-key="value"
+      multiple
+      searchable
+      size="sm"
+      class="min-w-[170px]"
+      placeholder="All projects"
+    >
+      <template #default="{ modelValue: selected }">
+        <div class="flex items-center gap-1.5">
+          <UIcon
+            name="i-lucide-folder"
+            class="size-3.5 shrink-0"
+            :class="(selected as number[]).length ? 'text-primary' : 'text-gray-400'"
+          />
+          <span v-if="!(selected as number[]).length" class="text-gray-500">All projects</span>
+          <span v-else-if="(selected as number[]).length === 1" class="truncate">{{
+            projectLabel((selected as number[])[0]!)
+          }}</span>
+          <span v-else>{{ (selected as number[]).length }} projects</span>
+        </div>
+      </template>
+    </USelectMenu>
 
     <USelect
       v-if="availableEnvironments.length > 0"
@@ -58,5 +110,9 @@ const fullRunsOnly = computed({
       <UCheckbox v-model="fullRunsOnly" size="sm" />
       Full runs only
     </label>
+
+    <UButton v-if="!isDefault" variant="ghost" size="sm" color="neutral" icon="i-lucide-x" @click="reset">
+      Reset
+    </UButton>
   </div>
 </template>

--- a/application/app/composables/useAnalyticsScope.ts
+++ b/application/app/composables/useAnalyticsScope.ts
@@ -3,12 +3,15 @@ import type { AnalyticsWidgetId } from '#shared/analytics/registry';
 
 export interface AnalyticsScopeState {
   days: number;
+  /** Selected project ids; empty = every project the caller can see. */
+  projectIds: number[];
   environment: string | null;
   fullRunsOnly: boolean;
 }
 
-const DEFAULT_STATE: AnalyticsScopeState = {
+export const DEFAULT_ANALYTICS_SCOPE_STATE: AnalyticsScopeState = {
   days: DEFAULT_ANALYTICS_DAYS,
+  projectIds: [],
   environment: null,
   fullRunsOnly: true,
 };
@@ -19,19 +22,22 @@ const DEFAULT_STATE: AnalyticsScopeState = {
  */
 export function useAnalyticsScope() {
   const state = useCookie<AnalyticsScopeState>('piwi-analytics-scope', {
-    default: () => ({ ...DEFAULT_STATE }),
+    default: () => ({ ...DEFAULT_ANALYTICS_SCOPE_STATE }),
     encode: (v) => JSON.stringify(v),
     decode: (v) => {
       try {
-        return v ? { ...DEFAULT_STATE, ...(JSON.parse(v) as Partial<AnalyticsScopeState>) } : { ...DEFAULT_STATE };
+        return v
+          ? { ...DEFAULT_ANALYTICS_SCOPE_STATE, ...(JSON.parse(v) as Partial<AnalyticsScopeState>) }
+          : { ...DEFAULT_ANALYTICS_SCOPE_STATE };
       } catch {
-        return { ...DEFAULT_STATE };
+        return { ...DEFAULT_ANALYTICS_SCOPE_STATE };
       }
     },
   });
 
   const scope = computed<AnalyticsScope>(() => ({
     days: state.value.days,
+    projectIds: state.value.projectIds.length > 0 ? state.value.projectIds : undefined,
     environment: state.value.environment,
     fullRunsOnly: state.value.fullRunsOnly,
   }));

--- a/application/app/pages/analytics.vue
+++ b/application/app/pages/analytics.vue
@@ -2,7 +2,7 @@
 import type { Component } from 'vue';
 import { ANALYTICS_WIDGETS, type AnalyticsWidgetId } from '#shared/analytics/registry';
 import { MAX_ANALYTICS_DAYS } from '#shared/analytics/scope';
-import type { TestRunForChart } from '~~/types/api';
+import type { ProjectMenuItem, TestRunForChart } from '~~/types/api';
 import {
   InsightsFeed,
   PortfolioScorecard,
@@ -19,6 +19,13 @@ import {
 useHead({ title: 'Analytics - Piwi Dashboard' });
 
 const { state, scopeQuery } = useAnalyticsScope();
+
+// Project options for the scope bar (slim list, same source as the sidebar menu).
+const { data: availableProjects } = await useFetch<ProjectMenuItem[]>('/api/projects/menu', {
+  lazy: true,
+  server: false,
+  default: () => [] as ProjectMenuItem[],
+});
 
 // Environment options for the scope bar (same source as the home filters).
 const { data: recentTestRuns } = await useFetch<TestRunForChart[]>('/api/test-runs/recent', {
@@ -85,9 +92,13 @@ const WIDGET_COMPONENTS: Record<AnalyticsWidgetId, Component> = {
     </template>
 
     <template #body>
-      <div class="p-6 space-y-6">
+      <div class="space-y-6">
         <FilterToolbar>
-          <AnalyticsScopeBar v-model="state" :available-environments="availableEnvironments" />
+          <AnalyticsScopeBar
+            v-model="state"
+            :available-projects="availableProjects"
+            :available-environments="availableEnvironments"
+          />
         </FilterToolbar>
 
         <UAlert


### PR DESCRIPTION
Expose the already-supported project scope in the analytics scope bar as a
searchable multi-select (empty = all accessible projects), and add a Reset
control now that the bar carries four filters. Drop the extra p-6 wrapper so
the page uses the default dashboard-panel body padding, matching the projects
list page.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NS7aUmQ1akYPTR3asXoxZ8