### PR TITLE
feat(app): surface reclaimable timeout time in the Wasted CI time widget

### DIFF
--- a/application/app/components/analytics/WastedTimeChart.vue
+++ b/application/app/components/analytics/WastedTimeChart.vue
@@ -48,6 +48,12 @@ const subtitle = computed(() => {
   const label = total < 60 ? `${Math.round(total)} min` : `${Math.round((total / 60) * 10) / 10} h`;
   return `${label} of CI time produced no signal`;
 });
+
+const reclaim = computed(() => wasted.value?.timeoutReclaimable ?? null);
+const reclaimLabel = computed(() => {
+  const m = reclaim.value?.estimatedMinutes ?? 0;
+  return m < 60 ? `${Math.round(m)} min` : `${Math.round((m / 60) * 10) / 10} h`;
+});
 </script>
 
 <template>
@@ -97,6 +103,25 @@ const subtitle = computed(() => {
           </div>
           <div><span class="text-amber-500">&#9679;</span> Wait steps: {{ tooltipData.waitMinutes }} min</div>
           <div><span class="text-red-500">&#9679;</span> Failed attempts: {{ tooltipData.failedExecMinutes }} min</div>
+        </div>
+      </div>
+
+      <div
+        v-if="reclaim"
+        class="mt-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5 text-sm dark:border-amber-900/50 dark:bg-amber-950/30"
+      >
+        <UIcon name="i-lucide-scissors" class="mt-0.5 shrink-0 text-amber-500" />
+        <div class="text-gray-700 dark:text-gray-300">
+          Up to <span class="font-semibold">≈{{ reclaimLabel }}</span> of this is avoidable —
+          {{ reclaim.oversizedCount }} oversized {{ reclaim.oversizedCount === 1 ? 'timeout' : 'timeouts' }} and
+          {{ reclaim.staleSlowCount }} stale <code class="text-xs">test.slow()</code>
+          {{ reclaim.staleSlowCount === 1 ? 'mark' : 'marks' }} inflate the failed-attempt time above.
+          <NuxtLink
+            v-if="reclaim.topProjectId"
+            :to="`/projects/${reclaim.topProjectId}#performance`"
+            class="text-primary hover:underline"
+            >Review</NuxtLink
+          >
         </div>
       </div>
 

--- a/application/app/components/project/TimeoutOpportunitiesTable.vue
+++ b/application/app/components/project/TimeoutOpportunitiesTable.vue
@@ -4,6 +4,7 @@ import type { TimeoutOpportunity } from '#shared/analytics/timeout-hygiene';
 
 const props = defineProps<{
   projectId: string | number;
+  projectName?: string | null;
 }>();
 
 const { data, pending } = await useFetch<TimeoutOpportunity[]>(
@@ -51,14 +52,22 @@ const columns: TableColumn<TimeoutOpportunity>[] = [
     <TableScroller v-else min-width="52rem" :bleed="false">
       <UTable :data="opportunities" :columns="columns" sticky class="max-h-[32rem]">
         <template #title-cell="{ row }">
-          <NuxtLink
-            :to="`/test-cases/${row.original.testCaseId}`"
-            class="flex flex-col min-w-0 text-primary hover:underline"
-            :title="row.original.filePath"
-          >
-            <span class="truncate">{{ row.original.title }}</span>
-            <span class="truncate font-mono text-xs text-gray-500">{{ row.original.filePath }}</span>
-          </NuxtLink>
+          <div class="min-w-0">
+            <NuxtLink
+              :to="`/test-cases/${row.original.testCaseId}`"
+              class="font-medium truncate block hover:text-primary hover:underline"
+            >
+              {{ row.original.title }}
+            </NuxtLink>
+            <div class="mt-1">
+              <OpenInIdeLink
+                :file-path="row.original.filePath"
+                :project-key="projectId"
+                :project-name="projectName"
+                class="text-xs"
+              />
+            </div>
+          </div>
         </template>
 
         <template #kind-cell="{ row }">

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -1006,7 +1006,7 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
               <div v-else class="text-center py-8 text-gray-500">No slow test data available yet.</div>
             </UCard>
 
-            <TimeoutOpportunitiesTable :project-id="String(projectId)" />
+            <TimeoutOpportunitiesTable :project-id="String(projectId)" :project-name="project?.name" />
 
             <UCard>
               <template #header>

--- a/application/shared/analytics/types.ts
+++ b/application/shared/analytics/types.ts
@@ -104,6 +104,20 @@ export interface AnalyticsWastedTime {
     waitMinutes: number;
     failedExecMinutes: number;
   }>;
+  /**
+   * Timeout-hygiene tie-in: much of the "failed attempts" time is tests hitting
+   * an oversized timeout, so this is the wait reclaimable (upper bound) by
+   * tightening oversized timeouts and removing stale `test.slow()` marks in
+   * scope. Null when no opportunities were found.
+   */
+  timeoutReclaimable: {
+    /** Sum of per-failure savings across opportunities, in minutes. */
+    estimatedMinutes: number;
+    oversizedCount: number;
+    staleSlowCount: number;
+    /** Project of the highest-impact opportunity (for a deep link). */
+    topProjectId: number | null;
+  } | null;
 }
 
 // ── Global flaky leaderboard ─────────────────────────────────────────────────
@@ -245,4 +259,6 @@ export interface AnalyticsTimeoutHygiene {
   oversizedCount: number;
   staleSlowCount: number;
   totalEstimatedSavingMs: number;
+  /** Project of the highest-impact opportunity (for a deep link). */
+  topProjectId: number | null;
 }

--- a/application/shared/handlers/analytics/timeout-hygiene.ts
+++ b/application/shared/handlers/analytics/timeout-hygiene.ts
@@ -50,5 +50,6 @@ export async function getAnalyticsTimeoutHygiene(
     oversizedCount: rows.filter((r) => r.kind === 'oversized-timeout').length,
     staleSlowCount: rows.filter((r) => r.kind === 'stale-slow').length,
     totalEstimatedSavingMs: rows.reduce((sum, r) => sum + r.estimatedSavingMs, 0),
+    topProjectId: rows[0]?.projectId ?? null,
   };
 }

--- a/application/shared/handlers/analytics/wasted-time.ts
+++ b/application/shared/handlers/analytics/wasted-time.ts
@@ -13,6 +13,7 @@ import {
   TERMINAL_RUN_STATUSES,
   type ProjectAccess,
 } from './common';
+import { getAnalyticsTimeoutHygiene } from './timeout-hygiene';
 
 const TOP_PROJECTS = 8;
 
@@ -33,6 +34,7 @@ export async function getAnalyticsWastedTime(
     totalWaitMinutes: 0,
     totalFailedExecMinutes: 0,
     byProject: [],
+    timeoutReclaimable: null,
   };
 
   const allowed = resolveAllowedProjects(scope, access);
@@ -98,6 +100,20 @@ export async function getAnalyticsWastedTime(
     };
   });
 
