### PR TITLE
feat(app): card layout for the run's test-case list on phones

### DIFF
--- a/application/app/components/run/TestCasesList.vue
+++ b/application/app/components/run/TestCasesList.vue
@@ -170,6 +170,26 @@ const columns = computed<Column[]>(() => {
   return cols;
 });
 
+/**
+ * Sort picker for the card layout below `md`, which has no column headers to
+ * click. `NATURAL_ORDER` stands in for "no sort key" — a `USelect` item may not
+ * carry an empty string, which the select reserves for clearing itself.
+ */
+const NATURAL_ORDER = 'natural';
+
+const sortOptions = computed(() => [
+  { label: 'Run order', value: NATURAL_ORDER },
+  ...columns.value.map((c) => ({ label: c.label, value: c.key })),
+]);
+
+const mobileSortKey = computed({
+  get: () => sortKey.value ?? NATURAL_ORDER,
+  set: (value: string) => {
+    sortKey.value = value === NATURAL_ORDER ? null : value;
+    if (value !== NATURAL_ORDER) sortDir.value = 'asc';
+  },
+});
+
 const gridTemplate = computed(() => columns.value.map((c) => c.width).join(' '));
 const gridMinWidth = computed(() => (hasWastedTime.value ? '47.5rem' : '41.5rem'));
 
@@ -310,6 +330,20 @@ defineExpose({ scrollToCase });
       <USelect v-model="testCaseBrowserFilter" :items="testCaseBrowserOptions" size="sm" class="w-36" />
       <UCheckbox v-if="!isLive" v-model="showNewRegressionsOnly" label="New regressions" size="sm" />
       <UCheckbox v-if="!isLive" v-model="showNewFlakyOnly" label="New flaky" size="sm" />
+      <!-- Phones get the card layout, which has no sortable column headers. -->
+      <div v-if="!treeView" class="flex items-center gap-1 md:hidden">
+        <USelect v-model="mobileSortKey" :items="sortOptions" size="sm" class="w-32" aria-label="Sort cases by" />
+        <UButton
+          size="sm"
+          variant="outline"
+          color="neutral"
+          :disabled="sortKey === null"
+          :icon="sortDir === 'asc' ? 'i-lucide-arrow-up-narrow-wide' : 'i-lucide-arrow-down-wide-narrow'"
+          :title="sortDir === 'asc' ? 'Sorted ascending' : 'Sorted descending'"
+          :aria-label="sortDir === 'asc' ? 'Sorted ascending' : 'Sorted descending'"
+          @click="sortDir = sortDir === 'asc' ? 'desc' : 'asc'"
+        />
+      </div>
     </FilterToolbar>
 
     <!-- Tree view -->
@@ -328,18 +362,23 @@ defineExpose({ scrollToCase });
     <template v-else-if="!treeView">
       <div
         v-if="sortedTestCases.length > 0"
-        class="flex-1 min-h-0 max-lg:h-[70dvh] overflow-x-auto overflow-y-hidden rounded-lg border border-default bg-default"
+        class="flex-1 min-h-0 max-lg:h-[70dvh] md:overflow-x-auto overflow-y-hidden rounded-lg border border-default bg-default"
       >
+        <!--
+          The grid only claims its minimum width from `md` up, where the columns
+          exist; below that the cards fit the viewport and the page must not
+          scroll sideways.
+        -->
         <div
-          class="flex flex-col h-full"
+          class="flex flex-col h-full md:min-w-(--grid-min-width)"
           role="table"
           aria-label="Test cases"
           :aria-rowcount="sortedTestCases.length + 1"
-          :style="{ minWidth: gridMinWidth }"
+          :style="{ '--grid-min-width': gridMinWidth }"
         >
-          <!-- Header -->
+          <!-- Header — the sort control below `md` lives in the toolbar instead -->
           <div
-            class="grid shrink-0 bg-elevated/50 border-b border-default"
+            class="hidden md:grid shrink-0 bg-elevated/50 border-b border-default"
             role="row"
             :style="{ gridTemplateColumns: gridTemplate }"
           >
@@ -399,8 +438,82 @@ defineExpose({ scrollToCase });
                   ]"
                   :data-index="index"
                 >
+                  <!--
+                    Below `md` the columns become a card: a phone cannot show
+                    seven of them without a horizontal scroll, and the numbers
+                    need their own labels once the header row is gone. The card
+                    mirrors the tree's row so the two views still read alike.
+                  -->
                   <div
