### PR TITLE
fix: correct latest run selection and SPA routing edge cases

### DIFF
--- a/application/app/plugins/spa-github-pages.client.ts
+++ b/application/app/plugins/spa-github-pages.client.ts
@@ -19,8 +19,14 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   sessionStorage.removeItem('spa:redirect');
 
-  nuxtApp.hook('app:mounted', () => {
+  nuxtApp.hook('app:mounted', async () => {
     const router = useRouter();
-    router.replace(redirect);
+    // Wait for the router's initial navigation to settle before replacing it,
+    // otherwise the restore can race the initial route resolution and be lost
+    // (leaving the user on the home page).
+    await router.isReady();
+    if (router.currentRoute.value.fullPath !== redirect) {
+      await router.replace(redirect).catch(() => {});
+    }
   });
 });

--- a/application/app/service-worker/demo-sw.ts
+++ b/application/app/service-worker/demo-sw.ts
@@ -28,6 +28,13 @@ declare const self: ServiceWorkerGlobalScope & typeof globalThis;
 //   API_PREFIX  = '/piwi-dashboard/demo/api/'
 const SW_DIR_URL = self.location.href.replace(/\/[^/]*$/, '/');
 const API_PREFIX = new URL(SW_DIR_URL).pathname.replace(/\/+$/, '') + '/api/';
+// The registration scope path (trailing slash), e.g. '/demo/'.
+const SCOPE_PATH = new URL(SW_DIR_URL).pathname;
+// The generated single-page app shell, served for in-scope navigations.
+const APP_SHELL_URL = SW_DIR_URL + 'index.html';
+// The bundled trace viewer has its own service worker + entry HTML; never
+// hand it the SPA shell.
+const TRACE_VIEWER_PREFIX = SCOPE_PATH + 'trace-viewer/';
 
 // Configure the db module to locate WASM + seed SQL relative to the SW.
 configureDemoDb(SW_DIR_URL);
