### PR TITLE
docs: split agent instructions into scoped guides and refresh them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,55 @@
 # Piwi Dashboard — Agent Instructions
 
-> **Note:** Piwi Dashboard is **not affiliated with, endorsed by, or connected to Microsoft Corporation** in any way.  
-> The name "Piwi" was chosen as a playful, unrelated name — it has no connection to any existing product or brand.  
-> Piwi Dashboard was originally called "Playwright Dashboard" and was renamed to avoid any confusion with Microsoft's Playwright testing framework.
+> **Note:** Piwi Dashboard is **not affiliated with, endorsed by, or connected to Microsoft Corporation** in any way.
+> The name "Piwi" was chosen as a playful, unrelated name. The project was originally called "Playwright Dashboard" and
+> was renamed to avoid confusion with Microsoft's Playwright testing framework.
 
-This file provides project context for any AI agent (opencode, Copilot, Cursor, etc.).
+Root guide for any AI agent (Claude Code, opencode, Copilot, Cursor, …). It covers the whole monorepo: what lives where,
+how to run and verify things, and the conventions that apply everywhere.
 
-## Project Overview
+**Area guides — read the one covering the directory you are editing, in addition to this file:**
 
-Piwi test results dashboard built with **Nuxt 4**, Nuxt UI dashboard template. Stores and displays Playwright test results organized by projects.
+| Editing… | Read first |
+|---|---|
+| `application/` — the Nuxt dashboard (app, server, demo, MCP) | [`application/AGENTS.md`](application/AGENTS.md) |
+| `reporter/` — the Playwright reporter package | [`reporter/AGENTS.md`](reporter/AGENTS.md) |
+| `desktop/` — the Tauri desktop shell | [`desktop/AGENTS.md`](desktop/AGENTS.md) |
+| `docs/` — the VitePress documentation site | [`docs/AGENTS.md`](docs/AGENTS.md) |
 
-## Prerequisites
+Reference material worth opening when you need the map rather than the rules:
+[`application/ARCHITECTURE.md`](application/ARCHITECTURE.md) (dashboard) and
+[`reporter/ARCHITECTURE.md`](reporter/ARCHITECTURE.md) (reporter).
 
-- Node.js 24+, npm, Git
-- Commands run from `application/` unless noted
+## Project overview
 