-                    class="grid items-center border-b border-default text-sm transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900/50"
+                    class="md:hidden border-b border-default px-3 py-2.5 space-y-1.5 text-sm transition-colors"
+                    :class="highlightedCaseId === item.id ? 'animate-pulse bg-yellow-100 dark:bg-yellow-900/30' : ''"
+                    role="row"
+                  >
+                    <div class="flex items-start gap-2">
+                      <UIcon
+                        :name="getStatusIcon(item.status)"
+                        class="size-4 shrink-0 mt-0.5"
+                        :class="[getStatusTextClass(item.status), isStatusInFlight(item.status) ? 'animate-spin' : '']"
+                        role="img"
+                        :aria-label="`Status: ${formatStatusLabel(item.status)}`"
+                        :title="formatStatusLabel(item.status)"
+                      />
+                      <a
+                        :href="`/test-run-cases/${item.id}`"
+                        class="text-highlighted hover:text-primary hover:underline font-medium flex-1 min-w-0"
+                        @click.prevent="navigateTo(`/test-run-cases/${item.id}`)"
+                        >{{ item.title }}</a
+                      >
+                      <BrowserBadge :browser="item.browser" size="sm" class="mt-0.5" />
+                    </div>
+
+                    <OpenInIdeLink
+                      v-if="item.location"
+                      :location="item.location"
+                      :project-key="projectKey"
+                      :project-name="projectName"
+                      class="block pl-6 text-xs text-gray-400 dark:text-gray-500"
+                    />
+
+                    <TestRowBadges
+                      :is-new-regression="Boolean(item.isNewRegression)"
+                      :is-new-flaky="Boolean(item.isNewFlaky)"
+                      :annotations="item.testAnnotations"
+                      :tags="item.tags"
+                      :meta="item.testMeta"
+                      :max-tags="3"
+                      class="pl-6"
+                    />
+
+                    <div class="pl-6 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+                      <span v-if="item.status === 'running'" class="text-info">In progress...</span>
+                      <DurationValue v-else-if="item.duration" :ms="item.duration" />
+                      <UBadge
+                        v-if="item.workerIndex != null"
+                        color="neutral"
+                        variant="soft"
+                        size="xs"
+                        class="font-mono"
+                        :title="`Worker ${item.workerIndex}`"
+                      >
+                        w{{ item.workerIndex }}
+                      </UBadge>
+                      <UBadge v-if="(item.retries ?? 0) > 0" color="warning" variant="soft" size="xs">
+                        {{ item.retries }}x
+                      </UBadge>
+                      <span
+                        v-if="item.wastedTimeMs"
+                        class="inline-flex items-center gap-0.5 text-amber-600 dark:text-amber-400"
+                        title="Wasted in fixed waits"
+                      >
+                        <UIcon name="i-lucide-hourglass" class="size-3 shrink-0" />
+                        <DurationValue :ms="item.wastedTimeMs" unit-class="opacity-60" no-title />
+                      </span>
+                    </div>
+                  </div>
+
+                  <div
+                    class="hidden md:grid items-center border-b border-default text-sm transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900/50"
                     :class="highlightedCaseId === item.id ? 'animate-pulse bg-yellow-100 dark:bg-yellow-900/30' : ''"
                     role="row"
                     :style="{ gridTemplateColumns: gridTemplate }"
@@ -413,7 +526,15 @@ defineExpose({ scrollToCase });
                     <!-- title -->
                     <div class="px-3 py-2 min-w-0 space-y-0.5" role="cell">
                       <div class="flex items-center gap-1.5 min-w-0">
-                        <!-- Same badge cluster, in the same order, as the tree's rows. -->
+                        <!-- Neutral title: green titles read as "passed" even on failed rows. -->
+                        <a
+                          :href="`/test-run-cases/${item.id}`"
+                          class="text-highlighted hover:text-primary hover:underline font-medium truncate"
+                          :title="item.title"
+                          @click.prevent="navigateTo(`/test-run-cases/${item.id}`)"
+                          >{{ item.title }}</a
+                        >
+                        <!-- Same badge cluster, in the same place, as the tree's rows. -->
                         <TestRowBadges
                           :is-new-regression="Boolean(item.isNewRegression)"
                           :is-new-flaky="Boolean(item.isNewFlaky)"
@@ -423,14 +544,6 @@ defineExpose({ scrollToCase });
                           :max-tags="3"
                           class="shrink-0"
                         />
-                        <!-- Neutral title: green titles read as "passed" even on failed rows. -->
-                        <a
-                          :href="`/test-run-cases/${item.id}`"
-                          class="text-highlighted hover:text-primary hover:underline font-medium truncate"
-                          :title="item.title"
-                          @click.prevent="navigateTo(`/test-run-cases/${item.id}`)"
-                          >{{ item.title }}</a
-                        >
                       </div>
                       <OpenInIdeLink
                         v-if="item.location"

