### PR TITLE
feat(app): support base path in file API URLs with compress option

### DIFF
--- a/application/app/components/diagnosis/DiagnosisScreenshots.vue
+++ b/application/app/components/diagnosis/DiagnosisScreenshots.vue
@@ -28,6 +28,8 @@ const emit = defineEmits<{
   (e: 'update:images', images: DiagnoseImage[]): void;
 }>();
 
+const config = useRuntimeConfig();
+
 const MAX_SCREENSHOTS = 8;
 
 async function blobToBase64(blob: Blob): Promise<{ data: string; mediaType: string }> {
@@ -67,7 +69,7 @@ async function loadScreenshots() {
         if (!isImageFile(att.path, att.contentType)) continue;
         if (results.length >= MAX_SCREENSHOTS) break;
         const imgName = att.name || att.path.split('/').pop() || 'screenshot';
-        const url = `/api/files/${getFileApiPath(att.path)}?compress=1`;
+        const url = fileApiUrl(att.path, att.contentType, config.app?.baseURL, true);
         try {
           const res = await fetch(url);
           if (!res.ok) continue;

--- a/application/app/components/run/RunReports.vue
+++ b/application/app/components/run/RunReports.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { ReportInfo } from '~~/types/api';
-import { formatBytes, getFileApiPath } from '~/utils';
+import { formatBytes, fileApiUrl } from '~/utils';
 
 defineProps<{
   reports?: ReportInfo[] | null;
 }>();
+
+const config = useRuntimeConfig();
 </script>
 
 <template>
@@ -12,7 +14,7 @@ defineProps<{
     <UButton
       v-for="report in reports"
       :key="`${report.type}-${report.path}`"
-      :href="`/api/files/${getFileApiPath(report.path)}`"
+      :href="fileApiUrl(report.path, null, config.app?.baseURL)"
       :icon="reportIcon(report.type)"
       :title="report.size ? formatBytes(report.size) : report.label"
       target="_blank"

--- a/application/app/components/run/RunSummary.vue
+++ b/application/app/components/run/RunSummary.vue
@@ -20,6 +20,7 @@ const emit = defineEmits<{
 }>();
 
 const toast = useToast();
+const config = useRuntimeConfig();
 const storageStats = computed(() => props.testRun?.storageStats);
 
 // Visibility of each metadata block, defined once and referenced by both the
@@ -547,7 +548,7 @@ function onLabelKeydown(e: KeyboardEvent) {
         <div v-if="storageStats?.totalFiles" class="space-y-1.5 text-sm">
           <div v-for="report in allReports" :key="report.label" class="flex items-center justify-between gap-2 min-w-0">
             <UButton
-              :href="`/api/files/${getFileApiPath(report.path)}`"
+              :href="fileApiUrl(report.path, null, config.app?.baseURL)"
               :icon="reportIcon(report.type)"
               target="_blank"
               size="xs"

--- a/application/app/utils/index.ts
+++ b/application/app/utils/index.ts
@@ -350,14 +350,22 @@ export function getFileApiPath(filePath: string): string {
  * `baseURL` is the app's base path (`useRuntimeConfig().app.baseURL`) — read
  * it once in setup and pass it in. Pass `contentType` for extension-less
  * attachment paths — it is forwarded as a query param so the server can set
- * the right Content-Type.
+ * the right Content-Type. `compress` asks the server to re-encode an image
+ * down before sending it.
  */
-export function fileApiUrl(filePath: string, contentType?: string | null, baseURL: string = '/'): string {
+export function fileApiUrl(
+  filePath: string,
+  contentType?: string | null,
+  baseURL: string = '/',
+  compress: boolean = false,
+): string {
   const base = (baseURL || '/').replace(/\/$/, '');
-  let url = `${base}/api/files/${getFileApiPath(filePath)}`;
+  const params = new URLSearchParams();
   const hasExt = /\.[a-z0-9]+$/i.test(filePath);
-  if (contentType && !hasExt) url += `?contentType=${encodeURIComponent(contentType)}`;
-  return url;
+  if (contentType && !hasExt) params.set('contentType', contentType);
+  if (compress) params.set('compress', '1');
+  const query = params.toString();
+  return `${base}/api/files/${getFileApiPath(filePath)}${query ? `?${query}` : ''}`;
 }
 
 /**

--- a/application/scripts/check-demo-runtime.mjs
+++ b/application/scripts/check-demo-runtime.mjs
@@ -128,6 +128,14 @@ async function main() {
   const pageErrors = [];
   page.on('pageerror', (e) => pageErrors.push(String(e).slice(0, 200)));
 
+  // A root-relative /api/ URL escapes the service worker's scope and hits the
+  // static host instead, so it can never be answered by the in-browser API.
+  const escapedApiUrls = new Set();
+  page.on('request', (r) => {
+    const url = r.url();
+    if (url.startsWith(`${ORIGIN}/api/`)) escapedApiUrls.add(url.slice(ORIGIN.length));
+  });
+
   try {
     await page.goto(`${ORIGIN}${BASE}`, { waitUntil: 'domcontentloaded' });
     check(await waitForServiceWorker(page), 'the service worker installs and takes control');
@@ -172,6 +180,12 @@ async function main() {
     const bytes = path ? (await readFile(path)).length : 0;
     check(bytes > 1000, 'the ZIP export downloads', `${bytes} bytes as ${download.suggestedFilename()}`);
     check(download.suggestedFilename().endsWith('.zip'), 'the download is named as a ZIP');
+
+    check(
+      escapedApiUrls.size === 0,
+      'every API request stays inside the demo base path',
+      [...escapedApiUrls].slice(0, 3).join(', '),
+    );
 
     check(pageErrors.length === 0, 'no uncaught page errors', pageErrors[0] ?? '');
   } catch (error) {

--- a/application/tests/unit/app-utils.test.ts
+++ b/application/tests/unit/app-utils.test.ts
@@ -16,6 +16,7 @@ import {
   clusterErrorTypeColor,
   fixVerificationBadge,
   getFileApiPath,
+  fileApiUrl,
   getTraceViewerUrl,
   errorMessage,
   filterCommits,
@@ -238,6 +239,25 @@ describe('file path helpers', () => {
   test('getFileApiPath strips the storage prefix and passes relative paths through', () => {
     expect(getFileApiPath('.data/storage/reports/index.html')).toBe('reports/index.html');
     expect(getFileApiPath('reports/index.html')).toBe('reports/index.html');
+  });
+
+  test('fileApiUrl prefixes the base path so the URL stays inside a sub-path deployment', () => {
+    expect(fileApiUrl('.data/storage/screenshots/a.png')).toBe('/api/files/screenshots/a.png');
+    expect(fileApiUrl('demo/screenshots/a.png', null, '/demo/')).toBe('/demo/api/files/demo/screenshots/a.png');
+  });
+
+  test('fileApiUrl forwards contentType only for extension-less paths', () => {
+    expect(fileApiUrl('attachments/blob', 'image/png')).toBe('/api/files/attachments/blob?contentType=image%2Fpng');
+    expect(fileApiUrl('attachments/a.png', 'image/png')).toBe('/api/files/attachments/a.png');
+  });
+
+  test('fileApiUrl combines the compress flag with the base path and contentType', () => {
+    expect(fileApiUrl('demo/screenshots/a.png', null, '/demo/', true)).toBe(
+      '/demo/api/files/demo/screenshots/a.png?compress=1',
+    );
+    expect(fileApiUrl('attachments/blob', 'image/png', '/demo/', true)).toBe(
+      '/demo/api/files/attachments/blob?contentType=image%2Fpng&compress=1',
+    );
   });
 
   test('getTraceViewerUrl embeds the encoded file API URL using the current origin', () => {


### PR DESCRIPTION
## What & why

This change enhances the `fileApiUrl()` utility function to properly support sub-path deployments (where the app runs under a base path like `/demo/`) and adds support for a `compress` query parameter to request image re-encoding from the server.

**Problem:** 
- File API URLs were hardcoded as root-relative (`/api/files/...`), which escape the service worker's scope in sub-path deployments and fail to work in offline/demo modes
- The compress feature existed but wasn't exposed through the utility function
- Components were manually constructing file API URLs instead of using the centralized utility

**Solution:**
- Updated `fileApiUrl()` to accept `baseURL` and `compress` parameters
- Refactored URL construction to use `URLSearchParams` for cleaner query parameter handling
- Updated all components (`RunReports.vue`, `DiagnosisScreenshots.vue`, `RunSummary.vue`) to use `fileApiUrl()` with `config.app?.baseURL`
- Added validation in the demo runtime check to ensure no API requests escape the configured base path

## How was it tested?

- Added comprehensive unit tests covering:
  - Base path prefixing for sub-path deployments
  - Content-Type query parameter (only for extension-less paths)
  - Compress flag combined with base path and content-type
- Existing tests pass
- Demo runtime check now validates that all API requests stay within the configured base path

## Checklist

- [x] PR title follows Conventional Commits (`feat(app): ...`)
- [x] Tests added for behavior changes (3 new test cases)
- [x] Components updated to use centralized utility function

https://claude.ai/code/session_01QFAkf77Hon88ZGcL8LcoPv