### PR TITLE
feat(app): run failing tests locally from the desktop app

### DIFF
--- a/application/app/components/desktop/DesktopProjectLinkCard.vue
+++ b/application/app/components/desktop/DesktopProjectLinkCard.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: manage the folder on this machine linked to a project.
+ * The link powers "run locally" retries and resolves "Open in IDE" paths
+ * without manual workspace-root configuration. Renders nothing without the
+ * IPC bridge, so the project page can mount it unconditionally.
+ */
+const props = defineProps<{ projectId: string | number }>();
+
+const { available, link, busy, pickAndLink, unlink } = useDesktopProjectLink(() => props.projectId);
+</script>
+
+<template>
+  <SectionCard v-if="available" icon="i-lucide-folder-symlink" title="Local folder">
+    <template #subtitle>
+      Link this project to its checkout on this machine to retry failures from here and open files in your IDE.
+    </template>
+
+    <div v-if="link" class="flex items-center justify-between gap-3">
+      <div class="flex items-center gap-2 min-w-0 text-sm">
+        <UIcon
+          :name="link.exists ? 'i-lucide-folder-check' : 'i-lucide-folder-x'"
+          class="size-4 shrink-0"
+          :class="link.exists ? 'text-success' : 'text-warning'"
+        />
+        <code class="text-xs break-all">{{ link.path }}</code>
+        <UBadge v-if="!link.exists" color="warning" variant="subtle" size="sm">missing</UBadge>
+      </div>
+      <div class="flex items-center gap-1.5 shrink-0">
+        <UButton
+          size="xs"
+          color="neutral"
+          variant="soft"
+          icon="i-lucide-folder-search"
+          :loading="busy"
+          @click="pickAndLink"
+        >
+          Change
+        </UButton>
+        <UButton size="xs" color="neutral" variant="ghost" icon="i-lucide-unlink" :disabled="busy" @click="unlink">
+          Unlink
+        </UButton>
+      </div>
+    </div>
+
+    <div v-else class="flex items-center justify-between gap-3">
+      <p class="text-sm text-muted">No folder linked yet.</p>
+      <UButton size="xs" icon="i-lucide-folder-plus" :loading="busy" @click="pickAndLink">Choose folder…</UButton>
+    </div>
+  </SectionCard>
+</template>

--- a/application/app/components/desktop/DesktopRunLocallyButton.vue
+++ b/application/app/components/desktop/DesktopRunLocallyButton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: the entry point to "run these tests locally". Renders
+ * nothing without the IPC bridge (plain browsers, web deployments), so pages
+ * can mount it unconditionally next to the copyable retry command.
+ */
+import type { RetryCase } from '~/utils/retry-command';
+
+const props = defineProps<{
+  projectId?: string | number | null;
+  projectLabel?: string | null;
+  cases: RetryCase[];
+}>();
+
+const available = ref(false);
+onMounted(() => {
+  available.value = !!tauriCore();
+});
+
+const open = ref(false);
+const canRun = computed(() => available.value && props.projectId != null && props.cases.length > 0);
+</script>
+
+<template>
+  <span v-if="canRun" class="inline-flex">
+    <UTooltip text="Run these tests on this machine">
+      <UButton size="xs" color="warning" variant="subtle" icon="i-lucide-monitor-play" @click="open = true">
+        Run locally
+      </UButton>
+    </UTooltip>
+    <DesktopRunLocallyModal v-model:open="open" :project-id="projectId!" :project-label="projectLabel" :cases="cases" />
+  </span>
+</template>

