### PR TITLE
fix(demo): show timeout-hygiene opportunities in the demo

### DIFF
--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -27,6 +27,7 @@ import {
   getProjectTestCases,
   parseTestCasesQuery,
   getProjectSlowTests,
+  getProjectTimeoutOpportunities,
   getProjectFailureClusters,
   updateProject,
   createProject,
@@ -215,6 +216,14 @@ const routes: RouteEntry[] = [
     handler: async (m, _, q) => {
       const runs = q ? Number(q.get('runs')) || 10 : 10;
       return getProjectSlowTests(await getDemoDb(), +m[1]!, runs);
+    },
+  },
+  {
+    method: 'GET',
+    pattern: /^\/api\/projects\/(\d+)\/timeout-opportunities$/,
+    handler: async (m, _, q) => {
+      const runs = q ? Number(q.get('runs')) || 20 : 20;
+      return getProjectTimeoutOpportunities(await getDemoDb(), +m[1]!, runs);
     },
   },
   {

--- a/application/public/demo/seed.version.json
+++ b/application/public/demo/seed.version.json
@@ -1,4 +1,4 @@
 {
-  "hash": "fddfee724a9eaf290dbe2533d4a50d7dbedf9a9363288ce5940883a9db1b0923",
-  "generatedAt": "2026-07-21T10:27:09.583Z"
+  "hash": "db0efe94553823803304c4cec77ee87ad040a6e69c46734206f4944fb01579af",
+  "generatedAt": "2026-07-21T11:02:41.414Z"
 }

--- a/application/scripts/generate-demo-seed.mjs
+++ b/application/scripts/generate-demo-seed.mjs
@@ -702,12 +702,14 @@ for (const proj of DEMO_PROJECTS) {
       const steps = buildSteps(proj, caseDuration);
       const slowestStep = steps.reduce((a, b) => (a.duration > b.duration ? a : b));
 
-      // Test annotations — failures link to their cluster, designated flaky
-      // cases are marked slow, and one checkout case carries a smoke marker.
+      // Test annotations — failures link to their cluster, the designated slow
+      // case is always marked slow (so timeout hygiene can surface it as a stale
+      // test.slow() once its durations no longer justify the tripled budget),
+      // and one checkout case carries a smoke marker.
       let testAnnotations = null;
       if (isFailedCase && story) {
         testAnnotations = [{ type: 'fixme', description: `Known issue — see cluster ${story.clusterId}` }];
-      } else if (isFlakyCase) {
+      } else if (flakyCaseId && caseId === flakyCaseId) {
         testAnnotations = [{ type: 'slow' }];
       } else if (proj.id === 1 && j === 0) {
         testAnnotations = [{ type: 'smoke' }];
@@ -746,6 +748,16 @@ for (const proj of DEMO_PROJECTS) {
         }));
       }
 
+      // Effective per-test timeout (ms), stable per test case across runs. Most
+      // tests keep a healthy 20s budget that timeout-hygiene never flags (its
+      // headroom stays under the 20s floor); the designated slow case keeps a
+      // tripled 90s budget it no longer needs, and one non-slow case per project
+      // is deliberately oversized at 120s — so the demo shows both opportunity
+      // kinds (stale test.slow() and oversized-timeout).
+      const isSlowCase = Boolean(flakyCaseId) && caseId === flakyCaseId;
+      const isOversizedCase = !isSlowCase && caseId === caseIds[1];
+      const caseTimeout = isSlowCase ? 90000 : isOversizedCase ? 120000 : 20000;
+
       const trcIdVal = trcId++;
       TEST_RUNS_CASES.push({
         id: trcIdVal,
@@ -753,6 +765,7 @@ for (const proj of DEMO_PROJECTS) {
         test_case_id: caseId,
         status: caseStatus,
         duration: caseDuration,
+        timeout: caseTimeout,
         error: isFailedCase ? storyEntry.failingCase.error : null,
         failure_cluster_id: story?.clusterId ?? null,
         retries: isFlakyCase ? 1 : 0,


### PR DESCRIPTION
## What & why

The timeout-hygiene feature (shipped in #293) rendered empty in the demo. Two causes, both fixed here:

1. **The demo API didn't route the new endpoint.** Demo mode serves an in-browser API (`app/demo/api/router.ts`) that maps each URL pattern to a handler; `/api/projects/:id/timeout-opportunities` was missing, so the project "Timeout opportunities" table fetched nothing. Added it, mirroring `slow-tests`. (The cross-project Insights feed already flows through the generic `runAnalyticsWidget`, so it needed no change.)
2. **The seed carried no per-test `timeout` data** — the column didn't exist when the seed generator was written — and the `test.slow()` marks were only applied on sporadic flaky runs, too sparse to detect. `generate-demo-seed.mjs` now gives most tests a healthy 20s budget (never flagged), makes the designated slow test *always* `test.slow()` with a tripled 90s budget, and marks one non-slow test per project oversized at 120s.

Net effect: the demo now surfaces **5 oversized-timeout + 5 stale-slow** opportunities (2 per project) in the per-project table and the Insights feed.

`seed.sql` is gitignored and regenerated at build time; only the committed `seed.version.json` marker changes here.

## How was it tested?

- `app:typecheck`, `app:lint`, and the full `app:test:unit` suite pass.
- Loaded the regenerated `seed.sql` into SQLite and ran the detection query to confirm it yields exactly 5 oversized + 5 stale-slow cases across the 5 demo projects, with healthy 20s budgets staying unflagged.
- Detection logic itself is covered by `tests/unit/timeout-hygiene.test.ts` (added in #293).

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — detection is already unit-tested; this is demo data + routing, verified against the regenerated seed
- [x] Docs updated if user-facing — user-facing docs were updated in #293; this change is demo-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxDMJdi64YrPZAWXaeqhfv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxDMJdi64YrPZAWXaeqhfv)_