+  // Timeout-hygiene tie-in: how much of the wasted time above is reclaimable by
+  // tightening oversized timeouts / removing stale test.slow() marks. Reuses the
+  // same detection as the Insights feed so the numbers stay consistent.
+  const hygiene = await getAnalyticsTimeoutHygiene(db, scope, access);
+  const timeoutReclaimable =
+    hygiene.oversizedCount + hygiene.staleSlowCount > 0
+      ? {
+          estimatedMinutes: minutes(hygiene.totalEstimatedSavingMs),
+          oversizedCount: hygiene.oversizedCount,
+          staleSlowCount: hygiene.staleSlowCount,
+          topProjectId: hygiene.topProjectId,
+        }
+      : null;
+
   return {
     points: points.slice(firstNonEmptyIndex(points, (p) => p.waitMinutes === 0 && p.failedExecMinutes === 0)),
     bucketDays: buckets.bucketDays,
@@ -113,5 +129,6 @@ export async function getAnalyticsWastedTime(
       }))
       .sort((a, b) => b.waitMinutes + b.failedExecMinutes - (a.waitMinutes + a.failedExecMinutes))
       .slice(0, TOP_PROJECTS),
+    timeoutReclaimable,
   };
 }

--- a/application/tests/unit/analytics-handlers.test.ts
+++ b/application/tests/unit/analytics-handlers.test.ts
@@ -391,6 +391,7 @@ describe('insight rules', () => {
         totalWaitMinutes: 0,
         totalFailedExecMinutes: 0,
         byProject: [],
+        timeoutReclaimable: null,
       },
       clusters: { totalOpen: 0, resolvedInPeriod: 0, byErrorType: [], clusters: [] },
       flakyTests: [],
@@ -423,7 +424,14 @@ describe('insight rules', () => {
         deltaPct: null,
         avgRunMinutes: null,
       },
-      wastedTime: { points: [], bucketDays: 1, totalWaitMinutes: 0, totalFailedExecMinutes: 0, byProject: [] },
+      wastedTime: {
+        points: [],
+        bucketDays: 1,
+        totalWaitMinutes: 0,
+        totalFailedExecMinutes: 0,
+        byProject: [],
+        timeoutReclaimable: null,
+      },
       clusters: { totalOpen: 0, resolvedInPeriod: 0, byErrorType: [], clusters: [] },
       flakyTests: [],
       regressionVelocity: {

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -104,7 +104,7 @@ Everything above is scoped to one project. The **Analytics** page (`/analytics`)
 
 - **Portfolio health** — every project's pass rate with its change vs the previous period, flaky volume, open failure clusters, and latest run, sorted worst-first.
 - **Pass rate heatmap** — projects × time, colored by pass rate, so you can see who degraded and when.
-- **CI time** and **Wasted CI time** — how many CI minutes your runs consume, and how many of those produce no signal (wait steps + failed attempts).
+- **CI time** and **Wasted CI time** — how many CI minutes your runs consume, and how many of those produce no signal (wait steps + failed attempts). Since a timed-out test burns its whole (often oversized) budget, the widget also calls out how much of that time is reclaimable by tightening oversized timeouts and removing stale `test.slow()` marks — the same [timeout opportunities](#performance) surfaced per project.
 - **Flakiest tests** — the global flaky leaderboard across all projects, using the [impact ranking](#impact-ranking) above.
 - **Failure clusters** — open root causes across all projects, by age and occurrences.
 - **Regression velocity** — new regressions and newly-flaky tests introduced per period (see [Regression signals](#regression-signals)), so you can see whether quality debt is growing or shrinking.


### PR DESCRIPTION
## What & why

Two follow-ups to the timeout-hygiene feature (#293, #295):

1. **Integrate timeout hygiene into the "Wasted CI time" analytics widget.** A timed-out test burns its whole (often oversized) budget, and that duration lands in the widget's "failed attempts" area — so timeout hygiene is the direct lever to shrink it. `getAnalyticsWastedTime` now returns a `timeoutReclaimable` summary (estimated reclaimable minutes + oversized / stale-`test.slow()` counts + a deep link), computed from the **same** `getAnalyticsTimeoutHygiene` detection the Insights feed uses, so the numbers stay consistent. It renders as a callout under the chart ("Up to ≈N min of this is avoidable — …").
2. **Fix the "Timeout opportunities" table file link.** It rendered the spec path as plain text; it now uses the shared `OpenInIdeLink` component (open-in-IDE), matching the "Slowest tests" table right above it. The project page passes `projectName` through.

## How was it tested?

- `app:typecheck`, `app:lint`, and the full `app:test:unit` suite pass.
- The `getAnalyticsWastedTime` unit test still passes with the new field; insight-context fixtures updated for the added `timeoutReclaimable` field.
- The demo exercises it end-to-end: its seed has 5 oversized + 5 stale-slow cases, so the demo's Wasted CI time widget now shows the reclaimable callout (~14 min) and the opportunities table shows the IDE link.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — detection is unit-tested; wiring verified via typecheck + updated fixtures
- [x] Docs updated if user-facing — `docs/flaky-tests.md` notes the wasted-time tie-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxDMJdi64YrPZAWXaeqhfv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxDMJdi64YrPZAWXaeqhfv)_