### PR TITLE
feat(app): add timeout-hygiene thresholds settings page

### DIFF
--- a/application/app/composables/useSettingsEnvState.ts
+++ b/application/app/composables/useSettingsEnvState.ts
@@ -34,6 +34,7 @@ export function useSettingsEnvState() {
     tags: false,
     storage: false,
     'wasted-time': false,
+    'timeout-hygiene': false,
     ai: false,
     about: false,
   });

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -111,7 +111,7 @@ import {
 } from './ai';
 import { apiGetAdminStats } from './admin';
 import { apiDeleteTestRun } from './test-runs';
-import { apiGetWastedWaits, apiPutWastedWaits } from './settings';
+import { apiGetWastedWaits, apiPutWastedWaits, apiGetTimeoutHygiene, apiPutTimeoutHygiene } from './settings';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
@@ -863,6 +863,12 @@ routes.push(
     method: 'PUT',
     pattern: /^\/api\/settings\/wasted-waits$/,
     handler: (_, body) => apiPutWastedWaits(body as Parameters<typeof apiPutWastedWaits>[0]),
+  },
+  { method: 'GET', pattern: /^\/api\/settings\/timeout-hygiene$/, handler: () => apiGetTimeoutHygiene() },
+  {
+    method: 'PUT',
+    pattern: /^\/api\/settings\/timeout-hygiene$/,
+    handler: (_, body) => apiPutTimeoutHygiene(body as Parameters<typeof apiPutTimeoutHygiene>[0]),
   },
 );
 

--- a/application/app/demo/api/settings.ts
+++ b/application/app/demo/api/settings.ts
@@ -13,6 +13,12 @@ import {
   parseWastedWaitPatterns,
   resolveStoredWastedPatterns,
 } from '#shared/utils/wasted-waits';
