### PR TITLE
feat(reporter): skip run registration in Playwright UI mode

### DIFF
--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -267,6 +267,8 @@ globalSetup: createGlobalSetup(dashboard, async (config) => {
 
 Registration is best-effort: if the server is unreachable the error is non-fatal and the reporter simply creates the run normally once tests begin.
 
+In Playwright's **UI mode** (`playwright test --ui`) registration is skipped entirely. UI mode keeps one long-lived process and re-runs `globalSetup` every time you press play, but swaps the reporter out for its own internal one — so a run registered from `globalSetup` would never be finished, leaving orphaned "initialising" runs (one at launch, one per manual run). A chained `userSetup` still runs, so your own setup logic is unaffected.
+
 ## Multiple reports
 
 Attach multiple report types to a single test run. Each report appears as a separate button in the dashboard UI.

--- a/reporter/src/internal/support/run-mode.ts
+++ b/reporter/src/internal/support/run-mode.ts
@@ -1,0 +1,30 @@
+/**
+ * Detect Playwright's interactive **UI mode** (`playwright test --ui`, or
+ * `--ui-host` / `--ui-port`).
+ *
+ * Why the reporter cares: UI mode keeps a single long-lived runner process and
+ * re-runs `globalSetup` every time you press play, while swapping the user's
+ * reporters out for Playwright's internal UI reporter. So a run registered from
+ * `globalSetup` would never be finished by the Piwi reporter — leaving orphaned
+ * "initialising" runs on the dashboard: one when the UI launches and another
+ * each time a run is started from it. Skipping registration in UI mode avoids
+ * those stray runs.
+ *
+ * `globalSetup` runs in the same process the CLI was launched in, so the
+ * `--ui*` flags are visible on `process.argv`. We only scan tokens after the
+ * `test` subcommand (mirroring `detectCliFileFilters`) so an unrelated value
+ * that happens to look like a UI flag can't trigger a false positive.
+ *
+ * `argv` is a parameter (defaulting to `process.argv`) purely so tests can drive
+ * it deterministically.
+ */
+const PW_UI_FLAGS = ['--ui', '--ui-host', '--ui-port'];
+
+export function isUiMode(argv: string[] = process.argv): boolean {
+  // Drop the node executable + script path, then start after the `test` subcommand.
+  const args = argv.slice(2);
+  const testIdx = args.indexOf('test');
+  const rest = testIdx >= 0 ? args.slice(testIdx + 1) : args;
+
+  return rest.some((tok) => PW_UI_FLAGS.some((flag) => tok === flag || tok.startsWith(`${flag}=`)));
+}

--- a/reporter/src/public/global-setup.ts
+++ b/reporter/src/public/global-setup.ts
@@ -8,6 +8,7 @@ import { Logger } from '../internal/support/logger.js';
 import { computeInstanceId } from '../internal/support/instance-id.js';
 import { detectCiRunLabel } from '../internal/support/ci.js';
 import { getSetupFilePath } from '../internal/support/setup-file.js';
+import { isUiMode } from '../internal/support/run-mode.js';
 
 /**
  * Create a Playwright `globalSetup` function that registers a test run on the
@@ -54,6 +55,16 @@ export function createGlobalSetup(
 
     const opts = resolveOptions({ ...inlineReporterOptions, ...options } as Record<string, any>);
     const logger = new Logger(opts.verbose ?? false);
+
+    // In Playwright's UI mode the reporter never runs to finish a registered
+    // run, so registering here would leave orphaned "initialising" runs (one at
+    // UI launch, one per manual run). Skip registration but still chain
+    // userSetup so the user's own setup keeps working under the UI.
+    if (isUiMode()) {
+      logger.debug('UI mode detected — skipping run registration.');
+      if (userSetup) return userSetup(config);
+      return;
+    }
 
     if (opts.enabled === false || !opts.serverUrl) {
       logger.info('Not enabled — set PIWI_DASHBOARD_URL or serverUrl to enable.');

--- a/reporter/tests/global-setup.spec.ts
+++ b/reporter/tests/global-setup.spec.ts
@@ -129,6 +129,29 @@ describe('createGlobalSetup', () => {
     }
   });
 
+  it('does not register when Playwright runs in UI mode (still chains userSetup)', async () => {
+    const { server, url, requests } = await startServer((_req, res) =>
+      jsonRes(res, 200, { runId: 1, setupToken: 't' }),
+    );
+    const savedArgv = process.argv;
+    process.argv = ['node', 'playwright', 'test', '--ui'];
+    try {
+      let userSetupCalled = false;
+      const setupFn = createGlobalSetup({ serverUrl: url, projectName: 'global-setup-ui-mode' }, async () => {
+        userSetupCalled = true;
+        return 'chained-result';
+      });
+      const result = await setupFn({ reporter: [PIWI_REPORTER_ENTRY] });
+      expect(requests).toHaveLength(0);
+      expect(userSetupCalled).toBe(true);
+      expect(result).toBe('chained-result');
+      expect(readSetupInfo('global-setup-ui-mode')).toBeNull();
+    } finally {
+      process.argv = savedArgv;
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
   it('extracts serverUrl/projectName from an inline reporter entry when no options are passed', async () => {
     const { server, url, requests } = await startServer((_req, res) =>
       jsonRes(res, 200, { runId: 7, setupToken: 'ttt' }),

--- a/reporter/tests/run-mode.spec.ts
+++ b/reporter/tests/run-mode.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isUiMode } from '../src/internal/support/run-mode.js';
+
+const NODE = ['/usr/bin/node', '/path/to/playwright'];
+
+describe('isUiMode', () => {
+  it('is false for a plain test run', () => {
+    expect(isUiMode([...NODE, 'test'])).toBe(false);
+    expect(isUiMode([...NODE, 'test', 'tests/login.spec.ts'])).toBe(false);
+  });
+
+  it('detects the --ui flag', () => {
+    expect(isUiMode([...NODE, 'test', '--ui'])).toBe(true);
+  });
+
+  it('detects --ui-host / --ui-port in both bare and = forms', () => {
+    expect(isUiMode([...NODE, 'test', '--ui-host', '0.0.0.0'])).toBe(true);
+    expect(isUiMode([...NODE, 'test', '--ui-host=0.0.0.0'])).toBe(true);
+    expect(isUiMode([...NODE, 'test', '--ui-port', '0'])).toBe(true);
+    expect(isUiMode([...NODE, 'test', '--ui-port=9000'])).toBe(true);
+  });
+
+  it('does not confuse a similarly-named token for a UI flag', () => {
+    // A positional file filter or unrelated flag must not trigger UI mode.
+    expect(isUiMode([...NODE, 'test', 'ui.spec.ts'])).toBe(false);
+    expect(isUiMode([...NODE, 'test', '--ui-nonsense'])).toBe(false);
+  });
+
+  it('only considers tokens after the `test` subcommand', () => {
+    // A `--ui` token sitting before `test` is not part of the test invocation.
+    expect(isUiMode([...NODE, '--ui', 'test'])).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Playwright's UI mode (`playwright test --ui`) keeps a single long-lived runner process and re-runs `globalSetup` every time the user presses play. However, it swaps out the user's reporters for its own internal UI reporter, meaning any run registered from `globalSetup` would never be finished by the Piwi reporter — leaving orphaned "initialising" runs on the dashboard (one at UI launch, one per manual run).

This change detects UI mode and skips run registration entirely, while still chaining any user-provided `userSetup` function so their own setup logic continues to work.

## How was it tested?

- Added comprehensive unit tests for the new `isUiMode()` function covering:
  - Plain test runs (returns false)
  - Detection of `--ui`, `--ui-host`, and `--ui-port` flags in both bare and `=` forms
  - False positive prevention (file names and unrelated flags)
  - Correct scoping (only tokens after the `test` subcommand)
- Added integration test in `global-setup.spec.ts` verifying that registration is skipped in UI mode while `userSetup` is still called
- All existing tests continue to pass

## Checklist

- [x] PR title follows Conventional Commits (`feat(reporter): ...`)
- [x] Tests added for behavior changes (unit tests + integration test)
- [x] Docs updated (`docs/reporter.md`)

https://claude.ai/code/session_01LyK3AFoThSKE3cXs1uEF9f