--- a/application/app/components/desktop/DesktopRunLocallyModal.vue
+++ b/application/app/components/desktop/DesktopRunLocallyModal.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: run the given test cases locally, in the folder linked to
+ * the project. The shell executes the folder's own Playwright with the bundled
+ * Node sidecar and streams output back here; results land in the dashboard
+ * through the project's regular Piwi reporter (which discovers the running app
+ * via `~/.piwi/desktop.json`).
+ */
+import type { RetryCase, RetryMode } from '~/utils/retry-command';
+import { buildLocalRunPlan, type LocalRunMode } from '~/utils/local-run-args';
+
+const props = defineProps<{
+  /** Piwi project id owning the linked folder. */
+  projectId: string | number;
+  projectLabel?: string | null;
+  /** The failing cases to retry. */
+  cases: RetryCase[];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+const { link, busy, pickAndLink } = useDesktopProjectLink(() => props.projectId);
+const { status, running, lines, exitCode, stepIndex, stepCount, start, stop } = useDesktopLocalRunner();
+
+const mode = ref<RetryMode>('file-line');
+const runMode = ref<LocalRunMode>('normal');
+const trace = ref(false);
+const repeatEach = ref(1);
+
+const modeItems = [
+  { label: 'File:line', value: 'file-line' },
+  { label: 'Title (grep)', value: 'grep' },
+  { label: 'File only', value: 'file' },
+];
+const runModeItems = [
+  { label: 'Headless', value: 'normal' },
+  { label: 'Headed', value: 'headed' },
+  { label: 'Debug (inspector)', value: 'debug' },
+  { label: 'UI mode', value: 'ui' },
+];
+
+const linked = computed(() => !!link.value?.exists);
+const plan = computed(() =>
+  buildLocalRunPlan(props.cases, {
+    mode: mode.value,
+    runMode: runMode.value,
+    trace: trace.value,
+    repeatEach: repeatEach.value,
+  }),
+);
+const preview = computed(() => plan.value.map((s) => s.display).join('\n'));
+
+const statusBadge = computed(() => {
+  switch (status.value) {
+    case 'running':
+      return {
+        label: stepCount.value > 1 ? `Running ${stepIndex.value + 1}/${stepCount.value}…` : 'Running…',
+        color: 'info' as const,
+      };
+    case 'passed':
+      return { label: 'Passed', color: 'success' as const };
+    case 'failed':
+      return { label: exitCode.value != null ? `Failed (exit ${exitCode.value})` : 'Failed', color: 'error' as const };
+    case 'stopped':
+      return { label: 'Stopped', color: 'neutral' as const };
+    case 'error':
+      return { label: 'Could not run', color: 'error' as const };
+    default:
+      return null;
+  }
+});
+
+async function run() {
+  await start(props.projectId, plan.value);
+}
+
+// Closing the modal mid-run stops the process — nothing keeps running unseen.
+watch(open, (value) => {
+  if (!value && running.value) void stop();
+});
+
+const outputEl = ref<HTMLElement | null>(null);
+watch(
+  () => lines.value.length,
+  async () => {
+    await nextTick();
+    outputEl.value?.scrollTo({ top: outputEl.value.scrollHeight });
+  },
+);
+</script>
+
+<template>
+  <UModal v-model:open="open" :ui="{ content: 'max-w-2xl' }">
+    <template #header>
+      <div class="flex items-center gap-2 min-w-0">
+        <UIcon name="i-lucide-monitor-play" class="size-5 text-primary shrink-0" />
+        <h2 class="text-base font-semibold truncate">Run tests locally</h2>
+        <UBadge color="neutral" variant="subtle" size="sm"
+          >{{ cases.length }} test{{ cases.length === 1 ? '' : 's' }}</UBadge
+        >
+      </div>
+    </template>
+
+    <template #body>
+      <div class="space-y-4">
+        <div v-if="!linked" class="space-y-3">
+          <p class="text-sm text-muted">
+            Link {{ projectLabel || 'this project' }} to its local checkout — the folder that contains these tests. Piwi
+            runs that folder's own Playwright with the app's bundled Node, so nothing else needs to be installed.
+          </p>
+          <UAlert
+            v-if="link && !link.exists"
+            color="warning"
+            variant="soft"
+            icon="i-lucide-folder-x"
+            title="The linked folder no longer exists"
+            :description="link.path"
+          />
+          <UButton icon="i-lucide-folder-plus" :loading="busy" @click="pickAndLink">Choose folder…</UButton>
+        </div>
+
+        <template v-else>
+          <div class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-2 min-w-0 text-sm">
+              <UIcon name="i-lucide-folder-check" class="size-4 text-success shrink-0" />
+              <code class="text-xs break-all">{{ link?.path }}</code>
+            </div>
+            <UButton
+              size="xs"
+              color="neutral"
+              variant="ghost"
+              icon="i-lucide-folder-search"
+              :loading="busy"
+              :disabled="running"
+              @click="pickAndLink"
+            >
+              Change
+            </UButton>
+          </div>
+
+          <div class="grid grid-cols-2 gap-3">
+            <UFormField label="Select tests by" name="mode">
+              <USelect v-model="mode" :items="modeItems" :disabled="running" class="w-full" />
+            </UFormField>
+            <UFormField label="Browser" name="runMode">
+              <USelect v-model="runMode" :items="runModeItems" :disabled="running" class="w-full" />
+            </UFormField>
+            <UFormField
+              label="Repeat each"
+              name="repeatEach"
+              description="Run every test N times — flake reproduction."
+            >
+              <UInput v-model.number="repeatEach" type="number" min="1" max="1000" :disabled="running" class="w-full" />
+            </UFormField>
+            <UFormField label="Trace" name="trace" description="Force trace recording (--trace=on).">
+              <USwitch v-model="trace" :disabled="running" />
+            </UFormField>
+          </div>
+
+          <div class="space-y-1">
+            <div class="text-xs text-muted">Runs in the linked folder</div>
+            <CodeBlock :code="preview" lang="sh" />
+          </div>
+
+          <p class="text-xs text-muted">
+            Results are reported by the folder's own Playwright config — with the Piwi reporter set up, the new run
+            appears in this app automatically.
+          </p>
+
+          <div v-if="status !== 'idle'" class="space-y-2">
+            <div ref="outputEl" class="h-64 overflow-y-auto rounded-md bg-zinc-950 p-3">
+              <p
+                v-for="(line, i) in lines"
+                :key="i"
+                class="font-mono text-xs whitespace-pre-wrap"
+                :class="line.error ? 'text-red-400' : 'text-zinc-300'"
+              >
+                {{ line.text || ' ' }}
+              </p>
+            </div>
+          </div>
+        </template>
+      </div>
+    </template>
+
+    <template #footer>
+      <div class="flex items-center justify-between w-full gap-3">
+        <UBadge v-if="statusBadge" :color="statusBadge.color" variant="subtle">{{ statusBadge.label }}</UBadge>
+        <span v-else />
+        <div class="flex items-center gap-2">
+          <UButton color="neutral" variant="ghost" @click="open = false">Close</UButton>
+          <UButton v-if="running" color="error" icon="i-lucide-square" @click="stop()">Stop</UButton>
+          <UButton v-else icon="i-lucide-play" :disabled="!linked || plan.length === 0 || busy" @click="run()">
+            {{ status === 'idle' ? 'Run' : 'Run again' }}
+          </UButton>
+        </div>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/application/app/components/run/RunSummary.vue
+++ b/application/app/components/run/RunSummary.vue
@@ -359,6 +359,12 @@ function onLabelKeydown(e: KeyboardEvent) {
                         </div>
                       </template>
                     </UPopover>
+                    <DesktopRunLocallyButton
+                      v-if="failedCases.length > 0"
+                      :project-id="testRun?.project?.id"
+                      :project-label="testRun?.project?.label ?? testRun?.project?.name"
+                      :cases="failedCases"
+                    />
                   </div>
                 </div>
               </div>

--- a/application/app/composables/useDesktopLocalRunner.ts
+++ b/application/app/composables/useDesktopLocalRunner.ts
@@ -1,0 +1,153 @@
+/**
+ * Drive a local `playwright test` run through the desktop shell.
+ *
+ * The shell spawns the linked folder's own Playwright with the bundled Node
+ * sidecar and streams output back as `piwi:local-run` events. A plan can have
+ * several steps (one per Playwright project); they run sequentially and the
+ * worst exit code wins. Output lines may arrive before the invoke that started
+ * the run resolves with its id, so unattributed events are buffered and
+ * replayed once the id is known.
+ */
+import type { LocalRunStep } from '~/utils/local-run-args';
+
+export type LocalRunnerStatus = 'idle' | 'running' | 'passed' | 'failed' | 'stopped' | 'error';
+
+export interface LocalRunnerLine {
+  text: string;
+  error: boolean;
+}
+
+interface LocalRunEventPayload {
+  id: number;
+  kind: 'stdout' | 'stderr' | 'error' | 'exit';
+  line: string | null;
+  code: number | null;
+}
+
+/** Output lines kept in memory — a soak run can produce hundreds of thousands. */
+const MAX_LINES = 2000;
+
+export function useDesktopLocalRunner() {
+  const status = ref<LocalRunnerStatus>('idle');
+  const lines = ref<LocalRunnerLine[]>([]);
+  const exitCode = ref<number | null>(null);
+  const stepIndex = ref(0);
+  const stepCount = ref(0);
+
+  const running = computed(() => status.value === 'running');
+
+  let currentRunId: number | null = null;
+  let starting = false;
+  let stopped = false;
+  let pending: LocalRunEventPayload[] = [];
+  let unlisten: (() => void) | null = null;
+  let resolveExit: ((code: number | null) => void) | null = null;
+
+  function pushLine(text: string, error: boolean) {
+    lines.value.push({ text, error });
+    if (lines.value.length > MAX_LINES) lines.value.splice(0, lines.value.length - MAX_LINES);
+  }
+
+  function handleEvent(payload: LocalRunEventPayload) {
+    if (payload.kind === 'exit') {
+      resolveExit?.(payload.code);
+      return;
+    }
+    pushLine(payload.line ?? '', payload.kind !== 'stdout');
+  }
+
+  async function ensureListener() {
+    if (unlisten) return;
+    const events = tauriEvent();
+    if (!events) throw new Error('The desktop bridge is unavailable.');
+    unlisten = await events.listen<LocalRunEventPayload>('piwi:local-run', ({ payload }) => {
+      if (payload.id === currentRunId) {
+        handleEvent(payload);
+      } else if (starting) {
+        pending.push(payload);
+      }
+    });
+  }
+
+  async function runStep(projectId: string | number, step: LocalRunStep): Promise<number | null> {
+    const core = tauriCore();
+    if (!core) throw new Error('The desktop bridge is unavailable.');
+    const exit = new Promise<number | null>((resolve) => {
+      resolveExit = resolve;
+    });
+    starting = true;
+    pending = [];
+    try {
+      currentRunId = await core.invoke<number>('desktop_run_local_tests', {
+        projectId: String(projectId),
+        args: step.args,
+      });
+    } finally {
+      starting = false;
+    }
+    for (const event of pending) {
+      if (event.id === currentRunId) handleEvent(event);
+    }
+    pending = [];
+    const code = await exit;
+    currentRunId = null;
+    resolveExit = null;
+    return code;
+  }
+
+  async function start(projectId: string | number, steps: LocalRunStep[]): Promise<void> {
+    if (running.value || steps.length === 0) return;
+    stopped = false;
+    lines.value = [];
+    exitCode.value = null;
+    stepCount.value = steps.length;
+    stepIndex.value = 0;
+    status.value = 'running';
+    try {
+      await ensureListener();
+      let worst: number | null = 0;
+      for (const [index, step] of steps.entries()) {
+        if (stopped) break;
+        stepIndex.value = index;
+        if (steps.length > 1) pushLine(`$ ${step.display}`, false);
+        const code = await runStep(projectId, step);
+        if (stopped) break;
+        if (code !== 0) worst = code ?? 1;
+      }
+      if (stopped) {
+        status.value = 'stopped';
+      } else {
+        exitCode.value = typeof worst === 'number' ? worst : 1;
+        status.value = worst === 0 ? 'passed' : 'failed';
+      }
+    } catch (error) {
+      pushLine(errorMessage(error), true);
+      status.value = 'error';
+    }
+  }
+
+  async function stop() {
+    if (!running.value) return;
+    stopped = true;
+    const core = tauriCore();
+    const id = currentRunId;
+    if (core && id != null) {
+      try {
+        await core.invoke('desktop_stop_local_tests', { runId: id });
+      } catch {
+        // The process already exited between the check and the kill.
+      }
+    }
+    // Unblock the awaited step even if no exit event follows the kill.
+    resolveExit?.(null);
+    status.value = 'stopped';
+  }
+
+  onScopeDispose(() => {
+    if (running.value) void stop();
+    unlisten?.();
+    unlisten = null;
+  });
+
+  return { status, running, lines, exitCode, stepIndex, stepCount, start, stop };
+}

--- a/application/app/composables/useDesktopProjectLink.ts
+++ b/application/app/composables/useDesktopProjectLink.ts
@@ -1,0 +1,89 @@
+/**
+ * The folder on this machine linked to a Piwi project (desktop shell only).
+ *
+ * Links are stored by the shell in its own settings store — a folder path is a
+ * fact about this machine, not about the project — and are what enable running
+ * tests locally and resolving IDE links without manual configuration. Every
+ * accessor feature-detects the IPC bridge and no-ops in a plain browser.
+ */
+
+export interface DesktopProjectLink {
+  path: string;
+  exists: boolean;
+}
+
+/** One-shot read of a project's linked folder; `null` without bridge or link. */
+export async function getDesktopProjectLink(
+  projectId: string | number | null | undefined,
+): Promise<DesktopProjectLink | null> {
+  const core = tauriCore();
+  if (!core || projectId == null || projectId === '') return null;
+  try {
+    return await core.invoke<DesktopProjectLink | null>('desktop_get_project_link', {
+      projectId: String(projectId),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function useDesktopProjectLink(projectId: MaybeRefOrGetter<string | number | null | undefined>) {
+  const toast = useToast();
+
+  /** The IPC bridge exists — resolved on mount so SSR renders nothing. */
+  const available = ref(false);
+  const link = ref<DesktopProjectLink | null>(null);
+  const busy = ref(false);
+
+  async function refresh() {
+    link.value = await getDesktopProjectLink(toValue(projectId));
+  }
+
+  onMounted(() => {
+    available.value = !!tauriCore();
+    if (available.value) void refresh();
+  });
+  watch(
+    () => toValue(projectId),
+    () => {
+      if (available.value) void refresh();
+    },
+  );
+
+  /** Open the native folder picker and link the chosen folder. False on cancel. */
+  async function pickAndLink(): Promise<boolean> {
+    const core = tauriCore();
+    const id = toValue(projectId);
+    if (!core || id == null || id === '') return false;
+    busy.value = true;
+    try {
+      const path = await core.invoke<string | null>('desktop_pick_folder');
+      if (!path) return false;
+      await core.invoke('desktop_set_project_link', { projectId: String(id), path });
+      await refresh();
+      return true;
+    } catch (error) {
+      toast.add({ title: 'Could not link the folder', description: errorMessage(error), color: 'error' });
+      return false;
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  async function unlink() {
+    const core = tauriCore();
+    const id = toValue(projectId);
+    if (!core || id == null || id === '') return;
+    busy.value = true;
+    try {
+      await core.invoke('desktop_set_project_link', { projectId: String(id), path: null });
+      link.value = null;
+    } catch (error) {
+      toast.add({ title: 'Could not unlink the folder', description: errorMessage(error), color: 'error' });
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  return { available, link, busy, refresh, pickAndLink, unlink };
+}

--- a/application/app/composables/useOpenInIde.ts
+++ b/application/app/composables/useOpenInIde.ts
@@ -187,7 +187,13 @@ export function useOpenInIde() {
     const rel = target.filePath;
     const line = target.line ?? null;
     const column = target.column ?? null;
-    const root = resolveRoot(target.projectKey);
+    // Desktop shell: a project's linked folder stands in for an unconfigured
+    // workspace root, so IDE links work with zero setup.
+    let root = resolveRoot(target.projectKey);
+    if (!root) {
+      const linked = await getDesktopProjectLink(target.projectKey);
+      if (linked?.exists) root = linked.path;
+    }
     const jbName = resolveJbProjectName(target.projectKey, target.projectName);
     const ctx: IdeSettingsContext = {
       projectKey: projectKeyOf(target.projectKey),

--- a/application/app/composables/useTauri.ts
+++ b/application/app/composables/useTauri.ts
@@ -11,8 +11,18 @@ interface TauriCore {
   invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
 }
 
+interface TauriEvent {
+  listen: <T = unknown>(event: string, handler: (event: { payload: T }) => void) => Promise<() => void>;
+}
+
 /** The native invoke bridge, or `null` when not running inside the desktop shell. */
 export function tauriCore(): TauriCore | null {
   const g = globalThis as unknown as { __TAURI__?: { core?: TauriCore } };
   return g.__TAURI__?.core ?? null;
+}
+
+/** The native event bridge (shell → webview), or `null` outside the desktop shell. */
+export function tauriEvent(): TauriEvent | null {
+  const g = globalThis as unknown as { __TAURI__?: { event?: TauriEvent } };
+  return g.__TAURI__?.event ?? null;
 }

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -688,6 +688,9 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
           </div>
         </div>
 
+        <!-- Desktop shell only (renders nothing without the IPC bridge). -->
+        <DesktopProjectLinkCard :project-id="projectId" />
+
         <!-- Mobile: a select replaces the cramped tab strip; the strip scrolls from sm up. -->
         <USelect
           v-model="activeTab"

--- a/application/app/pages/test-run-cases/[id].vue
+++ b/application/app/pages/test-run-cases/[id].vue
@@ -283,16 +283,15 @@ function stepBarColorClass(duration: number): string {
 const environment = computed(() => testCase.value?.testRun?.environment);
 
 // ── Retry command ─────────────────────────────────────────────────────────
-const retryCommand = computed(() =>
-  buildRetryCommand([
-    {
-      filePath: testCase.value?.filePath ?? '',
-      title: testCase.value?.title ?? '',
-      line: testCase.value?.line ?? null,
-      projectName: (testCase.value?.browser as { projectName?: string } | null)?.projectName ?? null,
-    },
-  ]),
-);
+const retryCases = computed(() => [
+  {
+    filePath: testCase.value?.filePath ?? '',
+    title: testCase.value?.title ?? '',
+    line: testCase.value?.line ?? null,
+    projectName: (testCase.value?.browser as { projectName?: string } | null)?.projectName ?? null,
+  },
+]);
+const retryCommand = computed(() => buildRetryCommand(retryCases.value));
 const { copy: copyRetry, copied: retryCopied } = useCopy();
 
 const navbarActions = computed(() => [
@@ -493,6 +492,12 @@ provide(clusterSectionLocatorKey, {
             v-if="testCase"
             :endpoint="`/api/test-run-cases/${testCase.id}/export`"
             :base-name="`piwi-execution-${testCase.id}`"
+            class="mr-2"
+          />
+          <DesktopRunLocallyButton
+            :project-id="testCase?.testRun?.project?.id"
+            :project-label="testCase?.testRun?.project?.label ?? testCase?.testRun?.project?.name"
+            :cases="retryCases"
             class="mr-2"
           />
           <NavbarActions :actions="navbarActions" />

--- a/application/app/utils/local-run-args.ts
+++ b/application/app/utils/local-run-args.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure builders for running `playwright test` locally from the desktop shell.
+ *
+ * Unlike `buildRetryCommand` (a copy-pastable shell string), the shell executes
+ * the run itself with no shell in between, so each step is a plain argv array —
+ * no escaping, no `&&`. Cases are grouped by Playwright project exactly like
+ * the copyable command: a `--project` filter and a `file:line` filter must pair
+ * up, so mixed-project retries become sequential steps.
+ */
+import { escapeGrep, toPosixPath, type RetryCase, type RetryMode } from './retry-command';
+
+/** How the browser runs. `debug` opens the inspector, `ui` opens UI mode. */
+export type LocalRunMode = 'normal' | 'headed' | 'debug' | 'ui';
+
+export interface LocalRunOptions {
+  mode?: RetryMode;
+  runMode?: LocalRunMode;
+  /** Force trace recording (`--trace=on`). */
+  trace?: boolean;
+  /** Run every matched test N times — flake reproduction. Clamped to 1–1000. */
+  repeatEach?: number;
+}
+
+export interface LocalRunStep {
+  /** Arguments to `playwright test`, one argv entry each. */
+  args: string[];
+  /** Human-readable preview of the step. */
+  display: string;
+}
+
+const RUN_MODE_FLAGS: Record<LocalRunMode, string[]> = {
+  normal: [],
+  headed: ['--headed'],
+  debug: ['--debug'],
+  ui: ['--ui'],
+};
+
+function groupByProject(cases: RetryCase[]): Map<string, RetryCase[]> {
+  const groups = new Map<string, RetryCase[]>();
+  for (const c of cases) {
+    const key = c.projectName || '';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(c);
+  }
+  return groups;
+}
+
+function specArgs(cases: RetryCase[], mode: RetryMode): string[] {
+  if (mode === 'grep') {
+    const escaped = cases.map((c) => escapeGrep(c.title));
+    return ['--grep', escaped.length === 1 ? escaped[0]! : `(${escaped.join('|')})`];
+  }
+  const seen = new Set<string>();
+  const specs: string[] = [];
+  for (const c of cases) {
+    const spec = mode === 'file-line' && c.line ? `${toPosixPath(c.filePath)}:${c.line}` : toPosixPath(c.filePath);
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    specs.push(spec);
+  }
+  return specs;
+}
+
+/** Quote an argument for display only — execution never goes through a shell. */
+function displayArg(arg: string): string {
+  return /[\s"'()|]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg;
+}
+
+export function buildLocalRunPlan(cases: RetryCase[], options: LocalRunOptions = {}): LocalRunStep[] {
+  if (cases.length === 0) return [];
+  const mode = options.mode ?? 'file-line';
+  const runMode = options.runMode ?? 'normal';
+  const repeatEach = Math.min(1000, Math.max(1, Math.floor(options.repeatEach ?? 1)));
+
+  const steps: LocalRunStep[] = [];
+  for (const [project, projectCases] of groupByProject(cases)) {
+    const args = specArgs(projectCases, mode);
+    if (project) args.push(`--project=${project}`);
+    args.push(...RUN_MODE_FLAGS[runMode]);
+    if (options.trace) args.push('--trace=on');
+    if (repeatEach > 1) args.push(`--repeat-each=${repeatEach}`);
+    steps.push({ args, display: ['playwright', 'test', ...args.map(displayArg)].join(' ') });
+  }
+  return steps;
+}

--- a/application/app/utils/retry-command.ts
+++ b/application/app/utils/retry-command.ts
@@ -1,6 +1,6 @@
 export type RetryMode = 'file-line' | 'grep' | 'file';
 
-interface RetryCase {
+export interface RetryCase {
   filePath: string;
   title: string;
   line?: number | null;
@@ -9,7 +9,7 @@ interface RetryCase {
 
 const MAX_CMD_LENGTH = 4096;
 
-function escapeGrep(text: string): string {
+export function escapeGrep(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 

--- a/application/shared/test-project-names.ts
+++ b/application/shared/test-project-names.ts
@@ -36,6 +36,7 @@ export const PROJECT = {
   DASHBOARD_PERF: 'dashboard-perf-tracking',
   DEFAULT_PROJECT: 'default-project',
   DELETE_TEST: 'delete-test-project',
+  DESKTOP_LOCAL_RUN: 'desktop-local-run-test',
   DIAGNOSE_STREAM: 'diagnose-stream-test',
   DOWNLOAD_TEST: 'download-test-project',
   DUP_UI: 'dup-ui-project',

--- a/application/tests/desktop-local-run.spec.ts
+++ b/application/tests/desktop-local-run.spec.ts
@@ -1,0 +1,173 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { waitForHydration, retryPost } from './utils';
+import { PROJECT } from '#shared/test-project-names';
+
+/**
+ * The desktop-only "Run locally" flow, driven against the regular web build
+ * with a faked Tauri IPC bridge. The UI gates itself purely on the bridge's
+ * presence, so installing `window.__TAURI__` before the app boots exercises the
+ * real components, composables and event plumbing end to end — everything but
+ * the Rust process spawn itself (covered by `desktop/e2e/`).
+ */
+
+interface FakeInvocation {
+  cmd: string;
+  args: Record<string, unknown> | undefined;
+}
+
+declare global {
+  interface Window {
+    __piwiFakeTauri: { invocations: FakeInvocation[] };
+  }
+}
+
+/** Install a fake `window.__TAURI__` before any app script runs. */
+async function installFakeBridge(page: Page, options: { linked: boolean }) {
+  await page.addInitScript((opts: { linked: boolean }) => {
+    const listeners: ((event: { payload: unknown }) => void)[] = [];
+    const state = {
+      link: opts.linked ? { path: '/home/dev/acme', exists: true } : null,
+      invocations: [] as { cmd: string; args: Record<string, unknown> | undefined }[],
+    };
+    Object.assign(window, { __piwiFakeTauri: state });
+    Object.assign(window, {
+      __TAURI__: {
+        core: {
+          invoke: async (cmd: string, args?: Record<string, unknown>) => {
+            state.invocations.push({ cmd, args });
+            switch (cmd) {
+              case 'desktop_get_project_link':
+                return state.link;
+              case 'desktop_pick_folder':
+                return '/home/dev/acme';
+              case 'desktop_set_project_link':
+                state.link = { path: '/home/dev/acme', exists: true };
+                return null;
+              case 'desktop_run_local_tests':
+                setTimeout(() => {
+                  for (const emit of listeners) {
+                    emit({ payload: { id: 7, kind: 'stdout', line: 'Running 1 test using 1 worker', code: null } });
+                    emit({ payload: { id: 7, kind: 'stdout', line: '  1 passed (2.0s)', code: null } });
+                    emit({ payload: { id: 7, kind: 'exit', line: null, code: 0 } });
+                  }
+                }, 50);
+                return 7;
+              case 'desktop_stop_local_tests':
+                return null;
+              default:
+                throw new Error(`unexpected command: ${cmd}`);
+            }
+          },
+        },
+        event: {
+          listen: async (name: string, cb: (event: { payload: unknown }) => void) => {
+            if (name === 'piwi:local-run') listeners.push(cb);
+            return () => {};
+          },
+        },
+      },
+    });
+  }, options);
+}
+
+test.describe('Desktop local run', () => {
+  let runId: number;
+
+  test.beforeAll(async ({ request }) => {
+    const startTime = Date.now();
+    const res = await retryPost(request, '/api/test-runs/submit', {
+      data: {
+        projectName: PROJECT.DESKTOP_LOCAL_RUN,
+        status: 'failed',
+        startTime: new Date(startTime).toISOString(),
+        duration: 12000,
+        totalTests: 2,
+        passedTests: 1,
+        failedTests: 1,
+        skippedTests: 0,
+        testCases: [
+          {
+            title: 'checkout completes',
+            status: 'failed',
+            duration: 8000,
+            location: 'tests/checkout.spec.ts:42:18',
+            browser: { name: 'chromium', projectName: 'chromium' },
+            error: 'TimeoutError: locator.click: Timeout 30000ms exceeded.',
+            retries: 0,
+            workerIndex: 0,
+            startedAt: startTime,
+          },
+          {
+            title: 'homepage loads',
+            status: 'passed',
+            duration: 1000,
+            location: 'tests/home.spec.ts:5:1',
+            retries: 0,
+            workerIndex: 0,
+            startedAt: startTime,
+          },
+        ],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    const proj = await (await request.get(`/api/projects/${data.projectId}`)).json();
+    runId = proj.testRuns[0].id;
+  });
+
+  test('without the bridge the button does not exist', async ({ page }) => {
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+    // The copyable Retry button proves the summary (where "Run locally" would
+    // sit) has rendered with failed cases.
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Run locally' })).toHaveCount(0);
+  });
+
+  test('runs the failed tests in the linked folder and streams output', async ({ page }) => {
+    await installFakeBridge(page, { linked: true });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    const dialog = page.getByRole('dialog');
+
+    // The linked folder and the exact command are shown before anything runs.
+    await expect(dialog.getByText('/home/dev/acme')).toBeVisible();
+    await expect(dialog.getByText('playwright test tests/checkout.spec.ts:42 --project=chromium')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Run', exact: true }).click();
+
+    await expect(dialog.getByText('Running 1 test using 1 worker')).toBeVisible();
+    await expect(dialog.getByText('1 passed (2.0s)')).toBeVisible();
+    await expect(dialog.getByText('Passed', { exact: true })).toBeVisible();
+
+    const runInvocation = await page.evaluate(() =>
+      window.__piwiFakeTauri.invocations.find((i) => i.cmd === 'desktop_run_local_tests'),
+    );
+    expect(runInvocation).toBeTruthy();
+    expect(runInvocation!.args!.args).toEqual(['tests/checkout.spec.ts:42', '--project=chromium']);
+    expect(String(runInvocation!.args!.projectId)).toMatch(/^\d+$/);
+  });
+
+  test('prompts to link a folder when none is linked yet', async ({ page }) => {
+    await installFakeBridge(page, { linked: false });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('button', { name: 'Choose folder…' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Choose folder…' }).click();
+
+    await expect(dialog.getByText('/home/dev/acme')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Run', exact: true })).toBeEnabled();
+
+    const setInvocation = await page.evaluate(() =>
+      window.__piwiFakeTauri.invocations.find((i) => i.cmd === 'desktop_set_project_link'),
+    );
+    expect(setInvocation!.args!.path).toBe('/home/dev/acme');
+  });
+});

--- a/application/tests/unit/local-run-args.test.ts
+++ b/application/tests/unit/local-run-args.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'vitest';
+import { buildLocalRunPlan } from '../../app/utils/local-run-args';
+
+const CASE = {
+  filePath: 'tests/checkout.spec.ts',
+  title: 'checkout completes',
+  line: 42,
+  projectName: 'chromium',
+};
+
+describe('buildLocalRunPlan', () => {
+  test('returns no steps for no cases', () => {
+    expect(buildLocalRunPlan([])).toEqual([]);
+  });
+
+  test('builds one file:line step per Playwright project', () => {
+    const plan = buildLocalRunPlan([
+      CASE,
+      { ...CASE, filePath: 'tests/login.spec.ts', line: 7, projectName: 'firefox' },
+    ]);
+    expect(plan).toHaveLength(2);
+    expect(plan[0]!.args).toEqual(['tests/checkout.spec.ts:42', '--project=chromium']);
+    expect(plan[1]!.args).toEqual(['tests/login.spec.ts:7', '--project=firefox']);
+    expect(plan[0]!.display).toBe('playwright test tests/checkout.spec.ts:42 --project=chromium');
+  });
+
+  test('omits --project when the case has none', () => {
+    const plan = buildLocalRunPlan([{ ...CASE, projectName: null }]);
+    expect(plan[0]!.args).toEqual(['tests/checkout.spec.ts:42']);
+  });
+
+  test('dedupes identical file:line specs and falls back to the file without a line', () => {
+    const plan = buildLocalRunPlan([CASE, { ...CASE, title: 'other' }, { ...CASE, title: 'third', line: null }]);
+    expect(plan[0]!.args).toEqual(['tests/checkout.spec.ts:42', 'tests/checkout.spec.ts', '--project=chromium']);
+  });
+
+  test('normalizes Windows separators to POSIX', () => {
+    const plan = buildLocalRunPlan([{ ...CASE, filePath: 'tests\\checkout.spec.ts' }]);
+    expect(plan[0]!.args[0]).toBe('tests/checkout.spec.ts:42');
+  });
+
+  test('grep mode escapes regex characters and joins titles', () => {
+    const plan = buildLocalRunPlan(
+      [
+        { ...CASE, title: 'pays (visa)' },
+        { ...CASE, title: 'refund $10' },
+      ],
+      { mode: 'grep' },
+    );
+    expect(plan[0]!.args).toEqual(['--grep', '(pays \\(visa\\)|refund \\$10)', '--project=chromium']);
+  });
+
+  test('file mode dedupes file paths', () => {
+    const plan = buildLocalRunPlan([CASE, { ...CASE, title: 'other', line: 60 }], { mode: 'file' });
+    expect(plan[0]!.args).toEqual(['tests/checkout.spec.ts', '--project=chromium']);
+  });
+
+  test('appends run mode, trace and repeat-each flags', () => {
+    const plan = buildLocalRunPlan([CASE], { runMode: 'headed', trace: true, repeatEach: 25 });
+    expect(plan[0]!.args).toEqual([
+      'tests/checkout.spec.ts:42',
+      '--project=chromium',
+      '--headed',
+      '--trace=on',
+      '--repeat-each=25',
+    ]);
+  });
+
+  test('debug and ui run modes map to their flags', () => {
+    expect(buildLocalRunPlan([CASE], { runMode: 'debug' })[0]!.args).toContain('--debug');
+    expect(buildLocalRunPlan([CASE], { runMode: 'ui' })[0]!.args).toContain('--ui');
+  });
+
+  test('clamps repeat-each to 1–1000 and omits it at 1', () => {
+    expect(buildLocalRunPlan([CASE], { repeatEach: 0 })[0]!.args).not.toContain('--repeat-each=0');
+    expect(buildLocalRunPlan([CASE], { repeatEach: 1.9 })[0]!.args.join(' ')).not.toContain('--repeat-each');
+    expect(buildLocalRunPlan([CASE], { repeatEach: 5000 })[0]!.args).toContain('--repeat-each=1000');
+    expect(buildLocalRunPlan([CASE], { repeatEach: 3.7 })[0]!.args).toContain('--repeat-each=3');
+  });
+
+  test('display quotes arguments with spaces or regex metacharacters, args stay raw', () => {
+    const plan = buildLocalRunPlan([{ ...CASE, title: 'pays (visa)' }], { mode: 'grep' });
+    expect(plan[0]!.args[1]).toBe('pays \\(visa\\)');
+    expect(plan[0]!.display).toBe('playwright test --grep "pays \\(visa\\)" --project=chromium');
+  });
+});

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -17,6 +17,10 @@ Targets for v1: **Windows (`.msi`)** and **macOS (`.dmg`)**. Linux is deferred.
    window at the server via a one-time token bootstrap (`/__piwi/session`).
 3. The tray offers **Run in background** (keep serving after the window closes),
    **Start on login**, and **Open data folder**.
+4. The dashboard can link a Piwi project to a folder on this machine and run
+   `playwright test` there (`src-tauri/src/runner.rs`): the shell resolves the
+   folder's own Playwright package, executes it with the bundled Node sidecar,
+   and streams output back to the webview as `piwi:local-run` events.
 
 Local access is gated by a per-launch token (see
 `application/server/middleware/desktop-guard.ts`), so only the app — not other

--- a/desktop/e2e/tests/shell.spec.ts
+++ b/desktop/e2e/tests/shell.spec.ts
@@ -38,4 +38,24 @@ test('the dashboard can reach the shell IPC commands', async ({ tauriPage }) => 
 
   expect(result.ok, `invoke was rejected: ${result.error ?? 'unknown'}`).toBe(true);
   expect(result.keys).toEqual(expect.arrayContaining(['run_in_background', 'start_on_login']));
+
+  // The local-runner commands are granted too: an unknown project resolves to
+  // null (not an ACL rejection)…
+  const link = (await tauriPage.evaluate(`
+    window.__TAURI__.core.invoke('desktop_get_project_link', { projectId: 'e2e-no-such-project' })
+      .then((l) => ({ ok: true, link: l ?? null }))
+      .catch((e) => ({ ok: false, error: String((e && e.message) || e) }))
+  `)) as { ok: boolean; error?: string; link?: unknown };
+  expect(link.ok, `desktop_get_project_link rejected: ${link.error ?? 'unknown'}`).toBe(true);
+  expect(link.link).toBeNull();
+
+  // …and a relative path is refused by the command's own validation, proving
+  // the call went through the ACL and into the handler.
+  const rejected = (await tauriPage.evaluate(`
+    window.__TAURI__.core.invoke('desktop_set_project_link', { projectId: 'e2e-no-such-project', path: 'not/absolute' })
+      .then(() => ({ rejected: false, error: '' }))
+      .catch((e) => ({ rejected: true, error: String((e && e.message) || e) }))
+  `)) as { rejected: boolean; error: string };
+  expect(rejected.rejected).toBe(true);
+  expect(rejected.error).toContain('absolute');
 });

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@piwitests/desktop",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@piwitests/desktop",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@srsholmes/tauri-playwright": "^0.4.1",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "piwi-desktop"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "rand 0.8.7",
  "serde",
@@ -2511,6 +2511,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-playwright",
@@ -2877,6 +2878,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3617,6 +3642,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.19",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "toml 1.1.3+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -19,6 +19,11 @@ fn main() {
             "desktop_open_external",
             "desktop_notify",
             "desktop_save_download",
+            "desktop_pick_folder",
+            "desktop_get_project_link",
+            "desktop_set_project_link",
+            "desktop_run_local_tests",
+            "desktop_stop_local_tests",
         ])),
     )
     .expect("failed to run tauri-build");

--- a/desktop/src-tauri/capabilities/remote.json
+++ b/desktop/src-tauri/capabilities/remote.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "remote-desktop-controls",
-  "description": "Let the bundled dashboard, served from the local loopback server, call the app's own IPC commands: read/set the service settings (run in background, start on login), open external links in the OS browser, show native notifications, and save downloads. Scoped to the loopback origins the sidecar binds — no external site is granted access, and only the desktop webview has the native bridge.",
+  "description": "Let the bundled dashboard, served from the local loopback server, call the app's own IPC commands: read/set the service settings (run in background, start on login), open external links in the OS browser, show native notifications, save downloads, manage per-project linked folders, and run Playwright tests in a linked folder with streamed output. Scoped to the loopback origins the sidecar binds — no external site is granted access, and only the desktop webview has the native bridge.",
   "windows": ["main"],
   "remote": {
     "urls": ["http://localhost:*", "http://127.0.0.1:*"]
@@ -13,6 +13,11 @@
     "allow-desktop-set-start-on-login",
     "allow-desktop-open-external",
     "allow-desktop-notify",
-    "allow-desktop-save-download"
+    "allow-desktop-save-download",
+    "allow-desktop-pick-folder",
+    "allow-desktop-get-project-link",
+    "allow-desktop-set-project-link",
+    "allow-desktop-run-local-tests",
+    "allow-desktop-stop-local-tests"
   ]
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@
 // and "start on login". Everything binds 127.0.0.1 — nothing is exposed to the
 // network.
 
+mod runner;
+
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -28,7 +30,12 @@ use tauri_plugin_shell::process::CommandChild;
 use tauri_plugin_shell::ShellExt as _;
 use tauri_plugin_store::StoreExt as _;
 
-const STORE_FILE: &str = "settings.json";
+use runner::{
+    desktop_get_project_link, desktop_pick_folder, desktop_run_local_tests,
+    desktop_set_project_link, desktop_stop_local_tests,
+};
+
+pub(crate) const STORE_FILE: &str = "settings.json";
 const RUN_BG_KEY: &str = "runInBackground";
 const READY_TIMEOUT_SECS: u64 = 60;
 /// Preferred loopback port — stable so the reporter can target it; falls back to
@@ -166,7 +173,7 @@ fn write_discovery_file(home: &Path, port: u16, token: &str) -> std::io::Result<
 /// Windows, Tauri's resource + app-data paths come back with the `\\?\` verbatim
 /// prefix, which Node's module resolver mishandles (it splits `\\?\C:\...` wrong
 /// and dies with `EISDIR: lstat 'C:'`) — strip it. No-op on other platforms.
-fn node_path(p: &std::path::Path) -> String {
+pub(crate) fn node_path(p: &std::path::Path) -> String {
     let s = p.to_string_lossy();
     s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
 }
@@ -356,6 +363,7 @@ pub fn run() {
             }
         }))
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_autostart::init(
@@ -379,9 +387,15 @@ pub fn run() {
             desktop_set_start_on_login,
             desktop_open_external,
             desktop_notify,
-            desktop_save_download
+            desktop_save_download,
+            desktop_pick_folder,
+            desktop_get_project_link,
+            desktop_set_project_link,
+            desktop_run_local_tests,
+            desktop_stop_local_tests
         ])
         .manage(ServerProcess::default())
+        .manage(runner::LocalRuns::default())
         .setup(move |app| {
             // --- data locations (survive app updates; outside the read-only bundle) ---
             let app_data_dir = app.path().app_data_dir()?;
@@ -666,6 +680,10 @@ pub fn run() {
                 // Best-effort: stop the bundled server so no orphan process lingers.
                 if let Some(child) = app_handle.state::<ServerProcess>().0.lock().unwrap().take() {
                     let _ = child.kill();
+                }
+                // Local test runs die with the shell — never orphan a browser fleet.
+                if let Some(runs) = app_handle.try_state::<runner::LocalRuns>() {
+                    runs.kill_all();
                 }
                 // Withdraw the reporter discovery file with the server it points
                 // at, so a later test run does not try a dead port.

--- a/desktop/src-tauri/src/runner.rs
+++ b/desktop/src-tauri/src/runner.rs
@@ -1,0 +1,280 @@
+// Local test execution for linked project folders.
+//
+// A Piwi project can be linked to a folder on this machine — the checkout that
+// produces its test runs. The link is what makes "run these tests locally"
+// possible: the shell resolves that folder's own Playwright installation and
+// executes it with the bundled Node sidecar, streaming output back to the
+// dashboard webview as events. Results reach the dashboard the same way any
+// local run does: the project's Playwright config already reports to Piwi, and
+// the reporter discovers this app via `~/.piwi/desktop.json`.
+//
+// Links live in the shell's own store (`settings.json`), not the server
+// database — a folder path is a fact about this machine, not about the project.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
+
+use serde_json::json;
+use tauri::{AppHandle, Emitter as _, Manager as _};
+use tauri_plugin_dialog::DialogExt as _;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt as _;
+use tauri_plugin_store::StoreExt as _;
+
+use crate::{node_path, STORE_FILE};
+
+/// Store key holding the `{ project id → absolute folder path }` map.
+const PROJECT_LINKS_KEY: &str = "projectLinks";
+
+/// Event channel every local run reports on; the payload carries the run id so
+/// the webview can tell concurrent runs apart.
+const RUN_EVENT: &str = "piwi:local-run";
+
+/// How many ancestors of the linked folder to search for a `node_modules`
+/// containing Playwright — covers monorepos with hoisted installs.
+const MAX_NODE_MODULES_WALK: usize = 12;
+
+/// `playwright test` flags the dashboard may pass. Anything else dash-like is
+/// rejected, so the webview cannot redirect config, output or reporters.
+const ALLOWED_FLAGS: [&str; 12] = [
+    "--headed",
+    "--debug",
+    "--ui",
+    "--trace",
+    "--repeat-each",
+    "--project",
+    "--grep",
+    "--workers",
+    "--retries",
+    "--max-failures",
+    "--timeout",
+    "--last-failed",
+];
+
+/// Running local test processes, keyed by run id so the webview can stop one.
+#[derive(Default)]
+pub struct LocalRuns {
+    next_id: AtomicU32,
+    children: Mutex<HashMap<u32, CommandChild>>,
+}
+
+impl LocalRuns {
+    /// Kill every process still tracked — called when the app exits so no
+    /// orphaned test run outlives the shell.
+    pub fn kill_all(&self) {
+        for (_, child) in self.children.lock().unwrap().drain() {
+            let _ = child.kill();
+        }
+    }
+}
+
+fn read_links(app: &AppHandle) -> HashMap<String, String> {
+    app.store(STORE_FILE)
+        .ok()
+        .and_then(|s| s.get(PROJECT_LINKS_KEY))
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
+}
+
+#[derive(serde::Serialize)]
+pub struct ProjectLink {
+    path: String,
+    exists: bool,
+}
+
+/// Native folder picker. Returns `None` when the user cancels.
+#[tauri::command]
+pub async fn desktop_pick_folder(app: AppHandle) -> Option<String> {
+    let dialog = app.dialog().file();
+    // The blocking picker must not run on the IPC/async worker it was called
+    // from — park it on a blocking thread and await the result.
+    tauri::async_runtime::spawn_blocking(move || {
+        dialog
+            .blocking_pick_folder()
+            .and_then(|f| f.into_path().ok())
+            .map(|p| p.to_string_lossy().to_string())
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+#[tauri::command]
+pub fn desktop_get_project_link(app: AppHandle, project_id: String) -> Option<ProjectLink> {
+    read_links(&app).get(&project_id).map(|p| ProjectLink {
+        exists: Path::new(p).is_dir(),
+        path: p.clone(),
+    })
+}
+
+/// Set (`path: Some`) or clear (`path: None`) the folder linked to a project.
+#[tauri::command]
+pub fn desktop_set_project_link(
+    app: AppHandle,
+    project_id: String,
+    path: Option<String>,
+) -> Result<(), String> {
+    if project_id.trim().is_empty() {
+        return Err("missing project id".into());
+    }
+    let mut links = read_links(&app);
+    match path {
+        Some(p) => {
+            let folder = PathBuf::from(&p);
+            if !folder.is_absolute() {
+                return Err("the folder path must be absolute".into());
+            }
+            if !folder.is_dir() {
+                return Err("the folder does not exist".into());
+            }
+            links.insert(project_id, p);
+        }
+        None => {
+            links.remove(&project_id);
+        }
+    }
+    let store = app.store(STORE_FILE).map_err(|e| e.to_string())?;
+    store.set(PROJECT_LINKS_KEY, json!(links));
+    store.save().map_err(|e| e.to_string())
+}
+
+/// Find the linked folder's own Playwright CLI entry, walking up so a package
+/// inside a monorepo with a hoisted root `node_modules` still resolves.
+fn resolve_playwright_cli(start: &Path) -> Option<PathBuf> {
+    let candidates = ["@playwright/test/cli.js", "playwright/cli.js"];
+    let mut dir = Some(start);
+    for _ in 0..MAX_NODE_MODULES_WALK {
+        let d = dir?;
+        for candidate in candidates {
+            let p = d.join("node_modules").join(candidate);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+fn validate_args(args: &[String]) -> Result<(), String> {
+    for arg in args {
+        if arg.contains('\0') {
+            return Err("invalid argument".into());
+        }
+        if arg.starts_with('-') {
+            let flag = arg.split('=').next().unwrap_or(arg);
+            if !ALLOWED_FLAGS.contains(&flag) {
+                return Err(format!("flag not allowed: {flag}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, serde::Serialize)]
+struct RunEventPayload {
+    id: u32,
+    kind: &'static str,
+    line: Option<String>,
+    code: Option<i32>,
+}
+
+/// Run `playwright test <args>` in the folder linked to `project_id`, using the
+/// bundled Node sidecar and the folder's own Playwright package. Returns a run
+/// id; progress arrives as `piwi:local-run` events carrying that id.
+#[tauri::command]
+pub async fn desktop_run_local_tests(
+    app: AppHandle,
+    project_id: String,
+    args: Vec<String>,
+) -> Result<u32, String> {
+    validate_args(&args)?;
+
+    let folder = read_links(&app)
+        .get(&project_id)
+        .map(PathBuf::from)
+        .ok_or("no folder is linked to this project")?;
+    if !folder.is_dir() {
+        return Err("the linked folder no longer exists — pick it again".into());
+    }
+    let cli = resolve_playwright_cli(&folder).ok_or(
+        "no Playwright installation found in the linked folder (or its parents) — run your package manager's install first",
+    )?;
+
+    let mut cmd_args: Vec<String> = vec![node_path(&cli), "test".into()];
+    cmd_args.extend(args);
+
+    let command = app
+        .shell()
+        .sidecar("node")
+        .map_err(|e| e.to_string())?
+        .args(cmd_args)
+        .current_dir(folder)
+        // Plain text for the in-app output pane.
+        .env("NO_COLOR", "1")
+        .env("FORCE_COLOR", "0");
+
+    let (mut rx, child) = command.spawn().map_err(|e| e.to_string())?;
+
+    let state = app.state::<LocalRuns>();
+    let id = state.next_id.fetch_add(1, Ordering::SeqCst) + 1;
+    state.children.lock().unwrap().insert(id, child);
+
+    let emit_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            let payload = match event {
+                CommandEvent::Stdout(line) => RunEventPayload {
+                    id,
+                    kind: "stdout",
+                    line: Some(String::from_utf8_lossy(&line).trim_end().to_string()),
+                    code: None,
+                },
+                CommandEvent::Stderr(line) => RunEventPayload {
+                    id,
+                    kind: "stderr",
+                    line: Some(String::from_utf8_lossy(&line).trim_end().to_string()),
+                    code: None,
+                },
+                CommandEvent::Error(err) => RunEventPayload {
+                    id,
+                    kind: "error",
+                    line: Some(err),
+                    code: None,
+                },
+                CommandEvent::Terminated(status) => {
+                    if let Some(runs) = emit_app.try_state::<LocalRuns>() {
+                        runs.children.lock().unwrap().remove(&id);
+                    }
+                    RunEventPayload {
+                        id,
+                        kind: "exit",
+                        line: None,
+                        code: status.code,
+                    }
+                }
+                _ => continue,
+            };
+            let _ = emit_app.emit(RUN_EVENT, &payload);
+        }
+    });
+
+    Ok(id)
+}
+
+/// Stop a running local test process. A run that already exited is a no-op.
+#[tauri::command]
+pub fn desktop_stop_local_tests(app: AppHandle, run_id: u32) -> Result<(), String> {
+    let child = app
+        .state::<LocalRuns>()
+        .children
+        .lock()
+        .unwrap()
+        .remove(&run_id);
+    match child {
+        Some(c) => c.kill().map_err(|e| e.to_string()),
+        None => Ok(()),
+    }
+}

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -99,6 +99,37 @@ actual one).
 > *other machines* over the network is intentionally not supported in the desktop
 > build — run the [Docker image](/deployment) for a shared, always-on server.
 
+## Running tests from the app
+
+A failing run is one click from a local retry. On a run page (or a single
+execution page), **Run locally** re-runs the failed tests on this machine:
+
+1. **Link the Piwi project to its checkout** — the folder that contains the
+   tests. The app asks on first use, or link it any time on the project page
+   under **Local folder**. The link stays on this machine; it is never sent
+   anywhere.
+2. **Pick what to re-run and how** — by `file:line`, title or file; headless,
+   headed, the Playwright inspector or UI mode; optional trace recording; and
+   `--repeat-each` up to 1000× for flake reproduction.
+3. **Run.** The app executes the folder's *own* Playwright with the app's
+   bundled Node — nothing extra to install — and streams the output into the
+   dialog. The exact command is shown before anything runs, and **Stop** (or
+   closing the dialog) kills the process.
+
+Results flow back automatically: the run executes your project's regular
+Playwright config, so the Piwi reporter in it reports to this app through the
+[discovery file](#sending-results-to-it), exactly like a run started from your
+terminal.
+
+Two prerequisites, both usually already true for a project that reports to
+Piwi: the linked folder has `@playwright/test` installed (`node_modules`
+present — monorepos with a hoisted root install work too), and its Playwright
+config includes the Piwi reporter.
+
+The linked folder also completes [Open in IDE](/ide-integration): when no
+workspace root is configured there, source links resolve against the linked
+folder automatically.
+
 ## Building from source
 
 See [`desktop/README.md`](https://github.com/PiwiTests/platform/blob/main/desktop/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
     },
     "application": {
       "name": "@piwitests/dashboard",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -173,7 +173,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -26293,11 +26293,11 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.18.2"
+      "version": "0.19.0"
     },
     "packages/server": {
       "name": "@piwitests/server",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.17.4",
@@ -26312,7 +26312,7 @@
     },
     "reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"


### PR DESCRIPTION
## What & why

The desktop app becomes a workbench instead of a viewer: a failing run is now one click from a local retry.

- **Project ↔ local folder linking.** A Piwi project can be linked to its checkout on this machine via a native folder picker — from the project page's new **Local folder** card or on first use of the run dialog. Links live in the shell's own settings store (a folder path is a fact about this machine, not the project), and the dashboard reaches them over the existing IPC bridge.
- **Run locally.** Run pages and single-execution pages get a desktop-only **Run locally** button: pick test selection (`file:line` / title / file), headless / headed / inspector / UI mode, optional `--trace=on`, and `--repeat-each` up to 1000× for flake reproduction. The shell resolves the linked folder's *own* Playwright package (walking up for hoisted monorepo installs), executes it with the bundled Node sidecar, and streams output back as `piwi:local-run` events into a live output pane. The exact command is always shown before anything runs.
- **Results loop closes by itself.** The run executes the project's regular Playwright config, so its Piwi reporter reports back to the app through the existing `~/.piwi/desktop.json` discovery — the new run appears in the dashboard like any terminal-started run.
- **Open in IDE with zero setup.** When no workspace root is configured, IDE links now resolve against the linked folder.

Safety posture: argv is validated shell-side against a `playwright test` flag allowlist (no shell, no config/output/reporter redirection), commands only run inside explicitly linked folders, closing the dialog stops the process, and all local runs are killed when the app exits. New IPC commands are wired through `build.rs` + `capabilities/remote.json`, enforced by the existing `desktop-acl-consistency` unit test.

## How was it tested?

- `cargo check` + `rustfmt --check` on the shell crate (new `runner.rs` module).
- Unit tests: new `local-run-args.test.ts` (grouping, dedup, flag composition, clamping, display quoting); `desktop-acl-consistency` validates the three-way ACL wiring. Full suite: 1132 passed.
- New app E2E spec `desktop-local-run.spec.ts` drives the real components against a faked `window.__TAURI__` bridge: button absent without the bridge, linked happy path (command preview → run → streamed output → passed badge → argv assertions), and the link-a-folder-first flow. 3/3 passed locally.
- Desktop shell E2E (`desktop/e2e`) extended with runtime ACL assertions for the new commands (runs on macOS CI).
- `nuxt typecheck`, oxlint, oxfmt all clean.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/desktop.md` "Running tests from the app", `desktop/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzMq6FrbK7RBHFMWymwkJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzMq6FrbK7RBHFMWymwkJN)_