### PR TITLE
fix(reporter): stop PiwiDashboardOptions from inheriting the Playwright config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,13 @@ Run typecheck, lint and tests **once at the end** before the final commit — no
 
 - **Never reference plans or specs.** No plan IDs (`A1`, `B3`), plan file names or plan titles in code. Strip all
   plan-track metadata before writing code — comments say what the code does, not where the requirement came from.
-- **Never write before/after comparisons.** No "was X, now Y", "replaced A with B", "better than the old approach".
-  Comments describe the current state only. Git holds the history.
+- **Never write before/after comparisons.** No "was X, now Y", "used to", "previously", "no longer", "replaced A with
+  B", "better than the old approach". Comments describe the current state only. Git holds the history.
+- **Never justify a change.** A reader of the code does not care what it looked like before or which alternative was
+  rejected — no "deliberately not X, because X caused Y", no bug-report retelling, no "this is why we changed it".
+  State the rule the code follows ("Piwi options only — the Playwright config goes in `defineConfig`"), not the story
+  behind it. The reasoning belongs in the commit message and the PR.
+- These rules apply to **every** comment: doc/JSDoc comments, inline comments and comments inside tests.
 
 ### Commits & PR titles (MUST follow — CI lints every commit)
 

--- a/reporter/src/public/options.ts
+++ b/reporter/src/public/options.ts
@@ -15,13 +15,9 @@ export interface ShardInfo {
 /**
  * Options for configuring the Piwi Dashboard reporter.
  *
- * Deliberately **not** an extension of `PlaywrightTestConfig`: these options are
- * the reporter's own, passed either as the second argument of `wrapConfig` or as
- * the reporter entry's options (`['@piwitests/reporter', { … }]`). Inheriting
- * Playwright's config made every Playwright option (`testDir`, `use`,
- * `timeout`, …) show up in editor completion here and silently typecheck, even
- * though the reporter ignores all of them — the Playwright config belongs in the
- * first argument of `wrapConfig` / in `defineConfig`.
+ * Piwi options only — the Playwright config belongs in `defineConfig` (i.e. in
+ * `wrapConfig`'s first argument). These go in `wrapConfig`'s second argument or
+ * in the reporter entry's options (`['@piwitests/reporter', { … }]`).
  */
 export interface PiwiDashboardOptions {
   /** Explicitly enable or disable the reporter. Defaults to `true` when `serverUrl` is set. Set to `false` to disable even if `serverUrl` is provided. */

--- a/reporter/src/public/options.ts
+++ b/reporter/src/public/options.ts
@@ -1,4 +1,3 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
 export type { PlaywrightTestConfig } from '@playwright/test';
 
 /**
@@ -13,8 +12,18 @@ export interface ShardInfo {
   total: number;
 }
 
-/** Options for configuring the Piwi Dashboard reporter */
-export interface PiwiDashboardOptions extends PlaywrightTestConfig {
+/**
+ * Options for configuring the Piwi Dashboard reporter.
+ *
+ * Deliberately **not** an extension of `PlaywrightTestConfig`: these options are
+ * the reporter's own, passed either as the second argument of `wrapConfig` or as
+ * the reporter entry's options (`['@piwitests/reporter', { … }]`). Inheriting
+ * Playwright's config made every Playwright option (`testDir`, `use`,
+ * `timeout`, …) show up in editor completion here and silently typecheck, even
+ * though the reporter ignores all of them — the Playwright config belongs in the
+ * first argument of `wrapConfig` / in `defineConfig`.
+ */
+export interface PiwiDashboardOptions {
   /** Explicitly enable or disable the reporter. Defaults to `true` when `serverUrl` is set. Set to `false` to disable even if `serverUrl` is provided. */
   enabled?: boolean;
   /** URL of the Piwi Dashboard server */

--- a/reporter/tests/build-output.spec.ts
+++ b/reporter/tests/build-output.spec.ts
@@ -62,10 +62,9 @@ describe.runIf(existsSync(dist('index.js')))('built entry (requires a build)', (
 
   it('keeps Playwright config options out of PiwiDashboardOptions', () => {
     const types = readFileSync(dist('index.d.ts'), 'utf-8');
-    // It used to `extends PlaywrightTestConfig`, which made editors complete
-    // `testDir` / `use` / `timeout` on the reporter's own options object and let
-    // them typecheck there even though the reporter ignores them. The Playwright
-    // config goes in `wrapConfig`'s first argument, not its second.
+    // The reporter's options are Piwi-only: inheriting a Playwright config type
+    // would complete and accept `testDir` / `use` / `timeout` on an options
+    // object the reporter never reads them from.
     expect(types).not.toMatch(/interface PiwiDashboardOptions\s+extends/);
   });
 });

--- a/reporter/tests/build-output.spec.ts
+++ b/reporter/tests/build-output.spec.ts
@@ -51,4 +51,21 @@ describe.runIf(existsSync(dist('index.js')))('built entry (requires a build)', (
     expect(source).toContain('piwiFixtures');
     expect(source).toContain('extendPiwiFixtures');
   });
+
+  it('exports the options type from the published .d.ts', () => {
+    const types = readFileSync(dist('index.d.ts'), 'utf-8');
+    expect(types).toMatch(/interface PiwiDashboardOptions\b/);
+    // Consumers `import type { PiwiDashboardOptions } from '@piwitests/reporter'`,
+    // so the declaration must also be re-exported from the entry.
+    expect(types).toMatch(/export \{[^}]*\bPiwiDashboardOptions\b/s);
+  });
+
+  it('keeps Playwright config options out of PiwiDashboardOptions', () => {
+    const types = readFileSync(dist('index.d.ts'), 'utf-8');
+    // It used to `extends PlaywrightTestConfig`, which made editors complete
+    // `testDir` / `use` / `timeout` on the reporter's own options object and let
+    // them typecheck there even though the reporter ignores them. The Playwright
+    // config goes in `wrapConfig`'s first argument, not its second.
+    expect(types).not.toMatch(/interface PiwiDashboardOptions\s+extends/);
+  });
 });


### PR DESCRIPTION
`PiwiDashboardOptions` extended `PlaywrightTestConfig`, so the reporter's own
options object — `wrapConfig`'s second argument, or the reporter entry's options
in the reporters array — advertised every Playwright config property in editor
completion and accepted them silently, even though the reporter reads none of
them. Nothing in the package ever consumed an inherited property, so drop the
`extends` and let the options type describe only the Piwi options; the Playwright
config stays in `wrapConfig`'s first argument.

`PiwiDashboardOptions` is still exported from the single `.` entry and lands in
the published `dist/index.d.ts`; new packaging guards pin both that export and
the absence of the `extends` so the completion noise cannot come back.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PBk9aobSJ14YQqmbiRP9Px