@@ -66,6 +73,33 @@ self.addEventListener('message', (event) => {
 
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
+
+  // Serve the SPA shell for top-level navigations within our scope. The demo
+  // is a static client-only SPA, so a deep-link reload (e.g. /demo/projects/123)
+  // has no matching static file — without this it would fall through to the
+  // static host's 404 handling and land the user back on the home page. Once the
+  // shell loads, Vue Router reads the URL and renders the correct page directly.
+  // API and trace-viewer paths are excluded (handled below / by their own SW).
+  if (
+    event.request.mode === 'navigate' &&
+    url.origin === self.location.origin &&
+    url.pathname.startsWith(SCOPE_PATH) &&
+    !url.pathname.startsWith(API_PREFIX) &&
+    !url.pathname.startsWith(TRACE_VIEWER_PREFIX)
+  ) {
+    event.respondWith(
+      (async () => {
+        try {
+          const shell = await fetch(APP_SHELL_URL, { credentials: 'same-origin' });
+          if (shell.ok) return shell;
+        } catch {
+          // Offline or fetch failure — fall back to the original request below.
+        }
+        return fetch(event.request);
+      })(),
+    );
+    return;
+  }
 
   // Only handle requests to the demo-scoped API prefix.
   if (!url.pathname.startsWith(API_PREFIX)) return;

--- a/application/shared/handlers/projects.ts
+++ b/application/shared/handlers/projects.ts
@@ -43,24 +43,44 @@ async function getProjects(db: DrizzleDB, scope: ProjectScope = 'all') {
 export async function listProjects(db: DrizzleDB, scope: ProjectScope = 'all') {
   const { ids: projectIds, projects: allProjects } = await getProjects(db, scope);
 
-  // 1. Run counts + latest run per project (single GROUP BY query instead of loading all rows)
+  // 1. Run counts per project (single GROUP BY query instead of loading all rows)
   const runStats: any[] = await db
     .select({
       projectId: testRuns.projectId,
       count: count(),
-      latestRunId: sql<number>`MAX(id)`,
-      latestStartTime: sql<Date>`MAX(start_time)`,
     })
     .from(testRuns)
     .where(inArray(testRuns.projectId, projectIds))
     .groupBy(testRuns.projectId);
 
   const runCountByProjectId = new Map<number, number>();
-  const latestRunIds: number[] = [];
   for (const r of runStats) {
     runCountByProjectId.set(r.projectId, r.count);
-    if (r.latestRunId) latestRunIds.push(r.latestRunId);
   }
+
+  // Latest run id per project, ranked by start_time (id as a deterministic
+  // tiebreaker). Using start_time rather than MAX(id) keeps "latest run"
+  // correct even when rows are ingested out of chronological order — e.g.
+  // historical uploads on the server, or the demo seed which inserts runs
+  // newest-first (so MAX(id) would be the oldest run).
+  const rankedRuns = db.$with('ranked_latest_runs').as(
+    db
+      .select({
+        id: testRuns.id,
+        projectId: testRuns.projectId,
+        rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${testRuns.projectId} ORDER BY ${testRuns.startTime} DESC, ${testRuns.id} DESC)`.as(
+          'rn',
+        ),
+      })
+      .from(testRuns)
+      .where(inArray(testRuns.projectId, projectIds)),
+  );
+  const latestIdRows: any[] = await db
+    .with(rankedRuns)
+    .select({ id: rankedRuns.id })
+    .from(rankedRuns)
+    .where(eq(rankedRuns.rn, 1));
+  const latestRunIds: number[] = latestIdRows.map((r) => r.id);
 
   // 2. Fetch full latest run rows
   const latestRuns: any[] =

--- a/application/tests/unit/list-projects-latest-run.test.ts
+++ b/application/tests/unit/list-projects-latest-run.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createClient } from '@libsql/client';
+import * as schema from '../../server/database/schema.sqlite';
+
+// The schema barrel picks the PostgreSQL schema at import time when
+// PIWI_DATABASE_URL is set, so clear it before importing the handler.
+delete process.env.PIWI_DATABASE_URL;
+const { listProjects } = await import('../../shared/handlers/projects');
+
+const now = Date.now();
+const at = (minutesAgo: number) => new Date(now - minutesAgo * 60 * 1000);
+
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+beforeAll(async () => {
+  db = drizzle(createClient({ url: ':memory:' }), { schema });
+  const migrationsFolder = fileURLToPath(new URL('../../server/database/migrations', import.meta.url));
+  await migrate(db, { migrationsFolder });
+
+  await db.insert(schema.projects).values([
+    { id: 1, name: 'Alpha' },
+    { id: 2, name: 'Beta' },
+  ]);
+
+  // Insert runs so that the NEWEST run (by start_time) has a LOWER id than an
+  // older run — exactly how the demo seed inserts runs (newest-first with an
+  // incrementing id). MAX(id) would therefore pick the OLDEST run.
+  await db.insert(schema.testRuns).values([
+    // Project 1: newest run (id 5, failed) is more recent than the old one (id 10, passed).
+    { id: 10, projectId: 1, status: 'passed', startTime: at(500), isFullRun: 1 },
+    { id: 5, projectId: 1, status: 'failed', startTime: at(1), isFullRun: 1 },
+    // Project 2: newest run (id 7, failed) is a partial run; old one (id 12, passed).
+    { id: 12, projectId: 2, status: 'passed', startTime: at(400), isFullRun: 1 },
+    { id: 7, projectId: 2, status: 'failed', startTime: at(2), isFullRun: 0 },
+  ]);
+});
+
+describe('listProjects latest run selection', () => {
+  test('picks the latest run by start_time, not MAX(id)', async () => {
+    const result = await listProjects(db);
+    const byName = new Map(result.map((p: any) => [p.name, p]));
+
+    const alpha = byName.get('Alpha');
+    expect(alpha.latestRun?.id).toBe(5);
+    expect(alpha.latestRun?.status).toBe('failed');
+    expect(alpha.totalRuns).toBe(2);
+
+    // Also honored when the newest run is a partial run.
+    const beta = byName.get('Beta');
+    expect(beta.latestRun?.id).toBe(7);
+    expect(beta.latestRun?.status).toBe('failed');
+  });
+});


### PR DESCRIPTION
## What & why

This PR fixes three related issues affecting the demo and project listing:

1. **Latest run selection bug**: `listProjects` was using `MAX(id)` to find the latest run, which fails when runs are ingested out of chronological order (e.g., historical uploads or the demo seed which inserts newest-first). Now uses `ROW_NUMBER() OVER (PARTITION BY projectId ORDER BY start_time DESC)` to correctly select by timestamp.

2. **SPA deep-link routing**: The demo service worker now serves the SPA shell (`index.html`) for top-level navigations within scope, enabling deep-link reloads (e.g., `/demo/projects/123`) to work correctly. Vue Router then reads the URL and renders the correct page. API and trace-viewer paths are excluded.

3. **SPA redirect race condition**: The `spa-github-pages` plugin now waits for the router to be ready before applying the redirect, preventing the restore from racing the initial route resolution and being lost.

## How was it tested

- Added comprehensive unit test (`list-projects-latest-run.test.ts`) that verifies latest run selection works correctly even when newer runs have lower IDs than older runs
- Service worker changes tested via demo navigation (deep-links now work)
- SPA redirect timing fixed to prevent race conditions during app mount

## Checklist

- [x] PR title follows Conventional Commits (`fix(scope): subject`)
- [x] Tests added for behavior changes (unit test for latest run selection)
- [x] No user-facing docs changes needed (internal fixes)

https://claude.ai/code/session_01WsdT2jiuJimGxegtR6eJbh