### PR TITLE
docs: restructure and rewrite for clarity and positioning

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -7,11 +7,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      # Temporary: dry-run the installer build on this branch without releasing
-      # (no tag → tagName stays empty → tauri-action builds but does not publish).
-      # Remove before merge — tags + workflow_dispatch cover real releases.
-      - claude/desktop-version-feasibility-0krz6q
   # Manual escape hatch / dry-run: build the installers without releasing.
   workflow_dispatch:
 
@@ -127,7 +122,7 @@ jobs:
           projectPath: desktop
           args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }}
           # Attach to the release release-please already made for this tag. On a
-          # branch push / dispatch (no tag) tagName is empty, so tauri-action just builds.
+          # manual dispatch (no tag) tagName is empty, so tauri-action just builds.
           tagName: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
           releaseName: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,29 @@ other `curl` examples may stay bash-only. `.env` file contents are not shell com
 - User-facing docs live in `docs/` (VitePress → GitHub Pages); `README.md` is the landing page.
 - API reference is **generated** — never hand-write endpoint docs. See [`docs/AGENTS.md`](docs/AGENTS.md).
 
+#### One canonical positioning line (MUST follow)
+
+Piwi is not a product being sold. Copy is informative, specific and honest — never promotional. The project describes
+itself the same way everywhere:
+
+> **Your Playwright results, kept and explained.** CI throws away every report it makes. Piwi keeps them — then groups
+> the failures by root cause, scores the flaky tests, and finds the locator you should have used. Self-hosted, MIT,
+> zero telemetry.
+
+Seven surfaces carry it, and they drift the moment one changes alone. Update them **in the same commit**:
+
+| Surface | Where |
+|---|---|
+| README subtitle | `README.md` |
+| Docs hero (`text` + `tagline`) | `docs/index.md` frontmatter |
+| Site description (meta + search index) | `docs/.vitepress/config.mts` → `description` |
+| Social cards | `docs/.vitepress/config.mts` → `og:`/`twitter:` title + description |
+| Docker Hub overview | `DOCKER_HUB.md` first paragraph |
+| npm package descriptions | `packages/server/package.json`, `reporter/package.json` |
+| GitHub repo description + topics | Repository settings — not in the repo, so check it by hand |
+
+Voice rules for all of them, and for `docs/`: see [`docs/AGENTS.md`](docs/AGENTS.md#voice).
+
 ### Tests
 
 - **Vitest** for unit tests (pure functions, no server/browser): `application/tests/unit/*.test.ts` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,18 @@ Run from `application/` unless noted:
 
 If an E2E test creates a project, use a static name registered in `application/shared/test-project-names.ts` (see the conventions in [AGENTS.md](AGENTS.md)).
 
+## Database & demo data
+
+| Command | What it does |
+|---|---|
+| `npm run db:generate` | Generate a SQLite migration from schema changes |
+| `npm run db:generate:pg` | Generate a PostgreSQL migration from schema changes |
+| `npm run db:studio` | Browse the SQLite database in Drizzle Studio |
+| `npm run db:studio:pg` | Browse the PostgreSQL database in Drizzle Studio |
+| `npm run app:seed:demo` | Regenerate the demo seed data used by the live demo |
+
+**Migration workflow:** edit `server/database/schema.sqlite.ts` (and `schema.pg.ts` for the PostgreSQL equivalent — `schema.ts` is just a dialect-selecting re-export, don't edit it) → run `npm run db:generate` (SQLite) or `npm run db:generate:pg` (PostgreSQL) → review the generated `.sql` file → restart the app. Never create migration files or edit `meta/_journal.json` by hand — the Drizzle migrator depends on the journal to track which migrations have been applied, and manual entries cause it to silently skip the migration.
+
 ## What to work on
 
 - Check [open issues](https://github.com/PiwiTests/platform/issues) and the [roadmap](ROADMAP.md).

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -33,7 +33,7 @@ The dashboard will be available at `http://localhost:3000`.
 - **Build Type**: Multistage build (builder + production stages)
 - **Image Size**: ~400 MB
 - **Architecture**: Multi-platform (linux/amd64, linux/arm64)
-- **Registry**: Docker Hub (`phenx/piwitests-server`)
+- **Registries**: Docker Hub (`phenx/piwitests-server`) and GHCR (`ghcr.io/piwitests/platform`)
 
 ## Building the Image Locally
 
@@ -159,10 +159,22 @@ Best practices:
 
 ## Available Tags
 
+The same multi-arch image is published to both Docker Hub and the GitHub Container Registry:
+
+```bash
+docker pull phenx/piwitests-server:latest        # Docker Hub
+docker pull ghcr.io/piwitests/platform:latest    # GHCR
+```
+
 - `latest` — Latest stable release
-- `0.9.0` — Specific version (semver)
-- `0.9` — Latest patch of a minor version
+- `0.18.2` — Specific version (semver)
+- `0.18` — Latest patch of a minor version
 - `0` — Latest release of the major version
+- `edge` — **GHCR only**; rebuilt from every push to `main`. Handy for trying an unreleased fix, but it
+  has had no release testing — don't run it in production.
+
+Pin a specific version in production. GHCR also lists `buildcache-linux-*` tags: those are BuildKit
+layer caches, not runnable images.
 
 ## Troubleshooting
 

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -47,9 +47,12 @@ Open `http://localhost:3000`. The SQLite database and file storage are created a
 | Tag       | Description                            |
 |-----------|----------------------------------------|
 | `latest`  | Latest stable release                  |
-| `0.11.0`  | Exact version (pinned, recommended)    |
-| `0.11`    | Latest patch for a minor version       |
+| `0.18.2`  | Exact version (pinned, recommended)    |
+| `0.18`    | Latest patch for a minor version       |
 | `0`       | Latest release for a major version     |
+
+The same image is mirrored to the GitHub Container Registry as `ghcr.io/piwitests/platform`, which also
+carries an `edge` tag built from `main`.
 
 ---
 

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -1,6 +1,6 @@
 # Piwi Dashboard
 
-**Self-hosted Playwright test results dashboard.** Collect, store, and visualize your end-to-end test results over time — failures, performance trends, flaky tests, and live run streaming — without sending data to any third party.
+**Your Playwright results, kept and explained.** A self-hosted dashboard that keeps every run — traces, HTML reports, history — then groups failures by root cause, scores flaky tests, and tracks performance over time. Zero telemetry: the only outbound calls are the ones you configure.
 
 📖 [Full documentation](https://piwitests.github.io) · 🎮 [Live demo](https://piwitests.github.io/demo/) · 💬 [GitHub](https://github.com/PiwiTests/platform)
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@
 </p>
 
 <p align="center">
-  <b>A permanent home for your Playwright test results.</b><br>
-  CI reports vanish on every build. Piwi keeps them — and turns them into live dashboards,
-  failure clusters, AI diagnosis, and cross-run analytics. Self-hosted, no SaaS.
+  <b>Your Playwright results, kept and explained.</b><br>
+  CI throws away every report it makes. Piwi keeps them — every run, trace, and HTML report — then
+  groups the failures by root cause, scores the flaky tests, and tells you which locator to use
+  instead of the one that just broke. Self-hosted, MIT, zero telemetry.
 </p>
 
 <p align="center">
-  <a href="https://piwitests.github.io/demo/"><img src="https://img.shields.io/badge/▶_Live_demo-try_it_now-2496ED?style=for-the-badge" alt="Live demo"></a>
-  <a href="https://piwitests.github.io"><img src="https://img.shields.io/badge/📖_Documentation-read_the_docs-020420?style=for-the-badge" alt="Documentation"></a>
+  <a href="https://piwitests.github.io/demo/">Live demo</a> ·
+  <a href="https://piwitests.github.io">Documentation</a> ·
+  <a href="./ROADMAP.md">Roadmap</a> ·
+  <a href="https://github.com/PiwiTests/platform/discussions">Discussions</a>
 </p>
 
 <p align="center">
@@ -19,7 +22,6 @@
   <a href="https://hub.docker.com/r/phenx/piwitests-server"><img src="https://img.shields.io/docker/v/phenx/piwitests-server?logo=docker&labelColor=020420&color=2496ED" alt="Docker"></a>
   <a href="https://github.com/PiwiTests/platform/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/PiwiTests/platform/ci.yml?branch=main&logo=githubactions&logoColor=white&labelColor=020420&label=CI" alt="CI status"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?labelColor=020420" alt="MIT license"></a>
-  <a href="https://github.com/PiwiTests/platform/stargazers"><img src="https://img.shields.io/github/stars/PiwiTests/platform?logo=github&labelColor=020420&color=f59e0b" alt="GitHub stars"></a>
 </p>
 
 <p align="center">
@@ -29,38 +31,32 @@
 </p>
 
 <p align="center">
-  <sub>▶ <a href="https://piwitests.github.io/demo/">Click through to the live demo</a> — sample data, no install, runs entirely in your browser — or <a href="https://piwitests.github.io/#see-it-in-action">watch the 30-second clip</a>.</sub>
+  <sub>A run streaming in live. The <a href="https://piwitests.github.io/demo/">demo</a> is the real app on seeded data — it runs entirely in your browser, no install and no backend.</sub>
 </p>
 
-## Why Piwi?
+## The problem it solves
 
-Native Playwright HTML reports are great for local debugging — but they're ephemeral. Once the next CI run completes, the old report is gone. Piwi keeps every run and makes them connected, searchable, and actionable:
+Playwright's HTML report is excellent, and it lasts exactly until the next build. So the questions that
+actually matter get hard to answer: *Has this test always been flaky? Did my fix work? Which of these
+forty red tests are the same bug? What did we change the day the suite started failing?*
 
-- 🗄️ **Permanent history** — every run, trace, and report stored and browsable across time.
-- ⚡ **Live streaming** — watch runs in real time as CI executes; no polling, no waiting.
-- 🔗 **Failure clustering** — failures sharing a root cause are auto-grouped by error fingerprint.
-- 📈 **Performance & flaky tracking** — P90 duration trends, slowest tests, composite flakiness scores.
-- 📊 **Cross-project analytics** — a portfolio dashboard with pass-rate trends, a project × time heatmap, CI-time and wasted-time trends, a global flaky leaderboard, and an auto-generated insights feed for higher-level decisions.
-- 🩹 **Locator healing** — when a locator breaks, ranked replacement locators captured from prior passing runs, with a recommended fix.
-- 🎬 **Self-hosted trace viewer** — open the full Playwright trace viewer from any failure; the trace stays on your server.
-- 🔔 **Notifications** — email, Slack, webhook, and in-browser alerts for failed runs and new failure clusters.
-- 🔌 **Built for automation** — drop-in reporter, REST API, OpenAPI docs, and an MCP server for agent integrations.
-- ☁️ **Zero lock-in** — self-hosted with Docker; your data in SQLite/PostgreSQL and local/S3 storage.
-- 🔒 **Private by design** — zero telemetry, no phone-home. The only outbound calls are the ones you configure (your AI provider, SMTP, S3).
-- 🤖 **AI-assisted diagnosis** *(optional)* — LLM analysis of a failure cluster, grounded in your actual SCM diff, to speed up triage.
+Piwi keeps the runs so you can answer them.
 
-👉 **[Explore the live demo](https://piwitests.github.io/demo/)** — no install required.
+- **Permanent history** — every run, trace, and report, browsable long after CI deleted its artifacts.
+- **Failures grouped by cause** — an error fingerprint collapses forty red tests into the three root
+  causes behind them, each triaged once.
+- **Flaky tests, scored and costed** — a composite score, a root-cause class, and the CI minutes each
+  flake wastes, so you fix the expensive ones rather than the annoying ones.
+- **Locator healing** — when a selector breaks, ranked replacements captured from the last passing run,
+  with a recommended fix.
+- **Evidence in one place** — the trace viewer, screenshots, console, network calls, Web Vitals, and the
+  failing call stack with real source, all served by your own instance.
+- **AI diagnosis, if you want it** — an LLM *you* configure explains a cluster against your actual git
+  diff, and its suggested patch is checked against your source before you see it. Off by default.
 
-## A quick tour
-
-| | |
-|---|---|
-| [![Failure cluster with AI diagnosis](./docs/public/screenshots/failure-cluster.png)](https://piwitests.github.io/ai-diagnosis) | [![AI diagnosis grounded in your SCM diff](./docs/public/screenshots/ai-diagnosis.png)](https://piwitests.github.io/ai-diagnosis) |
-| **Failure clusters** — one root cause, one card | **AI diagnosis** — grounded in your actual git diff |
-| [![Flaky test detection](./docs/public/screenshots/flaky-detection.png)](https://piwitests.github.io/flaky-tests) | [![Test run detail with worker timeline](./docs/public/screenshots/test-run.png)](https://piwitests.github.io/ui-overview) |
-| **Flaky tests** — scored, classified, impact-ranked | **Run detail** — cases, timeline, traces, retry command |
-| [![Locator healing suggestions](./docs/public/screenshots/locator-healing.png)](https://piwitests.github.io/reporter#locator-healing) | [![Performance trends](./docs/public/screenshots/performance-trends.png)](https://piwitests.github.io/flaky-tests) |
-| **Locator healing** — ranked replacements from passing runs | **Performance** — P90 trends and slowest-test tracking |
+Also in the box: cross-project analytics, live run streaming, notifications (email, Slack, webhook,
+browser), a REST API with in-app OpenAPI docs, and an MCP server so your coding agent can ask about
+test health.
 
 ## Quick start
 
@@ -77,21 +73,19 @@ docker run -p 3000:3000 -v $(pwd)/.data:/app/.data phenx/piwitests-server:latest
 docker run -p 3000:3000 -v ${PWD}/.data:/app/.data phenx/piwitests-server:latest
 ```
 
-Visit `http://localhost:3000`. A [`docker-compose.yml`](./docker-compose.yml) is also included.
+Visit `http://localhost:3000`. A [`docker-compose.yml`](./docker-compose.yml) is included, and with
+**Node.js 24+** you can skip Docker entirely — `npx @piwitests/server` creates its `.data/` in the
+current directory. There's also a [desktop build](https://piwitests.github.io/desktop) (Windows `.msi`,
+macOS `.dmg`) that bundles the server for a single machine.
 
-Prefer no Docker? With **Node.js 24+** you can run the server straight from npm — it creates its `.data/` in the current directory:
+> **Linux hosts:** the container runs as non-root UID 1001, so without the `chown` above, Docker
+> auto-creates `.data` owned by `root` and the container can't write to it. Docker Desktop on Windows
+> and macOS handles this for you. See [Troubleshooting](./DOCKER.md#troubleshooting).
 
-```bash
-npx @piwitests/server
-```
-
-Docker stays the recommended path for production; see the [deployment guide](https://piwitests.github.io/deployment) for both.
-
-**Prefer a desktop app?** A local **[desktop build](https://piwitests.github.io/desktop)** (Windows `.msi`, macOS `.dmg`) bundles the server and runs the whole dashboard on your machine — no Docker or Node required. Grab it from the [latest release](https://github.com/PiwiTests/platform/releases/latest).
-
-> **Linux hosts:** the container runs as non-root UID 1001, so without the `chown` above, Docker auto-creates `.data` owned by `root` and the container can't write to it. Windows and macOS (Docker Desktop) don't need this step. See [Troubleshooting](./DOCKER.md#troubleshooting) if you hit a permission error.
-
-> **Production tip:** set `PIWI_SECRET_KEY` (any long random string) so credentials you store in the dashboard — AI API keys, SCM tokens — are encrypted at rest. Generate one with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`. See the [deployment guide](https://piwitests.github.io/deployment).
+> **Before you expose it:** set `PIWI_SECRET_KEY` to a long random string so stored credentials (AI
+> keys, SCM tokens) are actually encrypted. Generate one with
+> `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`. See the
+> [deployment guide](https://piwitests.github.io/deployment).
 
 **2. Add the reporter to your test project**
 
@@ -115,9 +109,11 @@ export default defineConfig({
 })
 ```
 
-**3. Run your tests** — `npx playwright test`. Results appear automatically; the project is created on first submission.
+**3. Run your tests** — `npx playwright test`. Results appear as they finish; the project is created on
+first submission.
 
-**4. Add the capture fixtures** *(recommended)* — one small file unlocks the richest features: locator healing, slow-endpoint analysis, Web Vitals, console capture, and failure-time ARIA snapshots.
+**4. Add the capture fixtures** *(recommended)* — one file, and the deeper features light up: locator
+healing, slow-endpoint analysis, Web Vitals, console capture, failure-time ARIA snapshots.
 
 ```typescript
 // tests/fixtures.ts
@@ -128,56 +124,68 @@ export const test = base.extend(piwiFixtures)
 export { expect }
 ```
 
-Import `test` from this file in your specs instead of `@playwright/test` — that's it. Full details in the **[capture fixtures guide](https://piwitests.github.io/capture-fixtures)**; a runnable example lives in [`examples/playwright-fixtures`](./examples/playwright-fixtures).
+Import `test` from this file in your specs instead of `@playwright/test` — that's the whole change.
+Details in the [capture fixtures guide](https://piwitests.github.io/capture-fixtures); a runnable
+project lives in [`examples/playwright-fixtures`](./examples/playwright-fixtures).
 
-➡️ Full setup, configuration, and CI integration in the **[Getting started guide](https://piwitests.github.io/getting-started)**.
+In CI, set `PIWI_DASHBOARD_URL` (and `PIWI_API_KEY` if auth is on) and you're done — branch, commit, CI
+metadata and `--shard` merging are detected automatically. See
+[CI & sharding](https://piwitests.github.io/ci).
 
-## How is this different from…?
+## A quick tour
 
-| | Piwi | Playwright HTML report | Allure Report | ReportPortal | Currents |
-|---|---|---|---|---|---|
-| Run history across builds | ✅ | ❌ per-run, ephemeral | ➖ manual history files | ✅ | ✅ |
-| Self-hosted | ✅ single container | — | ➖ static files | ✅ multi-service stack | ❌ SaaS |
-| Live run streaming | ✅ | ❌ | ❌ | ➖ | ✅ |
-| Playwright traces, first-class | ✅ | ✅ | ➖ | ➖ | ✅ |
-| Flaky scoring & failure clustering | ✅ | ❌ | ❌ | ✅ ML triage | ✅ |
-| AI failure diagnosis on your git diff | ✅ optional | ❌ | ❌ | ➖ | ➖ |
-| Locator healing suggestions | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Price | Free, MIT | Free | Free | Free (self-host) | Paid |
+| | |
+|---|---|
+| [![Failure cluster with AI diagnosis](./docs/public/screenshots/failure-cluster.png)](https://piwitests.github.io/ai-diagnosis) | [![AI diagnosis grounded in your SCM diff](./docs/public/screenshots/ai-diagnosis.png)](https://piwitests.github.io/ai-diagnosis) |
+| **Failure clusters** — forty red tests, three root causes | **AI diagnosis** — read against your actual git diff |
+| [![Flaky test detection](./docs/public/screenshots/flaky-detection.png)](https://piwitests.github.io/flaky-tests) | [![Test run detail with worker timeline](./docs/public/screenshots/test-run.png)](https://piwitests.github.io/ui-overview) |
+| **Flaky tests** — scored, classified, ranked by wasted CI time | **Run detail** — cases, worker timeline, traces, retry command |
+| [![Locator healing suggestions](./docs/public/screenshots/locator-healing.png)](https://piwitests.github.io/reporter#locator-healing) | [![Performance trends](./docs/public/screenshots/performance-trends.png)](https://piwitests.github.io/flaky-tests#performance) |
+| **Locator healing** — replacements from the last passing run | **Performance** — P90 trends and slowest-test tracking |
 
-Every tool in that table is good at what it targets — the honest version with trade-offs is in **[Comparison & FAQ](https://piwitests.github.io/comparison)**.
+## Where this fits
+
+Playwright's own HTML report is the right tool for debugging a run on your machine; Piwi is for the runs
+you can't open anymore. It's deliberately **Playwright-only** — that's what makes traces, step timing,
+and locator healing first-class rather than lowest-common-denominator. If you need one place for JUnit,
+pytest and Cypress results too, [ReportPortal](https://reportportal.io) or
+[Allure](https://allurereport.org) fit that better. If you'd rather someone else ran the server,
+[Currents](https://currents.dev) is the managed option. And if you only ever debug locally and never
+look back, you don't need any of this.
+
+The longer version, including where Piwi loses, is in
+[Why Piwi?](https://piwitests.github.io/comparison).
+
+## Project status
+
+Pre-1.0 and under active development: expect occasional breaking changes between minor versions, pin a
+version tag, and keep backups of `.data/`. Every commit runs a CI matrix across SQLite/PostgreSQL and
+local/S3 storage with a full Playwright E2E suite, and upgrades apply database migrations
+automatically. Direction and non-goals live in the [roadmap](./ROADMAP.md).
 
 ## Documentation
 
-| Topic | Link |
-|-------|------|
-| Getting started | [piwitests.github.io/getting-started](https://piwitests.github.io/getting-started) |
-| Comparison & FAQ | [piwitests.github.io/comparison](https://piwitests.github.io/comparison) |
-| Playwright reporter | [piwitests.github.io/reporter](https://piwitests.github.io/reporter) |
-| Capture fixtures | [piwitests.github.io/capture-fixtures](https://piwitests.github.io/capture-fixtures) |
-| UI overview | [piwitests.github.io/ui-overview](https://piwitests.github.io/ui-overview) |
-| AI diagnosis & clustering | [piwitests.github.io/ai-diagnosis](https://piwitests.github.io/ai-diagnosis) |
-| Flaky tests & analytics | [piwitests.github.io/flaky-tests](https://piwitests.github.io/flaky-tests) |
-| Notifications & alerts | [piwitests.github.io/notifications](https://piwitests.github.io/notifications) |
-| Configuration reference | [piwitests.github.io/configuration](https://piwitests.github.io/configuration) |
-| API reference (interactive) | [piwitests.github.io/demo/docs](https://piwitests.github.io/demo/docs) |
-| MCP server | [piwitests.github.io/mcp](https://piwitests.github.io/mcp) |
-| Authentication | [piwitests.github.io/authentication](https://piwitests.github.io/authentication) |
-| Storage configuration | [piwitests.github.io/storage](https://piwitests.github.io/storage) |
-| Deployment | [piwitests.github.io/deployment](https://piwitests.github.io/deployment) |
+Full docs at **[piwitests.github.io](https://piwitests.github.io)**. The usual entry points:
 
-The running dashboard also serves self-contained interactive API docs at `/docs`, rendered in-app from the OpenAPI spec — no external CDN, so they work offline / air-gapped.
+- [Getting started](https://piwitests.github.io/getting-started) — install, reporter, first run
+- [Core concepts](https://piwitests.github.io/concepts) — runs, test cases, executions, clusters
+- [Reporter](https://piwitests.github.io/reporter) and [CI & sharding](https://piwitests.github.io/ci) — getting results in
+- [Deployment](https://piwitests.github.io/deployment) and [Configuration](https://piwitests.github.io/configuration) — running your instance
+- [Privacy & data flow](https://piwitests.github.io/privacy) — exactly what leaves your server (nothing you didn't configure)
+
+A running dashboard also serves interactive API docs at `/docs`, rendered in-app from its own OpenAPI
+spec — no external CDN, so they work offline.
 
 ## Community & support
 
-- 💬 **[GitHub Discussions](https://github.com/PiwiTests/platform/discussions)** — questions, ideas, show & tell.
-- 🐛 **[Issues](https://github.com/PiwiTests/platform/issues)** — bug reports and feature requests.
-- 🗺️ **[Roadmap](./ROADMAP.md)** — what's shipped, what's next.
-- 🔐 **[Security policy](./SECURITY.md)** — how to report a vulnerability.
+- 💬 [Discussions](https://github.com/PiwiTests/platform/discussions) — questions, ideas, show & tell
+- 🐛 [Issues](https://github.com/PiwiTests/platform/issues) — bugs and feature requests
+- 🔐 [Security policy](./SECURITY.md) — how to report a vulnerability
 
 ## Contributing
 
-Contributions are welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup, tests, and commit conventions, and **[AGENTS.md](AGENTS.md)** for architecture and the full development guide.
+Contributions are welcome — [CONTRIBUTING.md](CONTRIBUTING.md) covers dev setup, tests, and commit
+conventions; [AGENTS.md](AGENTS.md) has the architecture tour.
 
 ```bash
 cd application && npm install && npm run app:dev   # http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ test health.
 
 ## Quick start
 
+Four ways in, depending on what you already have:
+
+| Path | Start here if | What it costs |
+|---|---|---|
+| **[Live demo](https://piwitests.github.io/demo/)** | You just want to look around first | Nothing — seeded data, runs entirely in your browser |
+| **[Desktop app](https://piwitests.github.io/desktop)** | You run Playwright locally and don't want to run a server | Download an installer — no Docker, no Node |
+| **Docker** *(below)* | You have Docker, or you're setting up a shared instance | One command |
+| **`npx @piwitests/server`** | You have Node.js 24+ and would rather skip Docker | One command |
+
+The desktop app is the shortest path from "curious" to "looking at my own test history" — it bundles the
+same server in a native window. Two caveats worth knowing before you download: the installers are
+**not yet code-signed**, so the first launch needs a click-through (macOS: right-click → **Open**;
+Windows: SmartScreen → **More info** → **Run anyway**), and builds exist for **Windows x64 and
+Apple-silicon macOS** only — on Linux or an Intel Mac, use Docker or `npx`.
+
+The rest of this section sets up the server; the desktop app replaces step 1 only.
+
 **1. Start the dashboard**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ look back, you don't need any of this.
 The longer version, including where Piwi loses, is in
 [Why Piwi?](https://piwitests.github.io/comparison).
 
+## Published artifacts
+
+Everything below is built and published from this repository on each release.
+
+| Artifact | Registry | What it is |
+|---|---|---|
+| [`@piwitests/reporter`](https://www.npmjs.com/package/@piwitests/reporter) | npm | The Playwright reporter — add it to `playwright.config.ts` |
+| [`@piwitests/server`](https://www.npmjs.com/package/@piwitests/server) | npm | The dashboard server, runnable with `npx @piwitests/server` |
+| [`phenx/piwitests-server`](https://hub.docker.com/r/phenx/piwitests-server) | Docker Hub | The server container (`linux/amd64`, `linux/arm64`) |
+| [`ghcr.io/piwitests/platform`](https://github.com/PiwiTests/platform/pkgs/container/platform) | GHCR | The same container, mirrored — plus an `edge` tag built from `main` |
+| [`@piwitests/instrumentation`](https://www.npmjs.com/package/@piwitests/instrumentation) | npm | Optional: sends your Nitro/Nuxt backend's logs into a test run |
+| [`PiwiTests.Instrumentation.AspNetCore`](https://www.nuget.org/packages/PiwiTests.Instrumentation.AspNetCore) | NuGet | Optional: the same for an ASP.NET Core backend |
+| Desktop app (`.msi`, `.dmg`) | [GitHub Releases](https://github.com/PiwiTests/platform/releases/latest) | The server bundled in a native window — no Docker or Node |
+
+The two instrumentation packages are optional and only needed for
+[backend log capture](https://piwitests.github.io/backend-logs). Both container registries carry the
+same images; use whichever your organization prefers.
+
 ## Project status
 
 Pre-1.0 and under active development: expect occasional breaking changes between minor versions, pin a

--- a/README.md
+++ b/README.md
@@ -78,14 +78,22 @@ Visit `http://localhost:3000`. A [`docker-compose.yml`](./docker-compose.yml) is
 current directory. There's also a [desktop build](https://piwitests.github.io/desktop) (Windows `.msi`,
 macOS `.dmg`) that bundles the server for a single machine.
 
+It's one Node process: **~300 MB RAM idle** (1 GB comfortable), **1 vCPU**, `linux/amd64` or
+`linux/arm64`. Disk is the variable — traces and reports dominate, so budget roughly 50–200 MB per run
+and set a retention window. Your test project only needs a Node version Playwright supports; Node 24 is
+the *dashboard's* requirement.
+
 > **Linux hosts:** the container runs as non-root UID 1001, so without the `chown` above, Docker
 > auto-creates `.data` owned by `root` and the container can't write to it. Docker Desktop on Windows
 > and macOS handles this for you. See [Troubleshooting](./DOCKER.md#troubleshooting).
 
-> **Before you expose it:** set `PIWI_SECRET_KEY` to a long random string so stored credentials (AI
-> keys, SCM tokens) are actually encrypted. Generate one with
-> `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`. See the
-> [deployment guide](https://piwitests.github.io/deployment).
+> **Before you expose it:** authentication is **off by default** — the command above gives you an open
+> dashboard, which is fine on localhost and not fine on a network. Set `PIWI_AUTH_ENABLED=true`
+> ([guide](https://piwitests.github.io/authentication)) and set `PIWI_SECRET_KEY` to a long random
+> string so stored credentials (AI keys, SCM tokens) are actually encrypted — generate one with
+> `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`. Put it behind HTTPS;
+> see the [deployment guide](https://piwitests.github.io/deployment). Found a vulnerability? Please
+> report it privately via the [security policy](./SECURITY.md).
 
 **2. Add the reporter to your test project**
 
@@ -178,8 +186,12 @@ same images; use whichever your organization prefers.
 
 Pre-1.0 and under active development: expect occasional breaking changes between minor versions, pin a
 version tag, and keep backups of `.data/`. Every commit runs a CI matrix across SQLite/PostgreSQL and
-local/S3 storage with a full Playwright E2E suite, and upgrades apply database migrations
-automatically. Direction and non-goals live in the [roadmap](./ROADMAP.md).
+local/S3 storage with a full Playwright E2E suite.
+
+Upgrades apply database migrations automatically on startup — and those migrations are **forward-only**,
+so rolling back means restoring a backup, not pulling the old tag. Read
+[Upgrading](https://piwitests.github.io/upgrading) before your first version bump. Direction and
+non-goals live in the [roadmap](./ROADMAP.md).
 
 ## Documentation
 
@@ -189,6 +201,7 @@ Full docs at **[piwitests.github.io](https://piwitests.github.io)**. The usual e
 - [Core concepts](https://piwitests.github.io/concepts) — runs, test cases, executions, clusters
 - [Reporter](https://piwitests.github.io/reporter) and [CI & sharding](https://piwitests.github.io/ci) — getting results in
 - [Deployment](https://piwitests.github.io/deployment) and [Configuration](https://piwitests.github.io/configuration) — running your instance
+- [Upgrading](https://piwitests.github.io/upgrading) — what a version bump does, and why downgrading isn't a thing
 - [Privacy & data flow](https://piwitests.github.io/privacy) — exactly what leaves your server (nothing you didn't configure)
 
 A running dashboard also serves interactive API docs at `/docs`, rendered in-app from its own OpenAPI

--- a/application/app/pages/settings/about.vue
+++ b/application/app/pages/settings/about.vue
@@ -58,7 +58,9 @@ const dbBackendLabel = computed(() => {
     <SectionCard icon="i-lucide-book-open" title="Resources">
       <div class="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">
         <DocLink to="">Documentation</DocLink>
-        <DocLink to="api">API reference</DocLink>
+        <ULink to="/docs" class="inline-flex items-center gap-1 text-primary hover:underline">
+          API reference
+        </ULink>
         <ULink
           to="https://github.com/piwitests/platform"
           target="_blank"

--- a/application/app/utils/help-content.ts
+++ b/application/app/utils/help-content.ts
@@ -39,17 +39,17 @@ export const HELP_TOPICS = {
   'home.trend-bars': {
     title: 'Run history bars',
     text: 'One bar per full run (up to 20), oldest left → newest right. Green = pass, red = fail, amber = passed with flaky tests, gray = skipped/unknown. Click a bar to open that run.',
-    doc: 'ui-overview#home-page',
+    doc: 'ui-overview#home',
   },
   'home.tendency': {
     title: 'Tendency',
     text: 'Derived from the last 5 full runs. Failing = latest run failed; flaky = pass/fail mixed or flaky tests seen in the window; passing = all recent runs green.',
-    doc: 'ui-overview#home-page',
+    doc: 'ui-overview#home',
   },
   'home.project-health': {
     title: 'Project health',
     text: 'Every project at a glance — run history bars and a tendency badge so you can immediately see which project needs attention. Only full runs count.',
-    doc: 'ui-overview#home-page',
+    doc: 'ui-overview#home',
   },
   'home.get-started': {
     title: 'Get started',
@@ -86,7 +86,7 @@ export const HELP_TOPICS = {
   'analytics.cluster-landscape': {
     title: 'Failure clusters',
     text: 'Open failure clusters across all projects — the biggest and oldest unresolved root causes. Clusters outlive run retention, so this works on long horizons.',
-    doc: 'failure-clustering',
+    doc: 'ai-diagnosis#failure-clustering',
   },
   'analytics.regression-velocity': {
     title: 'Regression velocity',
@@ -110,7 +110,7 @@ export const HELP_TOPICS = {
   'projects.table': {
     title: 'Projects',
     text: 'Every project that has reported results, with its latest run, pass rate and activity. Click a row to drill in.',
-    doc: 'ui-overview#projects-page',
+    doc: 'ui-overview#projects',
   },
 
   // ── Project detail ────────────────────────────────────────────────────
@@ -143,7 +143,7 @@ export const HELP_TOPICS = {
   'project.slowest-tests': {
     title: 'Slowest tests',
     text: 'The tests taking the most time, ranked. Optimizing the top entries shortens your overall run the fastest.',
-    doc: 'ui-overview#performance-page',
+    doc: 'flaky-tests#performance',
   },
   'project.run-compare': {
     title: 'Run comparison',
@@ -566,7 +566,7 @@ export const HELP_TOPICS = {
   'account.connected-accounts': {
     title: 'Connected accounts',
     text: 'Sign in with an OAuth provider (Google or GitHub). Providers are configured by an operator through environment variables; one provider can be linked per account.',
-    doc: 'authentication#oauth-sign-in',
+    doc: 'authentication#oauth-google-github',
     envVars: [
       'PIWI_OAUTH_GOOGLE_CLIENT_ID',
       'PIWI_OAUTH_GOOGLE_CLIENT_SECRET',

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,7 +7,8 @@ const siteUrl = 'https://piwitests.github.io'
 
 export default defineConfig({
   title: 'Piwi Dashboard',
-  description: 'A modern dashboard for storing and visualising Playwright test results',
+  description:
+    'Self-hosted dashboard that keeps every Playwright run — then groups failures by root cause, scores flaky tests, and heals broken locators.',
   base: '/',
   // Example values in the generated configuration reference (PIWI_SITE_URL,
   // Ollama base URLs) are intentionally unreachable localhost URLs.
@@ -32,13 +33,13 @@ export default defineConfig({
   },
   head: [
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:title', content: 'Piwi Dashboard — A permanent home for your Playwright test results' }],
+    ['meta', { property: 'og:title', content: 'Piwi Dashboard — Your Playwright results, kept and explained' }],
     [
       'meta',
       {
         property: 'og:description',
         content:
-          'Live dashboards, failure clustering, and flaky-test tracking for your whole team — self-hosted, no SaaS.',
+          'CI throws away every report it makes. Piwi keeps them — then groups failures by root cause, scores flaky tests, and finds the locator you should have used. Self-hosted, MIT, zero telemetry.',
       },
     ],
     ['meta', { property: 'og:image', content: ogImage }],
@@ -46,13 +47,13 @@ export default defineConfig({
     ['meta', { property: 'og:image:height', content: '630' }],
     ['meta', { property: 'og:url', content: siteUrl }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'twitter:title', content: 'Piwi Dashboard — A permanent home for your Playwright test results' }],
+    ['meta', { name: 'twitter:title', content: 'Piwi Dashboard — Your Playwright results, kept and explained' }],
     [
       'meta',
       {
         name: 'twitter:description',
         content:
-          'Live dashboards, failure clustering, and flaky-test tracking for your whole team — self-hosted, no SaaS.',
+          'CI throws away every report it makes. Piwi keeps them — then groups failures by root cause, scores flaky tests, and finds the locator you should have used. Self-hosted, MIT, zero telemetry.',
       },
     ],
     ['meta', { name: 'twitter:image', content: ogImage }],
@@ -71,29 +72,47 @@ export default defineConfig({
       { text: 'Demo', link: 'https://piwitests.github.io/demo/' },
     ],
 
+    // Sidebar order follows the reader's journey: understand it → get results
+    // in → read them → run the instance → wire it into other tools.
     sidebar: [
-      { text: 'Getting started', link: '/getting-started' },
-      { text: 'Why Piwi? (comparison & FAQ)', link: '/comparison' },
-      { text: 'UI overview', link: '/ui-overview' },
-      { text: 'Reporter', link: '/reporter' },
-      { text: 'Capture fixtures', link: '/capture-fixtures' },
       {
-        text: 'Features',
+        text: 'Start here',
         items: [
-          { text: 'AI diagnosis & clustering', link: '/ai-diagnosis' },
-          { text: 'Flaky tests & analytics', link: '/flaky-tests' },
-          { text: 'Timeline markers', link: '/timeline-markers' },
-          { text: 'Notifications & alerts', link: '/notifications' },
+          { text: 'Getting started', link: '/getting-started' },
+          { text: 'Core concepts', link: '/concepts' },
+          { text: 'Why Piwi? (comparison & FAQ)', link: '/comparison' },
         ],
       },
       {
-        text: 'Configuration',
+        text: 'Sending results',
         items: [
+          { text: 'Reporter', link: '/reporter' },
+          { text: 'Capture fixtures', link: '/capture-fixtures' },
+          { text: 'CI & sharding', link: '/ci' },
+          { text: 'Backend logs', link: '/backend-logs' },
+        ],
+      },
+      {
+        text: 'Reading the results',
+        items: [
+          { text: 'UI overview', link: '/ui-overview' },
+          { text: 'AI diagnosis & clustering', link: '/ai-diagnosis' },
+          { text: 'Flaky tests', link: '/flaky-tests' },
+          { text: 'Analytics', link: '/analytics' },
+          { text: 'Timeline markers', link: '/timeline-markers' },
+          { text: 'Notifications & alerts', link: '/notifications' },
+          { text: 'Open in IDE', link: '/ide-integration' },
+        ],
+      },
+      {
+        text: 'Running your instance',
+        items: [
+          { text: 'Deployment', link: '/deployment' },
           { text: 'Configuration reference', link: '/configuration' },
           { text: 'Configuration generator', link: '/configuration/generator' },
           { text: 'Authentication', link: '/authentication' },
           { text: 'Storage configuration', link: '/storage' },
-          { text: 'Deployment', link: '/deployment' },
+          { text: 'Privacy & data flow', link: '/privacy' },
           { text: 'Desktop app', link: '/desktop' },
         ],
       },
@@ -102,8 +121,6 @@ export default defineConfig({
         items: [
           { text: 'API docs (interactive)', link: 'https://piwitests.github.io/demo/docs' },
           { text: 'MCP server', link: '/mcp' },
-          { text: 'Open in IDE', link: '/ide-integration' },
-          { text: 'Backend logs', link: '/backend-logs' },
         ],
       },
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,10 @@ export default defineConfig({
   description:
     'Self-hosted dashboard that keeps every Playwright run — then groups failures by root cause, scores flaky tests, and heals broken locators.',
   base: '/',
+  // AGENTS.md is the agent guide for this directory, not a page of the site:
+  // it links to sibling guides outside the docs root, so building it as a page
+  // both publishes the wrong thing and fails the dead-link check.
+  srcExclude: ['AGENTS.md'],
   // Example values in the generated configuration reference (PIWI_SITE_URL,
   // Ollama base URLs) are intentionally unreachable localhost URLs.
   ignoreDeadLinks: [/^https?:\/\/localhost/],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
         text: 'Running your instance',
         items: [
           { text: 'Deployment', link: '/deployment' },
+          { text: 'Upgrading', link: '/upgrading' },
           { text: 'Configuration reference', link: '/configuration' },
           { text: 'Configuration generator', link: '/configuration/generator' },
           { text: 'Authentication', link: '/authentication' },

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -35,6 +35,34 @@ When documenting a feature here, link to `[API docs](/docs)` (self-hosted) or th
 authored in the handler's `defineRouteMeta({ openAPI: … })` block — see
 [`../application/AGENTS.md`](../application/AGENTS.md#openapi-annotations).
 
+## Site structure (MUST follow)
+
+The sidebar in `.vitepress/config.mts` is ordered by the **reader's journey**, not by feature. A new page goes in the
+group matching what the reader is doing, and each page stays single-purpose:
+
+| Group | Covers | Pages |
+|---|---|---|
+| Start here | what it is, first run, vocabulary | `getting-started`, `concepts`, `comparison` |
+| Sending results | getting data in | `reporter`, `capture-fixtures`, `ci`, `backend-logs` |
+| Reading the results | using the dashboard | `ui-overview`, `ai-diagnosis`, `flaky-tests`, `analytics`, `timeline-markers`, `notifications`, `ide-integration` |
+| Running your instance | operating it | `deployment`, `configuration`, `configuration/generator`, `authentication`, `storage`, `privacy`, `desktop` |
+| Integrate | other tools | in-app API docs (external link), `mcp` |
+
+Extend an existing page before adding a new one.
+
+- **`concepts.md` is the vocabulary source of truth** — project / test run / **test case** (a test's identity across
+  time) / **execution** (one attempt, one browser — the `test_runs_cases` row) / failure cluster / fingerprint /
+  baseline. Use those words consistently in docs *and* UI copy; link the anchor instead of redefining a term.
+- **`ui-overview.md` is a map, not a manual** — one short paragraph per view plus a link to the page that explains the
+  concept. Feature explanations belong on the feature page.
+- **Contributor material does not belong on this site.** Build steps, source layout, migration workflow and dev
+  commands live in `CONTRIBUTING.md` / `AGENTS.md` / `reporter/ARCHITECTURE.md`. The site is for people *using* Piwi.
+- **Every user-visible reporter option** must appear in `reporter.md`'s options table (and its `PIWI_*` var in the
+  table below it) in the same change that adds it to `reporter/src/public/options.ts`.
+- **In-app help links point here.** `application/app/utils/help-content.ts` builds docs URLs from `doc:` string
+  literals that nothing validates — renaming a heading breaks them silently. Grep for the old anchor when you rename
+  one.
+
 ## Writing conventions
 
 - Update the affected page **in the same commit** as the code change; commit scope `docs`.
@@ -43,9 +71,20 @@ authored in the handler's `defineRouteMeta({ openAPI: … })` block — see
   portable single form.
 - Diagrams are theme-aware SVG assets under `docs/public/` — commit the asset rather than embedding a large inline
   `<svg>` in prose.
-- Subject-matter pages that already exist: getting started, deployment, configuration, storage, authentication,
-  notifications, reporter, capture fixtures, AI diagnosis, flaky tests, timeline markers, MCP, IDE integration,
-  desktop, backend logs, UI overview, comparison. Extend one before adding a new page.
+
+### Voice
+
+Informative, specific, honest — never promotional. Piwi is not a product being sold. The canonical positioning line
+and the seven surfaces that must carry it are in the [root guide](../AGENTS.md#documentation).
+
+- **Banned**: conversion CTA blocks ("Stop losing your…" + buttons), `for-the-badge` call-to-action badges, "try it
+  now" / pointing-hand CTAs, competitor feature tables with a **Price** row in the README (honest prose comparison
+  belongs in `comparison.md`), vanity badges (stars), superlatives ("powerful", "seamless", "unlock",
+  "best-in-class"), and more than ~8 feature bullets or cards on any one page — past that nobody reads them.
+- **Prefer the concrete over the categorical**: "groups forty red tests into three root causes" beats "observability
+  platform". Name a number, a behavior, or a limit.
+- **State limits plainly.** Playwright-only, pre-1.0, and "not the right tool if…" belong in the README and on the
+  landing page. Trust is the point, not a caveat to bury.
 
 ## Marketing screenshots
 

--- a/docs/ai-diagnosis.md
+++ b/docs/ai-diagnosis.md
@@ -225,6 +225,8 @@ API keys are encrypted at rest with [`PIWI_SECRET_KEY`](./configuration#general)
 
 ## See also
 
+- [Core concepts](./concepts#error-fingerprint-failure-cluster) — fingerprints, clusters, and baselines in one place
+- [Privacy & data flow](./privacy) — exactly what a diagnosis sends, and where
 - [Configuration reference](./configuration) — all environment variables
 - [Notifications](./notifications) — subscribe to `cluster.new` and `diagnosis.completed` to get alerted when a new cluster appears or a diagnosis completes (browser, email, Slack, or webhook)
 - [MCP server](./mcp) — let AI agents query clusters and diagnoses directly

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,79 @@
+---
+title: Analytics
+lang: en-US
+---
+
+# Analytics
+
+Every other view in Piwi answers a question about one project, one run, or one test. The **Analytics**
+page (`/analytics`) is the one that steps back: it aggregates every project over a time window you
+choose, so you can see where the suite as a whole is drifting — and hand a number to someone who
+doesn't read stack traces.
+
+## Scope
+
+A scope bar at the top sets:
+
+- **Period** — last 7 / 30 / 90 days, last year, or all time.
+- **Environment** — optional; restrict to runs labeled `production`, `staging`, … (see
+  [Environment](./concepts#environment)).
+- **Full runs only** — exclude partial and interrupted runs, which otherwise skew pass rates.
+
+Every widget re-aggregates against that scope, and each period is compared against the *preceding*
+period of the same length, which is where the "vs previous" deltas come from.
+
+## Widgets
+
+**Insights** — an auto-generated, severity-ranked feed of what actually changed: pass-rate drops,
+failing streaks, stale failure clusters, wasted CI time, oversized timeouts and stale `test.slow()`
+marks, regression surges, and slow shared endpoints. Each entry links to the project, run, cluster, or
+test case behind it. Start here; the rest of the page is the evidence.
+
+**Portfolio health** — one sortable row per project: pass rate and its change vs the previous period,
+flaky volume, open failure clusters, average run duration, and latest run. Worst health sorts first.
+
+**Pass rate heatmap** — projects × time, colored by daily (or weekly, over longer periods) pass rate.
+This is the fastest way to answer *when* something started degrading.
+
+**CI time** and **Wasted CI time** — total minutes your runs consumed, and how many of those produced
+no signal: time spent inside wait steps plus time spent executing attempts that ended failed or timed
+out. Because a timed-out test burns its entire (often oversized) budget, the widget also calls out how
+much is reclaimable by tightening timeouts and removing stale `test.slow()` marks.
+
+**Flakiest tests** — the global flaky leaderboard, using the same [scoring and impact
+ranking](./flaky-tests#impact-ranking) as each project's Flaky tests tab.
+
+**Failure clusters** — open root causes across all projects by age, occurrences, and error-type mix,
+with the oldest unresolved cluster highlighted.
+
+**Regression velocity** — new regressions and newly-flaky tests introduced per period, stacked, with
+the change vs the previous period. Rising bars mean quality debt is accumulating faster than it's paid
+down.
+
+**Browser matrix** — pass rate per project × browser, so a suite that's green on Chromium and failing
+on WebKit stands out without opening a single run.
+
+**Slow endpoints** — backend calls captured during tests, aggregated across all projects by normalized
+route: p50/p90 latency, error rate, and how many projects hit each one. A shared endpoint regressing
+shows up here before it's obvious in any single suite. Requires the
+[capture fixtures](./capture-fixtures).
+
+## Marking what you changed
+
+Trends are only actionable when you can line them up against events. [Timeline markers](./timeline-markers)
+let you record a deploy, a CI-runner migration, or a dependency bump against a project and see it drawn
+as a vertical line across the trend charts — so "the slowdown started the day we switched runners"
+becomes something you can see rather than remember.
+
+## How it's built
+
+Each widget is a registry entry backed by a shared handler and served by one generic endpoint,
+`GET /api/analytics/:widget`. The same handlers back the dashboard, the demo, and the API, so a number
+you read on the page is the number the API returns. Widgets fetch independently, so a slow one never
+blocks the rest of the page.
+
+## See also
+
+- [Flaky tests](./flaky-tests) — the per-project analysis these widgets aggregate
+- [Timeline markers](./timeline-markers) — annotate the trends with real-world events
+- [UI overview](./ui-overview#analytics) — where this sits in the navigation

--- a/docs/capture-fixtures.md
+++ b/docs/capture-fixtures.md
@@ -9,6 +9,8 @@ The [reporter](./reporter) uploads complete test results — statuses, errors, t
 
 If you do one thing beyond installing the reporter, do this.
 
+(What a captured [locator snapshot](./concepts#locator-snapshot) actually stores — and doesn't — is in Core concepts.)
+
 ## Setup
 
 **Option A — extend your existing fixtures:**

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,201 @@
+---
+title: CI & sharding
+lang: en-US
+---
+
+# CI & sharding
+
+CI is where Piwi earns its keep — it's the place your results were disappearing from. There is no
+Piwi-specific step to add: the reporter runs inside `npx playwright test` and pushes results as they
+happen. In practice you set two environment variables.
+
+```yaml
+env:
+  PIWI_DASHBOARD_URL: https://piwi.example.com
+  PIWI_API_KEY: ${{ secrets.PIWI_API_KEY }}   # only if authentication is enabled
+```
+
+Everything else — branch, commit, author, workflow, build URL, shard index — is
+[detected automatically](#what-gets-detected).
+
+## GitHub Actions
+
+```yaml
+name: e2e
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npx playwright test
+        env:
+          PIWI_DASHBOARD_URL: https://piwi.example.com
+          PIWI_API_KEY: ${{ secrets.PIWI_API_KEY }}
+```
+
+`actions/checkout` fetches a shallow clone by default. That's fine for the commit metadata Piwi
+records, but [AI diagnosis](./ai-diagnosis) reads the diff since the last green run from your git host
+over the API, not from the checkout — so no `fetch-depth` change is required.
+
+## GitLab CI
+
+```yaml
+e2e:
+  image: mcr.microsoft.com/playwright:v1.54.0-noble
+  script:
+    - npm ci
+    - npx playwright test
+  variables:
+    PIWI_DASHBOARD_URL: https://piwi.example.com
+    PIWI_API_KEY: $PIWI_API_KEY
+```
+
+## Other systems
+
+Jenkins, CircleCI, Azure DevOps, Travis, Buildkite, TeamCity, Bitbucket, Semaphore, AppVeyor and Drone
+are recognized too — set the same two variables however your system exposes them. Nothing about the
+reporter is platform-specific; unrecognized CI just means less auto-filled metadata.
+
+## What gets detected
+
+Without any configuration, the reporter records:
+
+- **Source control** — commit SHA, message, author, branch, and the repository URL, read from the local
+  git checkout.
+- **CI** — provider, workflow/job name, build number, and a link back to the CI build, from the
+  provider's environment variables.
+- **Environment** — Node, Playwright and OS versions, plus each test's browser and viewport.
+- **Shard index** — from Playwright's own `--shard` config.
+
+Turn off either collector with `collectScmInfo: false` / `collectCiInfo: false` if you'd rather not
+store it.
+
+## Sharding
+
+Playwright's `--shard=1/3` splits a suite across parallel jobs. Piwi merges them back into **one run**
+— you shouldn't have to think about shards when reading results.
+
+```yaml
+strategy:
+  matrix:
+    shard: [1, 2, 3]
+steps:
+  - run: npx playwright test --shard=${{ matrix.shard }}/3
+    env:
+      PIWI_DASHBOARD_URL: https://piwi.example.com
+      PIWI_API_KEY: ${{ secrets.PIWI_API_KEY }}
+```
+
+How the merge works:
+
+1. Each shard derives a **run label** — a stable identifier for the CI pipeline — from environment
+   variables (`GITHUB_RUN_ID`, `CI_PIPELINE_ID`, `CIRCLE_WORKFLOW_ID`, `TRAVIS_BUILD_ID`,
+   `BUILD_BUILDID`, `BUILD_ID`, `BUILDKITE_BUILD_ID`, `TEAMCITY_BUILD_ID`, `BITBUCKET_BUILD_NUMBER`,
+   `SEMAPHORE_WORKFLOW_ID`, `APPVEYOR_BUILD_ID`, `DRONE_BUILD_NUMBER`).
+2. Shards sharing a run label **and** a `projectName` resolve to the same run.
+3. Each shard streams independently; the run stays `running` until the **last** shard calls finish.
+4. Counters accumulate across shards. The run is `failed` if any shard reported a failure.
+5. The run detail page shows a shard progress badge (`2/3`) while shards are still arriving.
+
+**All shards must use the same `projectName`.** That's the one requirement.
+
+If your CI isn't detected, set the label yourself to anything common to all shards:
+
+```typescript
+['@piwitests/reporter', {
+  serverUrl: 'https://piwi.example.com',
+  projectName: 'my-project',
+  runLabel: process.env.BUILD_TAG || 'my-custom-label',
+}]
+```
+
+Both the streaming and the batch (`submit` / `upload`) paths support sharding.
+
+## Watching a run while CI is still going
+
+Streaming is on by default: the run appears in the dashboard when the suite starts and fills in test by
+test, with traces and attachments uploaded per test as they finish. You can open a failure and start
+reading the trace before the pipeline is done. See [Reporter → Live streaming](./reporter#live-streaming)
+to tune batch size or turn it off.
+
+## Getting the run URL back out of CI
+
+After results land, the reporter surfaces the dashboard run URL wherever a pipeline can pick it up, so
+a later step (a Slack post, a deploy gate, a PR comment) doesn't have to scrape stdout. All of it is
+best-effort — a failure in any channel is logged and never fails your run.
+
+**Always** — a `View run: <url>` line in the log.
+
+**GitHub Actions (automatic)** — step outputs, a job-summary link, and a `::notice::` annotation:
+
+```yaml
+- run: npx playwright test
+  id: e2e
+  env:
+    PIWI_DASHBOARD_URL: https://piwi.example.com
+- run: echo "Results: ${{ steps.e2e.outputs.piwi_run_url }}"
+  if: always()
+```
+
+Available outputs: `piwi_run_url`, `piwi_run_id`, `piwi_run_status`, `piwi_project_id`.
+
+**GitLab CI (automatic)** — a dotenv report (`piwi.env` by default, override with `PIWI_DOTENV_FILE`)
+carrying `PIWI_RUN_URL`, `PIWI_RUN_ID`, `PIWI_RUN_STATUS`, `PIWI_PROJECT_ID` and `PIWI_CI_BUILD_URL`.
+Declare it so later jobs inherit the variables:
+
+```yaml
+e2e:
+  script:
+    - npx playwright test
+  artifacts:
+    reports:
+      dotenv: piwi.env
+```
+
+**Any other system** — set `outputFile` (or `PIWI_OUTPUT_FILE`) and read the JSON:
+
+```yaml
+- run: npx playwright test
+  env:
+    PIWI_OUTPUT_FILE: piwi-run.json
+- run: cat piwi-run.json   # { runUrl, runId, projectId, projectName, status, ciBuildUrl }
+```
+
+## Notifying people instead
+
+If all you want is "tell the team when main goes red", you don't need any of the above — configure a
+[notification subscription](./notifications) on the dashboard side and let it push to Slack, email, or
+a webhook. That keeps the alerting rules in one place instead of in every pipeline.
+
+## Troubleshooting
+
+**Results don't appear.** Check the CI log for the reporter's own output; run with `PIWI_VERBOSE=true`
+for the full request trace. The usual causes are an unreachable `PIWI_DASHBOARD_URL` from the runner's
+network, or a missing API key against an instance with authentication enabled.
+
+**Shards create several runs instead of one.** The run label wasn't detected, or the shards disagree on
+`projectName`. Set `runLabel` explicitly.
+
+**Traces are missing.** Traces have to be recorded before they can be uploaded — set
+`use: { trace: 'retain-on-failure' }` (or `'on-first-retry'`) in your Playwright config.
+
+**A run is stuck as `interrupted`.** A live reporter heartbeats every ~15s; when a run goes quiet for
+two minutes — a cancelled job, an OOM-killed runner, a dropped network — the server marks it
+`interrupted` rather than leaving it `running` forever. If the reporter comes back (a long test, a
+transient blip) the next event revives the run automatically, so `interrupted` is only final when the
+job really died. Those runs are excluded by the **full runs only** filter in
+[Analytics](./analytics#scope).
+
+## See also
+
+- [Reporter](./reporter) — every option, streaming, and locator healing
+- [Authentication](./authentication) — creating the API key CI uses
+- [Concepts → Test run](./concepts#test-run) — why shards are one run
+- [Notifications](./notifications) — alerting without touching the pipeline

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -46,7 +46,7 @@ In the **Fault0** column, ➖ marks a capability we did not find in its public d
 
 ### Is my data safe? Does Piwi phone home?
 
-**Zero telemetry.** Piwi makes no outbound calls except the ones you explicitly configure: your AI provider (if you enable diagnosis), your SMTP server, your S3 endpoint, your Slack/webhook URLs, and your git host (if you connect a repository). No analytics, no update pings, no crash reporting. Your test results live in your SQLite file or PostgreSQL database, on your infrastructure.
+**Zero telemetry.** The full inventory is in [Privacy & data flow](./privacy). Piwi makes no outbound calls except the ones you explicitly configure: your AI provider (if you enable diagnosis), your SMTP server, your S3 endpoint, your Slack/webhook URLs, and your git host (if you connect a repository). No analytics, no update pings, no crash reporting. Your test results live in your SQLite file or PostgreSQL database, on your infrastructure.
 
 ### Does AI diagnosis send my code to a third party?
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,142 @@
+---
+title: Core concepts
+lang: en-US
+---
+
+# Core concepts
+
+Piwi reuses Playwright's vocabulary where it can, but a dashboard that keeps history needs a few
+distinctions Playwright doesn't have to make — most importantly between *a test* and *one run of that
+test*. This page defines the words the rest of the documentation and the UI use.
+
+## The object model
+
+```
+Project                      one test suite you submit results for
+└── Test run                 one `npx playwright test` (all shards merged)
+    └── Execution            one attempt of one test, on one browser
+        └── belongs to a Test case   the test's identity across all runs
+             │
+             └── Failure cluster     executions that failed the same way
+```
+
+Read it in two directions:
+
+- **Down** — "what happened in this run?" A run holds executions; each execution points at the test it
+  is an attempt of.
+- **Across** — "how has this test behaved?" A test case holds every execution of itself, in every run,
+  over time. That's the axis flakiness, pass rate, and duration trends are computed on.
+
+## Project
+
+A named container for one suite's results — usually one repository, or one suite within it. Projects
+are created automatically the first time results are submitted under a new `projectName`; you never
+have to pre-register one.
+
+A project carries its own tags, retention, access assignments, SCM connection, and AI-diagnosis
+instructions.
+
+## Test run
+
+Everything one `npx playwright test` invocation produced: counts, duration, the HTML report, CI and
+git metadata, and every execution inside it.
+
+Two things commonly surprise people:
+
+- **Shards merge into one run.** Ten `--shard` jobs produce one run, not ten. The reporter derives a
+  stable *run label* from your CI's pipeline ID and every shard submits against it; the run stays
+  `running` until the last shard finishes. See [CI & sharding](./ci).
+- **A run can be watched while it happens.** With streaming enabled (the default), the run row appears
+  when the suite starts and fills in test by test, so a failure is browsable before CI finishes.
+
+## Test case
+
+The **identity of a test across time**, keyed by project + file path + `describe` path + title. It is
+not a row you submit — it's created and reused as results arrive, so renaming a test creates a new one
+and moving a spec file does too.
+
+A test case is browser-independent: `login.spec.ts › signs in` is one test case whether it ran on
+Chromium, Firefox, or all five projects in your matrix.
+
+This is the object at `/test-cases/:id` — pass rate, duration trend, status history, and the list of
+every execution.
+
+## Execution
+
+**One attempt of one test case, in one run, on one browser.** Retries are separate executions, not a
+field on one: a test that failed twice and passed on the third attempt contributes three executions to
+the same run. So is each browser in a project matrix.
+
+This is the object at `/test-run-cases/:id` — the error, steps, trace, screenshots, console, network,
+Web Vitals, and (for a failure) the diagnosis view. When the docs say *execution* or *test-run case*,
+this is what they mean; when they say *test case*, they mean the identity above it.
+
+The distinction matters in practice: "this test is flaky" is a statement about a **test case**, and
+"here is the stack trace" is a statement about one **execution**.
+
+## Error fingerprint & failure cluster
+
+When an execution fails, Piwi hashes a normalized form of its error — error type, message with the
+volatile parts masked out (timeouts, numbers, UUIDs, URLs, expected/received values), and the locator
+with its dynamic arguments masked. That hash is the **error fingerprint**.
+
+Every failed execution sharing a fingerprint joins one **failure cluster**. Fifty red tests caused by
+one broken endpoint become one cluster you triage once, with a status (open / resolved / ignored) and
+a note.
+
+Fingerprints deliberately **ignore the failing stack frame**, so the same root cause reached from six
+different spec files stays one cluster. Full detail:
+[Failure clustering & AI diagnosis](./ai-diagnosis).
+
+## Baseline (last green run)
+
+Several views answer "what changed?" — run insights, the regression signals on a test, the environment
+and visual diffs, and the git diff behind an AI diagnosis. They all compare against a **baseline**: the
+most recent passing run of the same project (and branch, where relevant).
+
+Two derived flags are stored per execution:
+
+- **New regression** — passed in the baseline, fails now.
+- **New flaky** — didn't retry in the baseline, passed on retry now.
+
+## Flakiness score
+
+A test case's **composite score** from three independent signals — retry passes, status alternation
+across runs, and overall failure rate — plus a **root-cause class** (timing, network, assertion,
+environment, other) and an **impact ranking** in wasted CI minutes. It's a property of the test case,
+computed over its execution history, which is why a test needs a few runs of history before it can be
+called flaky. See [Flaky tests](./flaky-tests).
+
+## Locator snapshot
+
+When the [capture fixtures](./capture-fixtures) are installed, every successful locator call records
+what the element actually looked like — role, accessible name, test id, structural anchors — keyed by
+the **call site** (`file:line`) rather than the selector text. One row per call site, refreshed on each
+passing run.
+
+When that locator later fails, those snapshots are what Piwi ranks replacement locators from. See
+[Locator healing](./reporter#locator-healing).
+
+## Environment
+
+A free-text label on a run (`production`, `staging`, a preview URL, whatever you use), set with the
+reporter's `environment` option or `PIWI_ENVIRONMENT`. It's a **scoping** dimension, not a
+configuration one: flaky analysis, analytics, and timeline markers can all be narrowed to a single
+environment so a staging suite's noise doesn't blend into production's numbers.
+
+## Where each concept lives in the UI
+
+| Concept | URL | Docs |
+|---|---|---|
+| Project | `/projects/:id` | [UI overview](./ui-overview#project-detail) |
+| Test run | `/test-runs/:id` | [UI overview](./ui-overview#test-run-detail) |
+| Test case | `/test-cases/:id` | [UI overview](./ui-overview#test-case-detail) |
+| Execution | `/test-run-cases/:id` | [UI overview](./ui-overview#test-case-detail) |
+| Failure cluster | `/failure-clusters/:id` | [AI diagnosis & clustering](./ai-diagnosis) |
+| Cross-project view | `/analytics` | [Analytics](./analytics) |
+
+## See also
+
+- [Getting started](./getting-started) — get results flowing in
+- [UI overview](./ui-overview) — a map of every page
+- [Reporter](./reporter) — how each of these objects gets populated

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,16 +28,43 @@ The dashboard will be available at `http://localhost:3000`.
 
 > **Linux hosts:** without the `chown`, Docker auto-creates `.data` owned by `root` and the container (non-root UID 1001) can't write to it. Docker Desktop on Windows/macOS handles this automatically. See [Permission issues with volumes](#permission-issues-with-volumes) if you hit a permission error.
 
+### Registries
+
+The same multi-arch image is published to two registries — use whichever your organization prefers:
+
+::: code-group
+
+```bash [Docker Hub]
+docker pull phenx/piwitests-server:latest
+```
+
+```bash [GHCR]
+docker pull ghcr.io/piwitests/platform:latest
+```
+
+:::
+
+GHCR additionally carries an **`edge`** tag rebuilt from every push to `main`. It's useful for trying an
+unreleased fix; don't run it in production — it has had no release testing and can change under you.
+
 ### Available tags
 
-| Tag | Description |
-|-----|-------------|
-| `latest` | Latest stable release |
-| `0.9.0` | Specific version (semver) |
-| `0.9` | Latest patch of a minor version |
-| `0` | Latest release of the major version |
+| Tag | Description | Docker Hub | GHCR |
+|-----|-------------|:---:|:---:|
+| `latest` | Latest stable release | ✅ | ✅ |
+| `0.18.2` | Specific version (semver) | ✅ | ✅ |
+| `0.18` | Latest patch of a minor version | ✅ | ✅ |
+| `0` | Latest release of the major version | ✅ | ✅ |
+| `edge` | Built from `main`, unreleased | — | ✅ |
 
-Pin a specific version in production; [tags on Docker Hub](https://hub.docker.com/r/phenx/piwitests-server/tags).
+Pin a specific version in production. Browse the published tags on
+[Docker Hub](https://hub.docker.com/r/phenx/piwitests-server/tags) or
+[GHCR](https://github.com/PiwiTests/platform/pkgs/container/platform).
+
+::: tip
+GHCR also lists `buildcache-linux-amd64` / `buildcache-linux-arm64`. Those are BuildKit layer caches for
+the build itself, not runnable images — ignore them.
+:::
 
 ### Image details
 
@@ -47,7 +74,7 @@ Pin a specific version in production; [tags on Docker Hub](https://hub.docker.co
 | Build type | Multistage (builder + production stages) |
 | Image size | ~400 MB |
 | Platforms | `linux/amd64`, `linux/arm64` |
-| Registry | `phenx/piwitests-server` |
+| Registries | `phenx/piwitests-server`, `ghcr.io/piwitests/platform` |
 
 ### Volumes
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,8 @@ unreleased fix; don't run it in production — it has had no release testing and
 | `0` | Latest release of the major version | ✅ | ✅ |
 | `edge` | Built from `main`, unreleased | — | ✅ |
 
-Pin a specific version in production. Browse the published tags on
+Pin a specific version in production — and read [Upgrading](./upgrading) before you bump it, because
+migrations are forward-only. Browse the published tags on
 [Docker Hub](https://hub.docker.com/r/phenx/piwitests-server/tags) or
 [GHCR](https://github.com/PiwiTests/platform/pkgs/container/platform).
 
@@ -353,6 +354,8 @@ Compress-Archive -Path .data -DestinationPath piwi-backup.zip
 :::
 
 With PostgreSQL: `pg_dump` the database and copy `.data/storage/` (or rely on your S3 bucket's own durability/versioning).
+
+Take one before every version bump: migrations are forward-only, so a backup is the only rollback path. See [Upgrading](./upgrading).
 
 ## Resource requirements
 

--- a/docs/flaky-tests.md
+++ b/docs/flaky-tests.md
@@ -1,11 +1,15 @@
 ---
-title: Flaky tests & analytics
+title: Flaky tests
 lang: en-US
 ---
 
-# Flaky tests & analytics
+# Flaky tests
 
-Once Piwi has a few runs of history, it turns them into cross-run intelligence: which tests are flaky, what's regressing, where time is wasted, and how performance trends over time. This page covers the analytics features beyond a single run.
+A single run tells you what failed. A few dozen runs tell you what's *unreliable* — and that's a
+different, more expensive problem. This page covers what Piwi computes for one project once it has some
+history: flaky scoring, regression signals, performance trends, and spec health.
+
+For the same signals aggregated across every project, see [Analytics](./analytics).
 
 ## Flaky test detection
 
@@ -98,24 +102,16 @@ Network analysis and Web Vitals require the [capture fixtures](./capture-fixture
 
 A project-level overview groups test cases by spec file and colors each by pass rate, so an unhealthy area of the suite jumps out. Cells link straight to the filtered test-case list.
 
-## Cross-project analytics
+## Across every project
 
-Everything above is scoped to one project. The **Analytics** page (`/analytics`) lifts the same signals to the whole portfolio over a time window you choose (last 7 / 30 / 90 days, last year, or all time — plus an optional environment and a full-runs-only toggle). It answers the higher-level questions a single project page can't:
-
-- **Portfolio health** — every project's pass rate with its change vs the previous period, flaky volume, open failure clusters, and latest run, sorted worst-first.
-- **Pass rate heatmap** — projects × time, colored by pass rate, so you can see who degraded and when.
-- **CI time** and **Wasted CI time** — how many CI minutes your runs consume, and how many of those produce no signal (wait steps + failed attempts). Since a timed-out test burns its whole (often oversized) budget, the widget also calls out how much of that time is reclaimable by tightening oversized timeouts and removing stale `test.slow()` marks — the same [timeout opportunities](#performance) surfaced per project.
-- **Flakiest tests** — the global flaky leaderboard across all projects, using the [impact ranking](#impact-ranking) above.
-- **Failure clusters** — open root causes across all projects, by age and occurrences.
-- **Regression velocity** — new regressions and newly-flaky tests introduced per period (see [Regression signals](#regression-signals)), so you can see whether quality debt is growing or shrinking.
-- **Browser matrix** — pass rate per project × browser, to catch browser-specific breakage.
-- **Slow endpoints** — the backend calls captured during tests, aggregated across all projects by route (p50/p90 latency, error rate, projects affected).
-- **Insights** — an auto-generated, severity-ranked feed of the findings that matter (pass-rate drops, failing streaks, stale clusters, wasted time, oversized timeouts and stale `test.slow()` marks, regression surges, slow shared endpoints), each linking to the source.
-
-Each widget is served by `GET /api/analytics/:widget` and computed by a shared handler in `shared/handlers/analytics/`, so the same numbers back the dashboard, the demo, and any future API consumer.
+Everything above is scoped to one project. The **Analytics** page lifts the same signals to your whole
+portfolio over a time window you choose — portfolio health, a pass-rate heatmap, wasted CI minutes,
+regression velocity, a global flaky leaderboard, and an auto-generated insights feed. See
+[Analytics](./analytics).
 
 ## See also
 
+- [Analytics](./analytics) — the same signals across every project
 - [UI overview](./ui-overview) — where each of these views lives in the dashboard
 - [Reporter](./reporter) — how retries, traces, and run metadata get captured
 - [Capture fixtures](./capture-fixtures) — the test-side setup behind network analysis and Web Vitals

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,16 +7,18 @@ lang: en-US
 
 ## What is Piwi Dashboard?
 
-Piwi Dashboard is a self-hosted observability platform for [Playwright](https://playwright.dev) end-to-end tests. It replaces ephemeral CI reports with a permanent, searchable history — then goes further with live streaming, failure clustering, AI diagnosis, and cross-run analytics.
+Piwi Dashboard is a self-hosted home for [Playwright](https://playwright.dev) test results. Your CI
+deletes its HTML report on every build; Piwi keeps every run — with its traces, reports, and metadata —
+and then does the things a permanent history makes possible: grouping failures by root cause, scoring
+flaky tests, tracking performance, streaming runs live, and (optionally) diagnosing failures with an
+LLM you configure.
 
-**Key benefits:**
-- See test health trends across hundreds of runs with cross-run analytics
-- Stream results live from CI — investigate failures before the suite finishes
-- Failure clustering groups tests sharing the same root cause automatically
-- AI diagnosis analyzes clusters with full SCM diff context
-- Store HTML reports and trace files permanently for later debugging
-- Track performance regressions with avg/P90 duration charts
-- Self-hosted and open-source — your data stays on your infrastructure
+It is a **server plus a Playwright reporter**. The reporter runs inside `npx playwright test` and pushes
+results to the server; the server stores them and renders the dashboard. Two moving parts, and the rest
+of this page sets both of them up.
+
+New to the vocabulary — *run* vs *test case* vs *execution* vs *cluster*? [Core concepts](./concepts) is
+a five-minute read that makes the rest of the docs (and the UI) click.
 
 ## Requirements
 
@@ -192,44 +194,18 @@ The project `my-project` is created automatically if it doesn't exist yet. See t
 
 ## Running in CI
 
-Nothing Piwi-specific is required in CI — the reporter runs inside `npx playwright test` and pushes results to your dashboard. Point the reporter at your deployed instance (via the `PIWI_DASHBOARD_URL` env var or the `serverUrl` option) and pass an API key if [authentication](./authentication) is enabled. CI metadata (workflow, branch, commit, run URL) and [shard merging](./reporter#sharding) are detected automatically on GitHub Actions, GitLab CI, Jenkins, CircleCI, Azure DevOps, and more.
-
-**GitHub Actions:**
-
-```yaml
-name: e2e
-on: [push]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - run: npm ci
-      - run: npx playwright install --with-deps
-      - run: npx playwright test
-        env:
-          PIWI_DASHBOARD_URL: https://piwi.example.com
-          PIWI_API_KEY: ${{ secrets.PIWI_API_KEY }}
-```
-
-**GitLab CI:**
+Nothing Piwi-specific is required in CI — the same reporter runs inside `npx playwright test`. Point it
+at your deployed instance and pass an API key if [authentication](./authentication) is enabled:
 
 ```yaml
-e2e:
-  image: mcr.microsoft.com/playwright:v1.54.0-noble
-  script:
-    - npm ci
-    - npx playwright test
-  variables:
-    PIWI_DASHBOARD_URL: https://piwi.example.com
-    PIWI_API_KEY: $PIWI_API_KEY
+env:
+  PIWI_DASHBOARD_URL: https://piwi.example.com
+  PIWI_API_KEY: ${{ secrets.PIWI_API_KEY }}
 ```
 
-With live streaming enabled you can watch the run progress in the dashboard while CI is still executing — see [Reporter → Streaming](./reporter#live-streaming).
+Branch, commit, workflow, build URL and `--shard` merging are all detected automatically on GitHub
+Actions, GitLab CI, Jenkins, CircleCI, Azure DevOps and more. Full examples, sharding, and how to get
+the run URL back out into a later pipeline step: [CI & sharding](./ci).
 
 ## Dashboard navigation
 
@@ -247,24 +223,10 @@ After submitting results, the dashboard provides:
 
 See the [UI overview](./ui-overview) for a full map of every page and tab.
 
-## Development commands
+## Next steps
 
-Run these from the `application/` directory:
-
-| Command | Description |
-|---------|-------------|
-| `npm run app:dev` | Start development server with hot reload |
-| `npm run app:build` | Build for production |
-| `npm run app:preview` | Preview the production build locally |
-| `npm run app:typecheck` | TypeScript type checking |
-| `npm run app:lint` | Run oxlint (`app:lint:fix` to auto-fix) |
-| `npm run app:test:unit` | Run unit tests (Vitest) |
-| `npm run app:test` | Run Playwright end-to-end tests |
-| `npm test` | Run both unit and end-to-end tests |
-| `npm run db:generate` | Generate SQLite migration from schema changes |
-| `npm run db:generate:pg` | Generate PostgreSQL migration from schema changes |
-| `npm run db:studio` | Open Drizzle Studio to browse the SQLite database |
-| `npm run db:studio:pg` | Open Drizzle Studio to browse the PostgreSQL database |
-| `npm run app:seed:demo` | Regenerate demo seed data for the live demo |
-
-> **Migration workflow:** edit `server/database/schema.sqlite.ts` (and `schema.pg.ts` for the PostgreSQL equivalent — `schema.ts` is just a dialect-selecting re-export, don't edit it) → run `npm run db:generate` (SQLite) or `npm run db:generate:pg` (PostgreSQL) → review the generated `.sql` file → restart the app. Never create migration files or edit `meta/_journal.json` by hand — the Drizzle migrator depends on the journal to track which migrations have been applied, and manual entries cause it to silently skip the migration.
+- [Core concepts](./concepts) — the vocabulary the dashboard and these docs use
+- [Reporter](./reporter) — every option, streaming, sharding, and locator healing
+- [UI overview](./ui-overview) — a map of every page and tab
+- [Deployment](./deployment) — running it properly for a team
+- [Contributing](https://github.com/PiwiTests/platform/blob/main/CONTRIBUTING.md) — dev setup, tests, and commit conventions if you want to hack on Piwi itself

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,11 +20,35 @@ of this page sets both of them up.
 New to the vocabulary — *run* vs *test case* vs *execution* vs *cluster*? [Core concepts](./concepts) is
 a five-minute read that makes the rest of the docs (and the UI) click.
 
-## Requirements
+## Pick a path
 
-- **Node.js 24+** — only for running the dashboard **from source** (CI and the Docker image both use Node 24). With Docker, your test project just needs a Node version supported by Playwright
-- **npm** — for package management
-- **PostgreSQL 14+** — optional; required only when using the PostgreSQL backend
+The dashboard is one Node process, and there are four ways to get one running:
+
+| Path | Best for | Notes |
+|---|---|---|
+| [Live demo](https://piwitests.github.io/demo/) | Looking around before installing anything | Seeded data, runs in your browser, no backend |
+| [Desktop app](./desktop) | A single developer running Playwright locally | No Docker or Node needed; Windows x64 and Apple-silicon macOS only, and the installers are not yet signed |
+| Docker *(below)* | A shared instance for a team | The recommended path for anything long-lived |
+| [`npx @piwitests/server`](./deployment#npm-npx-quick-local-run) | A quick local run with Node 24+ already installed | Same server, no container |
+
+If you only want your own history, flaky scores and locator healing on a laptop, the
+[desktop app](./desktop) is the least setup: install it, copy its access token from **Settings →
+Storage**, and skip to [the reporter](#using-the-piwi-dashboard-reporter). Everything below about the
+reporter, CI and fixtures applies identically whichever path you pick.
+
+### Requirements
+
+Only the dashboard side has requirements — and only for some paths:
+
+| | Needs |
+|---|---|
+| Desktop app | Nothing; the runtime is bundled |
+| Docker | Docker; ~300 MB RAM, 1 vCPU, `linux/amd64` or `linux/arm64` |
+| `npx` / from source | **Node.js 24+** and npm |
+| PostgreSQL backend *(optional)* | PostgreSQL 14+ — otherwise SQLite is built in and needs no setup |
+
+Your **test project** is unaffected by all of this: it just needs a Node version Playwright supports.
+Node 24 is the dashboard's requirement, not your suite's.
 
 ## Quick start with Docker
 
@@ -229,4 +253,6 @@ See the [UI overview](./ui-overview) for a full map of every page and tab.
 - [Reporter](./reporter) — every option, streaming, sharding, and locator healing
 - [UI overview](./ui-overview) — a map of every page and tab
 - [Deployment](./deployment) — running it properly for a team
+- [Desktop app](./desktop) — the same dashboard as a local app, if you skipped it above
+- [Upgrading](./upgrading) — what a version bump does before you pull a new tag
 - [Contributing](https://github.com/PiwiTests/platform/blob/main/CONTRIBUTING.md) — dev setup, tests, and commit conventions if you want to hack on Piwi itself

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,8 @@ layout: home
 
 hero:
   name: "Piwi Dashboard"
-  text: "Self-hosted Playwright observability"
-  tagline: "Understand and fix failures — don't just watch them. Failure clustering, flaky-test scoring, locator healing, and optional AI diagnosis on top of your Playwright results. Self-hosted, no SaaS, no lock-in."
-  image: /logo-wide.svg
+  text: "Your Playwright results, kept and explained"
+  tagline: "CI throws away every report it makes. Piwi keeps them — then groups the failures by root cause, scores the flaky tests, and finds the locator you should have used. Self-hosted, MIT, zero telemetry."
 
   actions:
     - theme: brand
@@ -16,46 +15,37 @@ hero:
       text: Live demo
       link: https://piwitests.github.io/demo/
     - theme: alt
+      text: Core concepts
+      link: /concepts
+    - theme: alt
       text: GitHub
       link: https://github.com/PiwiTests/platform
 
 features:
+  - icon: 🗄️
+    title: History that outlives CI
+    details: Every run, trace, and HTML report kept and browsable long after the build agent deleted its artifacts — with pass-rate, duration, and stability trends computed across all of them.
   - icon: 🧩
     title: Failure clustering
-    details: Identical failures are grouped across specs by an error fingerprint, so one root cause is one thing to triage — not fifty scattered red tests.
-  - icon: 🤖
-    title: AI failure diagnosis
-    details: Optional, opt-in analysis grounded in your actual git diff since the last green run — with suggested-fix patches validated server-side. Runs against your own provider (or a local model); nothing leaves your server unless you configure it.
+    details: An error fingerprint collapses forty red tests into the three root causes behind them, grouped across specs and across runs, so one cause is one thing to triage.
   - icon: 📉
-    title: Flaky-test analytics
-    details: Composite flakiness score with root-cause classes (timing, network, assertion…) and CI-cost impact ranking, so you fix the flakes that actually waste the most CI minutes first.
+    title: Flaky tests, scored and costed
+    details: A composite flakiness score with a root-cause class (timing, network, assertion…) and the CI minutes each flake wastes — so you fix the expensive ones, not the annoying ones.
   - icon: 🩹
     title: Locator healing
-    details: When a locator breaks, get ranked replacement locators captured from prior passing runs — with a convention-preserving recommended fix and a data-testid nudge when nothing is stable.
-  - icon: 🎬
-    title: Self-hosted trace viewer
-    details: Open the full Playwright trace viewer straight from a failure — bundled and served by the dashboard, so traces never leave your server.
-  - icon: 🔔
-    title: Notifications & alerts
-    details: Email, Slack, webhook, and in-browser notifications for failed runs and new failure clusters, with per-project subscriptions, filters, and digest mode.
-  - icon: ⚡
-    title: Live run streaming
-    details: Watch a run update in real time over SSE as each test finishes — no polling, no waiting on CI to upload an artifact.
-  - icon: 📈
-    title: Performance tracking
-    details: Step-level timing, avg/P90 duration trends, slowest-tests analysis, and side-by-side run comparison.
-  - icon: 🌐
-    title: Network & Web Vitals
-    details: Slow API endpoints grouped by method and normalized route, plus Core Web Vitals (TTFB, FCP, CLS…) with color-coded thresholds.
-  - icon: 🔌
-    title: Drop-in reporter
-    details: Add one reporter to your Playwright config and results, HTML reports, and traces upload automatically after each run.
-  - icon: 🤝
-    title: MCP server for AI agents
-    details: Query runs, failures, clusters, and flaky tests from Claude Code or any MCP client — bring test health into your coding agent.
-  - icon: 🐳
-    title: Self-hosted, your data
-    details: One ~400 MB Docker image, SQLite or PostgreSQL, local or S3-compatible storage, optional role-based auth. Zero telemetry — nothing phones home.
+    details: When a selector breaks, ranked replacements captured from the last passing run, with a recommended fix that matches your existing conventions.
+  - icon: 🔬
+    title: Evidence in one place
+    details: The bundled Playwright trace viewer, screenshots, console, network calls, Web Vitals, and the failing call stack with real source — all served by your own instance.
+  - icon: 🤖
+    title: AI diagnosis, if you want it
+    details: Optional analysis by a provider you configure (a local model works), read against your actual git diff since the last green run, with suggested patches validated against your source. Off by default.
+  - icon: 📊
+    title: Cross-project analytics
+    details: Portfolio health, a pass-rate heatmap, wasted CI minutes, regression velocity, and an auto-generated insights feed — the view you need when someone asks how the suite is doing.
+  - icon: 🔒
+    title: Yours to run
+    details: One Docker container, SQLite or PostgreSQL, local or S3 storage, optional role-based auth. Zero telemetry — the only outbound calls are the ones you configure.
 ---
 
 <div class="screenshots">
@@ -104,13 +94,21 @@ features:
 
 </div>
 
-<div class="cta-footer">
-  <h2>Stop losing your test history.</h2>
-  <p>Self-hosted in one Docker command — your data, your infrastructure, nothing vanishes when CI finishes.</p>
-  <div class="cta-footer-actions">
-    <a class="cta-btn cta-btn-brand" href="/getting-started">Get started</a>
-    <a class="cta-btn cta-btn-alt" href="https://github.com/PiwiTests/platform">View on GitHub</a>
-  </div>
+<div class="next-steps">
+
+## Where to go next
+
+- **Setting it up** — [Getting started](/getting-started) walks from a Docker command to your first run in the dashboard.
+- **Wondering how it models your tests** — [Core concepts](/concepts) defines runs, test cases, executions, and clusters. Worth five minutes before the rest.
+- **Wiring up CI** — [CI & sharding](/ci): two environment variables, and why ten shards are one run.
+- **Comparing tools** — [Why Piwi?](/comparison) is an honest comparison, including when Piwi isn't the right choice.
+- **Running it for a team** — [Deployment](/deployment), [Configuration](/configuration), [Authentication](/authentication), and [Privacy & data flow](/privacy).
+
+Also here, without a card of their own: [live run streaming](/reporter#live-streaming),
+[notifications](/notifications) to Slack/email/webhooks, [timeline markers](/timeline-markers) for
+annotating trends, [backend log capture](/backend-logs), [Open in IDE](/ide-integration), and an
+[MCP server](/mcp) so a coding agent can ask about test health.
+
 </div>
 
 <style>
@@ -165,61 +163,26 @@ features:
   text-align: center;
 }
 
-.cta-footer {
+.next-steps {
   max-width: 1152px;
   margin: 0 auto 64px;
-  padding: 56px 24px;
-  text-align: center;
+  padding: 40px 24px 0;
   border-top: 1px solid var(--vp-c-divider);
 }
 
-.cta-footer h2 {
-  font-size: 1.75rem;
+.next-steps h2 {
+  font-size: 1.5rem;
   font-weight: 700;
-  margin-bottom: 12px;
+  margin-bottom: 20px;
 }
 
-.cta-footer p {
+.next-steps ul {
+  padding-left: 1.25rem;
+}
+
+.next-steps li {
+  margin-bottom: 10px;
   color: var(--vp-c-text-2);
-  font-size: 1rem;
-  margin-bottom: 28px;
-}
-
-.cta-footer-actions {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.vp-doc .cta-btn {
-  display: inline-block;
-  border-radius: 20px;
-  padding: 10px 24px;
-  font-size: 0.95rem;
-  font-weight: 600;
-  border: 1px solid transparent;
-  text-decoration: none;
-  transition: border-color 0.25s, color 0.25s, background-color 0.25s;
-}
-
-.cta-btn-brand {
-  background-color: var(--vp-button-brand-bg);
-  color: var(--vp-button-brand-text);
-}
-
-.cta-btn-brand:hover {
-  background-color: var(--vp-button-brand-hover-bg);
-}
-
-.cta-btn-alt {
-  background-color: var(--vp-button-alt-bg);
-  color: var(--vp-button-alt-text);
-  border-color: var(--vp-button-alt-border);
-}
-
-.cta-btn-alt:hover {
-  background-color: var(--vp-button-alt-hover-bg);
 }
 
 @media (max-width: 768px) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,7 @@ features:
 ## Where to go next
 
 - **Setting it up** — [Getting started](/getting-started) walks from a Docker command to your first run in the dashboard.
+- **Just want it on your laptop** — the [desktop app](/desktop) bundles the whole server in a native window: no Docker, no Node, your data in a local folder.
 - **Wondering how it models your tests** — [Core concepts](/concepts) defines runs, test cases, executions, and clusters. Worth five minutes before the rest.
 - **Wiring up CI** — [CI & sharding](/ci): two environment variables, and why ten shards are one run.
 - **Comparing tools** — [Why Piwi?](/comparison) is an honest comparison, including when Piwi isn't the right choice.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -112,6 +112,7 @@ Send a test email from **Settings → Notifications** to confirm delivery.
 
 ## See also
 
+- [CI & sharding](./ci) — the alternative: pull the run URL into your pipeline instead
 - [Authentication](./authentication) — required for non-browser notifications
 - [Configuration reference](./configuration) — all environment variables
 - [AI diagnosis & failure clustering](./ai-diagnosis) — what triggers `cluster.new` and `diagnosis.completed`

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,104 @@
+---
+title: Privacy & data flow
+lang: en-US
+---
+
+# Privacy & data flow
+
+Test results are unusually revealing: they carry your source paths, error messages, screenshots of your
+app, network calls, and sometimes your git history. That's a good reason to know exactly where the
+bytes go. This page is the inventory.
+
+The short version: **Piwi makes no outbound network call you didn't configure.** There is no telemetry,
+no usage analytics, no update check, no crash reporting, and no license or activation call. An instance
+running on an air-gapped network works the same as one on the internet.
+
+## What leaves your server
+
+Every outbound connection Piwi can make is something you switched on:
+
+| Destination | When | Carries |
+|---|---|---|
+| Your AI provider | Only if you configure [AI diagnosis](./ai-diagnosis) | The diagnosis context: error text, failing steps, the relevant git diff, and — if enabled — failure screenshots |
+| Your git host | Only if you connect a repository with a token | API reads: commits and diffs for the project's repo |
+| Your SMTP server | Only if you configure [email notifications](./notifications) | Notification and account emails |
+| Your Slack / webhook URLs | Only for subscriptions you create | The event payload (run status, cluster, test names) |
+| Your S3 endpoint | Only if you switch [storage](./storage) to S3 | Trace files, HTML reports, attachments |
+| Google / GitHub | Only if you enable [OAuth sign-in](./authentication#oauth-google-github) | The standard OAuth exchange |
+
+Nothing on that list has a default. With none of them configured, a Piwi instance talks to nobody.
+
+The **AI provider** is the one worth pausing on, because it's the only case where your code and error
+text can leave your network. It's opt-in, it goes only to the endpoint *you* set — including a local
+model over Ollama or vLLM, in which case nothing leaves the machine at all — you can preview the exact
+context before it's sent, and you can cap its size. See
+[AI diagnosis → Privacy](./ai-diagnosis#privacy).
+
+## What never leaves your server
+
+- **Traces.** The Playwright trace viewer is bundled and served by your own instance at
+  `/trace-viewer/`. Opening a trace from Piwi never uploads it anywhere — unlike sending a colleague to
+  the hosted `trace.playwright.dev`.
+- **The API reference.** `/docs` is rendered in-app from your instance's own OpenAPI spec, with no
+  third-party CDN, so it works offline.
+- **Screenshots, videos, HTML reports.** Stored on your disk or your S3 bucket, served by your instance.
+- **Your IDE mapping.** The [Open in IDE](./ide-integration) workspace root lives in your browser's
+  local storage, because the source is on your machine, not the server's. It is never sent to the
+  dashboard.
+
+## What Piwi deliberately does not capture
+
+Some data is skipped at the source, so it never exists to leak:
+
+- **Input values.** The [capture fixtures](./capture-fixtures) record what an element *is* — role,
+  accessible name, test id — never what was typed into it. A password field's value is never captured.
+- **Storage and cookie values.** Page state records the *names* of `localStorage` /`sessionStorage`
+  keys and their value lengths, and cookie names with their flags. Never the values.
+- **Sensitive headers.** `Authorization`, `Cookie` and friends are masked server-side in the trace
+  network view, and token-shaped strings in URLs and bodies are masked too — so a bearer token that
+  appeared in a request doesn't end up readable in the dashboard.
+- **Backend logs, in production.** The [backend-log integrations](./backend-logs) emit their header only
+  in development and test environments by default.
+
+## Secrets at rest
+
+Credentials you store in the dashboard — AI API keys, SCM tokens, webhook signing secrets — are
+encrypted with AES-256-GCM using `PIWI_SECRET_KEY`. **Set it in production.** With the variable unset,
+Piwi falls back to a hardcoded default string that is published in this repository — the values are
+encrypted, but against a key anyone can look up, so treat that as no protection at all.
+
+```bash
+node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
+```
+
+API keys are stored as SHA-256 hashes and shown exactly once, at creation. A leaked database gives an
+attacker no usable key.
+
+Secrets provided by environment variable are never written to the database and never returned by the
+API — the settings UI shows them as read-only with a lock badge.
+
+## The demo
+
+The [live demo](https://piwitests.github.io/demo/) has no backend. It runs the real application against
+an in-browser SQLite database seeded with fake data, inside a service worker. Nothing you click there
+reaches a server, and there is nothing for it to collect.
+
+## Retention
+
+Data you keep is data you're responsible for. Piwi can prune it for you: set `PIWI_RETENTION_DAYS` for
+nightly automatic pruning of old runs and their files, or delete in bulk from **Settings → Storage**.
+Deleting a run removes its executions, traces, reports, and any evidence payloads no longer referenced
+by anything else. See [Storage → Data retention](./storage#data-retention).
+
+## Verifying any of this
+
+You don't have to take the page's word for it. The source is MIT-licensed and the outbound surface is
+small enough to audit: watch the container's egress, or read
+[`server/utils/`](https://github.com/PiwiTests/platform/tree/main/application/server/utils) — the AI
+provider, SCM, SMTP, storage and notification clients are the only things there that open a socket.
+
+## See also
+
+- [Authentication](./authentication) — roles, API keys, and project-level access
+- [Deployment → Security](./deployment#security) — hardening a public instance
+- [Why Piwi?](./comparison#is-my-data-safe-does-piwi-phone-home) — the same question, short form

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -89,6 +89,7 @@ Any attachments Playwright records — including **videos** (`video: 'retain-on-
 
 | Option                      | Type     | Default                   | Description                                                                                 |
 |-----------------------------|----------|---------------------------|---------------------------------------------------------------------------------------------|
+| `enabled`                   | boolean  | `true` when `serverUrl` is set | Explicitly turn the reporter off without removing it from the config                   |
 | `serverUrl`                 | string   | `'http://localhost:3000'` | URL of the Piwi Dashboard server                                                            |
 | `projectName`               | string   | `'default-project'`       | Name of the project to report results under                                                 |
 | `uploadTraces`              | boolean  | `true`                    | Upload trace files to the dashboard                                                         |
@@ -100,6 +101,7 @@ Any attachments Playwright records — including **videos** (`video: 'retain-on-
 | `liveFileUploads`           | boolean  | `true`                    | Upload each test's trace and attachments as soon as the test finishes (streaming mode only) |
 | `projectDescription`        | string   | —                         | Description of the project                                                                  |
 | `environment`               | string   | —                         | Deployment environment for this run, e.g. `"production"`, `"staging"`, `"integration"`      |
+| `label`                     | string   | —                         | Display label for this run, e.g. `"v2.3.1 release"`                                         |
 | `relatedIssue`              | string   | —                         | Related issue reference, e.g. `"JIRA-123"`                                                  |
 | `ciInfo`                    | string   | —                         | CI job information                                                                          |
 | `tags`                      | string[] | —                         | Tags to categorize the test run                                                             |
@@ -108,17 +110,20 @@ Any attachments Playwright records — including **videos** (`video: 'retain-on-
 | `collectCiInfo`             | boolean  | `true`                    | Auto-collect CI environment info                                                            |
 | `collectPerformanceMetrics` | boolean  | `true`                    | Collect step timings, network requests and web vitals                                       |
 | `captureLocators`           | boolean  | `true`                    | Capture element snapshots from successful actions and passing assertions — these power [locator healing](#locator-healing). Auto-disabled when `collectPerformanceMetrics` is `false` |
+| `capturePageState`          | boolean  | `true`                    | Record the page's state at test end: URL, history state, storage **key names** and value *lengths*, cookie names and flags. Values are never captured. Auto-disabled when `collectPerformanceMetrics` is `false` |
+| `captureServerTraces`       | boolean  | `true`                    | Read server-side spans from the `X-Piwi-Trace` response header emitted by a Piwi [instrumentation plugin](./backend-logs), and show them next to the network request. Free when no instrumentation is present. Auto-disabled when `collectPerformanceMetrics` is `false` |
 | `inspectOnFailure`          | boolean  | `false`                   | Open Piwi's own inspector overlay on the failing page after a local headed failure — inspect any element and pick a locator for it (see [Inspect the failing page live](#inspect-the-failing-page-live-local-runs)). Never activates under CI |
 | `pickLocatorOnFailure`      | boolean  | `false`                   | Open Piwi's locator picker on the failing page after a local headed locator failure (see [Pick a replacement locator](#pick-a-replacement-locator-on-the-failing-page-local-runs)). Never activates under CI |
 | `username`                  | string   | —                         | Username for dashboard login (use `apiKey` instead when possible)                           |
 | `password`                  | string   | —                         | Password for dashboard login (used with `username`)                                         |
 | `apiKey`                    | string   | —                         | API key for authentication (preferred over `username`/`password` for CI)                    |
 | `runLabel`                  | string   | auto-detected from CI     | Stable label tying shards together (e.g. CI run ID). Auto-detected from CI env; override if needed |
+| `outputFile`                | string   | —                         | Write a JSON file with the submitted run's dashboard URL, id, project id and status, for a later CI step to consume (see [CI → Getting the run URL back out](./ci#getting-the-run-url-back-out-of-ci)) |
 | `verbose`                   | boolean  | `false`                   | Enable verbose logging for debugging                                                        |
 
 ### Environment variables
 
-Every option above can also be set via a `PIWI_*` environment variable. Env vars are fallbacks — an option passed in the reporter config takes precedence. The one exception is `PIWI_VERBOSE`, which wins over both the default and an explicit option (useful for toggling debug output without editing the config). The mapping is centralized in `src/config.ts` (`PIWI_ENV_KEYS`):
+Every option above can also be set via a `PIWI_*` environment variable. Env vars are fallbacks — an option passed in the reporter config takes precedence. The one exception is `PIWI_VERBOSE`, which wins over both the default and an explicit option (useful for toggling debug output without editing the config). The mapping is centralized in `src/internal/config/env.ts` (`PIWI_ENV_KEYS`):
 
 | Env var                         | Option                  | Format          |
 |---------------------------------|-------------------------|-----------------|
@@ -137,6 +142,9 @@ Every option above can also be set via a `PIWI_*` environment variable. Env vars
 | `PIWI_UPLOAD_TRACES`            | `uploadTraces`          | `true`/`false`  |
 | `PIWI_UPLOAD_REPORT`            | `uploadReport`          | `true`/`false`  |
 | `PIWI_CAPTURE_LOCATORS`         | `captureLocators`       | `true`/`false`  |
+| `PIWI_CAPTURE_PAGE_STATE`       | `capturePageState`      | `true`/`false`  |
+| `PIWI_CAPTURE_SERVER_TRACES`    | `captureServerTraces`   | `true`/`false`  |
+| `PIWI_OUTPUT_FILE`              | `outputFile`            | string (path)   |
 | `PIWI_INSPECT_ON_FAIL`          | `inspectOnFailure`      | `true`/`false`  |
 | `PIWI_PICK_LOCATOR_ON_FAIL`     | `pickLocatorOnFailure`  | `true`/`false`  |
 | `PIWI_VERBOSE`                  | `verbose`               | `true`/`false`  |
@@ -145,49 +153,10 @@ Every option above can also be set via a `PIWI_*` environment variable. Env vars
 
 ## Sharding
 
-When using Playwright's built-in test execution sharding (`--shard=1/3`), the reporter automatically groups
-all shards into a single logical test run on the dashboard.
-
-### How it works
-
-1. Each shard detects the **run label** — a stable CI pipeline/workflow identifier — from environment
-   variables (`GITHUB_RUN_ID`, `CI_PIPELINE_ID`, `CIRCLE_WORKFLOW_ID`, `TRAVIS_BUILD_ID`,
-   `BUILD_BUILDID`, `BUILD_ID`, `BUILDKITE_BUILD_ID`, `TEAMCITY_BUILD_ID`, `BITBUCKET_BUILD_NUMBER`,
-   `SEMAPHORE_WORKFLOW_ID`, `APPVEYOR_BUILD_ID`, `DRONE_BUILD_NUMBER`).
-
-2. All shards on the same CI run produce the same `instanceId` (derived from `runLabel + projectName`),
-   so the server groups them into one run.
-
-3. Each shard gets an independent stream token. The server keeps the run in `running` status
-   until **all** shards have called `/finish`.
-
-4. Counters (passed, failed, skipped, total) are **accumulated** across shards. The final status is
-   `failed` if any shard reported failures, otherwise `passed`.
-
-5. The dashboard shows a shard progress badge (e.g. `2/3`) on the run detail page while shards are
-   still running.
-
-### Zero-config CI
-
-For most CI platforms, no configuration is needed — the run label is auto-detected from environment
-variables. Ensure all shards use the same `projectName`.
-
-### Manual override
-
-If auto-detection doesn't work for your CI setup, set `runLabel` manually to a value common to all shards:
-
-```typescript
-['@piwitests/reporter', {
-  serverUrl: 'http://localhost:3000',
-  projectName: 'my-project',
-  runLabel: process.env.BUILD_TAG || 'my-custom-label',
-}]
-```
-
-### Playwright shard config
-
-The reporter reads `config.shard` (set by `--shard=1/3`) automatically — no extra config needed.
-All batch (`submit`/`upload`) and streaming paths support sharding.
+Playwright's `--shard` jobs are merged back into a single dashboard run automatically — no
+configuration beyond every shard using the same `projectName`. The `runLabel` option below is the
+manual override when your CI isn't auto-detected. Full detail, including the CI examples and how the
+merge works, is in [CI & sharding](./ci#sharding).
 
 ## Live streaming
 
@@ -549,29 +518,8 @@ The reporter calls `/api/auth/login` automatically before each upload.
 
 See [Authentication](/authentication) for details on enabling auth, creating users, and managing API keys.
 
-## Development
+## Working on the reporter itself
 
-The reporter source uses TypeScript (`.ts`) in `src/` and compiles to CommonJS JavaScript (`.js`) with type declarations (`.d.ts`) in `dist/` via the TypeScript compiler.
-
-### Building
-
-```bash
-cd reporter
-npm install
-npm run reporter:build   # compile TypeScript from src/ to dist/
-npm run reporter:dev     # watch mode — auto-recompile on changes
-```
-
-This produces one `.js` + one `.d.ts` per `.ts` source, mirroring the `src/` folder structure under `dist/`.
-
-The compiled output is what Playwright loads at runtime. The package has a single entry point (`@piwitests/reporter`) — the reporter, the config helpers, and the capture fixtures are all imported from it.
-
-### Source layout
-
-The package separates its **public API** (`src/index.ts` and `src/public/`) from internal plumbing (`src/internal/<domain>/` — `submit`, `transport`, `streaming`, `collect`, `files`, `capture`, `config`, `support`) and the type model (`src/types/`, where `wire.ts` is the server contract and `collected.ts` the in-process model).
-
-See **`reporter/ARCHITECTURE.md`** in the repository for the full map: the public/internal split, the two-process collect-and-submit data flow, the fallback ladder, and the package conventions.
-
-### Shared types
-
-Wire contract types are defined in `application/shared/types.ts` and used by the server for request validation. The reporter does not import them directly — it keeps its own structurally-compatible interfaces in `src/types.ts` (`CollectedTestCase`, `WireTestCase`, `StreamEvent`) so the monorepo path isn't leaked into the published `.d.ts`. When making changes, keep the two sides consistent: the reporter's wire shapes must match the server's `TestCasePayload`, `StreamEventPayload`, and `TestRunFinishPayload`.
+Building the package, its public/internal source layout, and the wire-contract conventions are covered
+in [`reporter/ARCHITECTURE.md`](https://github.com/PiwiTests/platform/blob/main/reporter/ARCHITECTURE.md)
+and [`CONTRIBUTING.md`](https://github.com/PiwiTests/platform/blob/main/CONTRIBUTING.md).

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -5,7 +5,7 @@ lang: en-US
 
 # UI overview
 
-This page is a **map of the dashboard** — where each view lives and what it's for. For the concepts behind a feature, follow the links to the dedicated pages ([Flaky tests & analytics](./flaky-tests), [AI diagnosis & clustering](./ai-diagnosis), [Reporter](./reporter)).
+This page is a **map of the dashboard** — where each view lives and what it's for. For the concepts behind a feature, follow the links to the dedicated pages ([Core concepts](./concepts), [Flaky tests](./flaky-tests), [AI diagnosis & clustering](./ai-diagnosis), [Reporter](./reporter)).
 
 The dashboard is a single-page app built with [Nuxt UI](https://ui.nuxt.com). It updates itself in real time over Server-Sent Events — pages refresh automatically when runs start or finish, so you never reload manually.
 
@@ -24,7 +24,7 @@ The sidebar gives access to the top-level sections:
 | Section | Path | Purpose |
 |---------|------|---------|
 | Home | `/` | Aggregate stats and activity across all projects |
-| Analytics | `/analytics` | Cross-project trends, portfolio health, and insights over a chosen time window |
+| Analytics | `/analytics` | Cross-project trends, portfolio health, and insights over a chosen time window (see [Analytics](./analytics)) |
 | Projects | `/projects` | Full project listing with search and tag filters |
 | Settings | `/settings` | Configuration — general, account, users, storage, tags, wasted time, AI, notifications |
 | API docs | `/docs` | Self-contained OpenAPI 3.1 reference (no external CDN) — browse endpoints and schemas, try requests live, copy cURL / fetch snippets |
@@ -47,20 +47,11 @@ A quick health check across all projects: **stats cards** (projects, runs, activ
 
 ## Analytics
 
-A cross-project decision view — where Home answers *"what's happening now"*, Analytics answers *"across projects, over time"*. A **scope bar** at the top sets the period (last 7 / 30 / 90 days, last year, or all time), an optional environment, and a full-runs-only toggle; every widget re-aggregates against that scope. The widgets:
+A cross-project decision view — where Home answers *"what's happening now"*, Analytics answers *"across projects, over time"*. A **scope bar** at the top sets the period (last 7 / 30 / 90 days, last year, or all time), an optional environment, and a full-runs-only toggle; every widget re-aggregates against that scope.
 
-- **Insights** — auto-generated, severity-ranked findings over the period (pass-rate drops, failing streaks, stale failure clusters, wasted CI time, CI-time growth). Each links straight to the project, run, cluster, or test case it's about.
-- **Portfolio health** — every project's pass rate (with its change vs the previous period), flaky volume, open failure clusters, average run duration, and latest run, in one sortable table with trend bars. Worst health sorts first.
-- **Pass rate heatmap** — a projects × time grid colored by daily (or, for longer periods, weekly) pass rate, so a project that degraded — and when — jumps out.
-- **CI time** — total CI minutes your runs consumed over the period, with the growth vs the previous period.
-- **Wasted CI time** — minutes that produced no signal: time inside wait steps plus time executing attempts that ended failed or timed out, split by project.
-- **Flakiest tests** — the worst flaky tests across all projects, using the same scoring as each project's Flaky tests tab, ranked by wasted-CI impact.
-- **Failure clusters** — open root causes across all projects, with age, occurrences, and error-type mix; the oldest unresolved cluster is highlighted.
-- **Regression velocity** — new regressions (tests that passed in a baseline and now fail) and newly-flaky tests introduced per period, as a stacked bar with the change vs the previous period. Rising bars mean quality debt is accumulating.
-- **Browser matrix** — pass rate per project × browser, so a suite that's green on one browser but failing on another stands out at a glance.
-- **Slow endpoints** — backend calls captured during tests, aggregated across all projects by route: p50/p90 latency, error rate, and how many projects hit each one, so a shared endpoint regressing surfaces before it's obvious in any single suite.
+Widgets: an **insights** feed, **portfolio health**, a **pass-rate heatmap**, **CI time** and **wasted CI time**, the global **flakiest tests** leaderboard, open **failure clusters**, **regression velocity**, a **browser matrix**, and cross-project **slow endpoints**. [Timeline markers](./timeline-markers) overlay your deploys and infrastructure changes on the trend charts.
 
-The analytics surface is **widget-driven**: each widget is a registry entry (`shared/analytics/registry.ts`) backed by a shared handler (`shared/handlers/analytics/`) and served by one generic endpoint, `GET /api/analytics/:widget`. See [Flaky tests & analytics](./flaky-tests).
+See [Analytics](./analytics) for what each widget answers and how the periods are compared.
 
 ## Projects
 
@@ -71,7 +62,7 @@ The primary hub: instant **text search**, **tag filters**, and a table showing e
 The complete history for one project, organized into tabs:
 
 - **Test runs** — every run with status, start time, duration, test counts, and browser badges; select two runs to compare. Runs with a shared failure signature roll up into **Failure clusters** here (see [AI diagnosis & clustering](./ai-diagnosis)).
-- **Flaky tests** — intermittent tests scored by a composite flakiness metric, with root-cause classification and impact ranking. See [Flaky tests & analytics](./flaky-tests#flaky-test-detection).
+- **Flaky tests** — intermittent tests scored by a composite flakiness metric, with root-cause classification and impact ranking. See [Flaky tests](./flaky-tests#flaky-test-detection).
 - **Performance** — average/P90 duration trends and a slowest-tests table. See [Performance](./flaky-tests#performance).
 - **Test cases** — every unique test with status, executed-only pass rate, result breakdown, average duration, and last run; searchable, filterable by status and last-run age (stale cases hidden by default), paginated, with flat and per-spec tree views.
 - **Compare** — side-by-side delta between two runs (new failures, recovered, duration changes).

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,121 @@
+---
+title: Upgrading
+lang: en-US
+---
+
+# Upgrading
+
+Piwi is pre-1.0. Patch and minor releases can carry breaking changes, and the database schema moves
+with them. Upgrading is normally a one-line change — but it's a one-way door, so it's worth knowing
+what happens before you pull a new tag.
+
+## The short version
+
+1. Read the [changelog](https://github.com/PiwiTests/platform/blob/main/CHANGELOG.md) for the versions
+   you're skipping, looking for **⚠ BREAKING CHANGES**.
+2. **Back up** the database and file storage ([how](./deployment#backups)).
+3. Pull the new tag and restart.
+4. Check the logs for `migrations completed successfully`, then confirm the version at
+   **Settings → About**.
+
+## What happens when a new version starts
+
+On boot, before the server accepts a single request:
+
+1. **Database migrations run automatically** — SQLite or PostgreSQL, whichever you're on. There is no
+   separate migrate command and nothing to run by hand.
+2. **A project-assignments backfill** runs (idempotent, safe on every start).
+3. **Failure clusters are re-fingerprinted** if the fingerprint algorithm changed in this release.
+   This is non-destructive: existing clusters are updated in place, and clusters that now collide are
+   merged rather than dropped, so your triage statuses and notes survive.
+
+Steps 2 and 3 log an error and continue if they fail — they never block startup. **Step 1 does not.**
+If a migration fails, the server refuses to start rather than serving against a half-migrated schema.
+That's deliberate: a loud failure you can restore from beats silent corruption.
+
+## Downgrading is not supported
+
+Migrations are **forward-only** — there are no down migrations. Once a new version has migrated your
+database, an older version will not run against it correctly, and starting one may make things worse.
+
+So the rollback path is not "pull the old tag", it's **restore your backup**:
+
+1. Stop the container.
+2. Restore the database and `.data/storage/` from the backup you took before upgrading.
+3. Start the previous version's tag.
+
+This is the entire reason step 2 of the short version isn't optional.
+
+## Pin a version
+
+Running `latest` in production means an unattended `docker pull` can move you across a breaking change.
+Pin the exact version and bump it deliberately:
+
+```yaml
+# docker-compose.yml
+services:
+  piwi:
+    image: phenx/piwitests-server:0.18.2   # not :latest
+```
+
+The available tag patterns — and the GHCR mirror — are in
+[Deployment → Available tags](./deployment#available-tags).
+
+## Verifying the upgrade landed
+
+Three ways, in increasing order of automation:
+
+- **Settings → About** shows the running version, the build SHA, the Node version, and which database
+  backend is active.
+- `GET /api/version` returns the same thing as JSON, with no authentication required:
+
+  ```bash
+  curl -s http://localhost:3000/api/version
+  ```
+
+- `GET /api/health` is the readiness probe — it verifies database connectivity and returns 503 when
+  the database isn't reachable, which is what you want a container orchestrator watching.
+
+In the startup logs, the lines worth grepping for are `Running <dialect> migrations from …` and
+`migrations completed successfully`.
+
+## Upgrading the reporter
+
+The reporter and the dashboard version independently, and you do **not** have to upgrade them in
+lockstep:
+
+- A **newer reporter against an older server** degrades gracefully — if the server doesn't understand
+  streaming, the reporter falls back to batch submission on its own.
+- An **older reporter against a newer server** keeps working; wire fields are added, not repurposed.
+
+That said, features land in pairs. Locator healing needs both a reporter that captures snapshots and a
+server that ranks them, so if a new capability doesn't appear, matching the two versions is the first
+thing to try.
+
+```bash
+npm install --save-dev @piwitests/reporter@latest
+```
+
+## Upgrading the desktop app
+
+The [desktop build](./desktop) bundles its own server, so installing a newer build upgrades both. Its
+database lives outside the app bundle and is migrated on first launch, exactly as the server does —
+which means the same forward-only rule applies. Back up its data directory before a major jump.
+
+## If an upgrade goes wrong
+
+**The container won't start after upgrading.** Check the logs for `Migration error`. The schema is
+mid-flight or incompatible; restore your backup and open an
+[issue](https://github.com/PiwiTests/platform/issues) with the error.
+
+**The dashboard loads but data looks wrong.** Don't downgrade — restore the backup instead, then
+report what you saw. Downgrading on a migrated database compounds the problem.
+
+**Failure clusters look reorganized.** Expected after a fingerprint-algorithm change: clusters that now
+share a root cause have merged. Triage state is carried across the merge.
+
+## See also
+
+- [Deployment → Backups](./deployment#backups) — what to back up and how
+- [Deployment → Available tags](./deployment#available-tags) — what to pin
+- [Changelog](https://github.com/PiwiTests/platform/blob/main/CHANGELOG.md) — breaking changes per release

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@piwitests/server",
   "version": "0.18.2",
-  "description": "Self-hosted Piwi Dashboard server — run with npx @piwitests/server",
+  "description": "Self-hosted dashboard that keeps and explains your Playwright test results — run with npx @piwitests/server",
   "type": "module",
   "bin": {
     "piwi-server": "bin/piwi-server.mjs"

--- a/reporter/package.json
+++ b/reporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@piwitests/reporter",
   "version": "0.18.2",
-  "description": "Playwright reporter for sending test results to Piwi Dashboard",
+  "description": "Playwright reporter that streams results, traces and HTML reports to a Piwi Dashboard instance",
   "url": "https://github.com/PiwiTests/platform",
   "homepage": "https://piwitests.github.io",
   "repository": {


### PR DESCRIPTION
## What & why

This is a comprehensive documentation restructure and rewrite that:

1. **Clarifies positioning** — establishes a single, consistent narrative across all surfaces (README, landing page, package descriptions) that Piwi is a self-hosted home for test results that keeps history and explains failures, rather than positioning it as an "observability platform"

2. **Reorganizes docs by reader journey** — moves from feature-centric to task-centric structure:
   - New "Start here" group: `getting-started`, `concepts`, `comparison`
   - New "Sending results" group: `reporter`, `capture-fixtures`, `ci`, `backend-logs`
   - New "Reading results" group: `ui-overview`, `ai-diagnosis`, `flaky-tests`, `analytics`, etc.
   - New "Running your instance" group: `deployment`, `configuration`, `authentication`, `storage`, `privacy`, `desktop`

3. **Adds three new core pages**:
   - `concepts.md` — vocabulary source of truth (project, test run, test case, execution, failure cluster, fingerprint, baseline, etc.)
   - `ci.md` — comprehensive CI integration guide (GitHub Actions, GitLab CI, sharding, run URL output, troubleshooting)
   - `analytics.md` — cross-project analytics and insights
   - `privacy.md` — data flow inventory and what never leaves your server

4. **Rewrites existing pages** for clarity:
   - `getting-started.md` — shorter, links to concepts, emphasizes "server + reporter" architecture
   - `index.md` (landing page) — tighter feature list, clearer value proposition
   - `flaky-tests.md` — removes cross-project analytics (moved to `analytics.md`), focuses on single-project signals
   - `ui-overview.md` — becomes a map, not a manual; links to dedicated pages
   - `reporter.md` — adds `enabled`, `label`, `capturePageState` options; clarifies streaming

5. **Updates supporting files**:
   - README.md — new positioning, cleaner link layout, updated feature descriptions
   - Package descriptions — aligned with new positioning
   - VitePress config — updated meta tags, added `srcExclude` for AGENTS.md
   - AGENTS.md (root) — documents the canonical positioning line and requires it be kept in sync across seven surfaces
   - CONTRIBUTING.md — adds database command reference
   - Help content — fixes anchor links

## How was it tested?

- VitePress builds without errors (no broken links, all new pages render)
- Sidebar navigation follows the documented structure in `docs/AGENTS.md`
- All cross-page links are valid (concepts anchors, feature page links)
- Positioning line is consistent across README, landing page, and package.json descriptions

## Checklist

- [x] PR title follows Conventional Commits (`docs: restructure and rewrite for clarity and positioning`)
- [x] No tests needed — documentation-only change
- [x] Docs updated (comprehensive rewrite of `docs/`, README, package descriptions, AGENTS.md)

https://claude.ai/code/session_012DmCHBmmtjZJ5b41xrptiT