--- a/application/app/components/run/TestCasesTree.vue
+++ b/application/app/components/run/TestCasesTree.vue
@@ -288,6 +288,28 @@ const flatRows = computed<FlatRow[]>(() => {
             :aria-label="`Status: ${formatStatusLabel(row.test.status)}`"
             :title="formatStatusLabel(row.test.status)"
           />
+          <!--
+            The title is the row's only navigation — a separate "View" button
+            pointed at the same page and just ate width. `self-stretch` keeps the
+            tap target the full height of the row on touch screens, and the
+            `min-w-32` floor stops a tagged test from squeezing its own title to
+            nothing on a phone: the badges wrap to a second line instead.
+
+            Neutral title: primary-green titles read as "passed" — on the one
+            row that failed, a green title actively lies. Status stays on the
+            icon; the link affordance shows on hover.
+
+            The badges follow the title rather than leading it: a row is scanned
+            by name, and a `@tag` in front of every name is noise to read past.
+          -->
+          <a
+            :href="`/test-run-cases/${row.test.id}`"
+            class="text-highlighted hover:text-primary hover:underline min-w-32 self-stretch flex items-center"
+            :title="row.test.title"
+            @click.prevent="navigateTo(`/test-run-cases/${row.test.id}`)"
+          >
+            <span class="truncate">{{ row.test.title }}</span>
+          </a>
           <TestRowBadges
             :is-new-regression="Boolean(row.test.isNewRegression)"
             :is-new-flaky="Boolean(row.test.isNewFlaky)"
@@ -297,26 +319,6 @@ const flatRows = computed<FlatRow[]>(() => {
             :max-tags="3"
             class="shrink-0"
           />
-          <!--
-            The title is the row's only navigation — a separate "View" button
-            pointed at the same page and just ate width. `self-stretch` keeps the
-            tap target the full height of the row on touch screens, and the
-            `min-w-32` floor stops a tagged test from squeezing its own title to
-            nothing on a phone: the numbers wrap to a second line instead.
-          -->
-          <!--
-            Neutral title: primary-green titles read as "passed" — on the one
-            row that failed, a green title actively lies. Status stays on the
-            icon; the link affordance shows on hover.
-          -->
-          <a
-            :href="`/test-run-cases/${row.test.id}`"
-            class="text-highlighted hover:text-primary hover:underline flex-1 min-w-32 self-stretch flex items-center"
-            :title="row.test.title"
-            @click.prevent="navigateTo(`/test-run-cases/${row.test.id}`)"
-          >
-            <span class="truncate">{{ row.test.title }}</span>
-          </a>
           <div class="flex items-center gap-1.5 sm:gap-2 shrink-0 ml-auto">
             <span v-if="row.test.status === 'running'" class="text-xs text-info">In progress...</span>
             <DurationValue v-else-if="row.test.duration" :ms="row.test.duration" class="text-xs text-muted" />


### PR DESCRIPTION
## What & why

Follow-up to #322, on the other half of the run's **Test cases** tab.

**The flat list on a phone.** Below `md` it was a seven-column grid behind 41.5 rem of horizontal scroll: every number lived off-screen, and the header row that labels those numbers was the first thing to slide away. Those columns now become one card per case — status icon, full title (no truncation), spec location, badges, then duration / worker / retries / wasted as labelled chips. The card deliberately mirrors the tree's row: two views of the same data should not need different reading habits. From `md` up the table is unchanged.

Because the sortable column headers now only exist from `md` up, the toolbar grows a sort picker below that breakpoint. "Run order" is the natural order that a third click on a column header used to restore.

**Tags and marks move behind the test name**, in both views. In front of it they pushed every name to a different starting column, and this list is scanned by name — the badges were something to read past before reaching the thing you came for. They sit immediately after the name rather than right-aligned, because the right edge is already the numbers' column.

Rebased onto current `main`, which had landed a colour pass while #322 was merging: the resolution keeps main's `bg-default`/zinc hovers and its neutral title treatment ("green titles read as *passed* — on the one row that failed, a green title actively lies"), and applies that same treatment to the new mobile card.

## How was it tested?

- `npm run app:test:unit` — 1110 passed / 76 files.
- Typecheck, lint and format clean.
- Verified both views in a browser at 375 px and 1440 px against seeded demo data: no horizontal page overflow at either width, full test titles now visible on phones.
- E2E (`mobile-responsiveness`, `dashboard-ui`, `test-run-case-page`, `failure-clusters` — 69 passed) was run before the rebase onto `main`; CI here is the check that covers the rebased tree.

One bug this caught in the browser that neither typecheck nor lint saw: the sort picker's "Run order" option first used `value: ''`, and Reka UI's `USelect` rejects an empty-string item value — it 500'd every run page. It now uses a `natural` sentinel that maps to "no sort key".

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — layout-only change; the existing unit and mobile-responsiveness suites cover it
- [x] Docs updated if user-facing — no docs change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiVQMu13N86EpUYnQ1SY9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiVQMu13N86EpUYnQ1SY9m)_