-## Repository Structure
+A test results dashboard for **Playwright**, built with **Nuxt 4** and **Nuxt UI**. It ingests test results from a custom
+reporter, stores them (SQLite or PostgreSQL), and adds analysis on top: flaky detection, failure clustering, AI diagnosis,
+locator healing, notifications and an MCP server for AI agents. Self-hosted only — no SaaS, no other test frameworks
+(see [`ROADMAP.md`](ROADMAP.md) for direction and non-goals).
+
+## Repository layout
 
 ```
-application/            — Nuxt 4 dashboard app
-application/shared/     — Shared types, constants & utilities (import via `#shared/...`, not relative paths or `~~/shared/...`)
-application/tests/      — Functional tests (Playwright)
-packages/core/          — `@piwitests/core`: pure logic shared by the app AND the reporter (bundled into the reporter — see below)
-packages/server/        — `@piwitests/server`: published npm run-option for the server (bundles the app's built `.output/` + a `bin` launcher; `npx @piwitests/server`)
-plans/                  — Design docs, audit plans & roadmap (see below)
-reporter/               — Custom Playwright reporter package (TypeScript → bundled JS via tsup)
+application/          Nuxt 4 dashboard — app (UI), server (API), demo SPA, MCP server
+application/shared/   Types, constants & pure utilities shared app-wide (import via `#shared/...`)
+packages/core/        @piwitests/core — private, zero-dependency logic shared by app AND reporter
+packages/server/      @piwitests/server — published npm run-option (`npx @piwitests/server`)
+reporter/             @piwitests/reporter — the Playwright reporter (TypeScript → bundled via tsup)
+desktop/              Tauri desktop shell that bundles and runs the same server locally
+docs/                 VitePress documentation site, published to GitHub Pages
+integrations/nitro/   Backend-log instrumentation for Nitro apps
+integrations/aspnetcore/  Backend-log instrumentation for ASP.NET Core (NuGet)
+examples/             Standalone usage examples (Playwright fixtures)
+plans/                Local working docs — gitignored, never committed
 ```
 
-> **Global tracking files:** 
-> - `plans/roadmap.md` — single source of truth for product direction, priorities, and progress
-> - `plans/exploration-findings.md` — log of bugs, tech debt, inconsistencies, and non-critical issues discovered during exploration (auto-appended by agents)
-> 
-> Detailed per-feature implementation plans live alongside them. (`plans/` is gitignored, so these are local working docs, not committed.)
+`plans/` holds two tracked-by-hand files: `plans/roadmap.md` (working priorities) and `plans/exploration-findings.md`
+(a log of bugs, tech debt and inconsistencies found while exploring). Both are local-only. Public direction lives in the
+committed [`ROADMAP.md`](ROADMAP.md).
 
-## Quick Start
+## Quick start
+
+Prerequisites: **Node.js 24+**, npm, Git. Commands run from `application/` unless noted.
 
 ```bash
 cd application
@@ -41,632 +57,123 @@ npm install
 npm run app:dev      # http://localhost:3000
 ```
 
-SQLite database auto-initializes on first API call.
+The SQLite database and `.data/` storage are created automatically on the first API call — no configuration needed.
 
-## Architecture
+## Commands
 
-### Shared types (`application/shared/types.ts`)
-- `TestCasePayload`, `StreamEventPayload`, `TestRunFinishPayload` — API payload shapes
-- `TestRunStatus`, `TestCaseStatus` — status type unions
-- Server endpoints import directly from `#shared/types`
-- The small wire **leaf shapes** (`BrowserConfig`, `TestStepEvent`, `SuiteConfigEntry`, `TestAnnotation`, `FilterDetails`) live in `@piwitests/core/wire` and are re-exported here — one source of truth shared with the reporter. The per-case payloads (`TestCasePayload`/`StreamEventPayload`) stay app-side and the reporter's `WireTestCase` stays reporter-side; the two are kept compatible by `tests/unit/wire-shared-drift.test.ts`.
-
-### Shared core (`@piwitests/core`, `packages/core/`)
-- Private, **zero-dependency**, browser/worker/server-safe workspace package holding pure cross-cutting logic: locator generation/scoring (`locator-generation`), ARIA parsing + element-match healing (`locator-fingerprint`), locator-healing types, the wire leaf shapes (`wire`), and the locator-builder method list (`locator-methods`).
-- **Consumed two ways:** the app imports it via thin `application/shared/*` re-export shims so `#shared/...` paths never change; the reporter `import`s it and **tsup bundles it into `dist/`** at build time, so the published package stays self-contained (no `@piwitests/core` runtime dep, no monorepo path in the public `dist/index.d.ts`).
-- Ships **TypeScript source** (no build step) — Vite/Vitest transpile it (`build.transpile`/`deps.inline`), the reporter's tsup inlines it.
-- **Do not** put app-only (Nuxt/Drizzle/server) or reporter-only (Node-dependent) code here; keep it pure. `packages/core/tests/boundary.test.ts` enforces zero deps + no `node:`/cross-package imports, and `tests/unit/reporter-core-identity.test.ts` asserts the reporter re-exports the core functions rather than re-implementing them (replacing the old hand-mirror drift tests).
-
-### Database
-- **ORM**: Drizzle ORM (SQLite via libSQL, or PostgreSQL via postgres.js)
-- **Schema**: `application/server/database/schema.ts`
-- **Migrations**: `application/server/database/migrations/` (SQLite) or `migrations-pg/` (PostgreSQL, auto-run on startup based on `PIWI_DATABASE_URL`)
-- **Tables**: `projects`, `test_runs`, `test_cases`, `test_runs_cases`, `failure_clusters`, `failure_diagnoses`, `app_settings`, `files`, `trace_resources`, `trace_blobs`, `case_payloads`, `tags`, `project_tags`, `users`, `api_keys`, `account_tokens`, `notification_channels`, `subscriptions`, `notification_deliveries`, `locator_snapshots`
-- `locator_snapshots`: one row per locator call site (`test_case_id` + `location`), upserted each run with the latest element attributes + pre-computed ranked alternative locators; powers locator healing. `last_seen_run_id` FK `ON DELETE set null`. Unique index on `(test_case_id, location)`
-- `case_payloads`: content-addressed storage for the large per-execution text payloads (`aria_snapshot`, `test_source`, `test_source_frames` JSON) — one row per unique content per project (SHA-256 `hash`, unique `(project_id, hash)`), referenced from `test_runs_cases.*_payload_id` columns. **Large per-case text payloads MUST go through `case_payloads`** (`server/utils/case-payloads.ts`: `upsertCasePayloads` at write, `inlineCasePayloads`/`resolveCasePayloadContents` at read) — never add a new fat inline text column to `test_runs_cases`. The legacy inline columns remain readable (readers coalesce payload → inline); the demo writer keeps writing inline (in-browser DB, dedup pointless there), which permanently exercises the fallback branch. GC lives in `server/utils/retention.ts` (unreferenced payloads deleted after run pruning + aged orphan sweep)
-- `users` has `email` (unique, nullable) and `emailVerified` (boolean) columns added
-- `account_tokens`: single-use SHA-256-hashed tokens for reset/invite/verify; purpose enum; TTL enforced at query time
-- `notification_channels`: email/slack/webhook/browser destinations; webhook secrets AES-256-GCM encrypted via `crypto.ts`
-- `subscriptions`: links a user to a channel + optional project; `events` JSON array; `filters` JSON; `mode` realtime/digest; `mutedUntil` timestamp; `active` boolean
-- `notification_deliveries`: outbox table; `dedupeKey` unique constraint for idempotency; `status` pending/sent/failed/skipped; `attempts` + `scheduledFor` for progressive retry (1/5/15/60/240 min backoff)
-- **Audit**: See `plans/` for schema audit plans with findings and recommended changes
-
-### Backend (server/api/)
-Nuxt file-based routing:
-- `GET /api/health` — Public health/readiness probe; verifies DB connectivity (200 ok / 503)
-- `GET /_openapi.json` — Auto-generated OpenAPI 3.1 spec (enabled via `nitro.experimental.openAPI`)
-- `GET /docs` — Self-contained in-app API reference UI (no external CDN) rendered from the OpenAPI spec; includes a "Try it out" console (same-origin requests) and cURL / fetch code samples
-- `POST /api/test-runs/submit` — Submit JSON test results
-- `POST /api/test-runs/upload` — Upload with HTML reports + traces
-- `POST /api/test-runs/start` / `[id]/events` / `[id]/finish` — Streaming protocol (live runs)
-- `POST /api/test-runs/[id]/case-files` — Upload one case's trace + attachments during a streaming run (streamToken auth, idempotent, publishes `case-files` SSE event)
-- `GET /api/projects` — List projects with stats (heavy: runs, test case counts, reports, tags)
-- `GET /api/projects/menu` — Slim project list for sidebar navigation (`id`, `name`, `label` only; one SELECT, no joins)
-- `GET /api/projects/[id]` — Project details + runs
-- `GET /api/test-runs/[id]` — Run details + cases
-- `GET /api/test-cases/[id]` — Case details + steps, web vitals, network requests
-- `GET /api/test-cases/[id]/traces` — Trace files for a test case
-- `GET /api/test-cases/[id]/history` — Execution history across runs
-- `GET /api/test-run-cases/[id]/diagnosis` — Stored **execution-scoped** AI diagnosis for one test-run case (shared `getExecutionDiagnosis`, mirrored in the demo router). Powers the test-run-case Diagnosis tab's inline result on reload
-- `POST /api/test-run-cases/[id]/diagnose` — Run an **execution-scoped** AI diagnosis (reporter/admin). Uses the case's cluster for context when it has one; execution rows are stored with `scope='execution'` and a **null `cluster_id`** (they key on `test_runs_case_id`), so `resolveDiagnosisProjectId` falls back through the run for authorization
-- `GET /api/test-run-cases/[id]/diagnosis-context` — Preview the execution-scoped AI context (`?format=json` → sections/coverage/tokenEstimate); backs the "Copy AI context" button
-- `GET /api/test-runs/[id]/cases/[caseId]/locator-healing` — Ranked alternative locators for a failing locator (locator healing); authorized by the **case's** own project (the `caseId` may belong to a run other than `[id]`, e.g. from the cluster page). Returns `source: 'none'` rather than 404 when no alternatives exist
-- `GET /api/files/[...path]` — Download reports/traces
-- `GET /api/projects/[id]/flaky-tests` — Cross-run flakiness analysis (retry-pass + alternation detection)
-- `GET /api/failure-clusters/[id]/diagnosis` — Stored AI diagnosis + saved `manualBaseCommit` for a cluster
-- `POST /api/failure-clusters/[id]/diagnose` — Run AI diagnosis synchronously; 503 if unconfigured; accepts `baseCommit`, `selectedCommitShas`, `additionalContext`, `images` in body
-- `PATCH /api/failure-clusters/[id]/base-commit` — Persist a manual baseline commit SHA for a cluster
-- `GET /api/failure-clusters/[id]/commits` — Recent commits for the cluster's repo with `limit` and `hasMore`; includes aggregate diff when `baseline` query param is provided
-- `GET /api/failure-clusters/[id]/commit-diff` — Diff (files + patches) for a single commit SHA (`?sha=`)
-- `GET /api/failure-clusters/[id]/context` — Preview the full AI context that would be sent; accepts `baseCommit` and `selectedCommitShas` query params
-- `GET /api/ai/status` — Public AI configuration status (never returns the key)
-- `GET /api/settings/ai` — Admin: full AI settings including `hasApiKey`, `envManaged`
-- `PUT /api/settings/ai` — Admin: save provider/model/key/baseUrl/autoDiagnose
-- `POST /api/settings/ai/test` — Admin: smoke-test the configured AI provider
-- `GET /api/settings/smtp` — Admin: SMTP display config (host/port/user/from; never returns password); `envManaged: true`
-- `POST /api/settings/smtp/test` — Admin: send test email to `{ to }` via env-configured SMTP
-- `POST /api/auth/forgot-password` — Public, rate-limited (5/15 min/IP); sends reset email; always returns `{ success: true }` (no enumeration)
-- `POST /api/auth/reset-password` — Public; accepts `{ token, password }`; accepts both `reset` and `invite` token purposes; single-use
-- `POST /api/auth/change-password` — Authenticated; `{ currentPassword, newPassword }`
-- `GET /api/auth/verify-email?token=` — Public; marks email verified; redirects to `/settings/account?verified=1`
-- `POST /api/auth/send-verify-email` — Authenticated; mints a `verify` token and emails it
-- `POST /api/users/[id]/invite` — Admin; sends invite email with a reset-password link (mode=invite)
-- `PATCH /api/users/[id]` — Admin; update name, email, or role
-- `GET /api/channels` — Authenticated; lists user's channels + global channels (admins see all)
-- `POST /api/channels` — Authenticated; creates channel; admins can set `global: true`; webhook secrets encrypted at rest
-- `DELETE /api/channels/[id]` — Authenticated; owner or admin
-- `POST /api/channels/[id]/test` — Authenticated; sends a test delivery through the channel
-- `GET /api/subscriptions?projectId=` — Authenticated; lists subscriptions with joined channel info; optional projectId filter
-- `POST /api/subscriptions` — Authenticated; `{ channelId, projectId?, events[], filters?, mode, digestAt? }`
-- `PATCH /api/subscriptions/[id]` — Authenticated; update events/filters/mode/digestAt/mutedUntil/active
-- `DELETE /api/subscriptions/[id]` — Authenticated; owner or admin
-- `GET /api/notifications/stream` — Authenticated; SSE stream for browser-channel notification deliveries (connection stays open even on hidden tabs)
-
-### Frontend (app/)
-- **Pages** (`app/pages/`):
-  - `/` — Dashboard home with stats
-  - `/projects` — Project list
-  - `/projects/[id]` — Project detail
-  - `/test-runs/[id]` — Run detail
-  - `/test-cases/[id]` — Case detail across runs (pass rate + duration stats, duration trend, status-history strip, recent executions, failure clusters)
-  - `/test-run-cases/[id]` — Single execution detail, **diagnosis-first**. A failing execution opens on a **Diagnosis** tab modeled on the cluster page: full-width error card, then a `grid grid-cols-1 xl:grid-cols-[3fr_2fr]` with a right rail (`TestCaseVerdictCard`, `FailureClusterCard`, `TestCaseAiCard`; `xl:order-2` so it follows the error on mobile) and a left evidence funnel (`TestCaseEvidenceCard`, `LocatorHealingPanel`, `EnvironmentDiffCard`, `VisualDiffCard`, console/network, `PageStateCard`, ARIA, `DomSnapshotCard`). A passing execution opens on **Steps** with an **Artifacts** tab. Both keep **Performance** (hints + Web Vitals, always enabled) and **History** (always enabled). Tab is synced to `?tab=` with legacy aliases (`error`→`diagnosis`, `traces`→`diagnosis`/`artifacts`); the page `provide`s `clusterSectionLocatorKey` so an AI-diagnosis citation can reveal/scroll to the matching evidence section.
-- **Components** (`app/components/`): organized into domain subfolders; all auto-imported without folder prefix (Nuxt `pathPrefix: false`).
-  - **`shared/`** — UI primitives used across multiple pages: `RunStatusBadge`, `TestStatusBar`, `RunReports`, `TagBadge`, `TagsSelect`, `BrowserBadge`, `CiEnvCard` (CI provider/build/workflow + environment + tooling versions; pass an optional `browser` to fold in a dense browser line — icon + screen resolution, full config in the `BrowserBadge` tooltip), `SourceInfoCard`, `OpenInIdeLink` (clickable source path/`file:line` → open in the local IDE; see the "Clickable source paths" rule), `CodeBlock`, `MarkdownPreview`, `ScreenshotLightbox`, `LocatorHealingPanel` (fetches `/api/test-runs/:id/cases/:caseId/locator-healing`; renders ranked alternatives + recommended fix; used on the test-case and cluster pages)
-  - **`run/`** — Test run detail page (`/test-runs/[id]`): `RunSummary` (summary card + CI/Source/Other metadata), `TestCasesList` (paginated table, sticky headers, row highlighting via `meta.class.tr`), `WorkersTimeline` (clickable bars, emits `selectTestCase`), `RunCompare` (self-contained, watches internal `compareRunA`), `SlowEndpoints` (fetches `/api/test-runs/:id/network-requests` internally), `FailureGroups`, `RunReports`
-  - **`test-case/`** — Single-execution detail page (`/test-run-cases/[id]`): `TestCaseSummary` (pinned summary: status, location, duration, retries, worker, slowest step, timing vs avg, signal badges, annotation chips, wasted-time), `TestCaseVerdictCard` (regression/flaky/retry chips + clickable recent-runs strip + failing-streak verdict), `FailureClusterCard` (signature/error-type/occurrences + cluster AI verdict + hand-off; evolved from the old `FailureClusterBanner`), `TestCaseAiCard` (execution-scoped **Copy AI context** + **Diagnose with AI**, renders `DiagnosisResult` inline via the execution `/diagnose` + `/diagnosis` endpoints), `TestCaseEvidenceCard` (grouped screenshots/videos/traces/attachments with a folded peek), `TestCaseTracesCard`, `TestCaseConsoleCard`, `TestCaseNetworkRequests`, `TestCaseAttachmentsCard`, `PageStateCard`, `DomSnapshotCard`, `TestCaseHistoryChart`, `TestEvidenceSection`, `TestEvidenceScreenshots`, `TestEvidenceVideos`, `TestEvidenceSignals`, `TestEvidenceTraces`
-  - **`cluster/`** — Failure cluster detail (`/failure-clusters/[id]`): `ClusterSummary` (top summary: signature/metadata info card + inline Triage card, wrapped in `FoldableSummary`), `ClusterTestEvidence` (one tab per affected case, each with an "Open test run case" link, an evidence chip strip and reordered screenshots/traces/failing-steps/signals/source/ARIA blocks; caches each case's detail), `ClusterInvestigation` (baseline picker + SCM diff; its status line is derived from the shared `useScmStatusSummary` composable), `CommitPicker` (baseline selector with aggregate diff stats, caches per baseline), `CommitBrowserModal` (full-screen split modal: paginated commit list + per-commit diff), `ClusterExtractCasesModal`, `RegressionContext`. The page wraps the left-column sections (error, alternative locators, test evidence, what changed) in `CollapsibleSectionCard` (folded by default with a peek) and `provide`s a `clusterSectionLocator` (`useClusterSectionLocator`) so a diagnosis citation can unfold + scroll to the matching section.
-  - **`diagnosis/`** — AI diagnosis panel (right column of the cluster page): `DiagnosisPanel` (header, context preview, additional context, diagnose/stream/result), `DiagnosisCoverageStrip` (compact chip row of which evidence sections will be sent + token estimate; click a chip to focus it in the context modal), `DiagnosisContextModal`, `DiagnosisResult` (result display; evidence citations open the context modal and, when the section maps to the page, offer a "show on page" affordance), `DiagnosisScreenshots`, `DiagnosisExportMenu`
-  - **`project/`** — Project detail page (`/projects/[id]`): `PassRateChart`, `PerformanceTrendChart`, `TestRunsChart`, `FlakyTestsList` (score badges, retry-pass / alternation breakdown), `FailureClustersList`, `ScmChangesView`, `SubscribeBell` (notification subscribe popover; hidden when auth disabled)
-  - **`layout/`** — App shell / navigation: `ProjectsMenu`, `UserMenu`, `GetStartedWizard`
-  - **`demo/`** — Demo mode only: `DemoBanner`, `DemoInitScreen`, `DemoSimulator`
-  - **`docs/`** — In-app API reference (`/docs`), rendered from `/_openapi.json` with no CDN: `ApiReference` (overview + filter + tag groups), `ApiOperation` (one collapsible endpoint), `ApiSchema` (recursive schema tree), `ApiTryIt` ("Try it out" console + cURL / fetch samples). Pure helpers/types live in `app/utils/openapi.ts` + `app/utils/openapi-console.ts`; the shared bearer token in `useApiConsole`
-  - **Shared building blocks in `shared/`** (prefer these over re-implementing):
-    - `SectionCard` — `UCard` with a standard header: optional `icon` (+ `iconClass`), `title`, optional `(count)` and `subtitle` (prop or `subtitle` slot). `actions` slot for header-right controls, `footer` slot forwarded to `UCard`. Use for any card that needs an icon/title (and optional description) header.
-    - `CollapsibleSectionCard` — a `SectionCard` that folds to a single header row. Same header contract as `SectionCard` (`icon`/`iconClass`/`title`/`count`/`help`/`subtitle`/`actions`) plus a required `storageKey` (fold state persisted per user in a cookie, defaulting to folded) and a `#folded` slot for the one-line peek shown when collapsed. `actions` stay clickable while folded; exposes `setFolded(value)` so a parent can open it programmatically. Fold state is backed by the `useFoldedState(cookieKey, defaultFolded)` composable (also used by `useFoldableSummary`). Use for any left-column detail section that should default to a compact, scannable header.
-    - `EmptyState` / `LoadingState` / `ErrorState` — centered empty/loading/error blocks (`ErrorState` has an `action` slot for a retry button). Default `py-8` padding, disable with `:padded="false"`.
-    - `ChartLegend` — `{ color, label }[]` legend dots (use `dense` for inline charts).
-    - `DurationValue` — compact duration display: the numeric value + its unit (`ms`/`s`/`m`) in a faded color, no space between them (`:ms`, optional `fallback`/`unitClass`). Backed by the pure `splitDuration` helper in `app/utils/index.ts`. Use wherever a duration should read as a tight `210ms` / `1.2s` instead of the verbose `formatDuration` ("0.21 seconds").
-    - `DiffPatch` (colored unified-diff lines) and `DiffFile` (file card: sticky header + `DiffPatch`). Use for any SCM patch rendering.
-    - `HelpHint` — discreet inline-help affordance (muted `i-lucide-circle-help` icon → click popover with a short explanation + optional "Learn more" docs link). Pass a `topic` key from `app/utils/help-content.ts` (preferred) or inline `title`/`text`/`doc`. Use `i-lucide-circle-help` for help; reserve `i-lucide-info` for informational/empty-state callouts. NOTE: a topic's `title` becomes the trigger's accessible name `Help: <title>`, so avoid titles that are substrings of nearby action-button labels on the same view (e.g. don't title it "Subscribe" next to a "Subscribe" button) — Playwright's substring `getByRole('button', { name })` will match both. A topic may carry `envVars: PiwiEnvVarName[]` — the popover then lists each `PIWI_*` env var (with its description from the registry) as a click-to-copy `<code>` line plus a "Configuration reference" docs link, so a system admin knows which env var backs the setting.
-    - `EnvManagedBadge` — lock icon with a tooltip naming the `PIWI_*` env var(s) that pin a field. Use on any field that is read-only because env wins (`:env-vars` typed `PiwiEnvVarName[]`).
-    - `EnvManagedAlert` — standard top-of-card banner for env-pinned settings; replaces ad-hoc `UAlert`s. Lists the env var(s) and links to the configuration reference.
-    - `SettingsField` — `UFormField` wrapper for the Settings pages: renders the label row with a `HelpHint` (incl. env var) and an `EnvManagedBadge` when `:env-managed`. Use for every editable settings field so the surface stays homogeneous.
-    - `DocLink` — standardized "Learn more →" external docs link. Pass a docs path (page + optional `#anchor`); it runs through `docsUrl()` (`shared/docs.ts`) and opens in a new tab with `rel` hardening + external-link icon. Route all outbound docs links through this.
-    - `ChartCard` — thin wrapper over `SectionCard` for `@unovis/vue` trend charts: standard header (`icon`/`title`/`subtitle`/`help`/`actions`) + optional `legend` slot. Use instead of ad-hoc `UCard + #header` so charts get headers and inline help.
-    - `NavbarActions` — action row for `UDashboardNavbar` `#right` slots. Pass `:actions` (`{ label, icon, color?, variant?, to?, loading?, disabled?, onClick? }[]`); each renders as a `UButton` whose text label is hidden below `sm` (icon-only, label kept as `aria-label`/`title`) so page actions never crowd the breadcrumb on phones. Extra controls go in the `leading` (before) / default (after) slots. Use for **every** navbar action group instead of bare `UButton`s.
-    - `BreadcrumbNav` — drop-in replacement for `<UBreadcrumb :items>`. From `sm` up it renders the full `UBreadcrumb` (custom per-item slots like `#project` are forwarded); below `sm` it collapses the ancestor levels into a dropdown and shows only the current page label. Use on any page whose breadcrumb has 3+ levels.
-    - `TableScroller` — horizontal-scroll wrapper for wide content (tables, diffs, charts). Props: `minWidth` (e.g. `'60rem'`), `bleed` (default `true`, bleeds to the card edge below `sm`). Wrap any `UTable`/`<table>` that can't fit a phone width so it scrolls in place instead of stretching the page. Prefer a dedicated mobile card layout (see the responsive convention) for dense tables; use `TableScroller` when a card view isn't warranted.
-    - `StatTile` + `StatTileGrid` — a stat tile (`label`/`value`/`hint`, `size` `sm`·`lg`, `valueClass`, `#label` slot for a `HelpHint`) inside an auto-fitting grid (`minTileWidth`, default `8.5rem`) that reflows from 2 columns on phones up with no per-page breakpoints. Use instead of ad-hoc `bg-gray-50 dark:bg-gray-900` tile markup.
-    - `FilterToolbar` — wrap-friendly list-filter toolbar: a `start` group (counts, view toggles) and the default group (search, pills, selects) sit side by side on wide screens and stack + wrap on phones. Use for list/table filter rows so they never force horizontal page scroll.
-  - **Responsive / mobile convention (MUST follow):** the app must be usable at ~375 px with **no horizontal page scroll**. Write mobile-first (stacked/narrow as the default; add `sm:`/`md:`/`lg:` for wider screens) and never hide *data* with `max-sm:hidden` — hide only decorations. Reuse the primitives above rather than re-inventing: `NavbarActions` for navbar actions, `BreadcrumbNav` for deep breadcrumbs, `StatTile`/`StatTileGrid` for stat blocks, `FilterToolbar` for filter rows, and for wide tables either a `md:hidden` card list + `hidden md:block` table (preferred for dense tables, see `ProjectTrendTable`) or a `TableScroller` wrapper. Many tabs collapse to a full-width `USelect` below `sm` while the tab strip (`:ui="{ list: 'overflow-x-auto', trigger: 'shrink-0' }"`) shows from `sm` up — see `DetailPageLayout` (tabs-as-switcher) and `projects/[id]/index.vue` (`UTabs`-with-content: mobile `USelect` + `:ui="{ list: 'max-sm:hidden' }"`, both bound to the same `activeTab`). On fixed-height detail layouts, mobile must scroll as one document (never `overflow-hidden` clipping a tall summary) — `DetailPageLayout` handles this (page scroll + sticky tabs + collapsible summary). Verify new/changed screens at 375 px before committing.
-  - **Inline-help convention (MUST follow):** any new **block-level** shared component that renders a header MUST accept an optional `help?: HelpTopicKey` prop (typed from `app/utils/help-content.ts`) and render `<HelpHint v-if="help" :topic="help" />` in its header. Add help copy by adding one entry to the `HELP_TOPICS` registry — never hardcode hint strings at call sites. Document only non-self-explanatory blocks; skip self-explanatory ones (counters, search boxes, basic CRUD forms, theme switcher, plain metadata). When adding a hint, **remove any always-on prose it now carries** (subtitle/intro paragraph) so the page gets quieter, not busier. If the documented setting is overridable by a `PIWI_*` env var, set `envVars: [...]` on the topic (typed `PiwiEnvVarName[]` from `shared/piwi-env-vars.ts`) — the popover then surfaces the env var(s) for system admins.
-  - **Settings surface convention (MUST follow):** the Settings pages are harmonized on `SectionCard` + `SettingsField` and driven by `app/utils/settings-metadata.ts` (`SETTINGS_PAGES` registry: page id, label, icon, route, required `roles`, and `fields` each carrying a `HelpTopicKey`). The nav (`useSettingsNav`) and env-state (`useSettingsEnvState`) are derived from this registry — admin-only pages are hidden for non-admins, and env-managed pages show a trailing lock badge. When adding a new Settings page or field: (1) add the env var to `shared/piwi-env-vars.ts`, (2) add/extend a `HELP_TOPICS` entry with its `envVars`, (3) add a `fields` entry to the page in `SETTINGS_PAGES`, (4) render the field with `SettingsField` (or `EnvManagedBadge`/`EnvManagedAlert` if read-only). Never hand-roll an env-managed `UAlert` or lock icon — use the shared primitives.
-- **Composables** (`app/composables/`):
-  - `useAiStatus.ts` — Fetches `GET /api/ai/status` once; shared across components to show/hide AI actions
-  - `useCopy.ts` — `{ copy, copied }` clipboard helper (wraps VueUse `useClipboard`); `copy(text, { toast })`. Use instead of hand-rolling `navigator.clipboard` + a `copied` flag.
-  - `useChartMarkers.ts` — Shared interactive SVG-marker + floating-tooltip logic for the `@unovis/vue` trend charts. Returns `{ tooltipData, tooltipPos, onRenderComplete }`; bind `:on-render-complete` on the `VisXYContainer`.
-- **Pages** (`app/pages/`):
-  - `/settings/account` — Email address + verification, change password, OAuth provider info (auth-gated)
-  - `/settings/notifications` — SMTP status card (read-only from env), notification channels CRUD, subscription list with mute/delete
-  - `/settings/ai` — AI diagnosis configuration (provider, model, API key, base URL, auto-diagnose toggle)
-  - `/forgot-password` — Public, layout-free; no user enumeration in UI
-  - `/reset-password` — Public, layout-free; handles both reset and invite (`?mode=invite`) flows
-- **Utilities** (`app/utils/`):
-  - `performance-hints.ts` — Generates performance warnings for slow/flaky tests
-  - `index.ts` — Shared helpers: `formatDuration`, `getStatusColor`, `getFileApiPath`, `formatRelativeTime`, `createSortHeader`, `formatBytes`, `errorMessage` (unwrap `$fetch` errors), `filterCommits`, `scmFileStatusMeta`, `parsePatchLines`/`patchLineClass`, `clusterStatusColor`, `clusterErrorTypeColor`
-
-### Reporter
-> **Layout & conventions:** see **`reporter/ARCHITECTURE.md`** for the full map (public/internal split, two-process collect-and-submit data flow, fallback ladder, conventions). The package is `strict`-mode TypeScript; Node built-ins are `import * as x from 'node:x'`; classes use `private readonly` constructor parameter-property DI; HTTP failures throw `HttpError` (carrying `status`); `catch (error)` is `unknown` (narrow with `instanceof`, format with `errorMessage`).
-
-- **Public API** — only what these expose is the supported surface:
-  - `reporter/src/index.ts` — the package's single public entry (`.`): re-exports the reporter, `wrapConfig`, `createGlobalSetup`, `piwiFixtures`, `extendPiwiFixtures`, and the public types incl. `PiwiFixtures` (there is no `./fixtures` subpath — fixtures import from `@piwitests/reporter`)
-  - `reporter/src/public/reporter.ts` — `PiwiDashboardReporter` (Playwright hooks + running counters; hands off to `RunSubmitter`)
-  - `reporter/src/public/options.ts` — `PiwiDashboardOptions` interface + `PlaywrightTestConfig` re-export
-  - `reporter/src/public/config-wrapper.ts` — `wrapConfig`; `reporter/src/public/global-setup.ts` — `createGlobalSetup`
-- **`reporter/src/internal/`** — private plumbing, grouped by domain:
-  - `submit/` — `run-submitter.ts` (the submit/fallback ladder: streaming → multipart → JSON → recovery), `uploader.ts` (JSON/multipart/streaming-file uploads), `serializer.ts` (`toWireTestCase`/`serializeRun`/`resolveOverallStatus` — single source of truth for the wire field list)
-  - `transport/http-client.ts` — `HttpClient` (one `request()` core; login/postJSON/postFormData; throws `HttpError`)
-  - `streaming/` — `stream-manager.ts`, `stream-buffer.ts`, `crash-recovery.ts`
-  - `collect/` — `metadata-collector.ts` (CI/SCM/browser + suite metadata; owns all Playwright-internal suite access via `getSuiteInfo`/`getBrowserConfig`), `step-analyzer.ts`, `skip-classify.ts`, `error-text.ts`
-  - `files/` — `file-handler.ts`, `compression.ts`
-  - `capture/` — `capture-fixtures.ts` (Playwright fixtures for network/web-vitals/console/locator capture; runs in the worker), `locator-healing.ts` (re-exports the pure generation/scoring/types from `@piwitests/core`, and keeps the reporter-only runtime: `captureCallerLocation`, snapshot dedupe, the fixture-proxy method surface, and `suggestLocatorsFromAria`'s same-style rendering), `attachments.ts` (the `piwi-*` attachment names)
-  - `config/env.ts` — `PIWI_ENV_KEYS`, `resolveOptions`, `applyOptionsToEnv` (the `PIWI_*` ↔ option map)
-  - `support/` — `logger.ts` (`Logger`), `errors.ts` (`errorMessage`), `instance-id.ts`, `setup-file.ts`, `source-snippet.ts`, `cli-filters.ts`, `worker-index.ts`, `ci.ts`, `run-url.ts`, `ci-output.ts` (`emitRunOutputs`: surfaces the dashboard run URL to CI after submit — universal JSON `outputFile`, GitHub Actions `$GITHUB_OUTPUT`/step-summary/annotation, GitLab dotenv report), `limiter.ts`
-- **`reporter/src/types/`** — `wire.ts` (EXTERNAL server contract; leaf shapes re-exported from `@piwitests/core/wire`, the per-case `WireTestCase`/stream union kept here and pinned to the server payloads by `wire-shared-drift.test.ts`) and `collected.ts` (INTERNAL in-process model); `reporter/src/types.ts` is a barrel over both
-- `reporter/package.json` — NPM package
-- Source is TypeScript (`.ts` in `src/`); compile with `npm run reporter:build` to produce `.js` + `.d.ts` in `dist/`
-
-## Key Features
-- Auto-create projects on submission
-- Stores: status, duration, errors, HTML reports (full directory with assets), trace files
-- File storage: `.data/storage/` — paths stored relative to storage dir
-- REST + multipart upload APIs
-- Auto-generated OpenAPI 3.1 spec at `/_openapi.json` with a self-contained in-app reference UI at `/docs` (no external CDN)
-
-## Code Style
-- Keep it simple (AI-friendly codebase)
-- Full TypeScript, Nuxt 4 conventions, Nuxt UI components
-- Sentence case in UI (e.g., "Test runs"), relative dates with date-fns, human-readable durations
-- Use American English spelling throughout (e.g., "initialize", "organize", "color")
-- **Extract shared Vue components** when the same block of template exceeds ~10 lines and appears more than once — avoid duplicating markup with identical logic across components
-- **Never duplicate logic between server and demo code.** Both `server/` and `app/demo/api/` mirror each other (same DB schema, same persist logic). Any new utility function that would otherwise need to live in both places must be extracted into a shared module — either in `server/utils/` (demo imports via `~~/server/utils/...`) or `shared/` — and imported by both. Exceptions only when the implementation fundamentally differs (e.g., error handling, auth).
-- **Capture global change requests**: when I ask you to apply a change across multiple files (e.g., "update all X to Y"), add a new instruction rule to `AGENTS.md` documenting that pattern so future edits follow the same convention
-- **Conventional Commits (MUST follow — CI lints every commit)**: every commit message and PR title MUST pass commitlint. `commitlint.config.js` (repo root) is the source of truth; `CONTRIBUTING.md` has the full guide and the type→release-bump table — release-please reads PR titles (squash-merge subjects) to compute version bumps and the changelog. The `commitlint` CI check lints **every commit in the PR's range**, so one bad message turns the PR red; if one slips through, amend/reword and force-push. Format `type(scope): subject` with:
-  - `type` — one of `feat` `fix` `perf` `docs` `chore` `ci` `refactor` `test` `build` `style` `revert`
-  - `scope` — **closed list, anything else fails**: `app` `reporter` `db` `ui` `demo` `ci` `docs` `deps` `auth` `ai` `notifications` `release` (`main` is reserved for release-please's own release PRs). Scope is optional (warn-only) but include the best-fitting one; never invent a new scope (e.g. a timeline component change is `fix(ui)`, not `fix(timeline)`)
-  - `subject` — starts lower-case (sentence-case/Start Case/PascalCase/UPPER-CASE all fail), imperative mood, no trailing period; full header ≤ 100 chars
-  - Self-check before pushing: `npx commitlint --from HEAD~<n> --to HEAD` from the repo root (or rely on the husky `commit-msg` hook — never bypass it with `--no-verify`)
-- **Never embed plan/spec references in code**: comments must never reference plan IDs (A1, A2, B3, etc.), plan file names, or plan document titles. Code comments should describe what the code does, not where the requirement came from. When implementing a plan, strip all plan-track metadata before writing any code.
-- **Never write "before/after" comparative comments**: comments must never describe what the code used to look like or how it changed (e.g., "was X, now Y", "replaced A with B", "better than the old approach"). Comments describe the current state only — the why and what, not the history. Git handles history.
-- **Share types between server and shared on new computed sections**: when adding a computed evidence section (not a DB field) to the diagnosis context, the SectionId union in `ai-context.types.ts`, the `DIAGNOSIS_SECTIONS` array in `diagnosis-sections.ts`, and any new fields in `DiagnosisContextCoverage` in `types/api.ts` must all be updated in a single batch before implementing the section builder.
-- **Cross-platform shell commands**: any shell command shown to the user (docs, README/`*.md`, in-app `CodeBlock` snippets) must be cross-platform, or provide both a Linux/macOS and a Windows (PowerShell) version. Concretely: prefer portable single commands when one exists — use `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"` instead of `openssl rand -hex 32` for secrets, `npm`/`npx`/`docker`/`git` which behave the same everywhere, and avoid bash `\` line continuation (write the command on one line). When no single portable form exists, show two versions: in VitePress docs (`docs/*.md`) use `::: code-group` with ```bash [Linux / macOS] + ```powershell [Windows (PowerShell)] tabs; in GitHub-rendered `*.md` use two consecutive labeled fenced blocks (a `# Linux / macOS` bash block and a `# Windows (PowerShell)` powershell block). Mappings: `$(pwd)` → `${PWD}`; inline `VAR=val cmd` → `$env:VAR='val'; cmd` (or set it in `application/.env`); `rm -rf X` → `Remove-Item -Recurse -Force X`; `\` continuation → backtick `` ` `` in PowerShell. Linux-only Docker host operations (`chmod`/`chown` on bind mounts) need no PowerShell form — just note they apply to Linux hosts (Docker Desktop handles permissions on Windows/macOS). `curl` examples: convert first-touch ones (submit, auth setup/login) to a PowerShell `Invoke-RestMethod` tab (build the body as a hashtable piped through `ConvertTo-Json`); other `curl` examples may stay bash-only as long as the in-app [API docs](/docs) include a "Windows users: use Git Bash/WSL or Invoke-RestMethod" tip at the top. `.env` file contents (`PIWI_*=...`) are not shell commands — leave them as-is.
-- **Flaky root cause classification**: Add new categories to `classifyFlakyRootCause()` in `server/utils/flaky-classify.ts`. Keyword arrays at the top of the file. New column `flaky_root_cause` on `test_cases` table. Include `rootCause` field in `FlakyTest` response type (`types/api.ts`). `FlakyTestsList.vue` renders it via `TagBadge` with root-cause color mapping.
-- **Impact scoring**: Compute `wastedCiMinutes` and `impact` in `getProjectFlakyTests` (`shared/handlers/projects.ts`). Sort flaky tests by impact descending. Include `impact`, `wastedCiMinutes`, `avgFailedDurationMs` in `FlakyTest`. Color scale: green < 5min, amber < 30min, red >= 30min in UI.
-- **Regression signals**: `isNewRegression` and `isNewFlaky` columns on `test_runs_cases` (integer, 0/1). Computed after run finish via `computeRegressionSignals()` (`server/utils/compute-regression-signals.ts`). Called from `finish.post.ts`. Included in `getTestRun` and `getTestRunCase` response mappers. `TestCasesList.vue` shows red "NEW" and purple "FLAKY" badges with checkbox filter toggles.
-- **Failure clustering / fingerprints**: The grouping key is computed in `shared/error-fingerprint.ts` (`computeErrorFingerprint`) over error type + normalized message + masked locator — the **stack frame is intentionally NOT hashed** (kept as `topFrameFile` for display only) so the same root cause groups across spec files. Add new volatile-token masking inside `maskVolatile` (message) / `maskSelector` (locator). When you change normalization, bump `FINGERPRINT_VERSION` and keep the demo mirror in `shared/demo/demo-fingerprint.mjs#computeDemoFingerprint` (a regex-for-regex Node-importable port, imported by both `scripts/generate-demo-seed.mjs` and `tests/unit/demo-seed-consistency.test.ts`'s parity assertions — the plain `.mjs` exists because the seed script runs under plain Node, which cannot resolve the TypeScript module or its `@piwitests/core` import) in sync. A version bump is **non-destructive**: `reclusterFailureFingerprints()` (`shared/handlers/failure-cluster-recluster.ts`) re-fingerprints existing clusters from their stored `sampleError` on startup, updating in place or merging collisions via `mergeFailureClusters()` (`shared/handlers/failure-cluster-ops.ts`) so triage state survives. Re-run `npm run app:seed:demo` after any change.
-- **Demo AI diagnosis is data-grounded, not canned prose**: the demo has no AI provider, but the diagnosis experience is fully wired. `app/demo/api/diagnosis-context.ts` rebuilds a real evidence context (sections + coverage + token estimate) from the seed DB; `app/demo/api/scm.ts` serves a canned repo history (commits, diffs, branches, source files) from `app/demo/demo-scm.ts`, which assembles it from `shared/demo/failure-stories.mjs` rather than hand-mirroring source/patch strings itself; `app/demo/api/ai.ts` generates a per-cluster streaming/non-streaming diagnosis from that cluster's *real* stats (`collectClusterEvidence`) — `diagnosisKind()` reads the kind straight off the cluster's story (nine kinds: `timeout-interaction`, `goto-timeout`, `http-500`, `assertion-mismatch`, `strict-mode`, `stale-locator`, `js-error`, `crash`, `env-visibility`, falling back to pattern-matching for clusters with no story) and its suggested-fix patch is genuinely `validatePatch`-checked against the seeded source files; `app/demo/api/diagnoses.ts` serves version history + persists feedback. These are **demo-only** (kept out of `shared/handlers/` so the canned SCM never enters the server bundle) — the server has its own real endpoints. The version-snapshot row shape is the one place shared, via `shared/handlers/diagnosis-versions.ts` (`buildDiagnosisVersionValues`, used by both `server/utils/ai-diagnosis.ts#snapshotDiagnosis` and the demo force-refresh). **`shared/demo/failure-stories.mjs` is the single source of truth** for every seeded failure: one "story" per cluster carries the exact failing spec line, a reporter-faithful error string, the app source files it traces to, and a suggested-fix patch *derived* from those same source lines (via a small unified-diff builder) — so a story's error, source snippet, patch and demo-scm source can never drift apart the way the old hand-authored `CLUSTER_DEFS`/`*_FIX_PATCH` constants could. The locator-centric stories (clusters 1/2/6/9) additionally carry an **authored failure-time DOM snapshot** (`domSnapshot: { viewport, html }`, coherent with the story's ARIA snapshot and seeded locator alternatives) — the demo dom-snapshot mirror (`app/demo/api/dom-snapshot.ts`) serves it as if extracted from the case's trace (source `dom`, resolved per case via `storyForCase`) with precedence over the committed trace ZIPs, whose recorded fixture pages are too bare for the locator picker; the ZIP-parse path remains the fallback for cases without an authored page. Seeded diagnoses + prior versions live in `scripts/generate-demo-seed.mjs` (`FAILURE_DIAGNOSES` / `FAILURE_DIAGNOSIS_VERSIONS`), pulling `suggestedFix`/`autoSelectedCommits` straight off each story. Clusters without a seeded diagnosis are intentional — a visitor triggers a live simulated stream. `tests/unit/demo-seed-consistency.test.ts` guards the whole chain (fingerprint parity, cluster↔case↔file coherence, patch validity, media wiring). Re-run `npm run app:seed:demo` after any change.
-- **Spec health**: Endpoint `GET /api/projects/[id]/spec-health` groups by spec prefix. `SpecHealthTable.vue` renders a sortable `UTable` (pass rate, flaky rate, failures, tests, avg time per spec prefix; pass-rate dot + linked prefix). Add `spec-health` to `validTabs` and `tabItems` in project `index.vue` page.
-- **API docs live in the in-app API reference UI, not in VitePress docs**: The auto-generated OpenAPI spec (`/_openapi.json`) and interactive reference (`/docs`) in the running app or demo are the single source of truth for API documentation. The `/docs` page is a self-contained Nuxt page (`app/pages/docs.vue` + `app/components/docs/`) that renders the spec in-app — no third-party CDN, so it works offline / air-gapped and makes no outbound calls. There is no `docs/api.md` file in the VitePress docs site. Instead, the VitePress nav/sidebar links to the demo's `/docs` page (`https://piwitests.github.io/demo/docs`). When documenting features in VitePress `.md` files, reference `[API docs](/docs)` (for self-hosted) or the live demo link rather than inline endpoint descriptions, and never create a static API reference page.
-- **Per-route required roles (`x-required-roles`) are the single source of truth**: a route's `defineRouteMeta` declares who may call it via `openAPI['x-required-roles']`, and that one literal drives **both** the `/docs` display (`routeRoleRequirement`) **and** enforcement — `requireAuth(event)` reads the current route's roles from the compiled route metas (`server/utils/route-required-roles.ts`, matched with rou3 the same way Nitro dispatches) and 403s a user who lacks them. So **do not** pass a roles argument to `requireAuth`/`requireProjectAccess` for normal routes; just declare the meta. **It MUST be a string-literal array** (`'x-required-roles': ['administrator', 'reporter']`) — Nitro's meta extractor (`astToObject`) only folds inline `ObjectExpression`/`ArrayExpression`/`Literal` nodes, so a variable, function call, or `Role.ADMINISTRATOR` enum member is silently dropped/emptied; values must equal the `Role` enum's string values (`administrator`/`reporter`/`user`). Conventions: sign-in-only routes declare `['administrator', 'reporter', 'user']` (rendered "Any signed-in user"); a subset excluding `user` renders as elevated (admin/reporter-only); public or token-authenticated routes omit the field (or `[]`) — a lookup miss means "authenticated, any role". The `requireAuth(event, roles)` argument still exists as an **explicit override** for the rare handler that computes its own authorization (e.g. `users/[id].patch.ts` self-or-admin) — the meta then documents it but does not drive it. The matcher is unit-tested (`tests/unit/route-roles-match.test.ts`) and enforcement is covered end-to-end in `tests/reporter-with-auth.spec.ts`.
-- **Locator healing**: Capture happens in the reporter fixtures (`reporter/src/internal/capture/capture-fixtures.ts`, mirrored by the dogfood `application/tests/fixtures.ts`): a `Proxy` wraps the page-level locator methods in `LOCATOR_METHODS` and, after each successful action — and each **passing positive web-first assertion**, intercepted at the private `_expect` funnel every `expect(locator).…` matcher calls (`EXPECT_METHOD`), gated by the `EXPECT_CAPTURE_EXPRESSIONS` allowlist (presence-proving expressions only: absence (`to.be.hidden`/`to.be.detached`), multi-element (`to.have.count`, `*.array`, `to.have.values`), page-level (`to.have.title`/`to.have.url`) and `isNot` calls are skipped; one probe per call site per test; a failed positive assertion records a `failedLocators` entry with its call site, same as a failed action; a missing/renamed `_expect` or `matches` field degrades to no capture, never a broken assertion) — records the element's attributes plus ranked alternatives (`generateAlternatives` in `reporter/src/internal/capture/locator-healing.ts`) stamped with `captureCallerLocation()`. The in-page probe also reports `hasLabel` (gates `getByLabel` — an accessible name approximated from placeholder/title must not produce one) and `selectorCounts` (querySelectorAll uniqueness counts; ambiguous testid/id/name/class alternatives are dropped). The live input `value` is deliberately never captured (secret leak). Snapshots are deduped by location (`dedupeSnapshotsByLocation`) before attaching. The snapshots ride the wire as the transient `locatorSnapshots` per-case field (`shared/types.ts`, never a column) → every ingest site (`submit`, `upload`, `[id]/events`, + the demo `app/demo/api/reporter.ts` mirror) passes it to `persistRunCases` → the **shared** `upsertLocatorSnapshots` (`server/utils/locator-healing.ts`, imported by both server and demo) upserts one row per `(test_case_id, location)` into `locator_snapshots`. **Two invariants live in that helper:** rows are deduped by `(caseId, location)` before the batch upsert (a repeated call site would otherwise make PostgreSQL reject the `ON CONFLICT DO UPDATE`), and the stale-location purge runs **only for cases whose run passed** (`purge` flag) so a run that failed before reaching later locators doesn't delete their valid prior-success rows. The probe additionally collects **structural context** (only when the element resolves a role): `rolePosition` (index/count among same-role elements document-wide, plus `levelCount` for headings) and up to 4 anchor-worthy `ancestors` (testid | id | explicit role | aria-label | container tag, with scoped/doc-wide uniqueness counts) — both are wire fields on `LocatorSnapshot.element` and MUST be folded into the `elementAttrs` JSON inside `upsertLocatorSnapshots` (that object is the storage whitelist; anything omitted there is silently dropped; no schema migration needed). The in-page probe (`probeElementAttrs`) is a single self-contained function serialized into the browser via `target.evaluate`; the dogfood fixture **imports and calls it** (with the shared `CAPTURED_ATTRS_ARG`) rather than re-inlining it. Because it can't reference module closures, it receives the ARIA role maps (`TAG_TO_ROLE`/`INPUT_TYPE_TO_ROLE`, the single source of truth used by `resolveAriaRole`) and the derived role-source selector as fields of that `evaluate` argument — do NOT re-declare those maps inside the probe. `generateAlternatives` uses them to emit rename-proof structural alternatives (testid-anchor chain 72 / id-anchor 64 / name-free unique role 58 / landmark-anchor 55; skipped when the element has its own unique testid). Chained alternatives carry the **leaf** method (`getByRole`) with flat args (`anchorTestId`/`anchorSelector`/`anchorRole`, **never a `name` key** — `fingerprintFromSnapshot` reads the element name from the first `getByRole` alternative's args). Heading `getByRole` args carry `{ level }` (from the h1-h6 tag or `aria-level`, which is in `CAPTURED_ATTRIBUTES`). Lookup (`getLocatorHealing`) runs a ladder: exact call-site location → `file:line` (path-suffix tolerant) → locator signature → cross-test (same signature captured by another test in the project, freshest wins) → element-match against the failing ARIA snapshot → ARIA fallback. The element-match (`elementMatchOutcome`, `shared/locator-fingerprint.ts`) narrows heading candidates by `[level=N]` (parsed into `AriaCandidate.level`) and, on a total rename (best Dice < 0.2), falls back to the stored `rolePosition` index — gated on the same-role count being unchanged. **Stale gating:** when the outcome is `no-match` and the stored fingerprint has a name (the old name is provably gone from the failing ARIA), `resolveStoredHit` sets `priorNameMayBeStale`, excludes the failing locator (`locatorIdentityEquals`) and old-name-derived alternatives (`alternativeUsesName`) from the recommendation pool (full list stays visible; empty pool → `recommendation: null`, never a stale pick), and populates `fromAriaSnapshot` as a failing-page supplement. `LocatorHealingPanel.vue` must NOT recompute a client-side recommendation when `priorNameMayBeStale` is set (it would resurrect the stale pick). A flaky failure on an unchanged page (`unchanged`) keeps the full pool — recommending the original locator is correct there. `recommendation.suggestAddTestId` is only meaningful for stability-scored sources (`prior-run`/`fingerprint`/`cross-test`) and is force-cleared otherwise. The locator signature must hash identically on both sides — capture via `locatorSignature(method, args)` and lookup via `locatorSignatureFromExpression(expr)` (`shared/locator-healing.ts`); the error's leaf selector is extracted by `extractLeafSelector` (`shared/error-fingerprint.ts`). Pure helpers live in **`@piwitests/core`** (`locator-generation`, `locator-fingerprint`, `locator-healing-types`) and are re-exported by the `shared/` shims (`locator-healing.ts`, `locator-fingerprint.ts`, `locator-generation.ts`, `locator-healing.types.ts`) for `#shared/...` imports; the reporter `import`s the same core modules and tsup bundles them in. There is no longer a hand-mirrored copy — `tests/unit/reporter-core-identity.test.ts` asserts the reporter re-exports the exact core functions (`generateAlternatives`, role maps, `CAPTURED_ATTRIBUTES`, `classifyCssStability`, `isAutoGenerated`, …), so a re-implementation fails the suite. `shared/locator-generation.ts` (the browser-side generator the dashboard's DOM-snapshot picker runs) is the same core module the picker calls. The picker enriches its in-iframe probe result with `accessibleName` (label text first, then `approximateAccessibleName`) and `selectorCounts` before calling `generateAlternatives` — without that enrichment no `getByRole(name)`/`getByLabel` alternatives are generated. Dashboard picks persist via the shared `saveLocatorPick` (`server/utils/locator-healing.ts`, used by both the `locator-pick` endpoint and the demo router mirror): the failing locator's identity (location + `usedArgsFp`) is re-derived server-side from the stored error with the same helpers the lookup ladder uses (never trust client-parsed args); an existing row keeps its captured element data and only gets the pick merged to the front of `alternatives`; a missing row is created from the pick (synthetic `pick:<fp>` location when the error carries no call site); a pick that can't be keyed returns `not-persisted` (surfaced as a toast) instead of being silently dropped. Any authenticated project member may save a pick — the endpoint deliberately carries no role list. Toggle with the `captureLocators` reporter option / `PIWI_CAPTURE_LOCATORS` env var (auto-off when `collectPerformanceMetrics` is false). Surfaced via `LocatorHealingPanel.vue` and the `locatorHealing` AI-diagnosis section. Re-run `npm run app:seed:demo` after changing the captured/stored shape.
-- **Test source is a call stack**: on failure the reporter captures the in-project source of every stack frame — the line that threw plus its callers (helpers, page objects) — not just the test line. `collectSourceFrames` (`reporter/src/internal/support/source-snippet.ts`) parses the stack, drops `node_modules`/out-of-project frames, and snippets each surviving frame (innermost first, project-relative path) into the `test_source_frames` JSON column (`Array<{ file, line, snippet }>`, leaf `TestSourceFrame` in `@piwitests/core/wire`). The legacy single-string `testSource` is still captured (feeds the AI-context section) and is the UI fallback for old runs. `TestSourceStack.vue` renders the frames (failing line marked, "Failed here"/"Caller" badges) on the test-case page and inside `ClusterTestEvidence`.
-- **Clickable source paths**: Render any repo-relative source path (and any `file:line` / `file:line:col` location) with the shared `OpenInIdeLink` component rather than a bare `{{ path }}` in a `<span>`/`<code>`. Pass `filePath` (+ optional `line`/`column`) or a `location` string, and thread `projectKey` (the Piwi project **id**) and `projectName` (the Piwi project **name**) whenever they're in scope so per-project workspace-root/JetBrains-project overrides resolve; omit them to fall back to the global default root. IDE method, workspace root(s), VS Code flavor and JetBrains product/port are a **per-browser client preference** kept in `useOpenInIde` (`piwi-ide-prefs`, `useLocalStorage`) and edited via `OpenInIdeSettingsModal` (mounted once in `app/layouts/default.vue`, opened from the link chooser and the user menu) — this is deliberately **not** part of the DB/env `SETTINGS_PAGES` registry and has **no** `PIWI_*` env var (the source lives on the user's machine, so the mapping is inherently per-device). Pure URL/path builders live in `app/utils/ide-links.ts` (unit-tested); the `file:line:col` parser is the shared `#shared/parse-location` used by server, demo and client alike. Only the JetBrains local-server method is detectable; `vscode://`/`jetbrains://` launches are fire-and-forget, so never report a confirmed "opened" for them.
-- **Timed-out tests fold into `failedTests`**: There is no `timedOutTests` column on `test_runs`. Timed-out tests (per-case status `'timedOut'` from Playwright, camelCase; `'timedout'` lowercase in the declared `TestCaseStatus` union) are folded into `failedTests` so the run summary reconciles (`total = passed + failed + skipped + didNotRun`) and matches the UI (which already treats timed-out as failed in the status filter, color, and retry command). Every ingest site that writes `failedTests` MUST use `sumFailedAndTimedOut(body.failedTests, body.timedOutTests)` (for body-field sites: `finish.post.ts`, `submit.post.ts`, `upload.post.ts`, and the demo `app/demo/api/reporter.ts` mirror) or `countFailedFromTally(insertedStatusCounts)` (for per-status-tally sites: `events.post.ts` and the demo mirror). Helpers live in `shared/utils/test-counts.ts`. When adding a new ingest site, import and use these helpers — never write `failedTests: body.failedTests` directly. The reporter sends `timedOutTests` separately in the finish/submit body; `TestRunSubmitPayload`/`TestRunFinishPayload` declare it as optional.
-
-## Environment
-- `.env.example` in `application/` — `PIWI_SITE_URL` (optional)
-- Works with no env vars set; `.data/` created automatically
-- **Typed env-var registry**: `shared/piwi-env-vars.ts` is the single source of truth for every `PIWI_*` env var the app understands — each entry pairs the var name (object key → compile-time-checked literal) with a human description, category, and machine-readable metadata (`type`, `enum`, `default`, `min`/`max` clamps, `secret`, `relevantWhen`/`requiredWhen` conditions, `since`/`until` version range, `docs` anchor, `notes`). `keyof typeof PIWI_ENV_VARS` (`PiwiEnvVarName`) is the typed union used everywhere a var is referenced, so a typo is a build error. The `HelpTopic.envVars` field is typed `PiwiEnvVarName[]`, and `app/utils/settings-metadata.ts` fields reference env vars by typed name. **When you add a new `PIWI_*` var to `nuxt.config.ts` or a server util, add it to `PIWI_ENV_VARS` in the same change, with a `since: '<next release>'` stamp** — `tests/unit/piwi-env-vars.test.ts` fails if a referenced `PIWI_*` name isn't registered, if a post-0.14.0 var lacks `since`, or if a recorded `default`/`min`/`max` drifts from the code constants (`CONTEXT_LIMIT_FIELDS`, `INGEST_LIMIT_FIELDS`, `DEFAULT_WASTED_WAIT_PATTERNS`). Helper exports: `getEnvVarMeta`, `envVarsByCategory`, `isRuntimeSetting`, `envVarAppliesToVersion`, `knownRegistryVersions`, `compareVersions`.
-- **`docs/configuration.md` is GENERATED — never edit it by hand.** The docs site builds it from the registry via `docs/scripts/generate-configuration.mjs` (`npm run docs:gen`, auto-run by `docs:dev`/`docs:build`; the file is gitignored). Section prose lives in `PIWI_ENV_CATEGORIES` (title/intro/note/order, `mergeInto` folds a category into another's table, `internal` hides harness vars). The interactive configuration generator at `/configuration/generator` (`docs/.vitepress/theme/components/EnvWizard.vue` + `ConfigModeSwitch.vue`) reads the same registry through the `#shared` Vite alias wired in `docs/.vitepress/config.mts`, and emits output through the pure, dependency-free emitters in `shared/env-format.ts` (unit-tested quoting for .env/compose/docker run/K8s/systemd/shell). To change anything on either page, edit the registry (or the emitters) — never the markdown. Keep `docs/configuration.md`'s section anchors stable (`#general`, `#wasted-time` are deep-linked from the app and other docs pages).
-- `PIWI_SECRET_KEY` — master key for AES-256-GCM encryption of secrets stored in the DB (AI API keys, SCM tokens). Recommended in production even without auth enabled. Generate with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"` (cross-platform) or `openssl rand -hex 32` (Linux/macOS). Falls back to an insecure default in development.
-- AI diagnosis env vars (all optional — can also be set via Settings UI):
-  - `PIWI_AI_PROVIDER` — `anthropic` or `openai`
-  - `PIWI_AI_API_KEY` — API key (env takes precedence over DB; `envManaged: true` in status)
-  - `PIWI_AI_MODEL` — model name (default: `claude-opus-4-8` for Anthropic)
-  - `PIWI_AI_RESEARCH_MODEL` — optional cheaper/faster model for a pre-analysis pass before the main model writes the final diagnosis; empty → single-stage. The research stage analyzes a lean projection (high-signal sections only) for token efficiency; the final stage sees the full context. Two-stage breakdown is stored in `failure_diagnoses.details.pipeline` and shown as a "2-stage" badge in the UI.
-  - `PIWI_AI_RESEARCH_PROVIDER` / `PIWI_AI_RESEARCH_BASE_URL` / `PIWI_AI_RESEARCH_API_KEY` — optional per-role overrides so the research stage can run on a different provider (e.g. a small local OpenAI-compatible model). Each falls back to the main `PIWI_AI_*` value when unset.
-  - `PIWI_AI_BASE_URL` — base URL for OpenAI-compatible providers (e.g. `http://localhost:11434/v1`)
-  - `PIWI_AI_AUTO_DIAGNOSE` — `true` to auto-diagnose new clusters on run finish
-- AI diagnosis **context limits** — cap how much evidence (and tokens) go into each diagnosis. Defaults live in `shared/ai-context-limits.ts`; resolved as defaults ← stored settings (`ai_context_limits` in `app_settings`) ← env (`server/utils/ai-context-limits.ts#resolveContextLimits`). Editable in Settings → AI, or pinned via env (env wins, UI shows the field read-only). Env vars: `PIWI_AI_MAX_SAMPLE_ERROR_CHARS`, `PIWI_AI_MAX_SCM_PATCH_BUDGET`, `PIWI_AI_MAX_AFFECTED_TESTS`, `PIWI_AI_MAX_STEPS`, `PIWI_AI_MAX_CONSOLE_ENTRIES`, `PIWI_AI_MAX_CONSOLE_ENTRY_CHARS`, `PIWI_AI_MAX_NETWORK_REQUESTS`, `PIWI_AI_MAX_ARIA_SNAPSHOT_CHARS`, `PIWI_AI_MAX_TEST_SOURCE_CHARS`.
-- SMTP email env vars (all required for email features; read-only in Settings UI — not stored in DB):
-  - `PIWI_SMTP_HOST` — SMTP hostname
-  - `PIWI_SMTP_PORT` — port (default: `587`)
-  - `PIWI_SMTP_USER` — SMTP username
-  - `PIWI_SMTP_PASS` — SMTP password (never returned by API)
-  - `PIWI_SMTP_FROM` — from address (`noreply@example.com`)
-  - `PIWI_SMTP_FROM_NAME` — display name (optional)
-  - `PIWI_SMTP_SECURE` — `true` for port 465 TLS (default: `false`)
-  - `PIWI_SITE_URL` — public base URL used in email links (e.g. `https://piwi.example.com`)
-
-## Dev Commands (from `application/`)
+From `application/`:
 
 | Command | Purpose |
-|---------|---------|
-| `npm install` | Install deps |
+|---|---|
 | `npm run app:dev` | Dev server |
-| `npm run app:build` | Production build |
+| `npm run app:build` / `app:preview` | Production build / preview it |
 | `npm run app:typecheck` | TypeScript check |
-| `npm run app:lint` | oxlint |
-| `npm run app:lint:fix` | oxlint (auto-fix) |
-| `npm run app:format` | oxfmt (format files) |
-| `npm run app:format:check` | oxfmt (check formatting) |
-| `npm test` | Run all tests (unit + Playwright) |
-| `npm run app:test:unit` | Run unit tests (Vitest) |
-| `npm run app:test` | Run Playwright E2E tests |
-| `npm run db:generate` | Generate migration |
-| `npm run db:migrate` | Apply migrations |
-| `npm run db:push` | Push schema (dev only) |
-| `npm run db:studio` | Drizzle Studio |
+| `npm run app:lint` / `app:lint:fix` | oxlint |
+| `npm run app:format` / `app:format:check` | oxfmt |
+| `npm run app:test:unit` | Unit tests (Vitest) — add `:coverage` for coverage |
+| `npm run app:test` | E2E tests (Playwright) — add `:ui` / `:report` |
+| `npm test` | Everything: unit first, then E2E |
+| `npm run db:generate` / `db:migrate` / `db:push` / `db:studio` | Drizzle, SQLite — append `:pg` for PostgreSQL |
 | `npm run app:seed:demo` | Regenerate demo seed data (`public/demo/seed.sql`) |
 | `npm run app:seed:dev` | Load the demo sample data into the local dev SQLite DB |
-| `npm run app:generate:demo` | Build demo SPA |
-| `npm run app:check:demo` | Verify demo routes |
-| `node scripts/db-query.mjs "<sql>"` | Query the local SQLite DB directly |
+| `npm run app:generate:demo` / `app:check:demo` | Build / verify the demo SPA |
+| `node scripts/db-query.mjs "<sql>" [--json]` | Query the local SQLite DB directly |
 
-**DB query examples** (run from `application/`):
-```bash
-node scripts/db-query.mjs "SELECT key, value FROM app_settings"
-node scripts/db-query.mjs "SELECT id, name FROM projects" --json
-```
+From `reporter/`: `reporter:build`, `reporter:dev` (watch), `reporter:typecheck`, `reporter:lint[:fix]`,
+`reporter:format[:check]`, `reporter:test[:watch|:coverage|:integration]`.
 
-### Running the app locally with sample data (verification & screenshots)
+Run typecheck, lint and tests **once at the end** before the final commit — not after every edit.
 
-**When you need to see a change working in the real app** — verify a UI tweak, drive a flow, or capture a screenshot — run a **plain (non-demo) dev server backed by a dev DB seeded from the demo data**. Do this instead of hunting for a way to boot the app each time.
+## Conventions that apply everywhere
 
-```bash
-cd application
-npm run app:seed:demo                            # 1. generate public/demo/seed.sql (skip if it already exists)
-mkdir -p .data && npm run db:migrate             # 2. create + migrate an empty dev DB (.data/piwi.db)
-npm run app:seed:dev                             # 3. load the sample data (server must be stopped — DB lock)
-NUXT_IGNORE_LOCK=1 npx nuxt dev --port 3002      # 4. plain dev server (auth disabled by default)
-```
+### Code
 
-Then drive `http://localhost:3002` with Playwright using the pre-installed Chromium at `/opt/pw-browsers/chromium` (see `scripts/take-demo-screenshots.mjs` for a working harness). `app:seed:dev` is idempotent (`INSERT OR IGNORE`), so re-running it is safe; to refresh stale rows, wipe `.data` and repeat from step 2.
+- **Keep it simple.** This is a deliberately AI-friendly codebase: obvious code beats clever code.
+- Full TypeScript; Nuxt 4 conventions and Nuxt UI components in the app.
+- **American English** spelling throughout ("initialize", "organize", "color").
+- **Extract a shared component/helper** when the same block exceeds ~10 lines and appears more than once.
 
-**Caveats (these cost real debugging time — read them first):**
-- **Do NOT use `PIWI_DEMO_MODE=true` for local verification.** The demo runs entirely in-browser via a service worker + WASM SQLite that does **not** install in headless Chromium, so pages render blank. Demo mode is only for building the static demo SPA.
-- **Test cases live under runs #21+.** Runs #1–20 have 0 cases (their rows target a migration-only table that the dev schema drops), so a test-run-case URL for those runs renders empty. Query the DB (`node scripts/db-query.mjs`) for a real `test_runs_cases.id` — e.g. `SELECT id FROM test_runs_cases ORDER BY id DESC LIMIT 5`.
-- **Clusters with data:** #3, #4, #5, #7, #8.
-- **Brand icons** (`i-simple-icons-*`, e.g. browser badges) resolve from the iconify CDN at runtime; with no outbound network they render blank (only the `lucide` collection is bundled locally). This is an environment limitation, not a bug.
+### Comments
 
-### Reporter commands (from `reporter/`)
+- **Never reference plans or specs.** No plan IDs (`A1`, `B3`), plan file names or plan titles in code. Strip all
+  plan-track metadata before writing code — comments say what the code does, not where the requirement came from.
+- **Never write before/after comparisons.** No "was X, now Y", "replaced A with B", "better than the old approach".
+  Comments describe the current state only. Git holds the history.
 
-| Command | Purpose |
-|---------|---------|
-| `npm run reporter:build` | Compile TypeScript (from `src/`) to `.js` + `.d.ts` (in `dist/`) |
-| `npm run reporter:dev`   | Watch mode — auto-recompile on changes |
-| `npm run reporter:format`| Format source code with oxfmt |
-| `npm run reporter:test`  | Run unit tests with Vitest |
-| `npm run reporter:test:watch` | Watch mode — re-run tests on changes |
-| `npm run reporter:lint`     | Lint with oxlint               |
-| `npm run reporter:lint:fix` | Lint with auto-fix             |
+### Commits & PR titles (MUST follow — CI lints every commit)
 
-## Making Changes
+`commitlint.config.js` at the repo root is the source of truth; [`CONTRIBUTING.md`](CONTRIBUTING.md) has the full guide
+and the type → release-bump table. release-please reads PR titles (squash-merge subjects) to compute version bumps.
 
-...**Reporter**: Edit `.ts` files in `reporter/src/` → `npm run reporter:build` (from `reporter/`) → test with `npm link`
+Format `type(scope): subject`:
 
-### Source files
+- **type** — `feat` `fix` `perf` `docs` `chore` `ci` `refactor` `test` `build` `style` `revert`
+- **scope** — closed list, anything else fails: `app` `reporter` `db` `ui` `demo` `ci` `docs` `deps` `auth` `ai`
+  `notifications` `release` (`main` is reserved for release-please). Optional but include the best fit; never invent one
+  (a timeline component change is `fix(ui)`, not `fix(timeline)`).
+- **subject** — lower-case start, imperative, no trailing period, full header ≤ 100 chars.
 
-| Area                          | Responsibility                              |
-|-------------------------------|---------------------------------------------|
-| `src/index.ts`                | Public entry (`.`) — reporter + helpers + fixtures + types |
-| `src/public/`                 | Public API: `reporter`, `options`, `config-wrapper`, `global-setup` |
-| `src/internal/submit/`        | `run-submitter` (fallback ladder), `uploader`, `serializer` |
-| `src/internal/transport/`     | `http-client` (+ `HttpError`)               |
-| `src/internal/streaming/`     | `stream-manager`, `stream-buffer`, `crash-recovery` |
-| `src/internal/collect/`       | `metadata-collector`, `step-analyzer`, `skip-classify`, `error-text` |
-| `src/internal/files/`         | `file-handler`, `compression`               |
-| `src/internal/capture/`       | `capture-fixtures`, `locator-healing`, `attachments` (worker-side) |
-| `src/internal/config/`        | `env` (`PIWI_*` ↔ options)                  |
-| `src/internal/support/`       | `logger`, `errors`, `instance-id`, `setup-file`, `source-snippet`, `cli-filters`, `worker-index`, `ci`, `limiter` |
-| `src/types/`                  | `wire` (server contract) + `collected` (internal model) |
+The `commitlint` CI check lints **every commit in the PR range**, so one bad message turns the PR red. Self-check with
+`npx commitlint --from HEAD~<n> --to HEAD` from the repo root, and never bypass the husky `commit-msg` hook with
+`--no-verify`.
 
-See **`reporter/ARCHITECTURE.md`** for the full map and conventions.
+### Cross-platform shell commands
 
-## Key server utilities
+Any command shown to a **user** (docs, `*.md`, in-app `CodeBlock` snippets) must work on Windows too. Prefer a portable
+single command — `npm`/`npx`/`docker`/`git` behave the same everywhere, and
+`node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"` replaces `openssl rand -hex 32`. Avoid
+bash `\` line continuations; write one line.
 
-| File | Purpose |
-|------|---------|
-| `server/utils/email.ts` | `getSmtpConfig()`, `isEmailConfigured()`, `sendEmail({to,subject,html,text})` (lazy transport, no-op if unconfigured), template renderers for reset/invite/verify/test/run-notification emails |
-| `server/utils/account-tokens.ts` | `mintAccountToken(db, userId, purpose)` → plaintext (SHA-256 stored), `validateAccountToken`, `consumeAccountToken`; TTLs: reset=1h, verify=24h, invite=72h |
-| `server/utils/rate-limit.ts` | `checkRateLimit(key, limit, windowMs)` — simple in-memory sliding-window rate limiter |
-| `server/utils/notifications/match.ts` | `matchAndEnqueue(db, event, payload)` — queries active subscriptions, applies filters (branch/status/mute/threshold), inserts `notification_deliveries` rows with dedupeKey |
-| `server/utils/notifications/dispatch.ts` | `sweepOutbox(db)` — dispatches pending deliveries to email/Slack/webhook; handles retry backoff; webhook uses HMAC-SHA256 `X-Piwi-Signature` |
-| `server/utils/notifications/emit.ts` | `emitNotification(db, event, payload)` — gates on `isAuthEnabled`, calls matchAndEnqueue then kicks sweepOutbox fire-and-forget |
-| `server/utils/notifications/run-notifications.ts` | `emitRunNotifications(db, runId)` — emits `run.finished` / `run.failed` / `run.failed.default_branch` / `cluster.new` after run finalization |
-| `server/tasks/notifications/sweep.ts` | Nitro scheduled task (`notifications:sweep`) — calls `sweepOutbox(db)` every minute |
-| `shared/notification-events.ts` | `NOTIFICATION_EVENTS` tuple, `NotificationEvent` type, payload interfaces, `renderEventSubject(event, payload)` |
+When no portable form exists, show both: in VitePress use `::: code-group` with ```bash [Linux / macOS] +
+```powershell [Windows (PowerShell)] tabs; in GitHub-rendered `*.md` use two consecutive labeled fenced blocks.
+Mappings: `$(pwd)` → `${PWD}`; `VAR=val cmd` → `$env:VAR='val'; cmd`; `rm -rf X` → `Remove-Item -Recurse -Force X`;
+`\` → backtick. Linux-only Docker host operations (`chmod`/`chown` on bind mounts) need no PowerShell form — just note
+they apply to Linux hosts. Convert first-touch `curl` examples (submit, auth setup/login) to an `Invoke-RestMethod` tab;
+other `curl` examples may stay bash-only. `.env` file contents are not shell commands — leave them as-is.
 
-## Authentication & Authorization
+### Documentation
 
-- **Roles are defined as a TypeScript string enum** (`Role` in `shared/types.ts`): `ADMINISTRATOR`, `REPORTER`, `USER`. Use `Role.ADMINISTRATOR` etc. everywhere — never raw string literals.
-- **Auth is optional**: enabled by `PIWI_AUTH_ENABLED=true` env var. When disabled, `requireAuth()` returns a virtual admin user, so all endpoints work without auth.
-- **Two auth methods** (when enabled): session cookie (browser) or API key (Bearer token or `X-API-Key` header, `pd_` prefix).
+- Update the affected doc **in the same commit** as the code change.
+- User-facing docs live in `docs/` (VitePress → GitHub Pages); `README.md` is the landing page.
+- API reference is **generated** — never hand-write endpoint docs. See [`docs/AGENTS.md`](docs/AGENTS.md).
 
-### Endpoint Auth Requirements (MUST follow)
+### Tests
 
-All endpoints MUST call `requireAuth(event)` or `requireAuth(event, [roles])` at the top of the handler:
+- **Vitest** for unit tests (pure functions, no server/browser): `application/tests/unit/*.test.ts` and
+  `packages/*/tests/`, `reporter/tests/`.
+- **Playwright** for E2E/integration (needs a server or browser): `application/tests/*.spec.ts`.
+- A test that creates a project MUST use a static name from `#shared/test-project-names` (`PROJECT.YOUR_KEY`) and
+  register it there alphabetically, so global-setup cleanup removes it. Never use `Date.now()` suffixes.
 
-| Role array | Who can access | Used for |
-|---|---|---|
-| no arg (any authenticated) | Any logged-in user | Read endpoints: project list, run details, test cases, clusters, etc. |
-| `[Role.ADMINISTRATOR, Role.REPORTER]` | Reporter + Admin | Submitting test results, uploading, streaming runs, trace checks, failure cluster triage |
-| `[Role.ADMINISTRATOR]` | Admin only | User management, settings, project CRUD, tags, admin endpoints |
-| `[Role.ADMINISTRATOR, Role.REPORTER, Role.USER]` | All roles | Self-service API key management |
+### Working with the user's requests
 
-- **Streaming protocol** endpoints (`begin`, `events`, `finish`, `case-files`) use **stream token** auth (not `requireAuth`) — the token is validated against the stored run's `streamToken`.
-- **Public endpoints** (no auth required): `POST /api/auth/login`, `POST /api/auth/logout`, `GET /api/auth/me`, `POST /api/auth/setup`, OAuth flow endpoints, `GET /api/ai/status`, `GET /api/health`, `POST /api/auth/forgot-password`, `POST /api/auth/reset-password`, `GET /api/auth/verify-email`.
+- **Capture global change requests**: when asked to apply a change across many files ("update all X to Y"), add the
+  resulting convention as a rule to the relevant `AGENTS.md` so future edits follow it. Put it in the narrowest file
+  that covers it — area guide first, this root file only if it truly applies everywhere.
+- **Log what you find**: bugs, inconsistencies and tech debt discovered while exploring go to
+  `plans/exploration-findings.md` (local, never committed) as:
 
-### Implementing Auth on a New Endpoint
+  ```markdown
+  ## [Date] — [Exploration type/area]
 
-```typescript
-import { Role } from '#shared/types';
-import { requireAuth } from '../../utils/auth';
-
-export default eventHandler(async (event) => {
-  await requireAuth(event, [Role.ADMINISTRATOR]); // or plain requireAuth(event)
-  // ...
-});
-```
-
-When the `User` type from DB has `role: string`, cast to `Role`: `user.role as Role`.
-
-### OpenAPI Security Annotations
-
-- Every endpoint has a `defineRouteMeta` block with `openAPI` metadata — this is non-negotiable.
-- Auth/public distinction is documented via the `security` field:
-  - **Public endpoints** (auth, ai/status): `security: []`
-  - **All other endpoints**: inherit root-level `security: [{ bearerAuth: [] }, { sessionCookie: [] }]` defined in `nuxt.config.ts`.
-- The root `nuxt.config.ts` defines `components.securitySchemes` with `bearerAuth` (API key) and `sessionCookie` (session) schemes. The `meta` is type-cast with `as any` to allow these extra OpenAPI fields — this is intentional.
-- When adding a new endpoint, include `security: []` ONLY if it's truly public. All other endpoints inherit the default security automatically.
-
-### Project-level Permissions
-
-A **project assignment** layer sits atop the role system:
-
-- **`ADMINISTRATOR`**: full access to all projects, never filtered, no assignment needed.
-- **`REPORTER`** and **`USER`**: only see projects they're assigned to. Assignment can be **per-project** (list of project IDs) or **global** (all projects, `projectId = null`).
-- **Default**: no assignments = no access. Existing users get backfilled with global access on upgrade.
-
-Key implementation details:
-
-- **Schema**: `project_assignments` table in both `schema.sqlite.ts` and `schema.pg.ts` with `userId` (FK users, cascade), `projectId` (nullable FK projects, cascade = global), `createdBy`, `createdAt`.
-- **Authorization**: `server/utils/project-access.ts` — `getProjectScope(db, user)` returns `'all' | Set<number>`. `requireProjectAccess(event, projectId, roles?)` combines role + scope check. Admin/auth-off short-circuits to `'all'`.
-- **List filtering**: Pass `scope` to shared handlers (`listProjects(db, scope)`, `getProjectMenu(db, scope)`, `getRecentTestRuns(db, scope)`, `searchProjectsTestRunsCases(db, q, scope)`). Empty set → `[]` immediate return.
-- **Route verification**: For endpoints where the route `:id` IS the project id, parse it with `requireRouteId(event, 'id', label)` then call `requireProjectAccess(event, id, roles?)` directly. For endpoints scoped by a child entity (a cluster, run, case, test-run-case, or diagnosis id), use `requireResolvedProjectAccess(event, id, resolveXProjectId, notFoundLabel, roles?)` — it resolves the entity's project via one of the `resolveRunProjectId`/`resolveCaseProjectId`/`resolveClusterProjectId`/`resolveTestRunCaseProjectId`/`resolveDiagnosisProjectId` resolvers, 404s if the entity doesn't exist, then calls `requireProjectAccess`, returning `{ db, projectId, user }` so callers don't need a second `getDatabase()`. Both helpers live in `server/utils/project-access.ts` alongside the primitives they compose. Use plain `requireAuth` only for endpoints with no project scoping.
-- **Write endpoints** (`submit`, `upload`, `start`, `setup`): Existing project → `scopeAllows(scope, projectId)`. New project creation → only if `scope === 'all'`.
-- **Management API**: `GET/PUT /api/users/[id]/projects` (per-user) and `GET/PUT /api/projects/[id]/members` (per-project), both admin-only.
-- **Backfill**: Runs idempotently after DB migrations in `server/database/index.ts`. Gives all existing `USER`/`REPORTER` rows a global `projectId = null` assignment.
-- **403 everywhere**: Role refusal AND scope refusal both return 403 with an explicit message.
-
-## Making Changes
-
-- **DB fields**: Update `schema.ts` → `npm run db:generate` (or `db:generate:pg` for PostgreSQL) → review migration → restart
-  ⚠ Never create migration files or edit `_journal.json` manually — always use `npm run db:generate`.
-- **API endpoints**: Create file in `server/api/` → use `eventHandler()` + `getDatabase()`
-- **OpenAPI annotations**: Add `defineRouteMeta({ openAPI: { tags, summary, parameters, security, ... } })` to each new handler to appear in the auto-generated spec at `/_openapi.json` and `/docs`. Include `security: [{ bearerAuth: [] }]` for auth-required endpoints, `security: []` for public ones.
-- **Pages**: Create Vue file in `app/pages/` → use `<UDashboardPanel>` + `useFetch()`
-- **Components**: Create Vue file in the matching subfolder of `app/components/` (`shared/`, `run/`, `test-case/`, `cluster/`, `project/`, `layout/`, `demo/`) → all auto-imported without path prefix (Nuxt `pathPrefix: false`) → follow existing patterns:
-  - Self-contained data fetching is preferred for tab content (use `watch` + `$fetch` or `useFetch` with `lazy: true`)
-  - Pass props from parent page only for data already fetched at the page level
-  - Use `v-if` for tab-switched components to ensure clean mount/unmount
-- **Navigation**: Edit `app/layouts/default.vue` links array
-- **Tests**: Two test runners — **Vitest** for unit tests, **Playwright** for E2E/integration tests.
-  - **Unit tests** (pure functions, no server/browser): Create `.test.ts` in `application/tests/unit/` → run `npm run app:test:unit`
-  - **E2E/integration tests** (need server or browser): Create `.spec.ts` in `application/tests/` → run `npm run app:test`
-  - `npm test` runs both (Vitest first, then Playwright).
-  - If the test creates a project, **add its name to `shared/test-project-names.ts`** (alphabetically sorted) so the global setup cleanup deletes it before the next run. Tests must use static project names, not `Date.now()` suffixes.
-  - Use `PROJECT.YOUR_KEY` from `#shared/test-project-names` in test code instead of raw string literals. This ensures every project name is tracked in one place.
-- **Reporter**: Edit `.ts` files in `reporter/src/` → `npm run reporter:build` (from `reporter/`) → test with `npm link`
-- **Shared types** (`application/shared/types.ts`): Wire contract between reporter and server. Server imports directly. The reporter shares the wire **leaf shapes** via `@piwitests/core/wire` (bundled in, so no monorepo path leaks into the published `.d.ts`); its per-case `WireTestCase` stays reporter-side and is pinned to the server payloads by `wire-shared-drift.test.ts`. Do NOT `import` `application/shared` from the reporter — use `@piwitests/core`
-- **Entity links** (`shared/link-detect.ts`): Pure utility for detecting external URL provider (Jira, GitHub, etc.) and extracting keys. Uses domain regex matching, no dependencies. Provider enum includes `jira`, `github-issue`, `github-pr`, `gitlab-issue`, `gitlab-mr`, `bitbucket`, `confluence`, `slack`, `linear`, `notion`, `generic`.
-- **Retry command** (`app/utils/retry-command.ts`): Pure function `buildRetryCommand(cases, opts?)` that builds a Playwright CLI command string. Three modes: `file-line` (default, most precise), `grep` (by title, survives line shifts), `file` (broadest, deduped files). Groups by project, escapes shell args, caps at 4096 chars with fallback modes.
-- **Entity Links API** (`server/api/links/`): CRUD endpoints for attaching external URLs to runs, test-case runs, or test cases. Uses three nullable FK columns (`test_run_id`, `test_runs_case_id`, `test_case_id`) with `ON DELETE CASCADE` — matches the `files` table pattern. Provider auto-detected on create. `entityType` query param accepts `test_run`, `test_runs_case`, or `test_case`. Write requires `[ADMINISTRATOR, REPORTER]` role, read requires any authenticated role. Embed links in existing GET responses (`test-runs/[id]`, `test-cases/[id]`).
-- **Adding a field to test run data**: Add to `shared/types.ts` payload(s) → add column to both `schema.sqlite.ts` and `schema.pg.ts` (a large text/JSON payload field must NOT become an inline `test_runs_cases` column — store it via `case_payloads`, see the Database section) → `npm run db:generate && npm run db:generate:pg` → update `types/api.ts` (frontend types) → update all API handlers (`submit`, `upload`, `[id]/events`, `[id].get`, `[id]/stream.get`, `test-cases/[id].get`) → update server utils (`persist-run-cases.ts`) → **update reporter**: add the field to `reporter/src/types/collected.ts` (`CollectedTestCase`) and `reporter/src/types/wire.ts` (`WireTestCase`), accumulate it in `reporter/src/public/reporter.ts` `onTestEnd`/`onTestBegin`, and project it in `reporter/src/internal/submit/serializer.ts` `toWireTestCase` (per-case) or `serializeRun` (run-level). `serializeRun` is the single source of truth for the run body — both `Uploader.uploadJSON` and `Uploader.uploadWithFiles` call it, so a run-level field only touches one serializer now. → update demo (`scripts/generate-demo-seed.mjs`, `demo/api/reporter.ts`, `demo/api/test-runs.ts`, `demo/api/test-cases.ts`, `demo/simulator.ts`) → update UI components that consume the new field → `npm run app:seed:demo`
-
-### Sharding Pattern
-
-When implementing or extending sharding support:
-
-- **runLabel**: Detected from CI env vars (`GITHUB_RUN_ID`, `CI_PIPELINE_ID`, etc.) by `MetadataCollector.detectCiRunLabel()` (reporter) and `detectCiRunLabel()` (helpers.ts). Users override via `PiwiDashboardOptions.runLabel`. Applied in `createGlobalSetup` too.
-- **instanceId**: When `runLabel` is set, `computeInstanceId(projectName, runLabel)` uses `projectName|runLabel` instead of `hostname|projectName`. All shards share the same instanceId.
-- **Per-shard tokens**: Each shard gets its own stream token. The server stores them in `RunEventBus.runStates[id].shardTokens` (`Set<string>`). Validated in `/events` and `/finish` endpoints as fallback when the main `streamToken` doesn't match.
-- **Shard detection**: Reporter reads `config.shard` (from `--shard` CLI) in `onBegin`. Server detects sharded runs by `shardTotal > 1` in request bodies.
-- **Server-side merge**: `/start`, `/setup`, and `/submit` reuse an existing run when `shardTotal > 1` and an active run with the same `instanceId` already exists. `/finish` accumulates counters via SQL `+` and sets final status only when `shardsFinished === shardTotal`. `cancelInstanceRuns()` skips sharded runs when `isShardedRun: true`.
-- **DB columns**: `test_runs.shardTotal` (nullable integer) and `test_runs.shardsFinished` (integer, default 0).
-- **New endpoint handler pattern**: Always validate shard tokens alongside the primary `streamToken`: check `cachedState.shardTokens?.has(body.streamToken)` as fallback. Use `validateAndReviveRun()` with the `isShardToken` callback.
-
-## UI Patterns
-
-- **UTable sticky headers**: Use the `sticky` boolean prop + `max-h-*` class on the table root element. Do NOT wrap tables in `overflow-y-auto` divs — UTable's own root handles overflow when `max-h` is set.
-- **Row highlighting**: Use `:meta="{ class: { tr: 'highlight-class' } }"` on UTable, NOT `:row-attrs` (which is unsupported in Nuxt UI v4).
-- **Tab panels with summary**: Use `DetailPageLayout` — renders the summary + tab bar + tab panels as direct flex children of the page body. From `lg` up: fixed summary, only the panel content scrolls (proper flex height propagation that `<UTabs>` content slots cannot provide). Below `lg`: the whole panel scrolls as one document (no clipping of a tall summary), the tab bar is sticky, the summary is collapsible via a "Hide summary" toggle, and the tab bar becomes a full-width `USelect` below `sm`.
-  ```vue
-  <DetailPageLayout v-model="activeTab" :tab-items="tabItems" :tab-panel-class="tabPanelClass">
-    <template #summary>
-      <!-- FoldableSummary or any summary content — rendered shrink-0 -->
-      <RunSummary ... />
-    </template>
-    <template #tab-test-cases>
-      <!-- Tab content — rendered inside flex-1 min-h-0 panel -->
-      <TestCasesList ... />
-    </template>
-  </DetailPageLayout>
+  ### Finding: [Brief title]
+  - **File/Component**: location in codebase
+  - **Issue**: what is wrong
+  - **Impact**: severity and effect
+  - **Suggested fix**: recommended action (omit if obvious)
   ```
-  The `tabPanelClass` prop lets tabs with self-scrolling content (UTable with `sticky`, etc.) use `overflow-hidden flex flex-col` instead of the default `overflow-y-auto` (applied at `lg`+ only; below `lg` the panel flows into the page scroll).
-- **Data fetching in children**: For self-contained components rendered conditionally (e.g., tab content), use `watch` + `$fetch` with reactive triggers rather than `useFetch` with `lazy: true`, since `useFetch` may not fire until the component is mounted.
 
-### UTable conventions (MUST follow)
-
-- **Always use template slots for cell rendering** — NEVER use `cell:` callbacks with `h()` or `resolveComponent()` in column definitions. The only exception is `createSortHeader<T>()` in `header:`.
-- **Mobile (MUST follow)**: a multi-column `UTable` overflows a phone. Give any table with ≥5 columns a `md:hidden` card list alongside a `hidden md:block` table (preferred — see `ProjectTrendTable`), or at minimum wrap it in `TableScroller` so it scrolls in place instead of stretching the page. Never leave a wide table to squeeze/overflow at 375 px.
-- **Slot naming**: `#${accessorKey}-cell="{ row }"` for data cells (e.g. `#errorType-cell`, `#lastSeenAt-cell`). For `id`-only columns use `#${id}-cell`. Header slots: `#${accessorKey}-header` or `#${id}-header`.
-- **Sort headers**: Use `createSortHeader<T>('Label')` (from `app/utils/index.ts`) for every sortable column. Non-sortable columns (actions, badges without natural ordering) use a plain string.
-- **Actions column pattern**:
-  ```ts
-  { id: 'actions', header: 'Actions' }
-  ```
-  ```html
-  <template #actions-header><div class="text-right">Actions</div></template>
-  <template #actions-cell="{ row }">
-    <div class="flex justify-end gap-2">
-      <UButton :to="`/.../${row.original.id}`" size="sm" variant="outline" trailing-icon="i-lucide-arrow-right">View</UButton>
-    </div>
-  </template>
-  ```
-- **No `import { h, resolveComponent }` in table components** — if a component needs it for something other than a table cell, that's fine, but table cells must use slots.
-
-## UI Best Practices
-- Sentence case headings/labels
-- Relative dates via date-fns (full timestamp on hover)
-- Human-readable durations (exact ms on hover)
-- Add `title` attribute on any button/control whose purpose isn't immediately obvious from its label alone. This provides a hover tooltip for clarity.
-
-## Documentation (keep in sync with code)
-- `docs/` — VitePress site published to GitHub Pages
-- `README.md` — Landing page
-- Update the relevant doc in the same commit as code changes (see `docs/` files for what each covers)
-- **Backend logs** are documented in `docs/backend-logs.md`
-- **Suite hierarchy (describe blocks)** and **test annotations** are documented in `docs/reporter.md` and the in-app [API docs](/docs).
-
-### Replacing demo screenshots, traces and videos (committed binary evidence)
-
-Demo screenshots (`application/public/demo/screenshots/*.png`), trace ZIPs (`application/public/demo/traces/*.zip`) and failure videos (`application/public/demo/videos/*.webm`) are real Playwright artifacts, committed to the repo, captured against the small self-contained "app-under-test" pages in **`scripts/demo-pages.mjs`** (a checkout form, a cart, a button gallery, a modal, a mobile nav shell, an admin dashboard) — never a real app, and never the Piwi dashboard itself (traces embed full page snapshots, and a screenshot of the *results UI* wouldn't be believable evidence of a failing *test*). Each page mirrors one failure story in `shared/demo/failure-stories.mjs` closely enough (headings, field labels, button names) that the captured evidence reads as the same app the seeded error/source/locator data describes.
-
-- **Screenshots**: `node scripts/take-demo-screenshots.mjs` (from `application/`). Serves the fake pages from a throwaway local HTTP server — no dev server, no seeded dev DB. Writes `public/demo/screenshots/*.png` directly.
-- **Traces + videos**: `node scripts/record-demo-media.mjs` (from `application/`). Drives each page with a real Playwright interaction that reproduces its story's failure mode (a click that times out on a disabled button, a strict-mode violation, a hidden-in-dark-mode assertion, a hung image load) and records a trace and/or video, per a `SCENARIOS` table in the script. Add a new scenario there (page + interaction + outputs) for a new failure story's media. Traces record with `sources: true` so the full call-stack-with-source evidence view has real content.
-- **Commit the new binaries**, then `npm run app:seed:demo` to re-wire `files` rows with the real sizes.
-- Playwright must be loaded via `require('/home/user/platform/node_modules/playwright/index.js')` from `createRequire(import.meta.url)` — ESM `import` from outside the workspace fails. Chromium is at `/opt/pw-browsers/chromium`.
-
-Media wiring is generalized in the seed generator: every `FAILURE_STORIES` entry with a `media.screenshot`/`trace`/`video` gets it attached to the **most recent failing execution of each of its member cases** — `max(test_runs_cases.id)` per (cluster, case), matching how `shared/handlers/failure-clusters.ts` picks `recentTestRunsCaseId`. A story with no `media` field intentionally has none (not every failure needs a screenshot).
-
-**Inspecting demo data in a plain dev server** (e.g. to eyeball a query against the seeded DB — not needed for screenshot capture anymore):
-```bash
-cd application
-NUXT_IGNORE_LOCK=1 npx nuxt dev --port 3002   # no PIWI_DEMO_MODE — auth disabled by default
-node scripts/seed-dev-from-demo.mjs           # reads public/demo/seed.sql, INSERT OR IGNORE into .data/piwi.db, idempotent
-```
-- **Do not use `PIWI_DEMO_MODE=true`** for this. The demo service worker does not install reliably in headless Chromium (cloud environment), so `#__nuxt` stays blank.
-- **Run IDs ≥ 21** have test cases. Runs #1–20 have 0 cases (the seed's `INSERT INTO __new_test_runs_cases` statements target a migration-only table that doesn't exist in the dev schema).
-- **Project #2** (`api-integration`) has failure clusters 3 and 4 (`/projects/2?tab=failure-clusters`); every seeded project has at least one cluster — see `shared/demo/failure-stories.mjs#FAILURE_STORIES` for the full cluster→project map.
-
-### Regenerating dashboard screenshots (light/dark split)
-
-Marketing screenshots in `docs/public/screenshots/*.png` (used by `README.md` and `docs/index.md`) are **1280×720**. The hero shots use a diagonal **light-top-left / dark-bottom-right** split. Reproduce one with the `playwright-cli` skill against the **live demo** (it already has seed data — no local server needed):
-
-1. **Capture both themes at the same viewport and scroll position** so they align pixel-for-pixel:
-   ```bash
-   playwright-cli open && playwright-cli resize 1280 720
-   playwright-cli goto "https://piwitests.github.io/demo/"
-   # Hide the demo banner for a clean shot (position:fixed, reflows cleanly when hidden):
-   playwright-cli eval "(()=>{const s=document.createElement('style');s.id='hero-clean';s.textContent='.demo-banner{display:none!important}';document.head.appendChild(s)})()"
-   playwright-cli screenshot --filename=hero-light.png
-   # Switch to dark — color mode is the localStorage key 'nuxt-color-mode'; reload to apply, then re-hide the banner:
-   playwright-cli localstorage-set nuxt-color-mode dark && playwright-cli reload
-   playwright-cli eval "(()=>{const s=document.createElement('style');s.id='hero-clean';s.textContent='.demo-banner{display:none!important}';document.head.appendChild(s)})()"
-   playwright-cli screenshot --filename=hero-dark.png
-   ```
-2. **Composite the diagonal split.** `playwright-cli` blocks `file://` and `run-code` has no `require`, so serve the repo over a throwaway local HTTP server and load an overlay page (the dark image is clipped to the bottom-right triangle, plus an SVG seam line):
-   ```html
-   <!-- hero-composite.html, alongside hero-light.png / hero-dark.png -->
-   <div id="stage" style="position:relative;width:1280px;height:720px">
-     <img src="hero-light.png" style="position:absolute;inset:0;width:1280px;height:720px">
-     <img src="hero-dark.png"  style="position:absolute;inset:0;width:1280px;height:720px;clip-path:polygon(100% 0,100% 100%,0 100%)">
-     <svg width="1280" height="720" style="position:absolute;inset:0;pointer-events:none">
-       <line x1="1280" y1="0" x2="0" y2="720" stroke="rgba(0,0,0,.35)" stroke-width="4"/>
-       <line x1="1280" y1="0" x2="0" y2="720" stroke="rgba(255,255,255,.85)" stroke-width="1.5"/>
-     </svg>
-   </div>
-   ```
-   ```bash
-   node -e "const h=require('http'),f=require('fs'),p=require('path'),t={'.html':'text/html','.png':'image/png'};h.createServer((q,r)=>{const fp=p.join(process.cwd(),q.url.split('?')[0]);f.readFile(fp,(e,d)=>e?(r.writeHead(404),r.end()):(r.writeHead(200,{'content-type':t[p.extname(fp)]||'application/octet-stream'}),r.end(d)))}).listen(8799)" &
-   playwright-cli goto "http://127.0.0.1:8799/hero-composite.html"
-   playwright-cli screenshot "#stage" --filename=docs/public/screenshots/home.png
-   ```
-3. **Clean up** the temp PNGs/HTML and the server; `playwright-cli close`. For a non-split refresh, skip step 2 and use a single capture.
-
-## Demo Data Requirements
-
-When adding features with database columns, API response fields, or UI-visible changes, the demo data must be updated in four places:
-1. **`scripts/generate-demo-seed.mjs`** — seed the new columns in the generated SQL
-2. **`app/demo/api/`** — mirror any new server API response fields in the demo API handlers
-3. **`app/demo/simulator.ts`** — emit any new streaming event fields in simulated runs
-4. **`docs/`** — update the relevant documentation file
-
-The OpenAPI spec (`.output/public/_openapi.json`) is generated by Nitro itself during `nuxt generate`: `nitro.openAPI.production: 'prerender'` in `nuxt.config.ts` makes Nitro register and prerender its built-in `/_openapi.json` route as a static file — no manual regeneration needed.
-
-Always regenerate the seed SQL after changes: `cd application && npm run app:seed:demo`
+  Reference notable findings from `plans/roadmap.md` under "Known Issues & Tech Debt" when they affect priorities.
 
 ## Troubleshooting
-- DB locked? Stop other processes accessing `.data/piwi.db`
-- Port 3000 in use? Use `PORT=3001 npm run app:dev` (Linux/macOS) or `$env:PORT=3001; npm run app:dev` (Windows PowerShell)
-- Tests failing? Ensure no dev server on port 3000 (tests start their own)
-- Reporter not found? `npm link` in `reporter/` then in target project
-- Migration not applying? If a migration file or `_journal.json` was created by hand (not via `npm run db:generate`), the Drizzle migrator may silently skip it — delete the hand-written migration, revert the journal entry, run `npm run db:generate` (or `db:generate:pg` for PostgreSQL), and manually run `ALTER TABLE ... ADD COLUMN` on the existing database if needed.
-- Command appears frozen / no output? It probably launched an interactive pager. Use `git --no-pager <cmd>` for `diff`/`log`/`show`, and avoid commands that open an editor or wait for input (non-interactive shells hang on them).
-- **Don't start the dev server interactively** — `npm run app:dev` / `nuxt dev` runs as a foreground process and blocks all subsequent commands. The tests handle server startup automatically via `webServer` in `playwright.config.ts`. If you need to start the server manually, do it as a background PowerShell job or use `Start-Process`. Starting it directly in a bash tool call will leave you stuck until the tool times out.
 
-## Testing API
-
-```bash
-curl -X POST http://localhost:3000/api/test-runs/submit \
-  -H "Content-Type: application/json" \
-  -d '{"projectName":"my-project","status":"passed","startTime":"2024-01-01T12:00:00Z","duration":120000,"totalTests":10,"passedTests":9,"failedTests":1,"skippedTests":0,"testCases":[{"title":"should login","status":"passed","duration":1500,"location":"tests/login.spec.ts:10:5"}]}'
-```
-
-## Demo Mode
-
-The app can be built as a fully client-side SPA (no server needed) by setting `PIWI_DEMO_MODE=true`. The demo build:
-
-1. **`npm run app:seed:demo`** — Generates `public/demo/seed.sql` (SQLite dump with 5 projects, 53 test cases, 73 test runs, ~820 test-run-case rows, 10 failure clusters) and `public/demo/seed.version.json` (SHA-256 hash of the SQL content + timestamp). Generation is deterministic (a seeded PRNG) — two runs with no source changes produce byte-identical output and the same hash. **`public/demo/seed.sql` is NOT committed** — it is gitignored and regenerated on demand (and in CI, `docs.yml` runs `app:seed:demo` before the demo build), so don't commit or stage it. Only `seed.version.json` is tracked. After editing `scripts/generate-demo-seed.mjs` or `shared/demo/failure-stories.mjs`, re-run `npm run app:seed:demo` and commit the generator + the updated `seed.version.json` (the regenerated `seed.sql` stays local).
-2. **`npm run app:generate:demo`** — Builds the SPA with `ssr: false` and PWA service worker that intercepts `/api/` calls, serving them from in-browser sql.js (WASM SQLite) via Drizzle ORM.
-3. The SQLite database is persisted in IndexedDB across page loads and re-seeded only when no persisted data exists.
-4. **Staleness detection**: The build injects `demoDataVersion` (the SHA-256 hash from `seed.version.json`) into `runtimeConfig.public`. At runtime, the layout compares it against the version stored in IndexedDB and shows a "New demo data available" button in the sidebar footer. Clicking it wipes IndexedDB and reloads the page.
-5. The service worker (`app/service-worker/demo-sw.ts`) handles API fetches via `app/demo/api/router.ts`. Both SW and main thread share `app/demo/db.client.ts` for DB initialization.
-6. **Run simulator**: the demo banner hosts a "Simulate a test run" menu (`DemoSimulator.vue` + `useDemoSimulator`) that replays the reporter streaming protocol (setup → begin → events → finish) through `$fetch` against in-browser endpoint ports (`app/demo/api/reporter.ts`). Scenarios live in `app/demo/simulator.ts` (`passing`, `failures`, `flaky`, `regression`, `interrupted`, `cross-browser`, `sharded`, `wait-heavy`, `healing`, `env-drift`) and target the seeded `e2e-checkout` project so history/cluster features light up. Failing tests in `failures`/`healing` reuse a seeded story's exact error text from `shared/demo/failure-stories.mjs`, so the simulated failure fingerprints identically and joins the real seeded cluster rather than spawning a lookalike duplicate — `KNOWN_TIMEOUT_ERROR`-style hand-copied error strings must never drift from the fixture source again. Live updates flow over a BroadcastChannel (`app/demo/run-events.ts`) instead of SSE: `useRunStream` and the test-run detail page subscribe to it in demo mode.
-
-## MCP Tool Conventions (MUST follow)
-
-MCP tools (`server/utils/mcp/tools.ts`) return JSON consumed by AI coding agents. Consistency across tools saves the agent from guessing.
-
-### Authorization & handler signature
-
-- Every handler has the signature `(db, params, ctx)` where `ctx: McpContext = { user, scope }`. `server/routes/mcp.post.ts` resolves `scope = getProjectScope(db, user)` once and passes it in.
-- **Every project- or entity-scoped tool MUST enforce scope**: call `assertProject(ctx, projectId)` when the route arg *is* a project id, or `checkEntityScope(db, ctx, id, resolveXProjectId)` (returns `'not-found'` → handler returns null/empty, throws when out of scope) for run/case/cluster/diagnosis ids. Cross-project feeds (`list_recent_activity`, `list_open_clusters`, `search`, `list_projects`) filter by `ctx.scope`.
-- **Write/triage tools** (`set_cluster_status`, `run_cluster_diagnosis`, `set_cluster_base_commit`, `submit_diagnosis_feedback`) MUST call `assertWriteRole(ctx)` (reporter or admin) *and* scope-check the target.
-- Prefer calling a **shared handler** (`#shared/handlers/*`) over re-querying. When a REST endpoint has inline logic an MCP tool also needs (e.g. `getProjectSpecHealth`, `getTestCaseStabilityTrend`), extract it to a shared handler and have both the endpoint and the tool call it — never duplicate.
-
-### Field naming
-
-| Field name | Meaning | Usage |
-|-----------|---------|-------|
-| `id` | The primary key of the **main entity** being returned (run ID, cluster ID, project ID) | Use only for the top-level entity |
-| `testCaseId` | Stable test case identity (`testCases.id`) | Use everywhere for referencing a test case |
-| `executionId` | Per-run execution record (`testRunsCases.id`) | Use for per-run case references (was `caseId` in some tools) |
-| `testRunsCaseId` | Same as `executionId` — internal naming | Use in `affectedTestCases` and `locatorHealing` entries |
-| `filePath` | Source file path from `testCases.filePath` | Always `filePath`, never `file` |
-| `startedAt` | ISO 8601 timestamp of when something started | Always `startedAt`, never `start` or `runStart` |
-| `runId` | Foreign key to `testRuns.id` | Use for run references in sub-entities |
-
-### Response shape
-
-- List tools (`list_runs`, `list_failed_cases`, `list_clusters`, `list_flaky_tests`, `get_test_case.recentExecutions`) return `{ items: T[], nextCursor: string | null }`.
-- Paginated sub-lists inside detail tools (`get_project.runs`) also use `{ items, nextCursor }`.
-- `dropNulls()` strips `null`, `''` (empty string), and `[]` (empty array) from every object before serialization.
-- All error text is truncated to **400 characters** via `trunc(msg, 400)`.
-
-### Shared types
-
-- Tool definitions live in `shared/mcp-tools.ts` — `MCP_TOOL_DEFS` array + `McpToolName` union.
-- `PaginatedResponse<T>` is defined there too (`{ items: T[]; nextCursor: string | null }`).
-- Handler behavior lives in `server/utils/mcp/tools.ts`; the route in `server/routes/mcp.post.ts`.
-
-### Validation
-
-- Use `numericParam(raw, name)` for every numeric param — throws on `NaN`.
-- Use `numericCursor(raw)` for numeric cursors — returns `undefined` for empty and throws a clean error (not a SQL failure) on garbage. Never `Number(cursor)` inline.
-- Use `clampPageSize(raw)` — returns 1–50, default 10.
-- Use `paginatedItems(items, pageSize, getCursor)` to wrap a `pageSize + 1` fetch into `{ items, nextCursor }`. **`getCursor` must read the POST-map field name** (e.g. `r.executionId`, not the pre-map `r.caseId`) — reading a field the mapper renamed yields a `"undefined"` cursor that crashes the next page.
-- In-memory-filtered list paths (e.g. `list_runs` branch filter) MUST still apply the cursor in memory on the same axis as the emitted cursor, or paging loops on the first page.
-
-## Important Notes
-- DB auto-initialized on first API call
-- Projects auto-created on first submission
-- Dates stored as Unix timestamps in SQLite
-- Run typecheck, lint, and tests only at the end before final commit (not after every task)
-
-### Exploration & Audit Findings
-
-When exploring the codebase or performing audits (schema reviews, dependency checks, code quality scans, etc.), log any bugs, inconsistencies, tech debt, or non-critical issues discovered in **`plans/exploration-findings.md`**. Use a structured format:
-
-```markdown
-## [Date] — [Exploration Type/Area]
-
-### Finding: [Brief title]
-- **File/Component**: location in codebase
-- **Issue**: Description of the bug or inconsistency
-- **Impact**: Severity and effect (e.g., "Low", "May affect performance", "Blocks feature X")
-- **Suggested fix**: Recommended action (optional if the fix is obvious from the issue)
-```
-
-**Do not commit these findings to git** — they're local working notes. The roadmap (`plans/roadmap.md`) should reference notable findings under a dedicated "Known Issues & Tech Debt" section if they impact ongoing work or priorities.
+- **DB locked?** Stop other processes touching `.data/piwi.db` (the dev server holds it — `app:seed:dev` needs it down).
+- **Port 3000 in use?** `PORT=3001 npm run app:dev` (Linux/macOS) or `$env:PORT=3001; npm run app:dev` (PowerShell).
+- **Tests failing?** Make sure no dev server is on port 3000 — the Playwright config starts its own.
+- **Reporter not found?** `npm link` in `reporter/`, then in the target project.
+- **Migration not applying?** A hand-written migration file or `_journal.json` edit makes the Drizzle migrator skip it
+  silently. Delete it, revert the journal entry, and re-run `npm run db:generate` (or `db:generate:pg`).
+- **Command appears frozen?** It probably opened an interactive pager. Use `git --no-pager <cmd>` for `diff`/`log`/`show`
+  and avoid anything that waits for input — non-interactive shells hang on them.
+- **Never start the dev server in the foreground of a tool call.** `npm run app:dev` blocks until timeout. Playwright
+  starts its own server via `webServer`; if you need one manually, run it in the background.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,8 @@
-See [AGENTS.md](AGENTS.md) for full project context, architecture, conventions, and instructions.
+See [AGENTS.md](AGENTS.md) for project context, architecture, conventions and instructions.
+
+Instructions are split by area — read the guide for the directory you are editing, in addition to the root file:
+
+- [`application/AGENTS.md`](application/AGENTS.md) — the Nuxt dashboard (app, server, demo, MCP); map in [`application/ARCHITECTURE.md`](application/ARCHITECTURE.md)
+- [`reporter/AGENTS.md`](reporter/AGENTS.md) — the Playwright reporter; map in [`reporter/ARCHITECTURE.md`](reporter/ARCHITECTURE.md)
+- [`desktop/AGENTS.md`](desktop/AGENTS.md) — the Tauri desktop shell
+- [`docs/AGENTS.md`](docs/AGENTS.md) — the VitePress documentation site

--- a/application/AGENTS.md
+++ b/application/AGENTS.md
@@ -1,0 +1,419 @@
+# Dashboard app — agent guide
+
+Rules for working inside `application/` (the Nuxt 4 app, its Nitro server, the demo SPA and the MCP server).
+Read [`../AGENTS.md`](../AGENTS.md) first for repo-wide conventions, and [`ARCHITECTURE.md`](ARCHITECTURE.md) when you
+need the map of what lives where.
+
+Everything below is a **rule or an invariant** — something you cannot infer by reading the code you happen to open.
+
+## Layout & imports
+
+- `app/` — Vue pages, components, composables, utils. Components live in domain subfolders and are auto-imported
+  **without a folder prefix** (`pathPrefix: false`), so names must be globally unique.
+- `server/` — Nitro API (`server/api/`), routes (`server/routes/`), utils, database, scheduled tasks.
+- `shared/` — types, constants and pure helpers shared by app + server + demo. Import as `#shared/...` — **never**
+  relative paths or `~~/shared/...`.
+- `app/demo/` — the in-browser mirror of the server, used by the demo SPA.
+- Cross-package pure logic lives in `@piwitests/core` (`packages/core/`) and is re-exported through thin `shared/*`
+  shims so `#shared/...` paths never change. Do **not** put app-only (Nuxt/Drizzle/server) or reporter-only
+  (Node-dependent) code there — `packages/core/tests/boundary.test.ts` enforces zero deps and no `node:` imports.
+
+### Never duplicate logic between server and demo
+
+`server/` and `app/demo/api/` mirror each other (same schema, same persist logic). Any helper that would otherwise
+live in both must be extracted into `server/utils/` (the demo imports it via `~~/server/utils/...`) or `shared/`, and
+imported by both. Exceptions only where the implementations genuinely differ (error handling, auth).
+
+## Database
+
+- Drizzle ORM, two dialects: SQLite via libSQL (default) and PostgreSQL via postgres.js, selected at runtime by
+  `PIWI_DATABASE_URL`.
+- **`server/database/schema.ts` is a conditional re-export only** — never edit it to add a table or column. Edit
+  **both** `schema.sqlite.ts` and `schema.pg.ts`, then `npm run db:generate && npm run db:generate:pg`.
+- ⚠ **Never hand-write a migration file or edit `_journal.json`** — always generate. A hand-made migration is silently
+  skipped by the migrator.
+- Dates are stored as Unix timestamps in SQLite.
+- **Large per-case text payloads MUST go through `case_payloads`** (content-addressed, deduped per project):
+  `upsertCasePayloads` on write, `inlineCasePayloads` / `resolveCasePayloadContents` on read (`server/utils/case-payloads.ts`).
+  Never add a new fat inline text column to `test_runs_cases`. Legacy inline columns stay readable (readers coalesce
+  payload → inline) and the demo writer keeps writing inline, which permanently exercises that fallback. GC lives in
+  `server/utils/retention.ts`.
+
+## Authentication & authorization
+
+- **Roles are a TypeScript string enum** (`Role` in `shared/types.ts`): `ADMINISTRATOR`, `REPORTER`, `USER`. Use
+  `Role.ADMINISTRATOR` — never raw string literals. When a DB `User` has `role: string`, cast: `user.role as Role`.
+- **Auth is optional**, enabled by `PIWI_AUTH_ENABLED=true`. When disabled `requireAuth()` returns a virtual admin, so
+  every endpoint keeps working.
+- Two methods when enabled: session cookie (browser) or API key (Bearer / `X-API-Key`, `pd_` prefix).
+
+### Per-route roles are declared once, in the route meta (MUST follow)
+
+A route's `defineRouteMeta` declares who may call it via `openAPI['x-required-roles']`, and that single literal drives
+**both** the `/docs` display and enforcement — `requireAuth(event)` reads the roles from the compiled route metas
+(`server/utils/route-required-roles.ts`, matched with rou3 exactly as Nitro dispatches).
+
+```typescript
+defineRouteMeta({ openAPI: { tags: ['Projects'], summary: '…', 'x-required-roles': ['administrator', 'reporter'] } });
+
+export default eventHandler(async (event) => {
+  await requireAuth(event); // no roles argument — the meta drives it
+});
+```
+
+- **It MUST be a string-literal array.** Nitro's meta extractor only folds inline `ObjectExpression` / `ArrayExpression`
+  / `Literal` nodes, so a variable, function call or `Role.ADMINISTRATOR` enum member is silently dropped. Values must
+  equal the `Role` enum's strings (`administrator` / `reporter` / `user`).
+- Conventions: sign-in-only routes declare all three roles (renders "Any signed-in user"); a subset excluding `user`
+  renders as elevated; public or token-authenticated routes omit the field — a lookup miss means "authenticated, any role".
+- `requireAuth(event, roles)` still exists as an **explicit override** for handlers computing their own authorization
+  (e.g. `users/[id].patch.ts` self-or-admin); the meta then documents but does not drive it.
+- Streaming endpoints (`start`, `events`, `finish`, `case-files`) use **stream-token** auth instead of `requireAuth`.
+
+### Project-level permissions
+
+A project-assignment layer sits atop roles (`project_assignments`; per-project ids or global with `projectId = null`).
+
+- `ADMINISTRATOR` → all projects, never filtered. `REPORTER` / `USER` → only assigned projects. No assignment = no access.
+- `server/utils/project-access.ts`: `getProjectScope(db, user)` → `'all' | Set<number>`; `requireProjectAccess(event, projectId, roles?)`
+  combines role + scope.
+- **Route `:id` is the project id** → `requireRouteId(event, 'id', label)` then `requireProjectAccess`.
+- **Scoped by a child entity** (run, case, cluster, test-run-case, diagnosis) → `requireResolvedProjectAccess(event, id, resolveXProjectId, notFoundLabel, roles?)`.
+  It resolves the project, 404s a missing entity, then authorizes, and returns `{ db, projectId, user }` so no second
+  `getDatabase()` is needed.
+- List handlers take `scope` (`listProjects(db, scope)`, `getProjectMenu`, `getRecentTestRuns`, `searchProjectsTestRunsCases`);
+  an empty set returns `[]` immediately.
+- Write endpoints: existing project → `scopeAllows(scope, projectId)`; creating a new project → only when `scope === 'all'`.
+- Plain `requireAuth` is only for endpoints with no project scoping. Role and scope refusals both 403 with an explicit message.
+
+### OpenAPI annotations
+
+Every endpoint gets a `defineRouteMeta({ openAPI: … })` block — non-negotiable, it is what feeds `/_openapi.json` and
+`/docs`. Public endpoints declare `security: []`; everything else inherits the root-level
+`security: [{ bearerAuth: [] }, { sessionCookie: [] }]` from `nuxt.config.ts` (whose `meta` is cast `as any` to allow
+those fields — intentional).
+
+## UI conventions
+
+### Reuse the shared primitives
+
+`app/components/shared/` holds the building blocks — **prefer them over re-implementing**. `SectionCard` /
+`CollapsibleSectionCard` (headers + folding), `EmptyState` / `LoadingState` / `ErrorState`, `StatTile` + `StatTileGrid`
+(never hand-rolled tile markup), `FilterToolbar`, `TableScroller`, `NavbarActions`, `BreadcrumbNav`, `ChartCard`,
+`DurationValue`, `DiffPatch` / `DiffFile`, `HelpHint`, `DocLink`, `EnvManagedBadge` / `EnvManagedAlert`,
+`SettingsField`, `OpenInIdeLink`. See [`ARCHITECTURE.md`](ARCHITECTURE.md) for what each one does.
+
+### Responsive / mobile (MUST follow)
+
+The app must be usable at **~375 px with no horizontal page scroll**. Write mobile-first (stacked/narrow default, add
+`sm:`/`md:`/`lg:` upward) and **never hide data** with `max-sm:hidden` — hide decorations only. For wide tables use
+either a `md:hidden` card list + `hidden md:block` table (preferred for dense tables, see `ProjectTrendTable`) or a
+`TableScroller`. On fixed-height detail layouts the mobile view must scroll as one document — never `overflow-hidden`
+clipping a tall summary; `DetailPageLayout` handles this. **Verify new or changed screens at 375 px before committing.**
+
+### Inline help (MUST follow)
+
+Any new **block-level** shared component with a header MUST accept an optional `help?: HelpTopicKey` prop (typed from
+`app/utils/help-content.ts`) and render `<HelpHint v-if="help" :topic="help" />`. Add copy by adding one entry to the
+`HELP_TOPICS` registry — never hardcode hint strings at call sites. Document only non-obvious blocks (skip counters,
+search boxes, basic CRUD forms, theme switcher). When adding a hint, **remove the always-on prose it replaces** so the
+page gets quieter. If a `PIWI_*` env var can override the setting, set `envVars: [...]` (typed `PiwiEnvVarName[]`) so
+the popover surfaces it for system admins.
+
+Use `i-lucide-circle-help` for help and reserve `i-lucide-info` for informational/empty-state callouts. A topic's
+`title` becomes the accessible name `Help: <title>` — avoid titles that are substrings of nearby button labels, or
+Playwright's substring `getByRole('button', { name })` matches both.
+
+### Settings surface (MUST follow)
+
+Settings pages are driven by the `SETTINGS_PAGES` registry in `app/utils/settings-metadata.ts`; `useSettingsNav` and
+`useSettingsEnvState` derive from it. To add a page or field: (1) add the env var to `shared/piwi-env-vars.ts`,
+(2) add or extend the `HELP_TOPICS` entry with its `envVars`, (3) add the `fields` entry to `SETTINGS_PAGES`,
+(4) render with `SettingsField`. Never hand-roll an env-managed `UAlert` or lock icon — use `EnvManagedBadge` /
+`EnvManagedAlert`.
+
+### UTable (MUST follow)
+
+- **Always use template slots for cells** — never `cell:` callbacks with `h()` / `resolveComponent()`. The only
+  exception is `createSortHeader<T>()` in `header:`. No `import { h, resolveComponent }` in table components for cells.
+- Slot naming: `#${accessorKey}-cell="{ row }"` (or `#${id}-cell` for id-only columns); headers `#${accessorKey}-header`.
+- Every sortable column uses `createSortHeader<T>('Label')` (`app/utils/index.ts`); non-sortable ones use a plain string.
+- Sticky headers: the `sticky` prop + a `max-h-*` class on the table root. Do **not** wrap tables in `overflow-y-auto`.
+- Row highlighting: `:meta="{ class: { tr: '…' } }"` — **not** `:row-attrs`, which Nuxt UI v4 dropped.
+- Actions column: `{ id: 'actions', header: 'Actions' }` plus right-aligned `#actions-header` / `#actions-cell` slots.
+- A table with ≥5 columns needs the mobile treatment from the responsive rule above.
+
+### Other UI rules
+
+- Sentence case headings and labels ("Test runs"), relative dates via date-fns (full timestamp on hover), human-readable
+  durations (exact ms on hover), `DurationValue` where a tight `210ms` reads better than "0.21 seconds".
+- Add a `title` attribute to any control whose purpose is not obvious from its label.
+- **Clickable source paths**: render any repo-relative path or `file:line[:col]` with `OpenInIdeLink`, never a bare
+  `<span>`/`<code>`. Pass `filePath` (+ `line`/`column`) or `location`, and thread `projectKey` (the Piwi project **id**)
+  and `projectName` when in scope so per-project workspace overrides resolve. IDE preferences are a **per-browser client
+  preference** (`useOpenInIde`, `piwi-ide-prefs`) — deliberately not in `SETTINGS_PAGES` and with no `PIWI_*` var, since
+  the source lives on the user's machine. Only the JetBrains local-server method is detectable; `vscode://` /
+  `jetbrains://` launches are fire-and-forget, so never report a confirmed "opened".
+- **Data fetching in tab children**: for self-contained components rendered conditionally, use `watch` + `$fetch` with
+  reactive triggers rather than `useFetch({ lazy: true })`, which may not fire before mount. Use `v-if` on tab-switched
+  components for clean mount/unmount. Pass props from the page only for data already fetched at page level.
+- `DetailPageLayout` renders summary + tab bar + panels; `tabPanelClass` lets a tab with self-scrolling content use
+  `overflow-hidden flex flex-col` instead of the default `overflow-y-auto`.
+
+## Environment variables
+
+`shared/piwi-env-vars.ts` is the **single source of truth** for every `PIWI_*` var — name, description, category, type,
+enum, default, min/max, `secret`, `relevantWhen`/`requiredWhen`, `since`/`until`, docs anchor. `PiwiEnvVarName`
+(`keyof typeof PIWI_ENV_VARS`) is the typed union used everywhere, so a typo is a build error.
+
+**When you add a `PIWI_*` var anywhere (nuxt.config, a server util), add it to `PIWI_ENV_VARS` in the same change with a
+`since: '<next release>'` stamp.** `tests/unit/piwi-env-vars.test.ts` fails if a referenced var is unregistered, if a
+post-0.14.0 var lacks `since`, or if a recorded `default`/`min`/`max` drifts from the code constants.
+
+Do not enumerate env vars in prose anywhere — link to the registry or the generated
+[configuration reference](../docs/AGENTS.md) instead. Two facts worth knowing without opening it: the app runs with **no
+env vars set**, and `PIWI_SECRET_KEY` is the master key for AES-256-GCM encryption of DB-stored secrets (AI keys, SCM
+tokens) — recommended in production even without auth, falling back to an insecure development default.
+
+## Adding the usual things
+
+- **API endpoint** — a file under `server/api/` using `eventHandler()` + `getDatabase()`, with a `defineRouteMeta`
+  `openAPI` block (including `x-required-roles`) and the right access helper from the authorization rules above.
+- **Page** — a Vue file in `app/pages/` built on `<UDashboardPanel>`; register it in the nav links array in
+  `app/layouts/default.vue` if it belongs in the sidebar.
+- **Component** — a Vue file in the matching `app/components/` subfolder. Auto-import has no folder prefix, so the name
+  must be unique repo-wide; follow the reuse and responsive rules below.
+- **Unit test** — `tests/unit/*.test.ts` (Vitest). **E2E test** — `tests/*.spec.ts` (Playwright), with any project name
+  registered in `shared/test-project-names.ts`.
+
+## Extension points
+
+Where to add things in subsystems whose wiring spans several files:
+
+| Change | Touch |
+|---|---|
+| Flaky root-cause category | `classifyFlakyRootCause()` + keyword arrays in `server/utils/flaky-classify.ts`; `rootCause` on `FlakyTest` (`types/api.ts`); `FlakyTestsList.vue` colour map |
+| Flaky impact scoring | `getProjectFlakyTests` (`shared/handlers/projects.ts`) — sorts by impact desc; `impact`, `wastedCiMinutes`, `avgFailedDurationMs` on `FlakyTest` |
+| Regression signals | `computeRegressionSignals()` (`server/utils/compute-regression-signals.ts`), called from `finish.post.ts`; surfaced by `getTestRun` / `getTestRunCase` mappers |
+| A computed AI-context section | Update the `SectionId` union (`ai-context.types.ts`), `DIAGNOSIS_SECTIONS` (`diagnosis-sections.ts`) and `DiagnosisContextCoverage` (`types/api.ts`) **in one batch** before writing the section builder |
+| Sharding behaviour | See the sharding invariants below |
+
+## Subsystem invariants
+
+These are the rules that a reasonable change would otherwise break.
+
+### Failure clustering & fingerprints
+
+The grouping key is `computeErrorFingerprint` (`shared/error-fingerprint.ts`) over error type + normalized message +
+masked locator. **The stack frame is intentionally NOT hashed** (kept as `topFrameFile` for display) so one root cause
+groups across spec files. Add volatile-token masking inside `maskVolatile` (message) / `maskSelector` (locator).
+
+When you change normalization, **bump `FINGERPRINT_VERSION`** and keep the demo mirror
+`shared/demo/demo-fingerprint.mjs#computeDemoFingerprint` in sync — a regex-for-regex plain-Node port that exists
+because the seed script runs under plain Node and cannot resolve the TypeScript module. A version bump is
+**non-destructive**: `reclusterFailureFingerprints()` re-fingerprints existing clusters from their stored `sampleError`
+on startup, updating in place or merging collisions via `mergeFailureClusters()`, so triage state survives.
+Re-run `npm run app:seed:demo` afterwards.
+
+### Timed-out tests fold into `failedTests`
+
+There is no `timedOutTests` column on `test_runs`. Timed-out cases (`'timedOut'` per-case from Playwright; `'timedout'`
+in the declared `TestCaseStatus` union) fold into `failedTests` so `total = passed + failed + skipped + didNotRun`
+reconciles and matches the UI. **Every ingest site MUST use the helpers in `shared/utils/test-counts.ts`** —
+`sumFailedAndTimedOut(body.failedTests, body.timedOutTests)` for body-field sites (`finish`, `submit`, `upload` + the
+demo `app/demo/api/reporter.ts` mirror) or `countFailedFromTally(insertedStatusCounts)` for per-status-tally sites
+(`events` + its demo mirror). Never write `failedTests: body.failedTests` directly.
+
+### Locator healing
+
+Ranked replacement locators for a broken selector. Pure generation/scoring/fingerprint logic lives in
+`@piwitests/core` (`locator-generation`, `locator-fingerprint`, `locator-healing-types`), re-exported by the `shared/*`
+shims for `#shared/...` and bundled into the reporter by tsup. **There is no hand-mirrored copy** —
+`tests/unit/reporter-core-identity.test.ts` asserts the reporter re-exports the exact core functions, so a
+re-implementation fails the suite.
+
+Rules when touching it:
+
+- **Capture** happens in the reporter fixtures (mirrored by the dogfood `tests/fixtures.ts`). The in-page probe
+  `probeElementAttrs` is serialized into the browser via `evaluate`, so it cannot reference module closures: the ARIA
+  role maps (`TAG_TO_ROLE` / `INPUT_TYPE_TO_ROLE`) arrive as fields of the `evaluate` argument — **do not re-declare
+  them inside the probe**, and have the dogfood fixture import and call it rather than re-inlining.
+- The live input `value` is **deliberately never captured** (secret leak).
+- Snapshots ride the wire as the transient per-case `locatorSnapshots` field (`shared/types.ts`, **never a column**);
+  every ingest site passes it to `persistRunCases` → the shared `upsertLocatorSnapshots` (`server/utils/locator-healing.ts`,
+  used by server **and** demo). **Two invariants live in that helper:** rows are deduped by `(caseId, location)` before
+  the batch upsert (a repeated call site otherwise breaks PostgreSQL's `ON CONFLICT DO UPDATE`), and the stale-location
+  purge runs **only for cases whose run passed**, so a run that failed early does not delete valid prior-success rows.
+- `elementAttrs` inside `upsertLocatorSnapshots` is the **storage whitelist** — a new wire field on
+  `LocatorSnapshot.element` (e.g. `rolePosition`, `ancestors`) must be folded in there or it is silently dropped.
+  No migration needed.
+- Chained alternatives carry the **leaf** method with flat args (`anchorTestId` / `anchorSelector` / `anchorRole`) and
+  **never a `name` key** — `fingerprintFromSnapshot` reads the element name from the first `getByRole` alternative's args.
+- The signature must hash identically on both sides: capture via `locatorSignature(method, args)`, look up via
+  `locatorSignatureFromExpression(expr)` (`shared/locator-healing.ts`).
+- **Stale gating:** when the stored fingerprint's name is provably gone from the failing ARIA, `resolveStoredHit` sets
+  `priorNameMayBeStale` and excludes the failing locator and old-name-derived alternatives from the recommendation pool
+  (an empty pool yields `recommendation: null` — never a stale pick). `LocatorHealingPanel.vue` MUST NOT recompute a
+  client-side recommendation when that flag is set; it would resurrect the stale pick.
+- Dashboard picks persist via the shared `saveLocatorPick`: the failing locator's identity is re-derived **server-side**
+  from the stored error with the same helpers the lookup ladder uses — never trust client-parsed args. A pick that
+  cannot be keyed returns `not-persisted` (surfaced as a toast) rather than being silently dropped. Any authenticated
+  project member may save one, so the endpoint deliberately carries no role list.
+- Re-run `npm run app:seed:demo` after changing the captured or stored shape.
+
+### Sharding
+
+- **runLabel** is detected from CI env vars by `MetadataCollector.detectCiRunLabel()` (reporter) and `detectCiRunLabel()`
+  (helpers); users override via `PiwiDashboardOptions.runLabel`; `createGlobalSetup` applies it too.
+- When `runLabel` is set, `computeInstanceId(projectName, runLabel)` replaces the `hostname|projectName` key so all
+  shards share one instanceId.
+- Each shard gets its own stream token, stored in `RunEventBus.runStates[id].shardTokens`. **Any new streaming endpoint
+  MUST validate shard tokens alongside the primary one** — check `cachedState.shardTokens?.has(body.streamToken)` as a
+  fallback, via `validateAndReviveRun()` with the `isShardToken` callback.
+- Server-side merge: `/start`, `/setup` and `/submit` reuse an existing run when `shardTotal > 1` and an active run with
+  the same `instanceId` exists; `/finish` accumulates counters with SQL `+` and only sets the final status when
+  `shardsFinished === shardTotal`. `cancelInstanceRuns()` skips sharded runs when `isShardedRun: true`.
+
+## Adding a field to test run data
+
+The full chain, in order:
+
+1. `shared/types.ts` — add to the payload(s).
+2. Both `schema.sqlite.ts` and `schema.pg.ts` (a large text/JSON field must go through `case_payloads`, not a new
+   inline `test_runs_cases` column) → `npm run db:generate && npm run db:generate:pg`.
+3. `types/api.ts` — frontend types.
+4. All API handlers: `submit`, `upload`, `[id]/events`, `[id].get`, `[id]/stream.get`, `test-cases/[id].get`.
+5. `server/utils/persist-run-cases.ts`.
+6. **Reporter**: `src/types/collected.ts` (`CollectedTestCase`) + `src/types/wire.ts` (`WireTestCase`), accumulate in
+   `src/public/reporter.ts` (`onTestBegin`/`onTestEnd`), project in `src/internal/submit/serializer.ts` —
+   `toWireTestCase` for per-case, `serializeRun` for run-level (the single source of truth for the run body, used by
+   both `uploadJSON` and `uploadWithFiles`).
+7. **Demo**: `scripts/generate-demo-seed.mjs`, `app/demo/api/reporter.ts`, `app/demo/api/test-runs.ts`,
+   `app/demo/api/test-cases.ts`, `app/demo/simulator.ts`.
+8. UI components that consume it.
+9. `npm run app:seed:demo`.
+
+`shared/types.ts` is the wire contract; the server imports it directly. The reporter shares only the **leaf shapes**
+via `@piwitests/core/wire` (bundled in, so no monorepo path leaks into the published `.d.ts`) and keeps its own
+`WireTestCase`, pinned to the server payloads by `tests/unit/wire-shared-drift.test.ts`. **Never `import`
+`application/shared` from the reporter** — use `@piwitests/core`.
+
+## Demo mode
+
+`PIWI_DEMO_MODE=true` builds a fully client-side SPA: a service worker intercepts `/api/` and serves from in-browser
+sql.js (WASM SQLite) through Drizzle, persisted in IndexedDB. `app/demo/api/router.ts` dispatches; SW and main thread
+share `app/demo/db.client.ts`.
+
+- **`public/demo/seed.sql` is NOT committed** — gitignored, regenerated on demand (`npm run app:seed:demo`, and by CI in
+  `docs.yml` before the demo build). Only `seed.version.json` (SHA-256 of the SQL + timestamp) is tracked. Generation is
+  deterministic (seeded PRNG), so two runs with no source changes are byte-identical. After editing
+  `scripts/generate-demo-seed.mjs` or `shared/demo/failure-stories.mjs`, re-seed and commit the generator plus the
+  updated `seed.version.json`; never stage `seed.sql`.
+- Staleness detection injects `demoDataVersion` into `runtimeConfig.public`; the layout compares it to the IndexedDB
+  copy and offers a "New demo data available" reset.
+- The run simulator (`DemoSimulator.vue` + `app/demo/simulator.ts`) replays the reporter's streaming protocol against
+  the in-browser endpoints. Failing tests **must reuse a seeded story's exact error text** from
+  `shared/demo/failure-stories.mjs` so the simulated failure fingerprints identically and joins the real cluster
+  instead of spawning a lookalike — hand-copied error strings must never drift from the fixture source again. Live
+  updates flow over a BroadcastChannel (`app/demo/run-events.ts`), not SSE.
+
+### Demo data requirements
+
+Any feature adding a DB column, an API response field or a UI-visible change updates the demo in four places:
+`scripts/generate-demo-seed.mjs` (seed the columns), `app/demo/api/` (mirror the response fields), `app/demo/simulator.ts`
+(emit new streaming fields), and `docs/` — then `npm run app:seed:demo`.
+
+**`shared/demo/failure-stories.mjs` is the single source of truth for every seeded failure**: one story per cluster
+carries the failing spec line, a reporter-faithful error string, the app source files it traces to, and a suggested-fix
+patch *derived* from those same lines — so error, snippet, patch and demo SCM source cannot drift. Locator-centric
+stories also carry an authored failure-time DOM snapshot served by `app/demo/api/dom-snapshot.ts` with precedence over
+the committed trace ZIPs (whose recorded pages are too bare for the locator picker); the ZIP-parse path stays the
+fallback. Demo AI diagnosis is **data-grounded, not canned prose** — rebuilt from the seeded DB and each cluster's real
+stats, with suggested patches genuinely `validatePatch`-checked. Demo-only AI/SCM code stays out of `shared/handlers/`
+so the canned SCM never enters the server bundle; the one shared piece is the version-snapshot row shape
+(`shared/handlers/diagnosis-versions.ts`). `tests/unit/demo-seed-consistency.test.ts` guards the whole chain.
+
+## MCP tool conventions (MUST follow)
+
+MCP tools (`server/utils/mcp/tools.ts`, route `server/routes/mcp.post.ts`, definitions `shared/mcp-tools.ts`) return
+JSON consumed by AI coding agents; consistency saves the agent from guessing.
+
+**Authorization** — every handler is `(db, params, ctx)` with `ctx: McpContext = { user, scope }` (the route resolves
+`scope = getProjectScope(db, user)` once). Every project- or entity-scoped tool MUST enforce scope: `assertProject(ctx, projectId)`
+when the arg *is* a project id, or `checkEntityScope(db, ctx, id, resolveXProjectId)` for run/case/cluster/diagnosis ids
+(`'not-found'` → return null/empty; out of scope → throws). Cross-project feeds filter by `ctx.scope`. Write/triage
+tools MUST also call `assertWriteRole(ctx)`.
+
+**Reuse** — prefer a shared handler (`#shared/handlers/*`) over re-querying. When a REST endpoint has inline logic a
+tool also needs, extract it to a shared handler and call it from both. Never duplicate.
+
+**Field naming** — `id` only for the top-level entity; `testCaseId` for stable test-case identity; `executionId` for a
+per-run execution record (`testRunsCases.id`), spelled `testRunsCaseId` inside `affectedTestCases` / `locatorHealing`;
+`runId` for run references in sub-entities; always `filePath` (never `file`) and `startedAt` (never `start`/`runStart`).
+
+**Response shape** — list tools and paginated sub-lists return `{ items, nextCursor }` (`PaginatedResponse<T>` in
+`shared/mcp-tools.ts`). `dropNulls()` strips `null`, `''` and `[]` before serialization. Error text truncates to 400
+chars via `trunc(msg, 400)`.
+
+**Validation** — `numericParam(raw, name)` for every numeric param; `numericCursor(raw)` for cursors (never
+`Number(cursor)` inline); `clampPageSize(raw)` (1–50, default 10); `paginatedItems(items, pageSize, getCursor)` to wrap
+a `pageSize + 1` fetch. **`getCursor` must read the POST-map field name** (`r.executionId`, not the pre-map `r.caseId`)
+— reading a renamed field yields an `"undefined"` cursor that crashes the next page. In-memory-filtered list paths must
+apply the cursor in memory on the same axis as the emitted cursor, or paging loops on page one.
+
+## Running the app locally to verify a change
+
+When you need to see a change working — a UI tweak, a flow, a screenshot — run a **plain (non-demo) dev server backed by
+a dev DB seeded from the demo data**:
+
+```bash
+cd application
+npm run app:seed:demo                            # 1. generate public/demo/seed.sql (skip if present)
+mkdir -p .data && npm run db:migrate             # 2. create + migrate an empty dev DB (.data/piwi.db)
+npm run app:seed:dev                             # 3. load sample data (server must be stopped — DB lock)
+NUXT_IGNORE_LOCK=1 npx nuxt dev --port 3002      # 4. plain dev server, auth disabled by default
+```
+
+`app:seed:dev` is idempotent (`INSERT OR IGNORE`); to refresh stale rows wipe `.data` and repeat from step 2. Drive the
+app with Playwright — `scripts/take-demo-screenshots.mjs` is a working harness.
+
+**Caveats that cost real debugging time:**
+
+- **Do NOT use `PIWI_DEMO_MODE=true` for local verification.** The demo's service worker + WASM SQLite does not install
+  in headless Chromium, so pages render blank. Demo mode is only for building the static SPA.
+- **Test cases live under runs #21+.** Runs #1–20 have 0 cases (their rows target a migration-only table the dev schema
+  drops). Query a real id: `node scripts/db-query.mjs "SELECT id FROM test_runs_cases ORDER BY id DESC LIMIT 5"`.
+  Clusters with data: #3, #4, #5, #7, #8; project #2 (`api-integration`) owns clusters 3 and 4.
+- **Brand icons** (`i-simple-icons-*`) resolve from the iconify CDN at runtime; with no outbound network they render
+  blank. Only the `lucide` collection is bundled locally. Environment limitation, not a bug.
+
+## Demo evidence media (committed binaries)
+
+Demo screenshots (`public/demo/screenshots/*.png`), trace ZIPs (`public/demo/traces/*.zip`) and failure videos
+(`public/demo/videos/*.webm`) are **real Playwright artifacts**, captured against the small self-contained
+app-under-test pages in `scripts/demo-pages.mjs` — never a real app, and never the Piwi dashboard itself (traces embed
+full page snapshots, and a screenshot of the *results UI* is not believable evidence of a failing *test*). Each page
+mirrors one story in `shared/demo/failure-stories.mjs` closely enough (headings, labels, button names) that the evidence
+reads as the same app the seeded data describes.
+
+- Screenshots: `node scripts/take-demo-screenshots.mjs` — serves the fake pages from a throwaway HTTP server, no dev
+  server or seeded DB needed.
+- Traces + videos: `node scripts/record-demo-media.mjs` — drives each page with a real interaction reproducing its
+  story's failure mode, per the `SCENARIOS` table in the script (add an entry for a new story's media). Traces record
+  with `sources: true` so the call-stack evidence view has real content.
+- Commit the binaries, then `npm run app:seed:demo` to re-wire the `files` rows with real sizes.
+- Playwright must be loaded through `createRequire(import.meta.url)` from the repo-root `node_modules` — an ESM
+  `import` from outside the workspace fails. Point at the Chromium in `PLAYWRIGHT_BROWSERS_PATH` when the environment
+  provides one instead of a downloaded browser.
+
+The seed generator wires media generically: every story with `media.screenshot`/`trace`/`video` attaches it to the
+**most recent failing execution of each member case** (`max(test_runs_cases.id)` per cluster+case, matching how
+`shared/handlers/failure-clusters.ts` picks `recentTestRunsCaseId`). A story with no `media` intentionally has none.
+
+## Testing the API by hand
+
+```bash
+curl -X POST http://localhost:3000/api/test-runs/submit \
+  -H "Content-Type: application/json" \
+  -d '{"projectName":"my-project","status":"passed","startTime":"2024-01-01T12:00:00Z","duration":120000,"totalTests":10,"passedTests":9,"failedTests":1,"skippedTests":0,"testCases":[{"title":"should login","status":"passed","duration":1500,"location":"tests/login.spec.ts:10:5"}]}'
+```

--- a/application/ARCHITECTURE.md
+++ b/application/ARCHITECTURE.md
@@ -1,0 +1,185 @@
+# Dashboard app — architecture map
+
+Reference for `application/`: what exists and where. The **rules** for changing it live in
+[`AGENTS.md`](AGENTS.md) — read that before editing.
+
+This map describes structure and intent, not every file. Directory listings and the auto-generated
+[`/_openapi.json`](#backend) are the authority on exact names.
+
+## Shape
+
+```
+app/          Vue 4 SPA/SSR front end — pages, components, composables, utils, layouts
+server/       Nitro back end — api/, routes/, utils/, database/, middleware/, tasks/
+shared/       Types, constants, pure helpers shared by app + server + demo (`#shared/...`)
+app/demo/     In-browser mirror of the server for the demo SPA
+scripts/      Seed generation, demo media capture, DB query helper
+tests/        Playwright specs (`*.spec.ts`) + Vitest unit tests (`tests/unit/*.test.ts`)
+types/        Front-end API response types (`api.ts`)
+```
+
+## Shared types & core
+
+- `shared/types.ts` — the **wire contract**: `TestCasePayload`, `StreamEventPayload`, `TestRunSubmitPayload`,
+  `TestRunFinishPayload`, the `TestRunStatus` / `TestCaseStatus` unions, and the `Role` enum. Server endpoints import it
+  directly via `#shared/types`.
+- The small wire **leaf shapes** (`BrowserConfig`, `TestStepEvent`, `SuiteConfigEntry`, `TestAnnotation`,
+  `FilterDetails`, `TestSourceFrame`) live in `@piwitests/core/wire` and are re-exported here — one source of truth
+  shared with the reporter. Per-case payloads stay app-side; the reporter's `WireTestCase` stays reporter-side. The two
+  are kept compatible by `tests/unit/wire-shared-drift.test.ts`.
+- `@piwitests/core` (`packages/core/`) is a private, **zero-dependency**, browser/worker/server-safe package holding
+  pure cross-cutting logic: locator generation/scoring, ARIA parsing + element-match healing, locator-healing types, the
+  wire leaves, and the locator-method list. It ships **TypeScript source** (no build step) — Vite/Vitest transpile it,
+  the reporter's tsup inlines it. The app consumes it through thin `shared/*` re-export shims.
+
+## Database
+
+Drizzle ORM over **SQLite (libSQL)** or **PostgreSQL (postgres.js)**, chosen at runtime by `PIWI_DATABASE_URL`.
+
+- `server/database/schema.sqlite.ts` and `schema.pg.ts` — the real schemas (edit both).
+- `server/database/schema.ts` — a conditional re-export that picks a dialect at module init; type-checking uses the
+  SQLite schema as canonical. Never edit it to add tables.
+- `server/database/migrations/` (SQLite) and `migrations-pg/` (PostgreSQL, auto-run on startup).
+
+Tables, by area:
+
+| Area | Tables |
+|---|---|
+| Core results | `projects`, `test_runs`, `test_suites`, `test_cases`, `test_runs_cases`, `network_requests` |
+| Failure analysis | `failure_clusters`, `failure_cluster_aliases`, `cluster_merge_suggestions`, `failure_diagnoses`, `failure_diagnosis_versions` |
+| Evidence & storage | `files`, `trace_resources`, `trace_blobs`, `case_payloads`, `locator_snapshots` |
+| Metadata | `tags`, `project_tags`, `markers`, `entity_links`, `app_settings` |
+| Identity | `users`, `api_keys`, `account_tokens`, `project_assignments` |
+| Notifications | `notification_channels`, `subscriptions`, `notification_deliveries` |
+
+Non-obvious ones:
+
+- **`case_payloads`** — content-addressed storage for large per-execution text (`aria_snapshot`, `test_source`,
+  `test_source_frames`): one row per unique content per project (SHA-256 `hash`, unique `(project_id, hash)`),
+  referenced from `test_runs_cases.*_payload_id`. See the rule in `AGENTS.md`.
+- **`locator_snapshots`** — one row per locator call site (`test_case_id` + `location`), upserted each run with the
+  latest element attributes and pre-computed ranked alternatives. Unique index on `(test_case_id, location)`;
+  `last_seen_run_id` FK is `ON DELETE set null`.
+- **`account_tokens`** — single-use SHA-256-hashed tokens for reset/invite/verify, with a purpose enum and TTL enforced
+  at query time.
+- **`notification_deliveries`** — an outbox: `dedupeKey` unique for idempotency, `status`, `attempts` + `scheduledFor`
+  for progressive retry (1/5/15/60/240 min).
+- **`entity_links`** — external URLs (Jira, GitHub…) attached to a run, execution or test case via three nullable FK
+  columns with `ON DELETE CASCADE`, mirroring the `files` pattern. Provider auto-detected by `shared/link-detect.ts`.
+
+## Backend
+
+Nitro file-based routing under `server/api/`, plus `server/routes/` for non-`/api` routes. The auto-generated
+**OpenAPI 3.1** spec at `/_openapi.json` and the in-app reference at `/docs` are the authoritative endpoint list — this
+is only the shape of it.
+
+| Family | What it covers |
+|---|---|
+| `test-runs/` | Ingest (`submit`, `upload`), the streaming protocol (`setup`, `start`, `[id]/events`, `[id]/finish`, `[id]/case-files`), run detail, SSE `stream`, network requests, comparison, deletion |
+| `test-cases/`, `test-run-cases/` | Stable test-case detail/history/traces; per-execution detail, execution-scoped diagnosis (`diagnose`, `diagnosis`, `diagnosis-context`), locator healing, DOM snapshots |
+| `projects/` | List (heavy stats), `menu` (slim sidebar list, one SELECT), `overview`, detail, CRUD, members, flaky tests, spec health, trends, SCM |
+| `failure-clusters/`, `cluster-merge-suggestions/`, `failure-diagnoses/` | Cluster detail and triage, AI diagnosis (`diagnose`, `context`, `commits`, `commit-diff`, `base-commit`), semantic merge suggestions, diagnosis version history and feedback |
+| `analytics/[widget]` | Cross-project analytics widgets backing `/analytics` |
+| `auth/`, `users/` | Login/logout/me/setup, OAuth, password reset & change, email verification, invites, user + API-key management |
+| `channels/`, `subscriptions/`, `notifications/stream` | Notification destinations, per-project subscriptions, SSE delivery stream |
+| `settings/` | AI, SMTP and other admin settings (secrets never returned; env-managed flags exposed) |
+| `files/`, `traces/`, `markers/`, `links/`, `tags/`, `search`, `admin/` | Artifact download, trace checks, timeline markers, entity links, tags, global search, admin stats/cleanup |
+| `health`, `version`, `desktop/` | Readiness probe (200/503 with DB check), build info, desktop-shell helpers |
+| `server/routes/mcp.post.ts` | The MCP server endpoint (tool defs in `shared/mcp-tools.ts`, handlers in `server/utils/mcp/`) |
+| `server/routes/__piwi/` | Desktop session bootstrap, guarded by `server/middleware/desktop-guard.ts` |
+
+Key server utilities (`server/utils/`):
+
+| File / folder | Purpose |
+|---|---|
+| `persist-run-cases.ts` | The single write path for run cases — every ingest site goes through it |
+| `case-payloads.ts` | Content-addressed payload upsert/inline/resolve |
+| `locator-healing.ts` | Shared `upsertLocatorSnapshots`, `getLocatorHealing`, `saveLocatorPick` (server + demo) |
+| `project-access.ts` | `getProjectScope`, `requireProjectAccess`, `requireResolvedProjectAccess`, entity resolvers |
+| `route-required-roles.ts`, `route-roles-match.ts` | Read `x-required-roles` from compiled route metas; rou3 matching |
+| `ai-*.ts` | Provider abstraction, diagnosis, context building + limits, research stage, embeddings, images, system prompt |
+| `cluster-*.ts` | Similarity, semantic adjudication, naming, reconciliation |
+| `scm/` | Repo history, diffs and patch validation for AI diagnosis |
+| `notifications/` | `match.ts` (subscription matching → outbox rows), `dispatch.ts` (`sweepOutbox`, HMAC-SHA256 `X-Piwi-Signature`), `emit.ts`, `run-notifications.ts` |
+| `email.ts`, `account-tokens.ts`, `rate-limit.ts`, `crypto.ts` | SMTP transport + templates, single-use tokens (reset 1 h / verify 24 h / invite 72 h), in-memory sliding window, AES-256-GCM |
+| `retention.ts` | Nightly pruning of runs, notification history, diagnosis versions and orphan payloads |
+| `compute-regression-signals.ts`, `flaky-classify.ts` | `isNewRegression` / `isNewFlaky` signals; flaky root-cause classification |
+| `server/tasks/notifications/sweep.ts` | Nitro scheduled task — sweeps the outbox every minute |
+
+## Front end
+
+### Pages (`app/pages/`)
+
+`/` dashboard home · `/projects` + `/projects/[id]` · `/test-runs/[id]` · `/test-cases/[id]` (stable case across runs)
+· `/test-run-cases/[id]` (one execution) · `/failure-clusters/[id]` · `/analytics` · `/settings/*` · `/docs` (in-app API
+reference) · `/mcp` · `/login`, `/forgot-password`, `/reset-password` (public, layout-free).
+
+`/test-run-cases/[id]` is **diagnosis-first**: a failing execution opens on a **Diagnosis** tab (full-width error card,
+then a right rail of verdict/cluster/AI cards beside a left evidence funnel); a passing one opens on **Steps** with an
+**Artifacts** tab. Both keep **Performance** and **History**. The tab is synced to `?tab=` with legacy aliases, and the
+page `provide`s a section locator so an AI citation can reveal and scroll to the matching evidence block.
+
+### Components (`app/components/`)
+
+Domain subfolders, all auto-imported **without a folder prefix** (`pathPrefix: false`), so names are globally unique:
+
+| Folder | Scope |
+|---|---|
+| `shared/` | Cross-page primitives and widgets — see below |
+| `run/` | Run detail: summary, cases table, workers timeline, comparison, slow endpoints, failure groups, reports |
+| `test-case/` | Single-execution detail: summary, verdict, cluster card, AI card, evidence, console/network, DOM/ARIA, history |
+| `cluster/` | Failure-cluster detail: summary, per-case evidence tabs, investigation + baseline picker, commit browser |
+| `diagnosis/` | AI diagnosis panel: context preview + coverage strip, result with evidence citations, export |
+| `project/` | Project detail charts, flaky list, cluster list, SCM changes, subscribe bell |
+| `analytics/` | Cross-project widgets: scorecard, heatmaps, leaderboards, trend charts, insights feed |
+| `home/`, `layout/`, `settings/`, `desktop/`, `docs/`, `demo/` | Home filters; app shell/nav; settings surfaces; desktop-only cards; in-app API reference; demo-only banner/simulator |
+
+Shared building blocks worth knowing before writing new markup (`AGENTS.md` makes reuse a rule):
+
+- **Structure** — `SectionCard` (standard icon/title/count/subtitle header, `actions` + `footer` slots),
+  `CollapsibleSectionCard` (same contract + required `storageKey`, cookie-persisted fold state via `useFoldedState`,
+  `#folded` peek slot), `FoldableSummary`, `DetailPageLayout` (summary + tabs + panels with correct flex height at `lg`+,
+  single-document scroll below), `BlockCard`, `StatusBlock`.
+- **States** — `EmptyState`, `LoadingState`, `ErrorState` (with an `action` slot).
+- **Data display** — `StatTile` + `StatTileGrid` (auto-fitting, no per-page breakpoints), `TableScroller`,
+  `FilterToolbar`, `ChartCard`, `ChartLegend`, `ChartMarkerTooltip`, `MiniRunBars`, `DurationValue` (tight `210ms` via
+  the pure `splitDuration`), `CodeBlock`, `MarkdownPreview`, `DiffPatch` / `DiffFile`.
+- **Navigation & actions** — `NavbarActions` (every `UDashboardNavbar` `#right` group; labels collapse to icons below
+  `sm`), `BreadcrumbNav` (drop-in for `UBreadcrumb`, collapses ancestors below `sm`), `OpenInIdeLink` +
+  `OpenInIdeSettingsModal`, `DocLink`, `LinkChip` / `EntityLinks`.
+- **Help & settings** — `HelpHint` (topic keys from `app/utils/help-content.ts`), `SettingsField`, `EnvManagedBadge`,
+  `EnvManagedAlert`.
+- **Domain widgets** — `RunStatusBadge`, `TestStatusBar`, `TagBadge` / `TagsSelect`, `BrowserBadge`, `CiEnvCard`,
+  `SourceInfoCard`, `MarkerBadge` / `MarkerFormModal`, `ScreenshotLightbox`, `VideoPlayer`, `TraceListItem`,
+  `LocatorHealingPanel` / `LocatorAlternativeRow`, `SnapshotLocatorPicker`, `EnvironmentDiffCard`, `DataLocationCard`.
+
+### Composables & utils
+
+`app/composables/` covers cross-component state and behaviour — auth and dashboard shell, run streaming
+(`useRunStream`, `useNotificationStream`), diagnosis (`useClusterDiagnosis`, `useStreamingDiagnosis`,
+`useDiagnosisNotification`), timeline (`useTimelineModel`, `useTimelineViewport`), fold/tree state
+(`useFoldedState`, `useFoldableSummary`, `useTreeViewCookie`), settings derivation (`useSettingsNav`,
+`useSettingsEnvState`), analytics scope, IDE preferences (`useOpenInIde`), desktop detection (`useIsDesktop`,
+`useTauri`), demo helpers, and small utilities (`useCopy` / `useCopyRich` — use these instead of hand-rolling
+`navigator.clipboard`, `useAiStatus`, `useChartMarkers`).
+
+`app/utils/` holds pure helpers: `index.ts` (`formatDuration`, `splitDuration`, `getStatusColor`, `getFileApiPath`,
+`formatRelativeTime`, `createSortHeader`, `formatBytes`, `errorMessage`, patch/commit helpers, cluster colour maps),
+`performance-hints.ts`, `retry-command.ts` (`buildRetryCommand` — `file-line` / `grep` / `file` modes, shell-escaped,
+capped at 4096 chars), `ide-links.ts`, `help-content.ts`, `settings-metadata.ts`, `openapi.ts` / `openapi-console.ts`.
+
+## Demo SPA
+
+`PIWI_DEMO_MODE=true` builds a client-only SPA: a PWA service worker (`app/service-worker/demo-sw.ts`) intercepts
+`/api/` and serves it from in-browser sql.js (WASM SQLite) through Drizzle, persisted in IndexedDB. `app/demo/api/router.ts`
+dispatches to per-domain handlers that mirror the server; `app/demo/db.client.ts` is shared by SW and main thread.
+Live updates use a BroadcastChannel instead of SSE. Rules and invariants: see `AGENTS.md`.
+
+## Key features
+
+Auto-created projects on first submission · run ingest by JSON, multipart upload or live streaming (with shard merge and
+crash recovery) · HTML reports, traces, videos and screenshots stored under `.data/storage/` with relative paths ·
+flaky detection with root-cause classification and impact scoring · failure clustering with semantic merge suggestions ·
+AI diagnosis grounded in real SCM diffs, optionally two-stage · locator healing · timeline markers · notifications
+(email, Slack, webhook, browser) · an MCP server for AI agents · optional auth with project-level permissions ·
+retention and storage housekeeping.

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -1,0 +1,37 @@
+# Desktop app — agent guide
+
+Rules for working inside `desktop/` (the Tauri shell that bundles and runs the dashboard locally). Read
+[`../AGENTS.md`](../AGENTS.md) first for repo-wide conventions, and [`README.md`](README.md) for how the shell works,
+build prerequisites and the release flow.
+
+## What it is
+
+A [Tauri](https://tauri.app) window around **the same Nuxt/Nitro server** shipped as the Docker image and
+`@piwitests/server`. On launch the Rust shell picks a free loopback port, resolves a per-user data dir, spawns the
+bundled server as a **Node sidecar**, polls `GET /api/health` until the database is migrated, then points the window at
+it through a one-time token bootstrap (`/__piwi/session`). Targets for v1 are Windows (`.msi`) and macOS (`.dmg`);
+Linux is deferred.
+
+## Rules
+
+- **Never fork the server.** The desktop app must keep running the unmodified built server. Anything the shell needs
+  from the backend goes in `application/` behind a desktop-aware guard, not into a desktop-only copy.
+- **Everything binds `127.0.0.1`.** Local access is gated by a per-launch token enforced by
+  `application/server/middleware/desktop-guard.ts` — so only the app, not other local processes or browser pages, can
+  reach the bundled API. Any new desktop-only route must stay behind that guard.
+- Front-end code that behaves differently inside the shell uses the `useIsDesktop` / `useTauri` composables and the
+  `app/components/desktop/` cards — do not sniff user agents.
+- The sidecar layout (`src-tauri/binaries/node-<triple>`, `src-tauri/resources/app-server/.output/`) is what the
+  packaging scripts and CI (`desktop-release.yml`, `desktop-e2e.yml`) expect; changing it means updating both.
+- Commit scope for changes here is `app` unless the change is CI-only (`ci`) — `desktop` is not in the commitlint
+  scope list.
+
+## Commands
+
+```bash
+npm run fetch-node   # download the Node sidecar binary for this platform
+npm run stage        # build the server and stage it into src-tauri/resources
+npm run dev          # tauri dev — run the shell against a staged server
+npm run build        # produce the platform installer
+npm run e2e          # Playwright smoke test of the shell integration
+```

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,79 @@
+# Documentation site — agent guide
+
+Rules for working inside `docs/` (the VitePress site published to GitHub Pages). Read [`../AGENTS.md`](../AGENTS.md)
+first — in particular the **cross-platform shell commands** rule, which applies to every snippet on this site.
+
+```bash
+npm run docs:dev      # local preview (runs docs:gen first)
+npm run docs:build    # production build (runs docs:gen first)
+npm run docs:gen      # regenerate the derived pages only
+```
+
+## Two pages are generated — never edit them by hand
+
+### `docs/configuration.md`
+
+Built from the typed env-var registry (`application/shared/piwi-env-vars.ts`) by
+`docs/scripts/generate-configuration.mjs`. The file is **gitignored** and rebuilt by `docs:gen`.
+
+- To change a variable's name, description, default or category → edit the **registry**.
+- To change section prose or ordering → edit `PIWI_ENV_CATEGORIES` (title/intro/note/order; `mergeInto` folds one
+  category's table into another; `internal` hides harness-only vars).
+- The interactive generator at `/configuration/generator` reads the **same registry** through the `#shared` Vite alias
+  wired in `docs/.vitepress/config.mts`, and emits output through the pure emitters in `application/shared/env-format.ts`
+  (unit-tested quoting for .env / compose / docker run / K8s / systemd / shell). Change the emitters, not the markup.
+- Keep the section anchors stable (`#general`, `#wasted-time` are deep-linked from the app and other pages).
+
+### The API reference
+
+There is **no `docs/api.md`, and you must not create one.** The auto-generated OpenAPI spec (`/_openapi.json`) and the
+self-contained in-app reference at `/docs` in the running app are the single source of truth for API documentation —
+the in-app page renders the spec with no third-party CDN, so it works offline and air-gapped.
+
+When documenting a feature here, link to `[API docs](/docs)` (self-hosted) or the live demo
+(`https://piwitests.github.io/demo/docs`) rather than inlining endpoint descriptions. Endpoint documentation is
+authored in the handler's `defineRouteMeta({ openAPI: … })` block — see
+[`../application/AGENTS.md`](../application/AGENTS.md#openapi-annotations).
+
+## Writing conventions
+
+- Update the affected page **in the same commit** as the code change; commit scope `docs`.
+- American English, sentence-case headings, and the shell-portability rule from the root guide: VitePress uses
+  `::: code-group` with ```bash [Linux / macOS] + ```powershell [Windows (PowerShell)] tabs when a command has no
+  portable single form.
+- Diagrams are theme-aware SVG assets under `docs/public/` — commit the asset rather than embedding a large inline
+  `<svg>` in prose.
+- Subject-matter pages that already exist: getting started, deployment, configuration, storage, authentication,
+  notifications, reporter, capture fixtures, AI diagnosis, flaky tests, timeline markers, MCP, IDE integration,
+  desktop, backend logs, UI overview, comparison. Extend one before adding a new page.
+
+## Marketing screenshots
+
+Hero images in `docs/public/screenshots/*.png` are **1280×720**, with a diagonal light-top-left / dark-bottom-right
+split. Capture them against the **live demo** (it already has seed data — no local server needed) using the
+`playwright-cli` skill:
+
+1. **Capture both themes at the same viewport and scroll position** so they align pixel-for-pixel. Resize to
+   `1280 720`, load `https://piwitests.github.io/demo/`, hide the demo banner by injecting
+   `.demo-banner{display:none!important}`, and screenshot. Then switch theme with the `nuxt-color-mode` localStorage
+   key, reload, re-hide the banner, and screenshot again.
+2. **Composite the split.** `playwright-cli` blocks `file://` and `run-code` has no `require`, so serve the two PNGs
+   plus a small overlay page over a throwaway local HTTP server and screenshot the stage element. The overlay stacks
+   both images at 1280×720 and clips the dark one to the bottom-right triangle, with an SVG seam line:
+
+   ```html
+   <div id="stage" style="position:relative;width:1280px;height:720px">
+     <img src="hero-light.png" style="position:absolute;inset:0;width:1280px;height:720px">
+     <img src="hero-dark.png"  style="position:absolute;inset:0;width:1280px;height:720px;clip-path:polygon(100% 0,100% 100%,0 100%)">
+     <svg width="1280" height="720" style="position:absolute;inset:0;pointer-events:none">
+       <line x1="1280" y1="0" x2="0" y2="720" stroke="rgba(0,0,0,.35)" stroke-width="4"/>
+       <line x1="1280" y1="0" x2="0" y2="720" stroke="rgba(255,255,255,.85)" stroke-width="1.5"/>
+     </svg>
+   </div>
+   ```
+
+3. **Clean up** the temporary PNGs, the overlay page and the server. For a non-split refresh, skip step 2 and use a
+   single capture.
+
+Demo *evidence* media (the screenshots, traces and videos shown inside the product) is a different pipeline — see
+[`../application/AGENTS.md`](../application/AGENTS.md#demo-evidence-media-committed-binaries).

--- a/reporter/AGENTS.md
+++ b/reporter/AGENTS.md
@@ -1,0 +1,45 @@
+# Reporter — agent guide
+
+Rules for working inside `reporter/` (the published `@piwitests/reporter` package). Read
+[`../AGENTS.md`](../AGENTS.md) first for repo-wide conventions, and **[`ARCHITECTURE.md`](ARCHITECTURE.md)** for the
+full map: public/internal split, the two-process collect-and-submit data flow, the submit fallback ladder, and the
+per-directory responsibilities.
+
+## The contracts you can break
+
+1. **Public API** — anything exported from `src/index.ts` (the single `.` entry). Changing it is a breaking change.
+   Everything under `src/internal/` is private plumbing; change it freely.
+2. **Wire types** (`src/types/wire.ts`) — the JSON exchanged with the server. A change here is a server-contract change
+   and must land with the matching dashboard change; `application/tests/unit/wire-shared-drift.test.ts` pins the two
+   together.
+3. **Side effects** — `PIWI_*` env vars (`internal/config/env.ts`), `piwi-*` attachment names
+   (`internal/capture/attachments.ts`), temp files in `os.tmpdir()`, and `[Piwi Dashboard]`-prefixed log output.
+
+## Conventions
+
+- The package is **strict-mode TypeScript**. Node built-ins are imported as `import * as x from 'node:x'`.
+- Classes use `private readonly` constructor parameter-property DI.
+- HTTP failures throw `HttpError` (carrying `status`) from `internal/transport/http-client.ts`.
+- `catch (error)` is `unknown` — narrow with `instanceof`, format with `errorMessage` (`internal/support/errors.ts`).
+- Shared pure logic (locator generation/scoring, ARIA fingerprints, wire leaf shapes) comes from **`@piwitests/core`**
+  and is bundled in by tsup, so the published package stays self-contained. **Never re-implement a core function here**
+  — `application/tests/unit/reporter-core-identity.test.ts` asserts the reporter re-exports the exact core functions and
+  fails on a copy. **Never import `application/shared`** from the reporter.
+- `internal/submit/serializer.ts` is the single source of truth for the wire field list: `toWireTestCase` for per-case
+  fields, `serializeRun` for the run body (used by both `uploadJSON` and `uploadWithFiles`).
+
+## Workflow
+
+```bash
+npm run reporter:build      # tsup → dist/ (.js + .d.ts); reporter:dev for watch mode
+npm run reporter:typecheck
+npm run reporter:lint       # :fix to auto-fix
+npm run reporter:format     # :check to verify only
+npm run reporter:test       # :watch, :coverage, :integration
+```
+
+Source is TypeScript in `src/`; `dist/` is generated — never edit it. To try the package in a real project, build then
+`npm link` here and in the target project.
+
+Adding a field that flows from Playwright to the dashboard touches both repos' halves — follow the ordered checklist in
+[`../application/AGENTS.md`](../application/AGENTS.md#adding-a-field-to-test-run-data).


### PR DESCRIPTION
AGENTS.md had grown to 103 KB (~26k tokens) that every agent session paid
for up front, while drifting from the codebase: it missed the desktop app,
the ASP.NET Core integration, analytics, timeline markers, entity links and
eight database tables, contradicted itself on the schema entry point, and
inventoried three of thirty-four composables.

Split it into a slim root guide plus per-area guides that load only when
the relevant directory is touched, and separate the descriptive map from
the rules:

- AGENTS.md — repo layout, commands, and the conventions that apply
  everywhere (commits, comments, shell portability, docs, tests)
- application/AGENTS.md — app rules: schema, authorization, UI
  conventions, subsystem invariants, demo, MCP
- application/ARCHITECTURE.md — the app map, matching the reporter's
  existing ARCHITECTURE.md convention
- reporter/, desktop/, docs/AGENTS.md — area rules and workflows

Corrections: complete repository layout and table list, both dialect
schemas as the edit target, env vars deferred to the typed registry
instead of a stale partial list, and full command tables. Every MUST rule
from the previous file is preserved; historical implementation notes and
duplicated inventories are not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EyXQ9eWyRT1J54jd6HZSGM