+import {
+  DEFAULT_TIMEOUT_THRESHOLDS,
+  TIMEOUT_THRESHOLDS_KEY,
+  resolveTimeoutThresholds,
+  type TimeoutThresholds,
+} from '#shared/analytics/timeout-hygiene';
 
 /** GET /api/settings/wasted-waits */
 export async function apiGetWastedWaits() {
@@ -34,4 +40,25 @@ export async function apiPutWastedWaits(body: { patterns?: string[] | string | n
 
   const stored = await getAppSetting<{ value: string[] }>(db, WASTED_WAIT_PATTERNS_KEY);
   return { ...resolveStoredWastedPatterns(stored), envManaged: false, defaults: [...DEFAULT_WASTED_WAIT_PATTERNS] };
+}
+
+/** GET /api/settings/timeout-hygiene */
+export async function apiGetTimeoutHygiene() {
+  const db = await getDemoDb();
+  const stored = await getAppSetting<Partial<TimeoutThresholds>>(db, TIMEOUT_THRESHOLDS_KEY);
+  return { thresholds: resolveTimeoutThresholds(stored), defaults: DEFAULT_TIMEOUT_THRESHOLDS };
+}
+
+/** PUT /api/settings/timeout-hygiene */
+export async function apiPutTimeoutHygiene(body: { thresholds?: Partial<TimeoutThresholds> | null }) {
+  const db = await getDemoDb();
+
+  if (body.thresholds === null) {
+    await deleteAppSetting(db, TIMEOUT_THRESHOLDS_KEY);
+  } else {
+    await setAppSetting(db, TIMEOUT_THRESHOLDS_KEY, resolveTimeoutThresholds(body.thresholds));
+  }
+
+  const stored = await getAppSetting<Partial<TimeoutThresholds>>(db, TIMEOUT_THRESHOLDS_KEY);
+  return { thresholds: resolveTimeoutThresholds(stored), defaults: DEFAULT_TIMEOUT_THRESHOLDS };
 }

--- a/application/app/pages/settings/timeout-hygiene.vue
+++ b/application/app/pages/settings/timeout-hygiene.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import type { TimeoutThresholds } from '#shared/analytics/timeout-hygiene';
+
+interface TimeoutHygieneSettings {
+  thresholds: TimeoutThresholds;
+  defaults: TimeoutThresholds;
+}
+
+const toast = useToast();
+const { data: settings, refresh } = await useFetch<TimeoutHygieneSettings>('/api/settings/timeout-hygiene');
+
+const saving = ref(false);
+const values = reactive<Record<keyof TimeoutThresholds, number>>({
+  minRuns: 0,
+  factor: 0,
+  floorMs: 0,
+  safety: 0,
+  recommendedFloorMs: 0,
+  slowStaleP95Ms: 0,
+});
+
+watchEffect(() => {
+  if (settings.value) Object.assign(values, settings.value.thresholds);
+});
+
+const fields: Array<{ key: keyof TimeoutThresholds; label: string; description: string; min: number; step: number }> = [
+  {
+    key: 'minRuns',
+    label: 'Minimum runs',
+    description: 'Executions with a duration needed before a test is judged.',
+    min: 1,
+    step: 1,
+  },
+  {
+    key: 'factor',
+    label: 'Oversize factor (×)',
+    description: 'Flag a timeout when it is at least this many times the test’s p95 duration.',
+    min: 1,
+    step: 0.5,
+  },
+  {
+    key: 'floorMs',
+    label: 'Minimum headroom (ms)',
+    description: 'Only flag when the timeout − p95 gap is at least this many ms.',
+    min: 0,
+    step: 1000,
+  },
+  {
+    key: 'safety',
+    label: 'Recommendation safety (×)',
+    description: 'Recommended timeout = p95 × this.',
+    min: 1,
+    step: 0.5,
+  },
+  {
+    key: 'recommendedFloorMs',
+    label: 'Recommendation floor (ms)',
+    description: 'Never recommend a timeout below this many ms.',
+    min: 0,
+    step: 1000,
+  },
+  {
+    key: 'slowStaleP95Ms',
+    label: 'Stale slow() p95 (ms)',
+    description: 'A test.slow() test is stale when its p95 duration stays under this.',
+    min: 0,
+    step: 1000,
+  },
+];
+
+async function save() {
+  saving.value = true;
+  try {
+    const updated = await $fetch<TimeoutHygieneSettings>('/api/settings/timeout-hygiene', {
+      method: 'PUT',
+      body: { thresholds: { ...values } },
+    });
+    settings.value = updated;
+    toast.add({ title: 'Timeout-hygiene thresholds saved', color: 'success' });
+    await refresh();
+  } catch (error: unknown) {
+    const message =
+      error && typeof error === 'object' && 'data' in error ? (error.data as { message?: string })?.message : undefined;
+    toast.add({ title: 'Save failed', description: message || 'An error occurred', color: 'error' });
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function resetToDefaults() {
+  saving.value = true;
+  try {
+    const updated = await $fetch<TimeoutHygieneSettings>('/api/settings/timeout-hygiene', {
+      method: 'PUT',
+      body: { thresholds: null },
+    });
+    settings.value = updated;
+    Object.assign(values, updated.thresholds);
+    toast.add({ title: 'Reset to defaults', color: 'success' });
+    await refresh();
+  } catch {
+    toast.add({ title: 'Reset failed', color: 'error' });
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <SectionCard icon="i-lucide-scissors" title="Timeout hygiene" help="settings.timeout-hygiene">
+      <template #subtitle>
+        Tune how timeout opportunities are detected — oversized per-test timeouts and stale <code>test.slow()</code>
+        marks — surfaced per project (Performance tab) and in Analytics. Opportunities are recomputed when viewed, so
+        changes apply to existing runs immediately.
+      </template>
+
+      <div class="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
+        <UFormField
+          v-for="f in fields"
+          :key="f.key"
+          :label="f.label"
+          :description="f.description"
+          :hint="`default ${settings?.defaults[f.key] ?? ''}`"
+        >
+          <UInput
+            v-model.number="values[f.key]"
+            type="number"
+            :min="f.min"
+            :step="f.step"
+            :placeholder="`default ${settings?.defaults[f.key] ?? ''}`"
+            class="w-full"
+          />
+        </UFormField>
+      </div>
+
+      <template #footer>
+        <div class="flex items-center justify-end gap-2">
+          <UButton
+            variant="ghost"
+            color="neutral"
+            :disabled="saving"
+            label="Reset to defaults"
+            @click="resetToDefaults"
+          />
+          <UButton color="primary" :loading="saving" icon="i-lucide-save" @click="save">Save</UButton>
+        </div>
+      </template>
+    </SectionCard>
+  </div>
+</template>

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -511,6 +511,11 @@ export const HELP_TOPICS = {
     doc: 'flaky-tests#performance',
     envVars: ['PIWI_WASTED_WAIT_PATTERNS'],
   },
+  'settings.timeout-hygiene': {
+    title: 'Timeout hygiene',
+    text: 'Thresholds for flagging oversized per-test timeouts and stale test.slow() marks. Opportunities are recomputed at read time, so changes apply to existing runs immediately.',
+    doc: 'flaky-tests#performance',
+  },
   'settings.auto-diagnose': {
     title: 'Auto-diagnose',
     text: 'When a run finishes, up to 3 new failure clusters are diagnosed automatically — each diagnosis is one research call (when a research model is configured) plus one diagnosis call — and new clusters get human-readable titles in one batched call. Requires the diagnosis model to be configured.',

--- a/application/app/utils/settings-metadata.ts
+++ b/application/app/utils/settings-metadata.ts
@@ -25,6 +25,7 @@ export type SettingsPageId =
   | 'tags'
   | 'storage'
   | 'wasted-time'
+  | 'timeout-hygiene'
   | 'ai'
   | 'about';
 
@@ -119,6 +120,15 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     roles: [Role.ADMINISTRATOR],
     introHelp: 'settings.wasted-time',
     fields: [{ id: 'wasted-time.patterns', label: 'Wasted-time patterns', help: 'settings.wasted-time' }],
+  },
+  {
+    id: 'timeout-hygiene',
+    label: 'Timeout hygiene',
+    icon: 'i-lucide-scissors',
+    to: '/settings/timeout-hygiene',
+    roles: [Role.ADMINISTRATOR],
+    introHelp: 'settings.timeout-hygiene',
+    fields: [{ id: 'timeout-hygiene.thresholds', label: 'Detection thresholds', help: 'settings.timeout-hygiene' }],
   },
   {
     id: 'ai',


### PR DESCRIPTION
## What & why

The timeout-hygiene detection thresholds were already tunable via the `/api/settings/timeout-hygiene` endpoints (added in #293) but had no UI — this adds the admin settings page for them, closing out the last deferred piece of the feature.

- **Settings → "Timeout hygiene"** page with numeric fields for the six thresholds (`minRuns`, oversize `factor`, headroom `floorMs`, recommendation `safety`/`recommendedFloorMs`, stale-`slow()` `slowStaleP95Ms`), each showing its default, plus a reset-to-defaults action. Mirrors the AI-limits / wasted-time settings pages.
- Registered in the settings nav (`SETTINGS_PAGES` + `SettingsPageId`), added the `settings.timeout-hygiene` help topic, and filled the exhaustive `useSettingsEnvState` map.
- Mirrored the get/put endpoints in **demo mode** (`app/demo/api/settings.ts` + router) so the page works in the demo too.

No server or schema changes — the endpoints and the `resolveTimeoutThresholds` sanitizer already existed.

## How was it tested?

- `app:typecheck`, `app:lint`, and the full `app:test:unit` suite pass.
- The page reuses the proven settings-page pattern (fetch `{ thresholds, defaults }`, PUT to save, PUT `{ thresholds: null }` to reset); the endpoints were shipped and covered in #293, and the demo handlers mirror them exactly.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — UI page over existing, already-covered endpoints; verified via typecheck + lint + unit
- [x] Docs updated if user-facing — the thresholds/tie-in are documented in `docs/flaky-tests.md` (from #293/#296); the page is self-describing with inline help

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxDMJdi64YrPZAWXaeqhfv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxDMJdi64YrPZAWXaeqhfv)_