### PR TITLE
feat(app): one-click MCP client configuration in the desktop app

### DIFF
--- a/application/app/components/desktop/DesktopMcpClientsCard.vue
+++ b/application/app/components/desktop/DesktopMcpClientsCard.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: one-click MCP client configuration. The shell detects
+ * installed clients (Claude Code, Claude Desktop, Cursor, VS Code, Windsurf,
+ * Gemini CLI), writes the `piwi` entry into their own config files, and keeps
+ * written entries current across launches. Renders nothing without the IPC
+ * bridge, so the /mcp page can mount it unconditionally.
+ */
+interface McpClientStatus {
+  id: string;
+  label: string;
+  config_path: string;
+  status: 'not_installed' | 'not_connected' | 'connected' | 'stale' | 'manual';
+  detail: string | null;
+}
+
+const toast = useToast();
+
+const available = ref(false);
+const loading = ref(true);
+const clients = ref<McpClientStatus[]>([]);
+const busyId = ref<string | null>(null);
+
+async function refresh() {
+  const core = tauriCore();
+  if (!core) return;
+  try {
+    clients.value = await core.invoke<McpClientStatus[]>('desktop_mcp_clients');
+    available.value = true;
+  } catch {
+    available.value = false;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  if (tauriCore()) void refresh();
+  else loading.value = false;
+});
+
+async function setConnected(client: McpClientStatus, connect: boolean) {
+  const core = tauriCore();
+  if (!core) return;
+  busyId.value = client.id;
+  try {
+    const updated = await core.invoke<McpClientStatus>(connect ? 'desktop_mcp_connect' : 'desktop_mcp_disconnect', {
+      clientId: client.id,
+    });
+    clients.value = clients.value.map((c) => (c.id === updated.id ? updated : c));
+    toast.add({
+      title: connect ? `${client.label} connected` : `${client.label} disconnected`,
+      description: connect ? `Restart ${client.label} to pick up the new server.` : undefined,
+      color: 'success',
+      icon: 'i-lucide-plug',
+    });
+  } catch (error) {
+    toast.add({ title: `Could not update ${client.label}`, description: errorMessage(error), color: 'error' });
+  } finally {
+    busyId.value = null;
+  }
+}
+
+async function reveal(client: McpClientStatus) {
+  const core = tauriCore();
+  if (!core) return;
+  try {
+    await core.invoke('desktop_mcp_reveal', { clientId: client.id });
+  } catch (error) {
+    toast.add({ title: 'Could not open the file', description: errorMessage(error), color: 'error' });
+  }
+}
+
+function badgeOf(client: McpClientStatus): { label: string; color: 'success' | 'warning' | 'neutral' } | null {
+  switch (client.status) {
+    case 'connected':
+      return { label: 'Connected', color: 'success' };
+    case 'stale':
+      return { label: 'Needs update', color: 'warning' };
+    case 'manual':
+      return { label: 'Manual setup', color: 'warning' };
+    case 'not_installed':
+      return { label: 'Not detected', color: 'neutral' };
+    default:
+      return null;
+  }
+}
+</script>
+
+<template>
+  <SectionCard v-if="available" icon="i-lucide-plug-zap" title="Connect a client on this machine">
+    <template #subtitle>
+      One click writes the <code>piwi</code> entry into the client's own config file (a backup is kept next to it), and
+      entries are kept current when this app's address changes. Restart the client after connecting.
+    </template>
+
+    <div v-if="loading" class="flex items-center gap-2 text-sm text-muted">
+      <UIcon name="i-lucide-loader-2" class="size-4 animate-spin" /> Detecting clients…
+    </div>
+
+    <div v-else class="space-y-2">
+      <div
+        v-for="client in clients"
+        :key="client.id"
+        :data-testid="`mcp-client-${client.id}`"
+        class="flex items-center gap-3 rounded-md border border-default p-2.5"
+        :class="client.status === 'not_installed' ? 'opacity-60' : ''"
+      >
+        <UIcon name="i-lucide-bot" class="size-4 text-gray-400 shrink-0" />
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2">
+            <p class="text-sm font-medium">{{ client.label }}</p>
+            <UBadge v-if="badgeOf(client)" :color="badgeOf(client)!.color" variant="subtle" size="sm">
+              {{ badgeOf(client)!.label }}
+            </UBadge>
+          </div>
+          <p v-if="client.config_path" class="text-xs text-muted truncate">{{ client.config_path }}</p>
+          <p v-if="client.detail" class="text-xs text-warning">{{ client.detail }}</p>
+        </div>
+        <div class="flex items-center gap-1.5 shrink-0">
+          <UButton
+            v-if="client.status === 'not_connected'"
+            size="xs"
+            icon="i-lucide-plug"
+            :loading="busyId === client.id"
+            @click="setConnected(client, true)"
+          >
+            Connect
+          </UButton>
+          <UButton
+            v-else-if="client.status === 'stale'"
+            size="xs"
+            color="warning"
+            icon="i-lucide-refresh-cw"
+            :loading="busyId === client.id"
+            @click="setConnected(client, true)"
+          >
+            Update
+          </UButton>
+          <UButton
+            v-if="client.status === 'connected' || client.status === 'stale'"
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-lucide-unplug"
+            :loading="busyId === client.id"
+            @click="setConnected(client, false)"
+          >
+            Disconnect
+          </UButton>
+          <UButton
+            v-if="client.status !== 'not_installed' && client.config_path"
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-lucide-folder-open"
+            aria-label="Reveal config file"
+            title="Reveal config file"
+            @click="reveal(client)"
+          />
+        </div>
+      </div>
+
+      <p class="text-xs text-muted">
+        A client that is not listed — or marked manual — can always be connected with the snippets below.
+      </p>
+    </div>
+  </SectionCard>
+</template>

--- a/application/app/pages/mcp.vue
+++ b/application/app/pages/mcp.vue
@@ -128,6 +128,10 @@ const windsurfSnippet = computed(() =>
           description="The MCP endpoint is not active in this demo — it requires a real Piwi backend. The tools and client setup shown below reflect what your own deployment exposes."
         />
 
+        <!-- Desktop shell only: one-click writes into detected clients' config
+             files (renders nothing without the IPC bridge). -->
+        <DesktopMcpClientsCard />
+
         <!-- Client setup — the single place to connect any MCP client. On the
              desktop build this also carries the real URL + local access token,
              already baked into every snippet (no placeholder to swap). -->

--- a/application/tests/desktop-mcp-clients.spec.ts
+++ b/application/tests/desktop-mcp-clients.spec.ts
@@ -1,0 +1,128 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { waitForHydration } from './utils';
+
+/**
+ * The desktop-only MCP client configuration card on /mcp, driven against the
+ * regular web build with a faked Tauri bridge. Detection, file editing and
+ * healing live in the Rust shell (unit-tested there); this covers the
+ * dashboard side: statuses render, connect/disconnect round-trip, and the
+ * card stays out of plain browsers.
+ */
+
+interface FakeClient {
+  id: string;
+  label: string;
+  config_path: string;
+  status: string;
+  detail: string | null;
+}
+
+declare global {
+  interface Window {
+    __piwiMcpInvocations: { cmd: string; args: Record<string, unknown> | undefined }[];
+  }
+}
+
+async function installFakeBridge(page: Page) {
+  await page.addInitScript(() => {
+    const clients: FakeClient[] = [
+      {
+        id: 'claude-code',
+        label: 'Claude Code',
+        config_path: '/home/dev/.claude.json',
+        status: 'not_connected',
+        detail: null,
+      },
+      {
+        id: 'claude-desktop',
+        label: 'Claude Desktop',
+        config_path: '/home/dev/.config/Claude/claude_desktop_config.json',
+        status: 'stale',
+        detail: null,
+      },
+      { id: 'cursor', label: 'Cursor', config_path: '/home/dev/.cursor/mcp.json', status: 'connected', detail: null },
+      {
+        id: 'vscode',
+        label: 'VS Code',
+        config_path: '/home/dev/.config/Code/User/mcp.json',
+        status: 'manual',
+        detail: 'the file is not plain JSON — add the entry manually',
+      },
+      { id: 'windsurf', label: 'Windsurf', config_path: '', status: 'not_installed', detail: null },
+      {
+        id: 'gemini-cli',
+        label: 'Gemini CLI',
+        config_path: '/home/dev/.gemini/settings.json',
+        status: 'not_connected',
+        detail: null,
+      },
+    ];
+    const invocations: { cmd: string; args: Record<string, unknown> | undefined }[] = [];
+    Object.assign(window, { __piwiMcpInvocations: invocations });
+    Object.assign(window, {
+      __TAURI__: {
+        core: {
+          invoke: async (cmd: string, args?: Record<string, unknown>) => {
+            invocations.push({ cmd, args });
+            switch (cmd) {
+              case 'desktop_mcp_clients':
+                return clients;
+              case 'desktop_mcp_connect':
+              case 'desktop_mcp_disconnect': {
+                const client = clients.find((c) => c.id === args?.clientId);
+                if (!client) throw new Error('unknown client');
+                client.status = cmd === 'desktop_mcp_connect' ? 'connected' : 'not_connected';
+                return client;
+              }
+              case 'desktop_take_pending_open_files':
+                return [];
+              default:
+                throw new Error(`unexpected command: ${cmd}`);
+            }
+          },
+        },
+        event: {
+          listen: async () => () => {},
+        },
+      },
+    });
+  });
+}
+
+test.describe('Desktop MCP client configuration', () => {
+  test('the card does not exist without the bridge', async ({ page }) => {
+    await page.goto('/mcp');
+    await waitForHydration(page);
+    await expect(page.getByRole('heading', { name: 'MCP server' }).first()).toBeVisible();
+    await expect(page.getByText('Connect a client on this machine')).toHaveCount(0);
+  });
+
+  test('shows detected clients and connects one', async ({ page }) => {
+    await installFakeBridge(page);
+    await page.goto('/mcp');
+    await waitForHydration(page);
+
+    await expect(page.getByText('Connect a client on this machine')).toBeVisible();
+
+    // One row per status flavor.
+    await expect(page.getByTestId('mcp-client-cursor').getByText('Connected')).toBeVisible();
+    await expect(page.getByTestId('mcp-client-claude-desktop').getByText('Needs update')).toBeVisible();
+    await expect(page.getByTestId('mcp-client-vscode').getByText('Manual setup')).toBeVisible();
+    await expect(page.getByTestId('mcp-client-windsurf').getByText('Not detected')).toBeVisible();
+
+    const claudeCode = page.getByTestId('mcp-client-claude-code');
+    await claudeCode.getByRole('button', { name: 'Connect' }).click();
+    await expect(claudeCode.getByText('Connected')).toBeVisible();
+    await expect(claudeCode.getByRole('button', { name: 'Disconnect' })).toBeVisible();
+
+    const connectCall = await page.evaluate(() =>
+      window.__piwiMcpInvocations.find((i) => i.cmd === 'desktop_mcp_connect'),
+    );
+    expect(connectCall?.args?.clientId).toBe('claude-code');
+
+    // Disconnect round-trips too.
+    await claudeCode.getByRole('button', { name: 'Disconnect' }).click();
+    await expect(claudeCode.getByRole('button', { name: 'Connect' })).toBeVisible();
+  });
+});

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -26,6 +26,10 @@ Targets for v1: **Windows (`.msi`)** and **macOS (`.dmg`)**. Linux is deferred.
    dashboard over IPC (`desktop_take_pending_open_files` + a `piwi:open-files`
    poke), which imports them by path through the desktop-only
    `/api/desktop/import-local` route.
+6. The dashboard's /mcp page can write the `piwi` MCP entry into detected
+   clients' config files (`src-tauri/src/mcp_clients.rs`): strict-JSON merge
+   of one key with a backup next to the file, and a startup pass that rewrites
+   entries whose URL/token drifted after a port change.
 
 Local access is gated by a per-launch token (see
 `application/server/middleware/desktop-guard.ts`), so only the app — not other

--- a/desktop/e2e/tests/shell.spec.ts
+++ b/desktop/e2e/tests/shell.spec.ts
@@ -58,4 +58,15 @@ test('the dashboard can reach the shell IPC commands', async ({ tauriPage }) => 
   `)) as { rejected: boolean; error: string };
   expect(rejected.rejected).toBe(true);
   expect(rejected.error).toContain('absolute');
+
+  // The MCP configurator command is granted and reports every known client.
+  const mcp = (await tauriPage.evaluate(`
+    window.__TAURI__.core.invoke('desktop_mcp_clients')
+      .then((list) => ({ ok: true, ids: (list || []).map((c) => c.id) }))
+      .catch((e) => ({ ok: false, error: String((e && e.message) || e) }))
+  `)) as { ok: boolean; error?: string; ids?: string[] };
+  expect(mcp.ok, `desktop_mcp_clients rejected: ${mcp.error ?? 'unknown'}`).toBe(true);
+  expect(mcp.ids).toEqual(
+    expect.arrayContaining(['claude-code', 'claude-desktop', 'cursor', 'vscode', 'windsurf', 'gemini-cli']),
+  );
 });

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -25,6 +25,10 @@ fn main() {
             "desktop_run_local_tests",
             "desktop_stop_local_tests",
             "desktop_take_pending_open_files",
+            "desktop_mcp_clients",
+            "desktop_mcp_connect",
+            "desktop_mcp_disconnect",
+            "desktop_mcp_reveal",
         ])),
     )
     .expect("failed to run tauri-build");

--- a/desktop/src-tauri/capabilities/remote.json
+++ b/desktop/src-tauri/capabilities/remote.json
@@ -19,6 +19,10 @@
     "allow-desktop-set-project-link",
     "allow-desktop-run-local-tests",
     "allow-desktop-stop-local-tests",
-    "allow-desktop-take-pending-open-files"
+    "allow-desktop-take-pending-open-files",
+    "allow-desktop-mcp-clients",
+    "allow-desktop-mcp-connect",
+    "allow-desktop-mcp-disconnect",
+    "allow-desktop-mcp-reveal"
   ]
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@
 // and "start on login". Everything binds 127.0.0.1 — nothing is exposed to the
 // network.
 
+mod mcp_clients;
 mod runner;
 
 use std::path::{Path, PathBuf};
@@ -30,6 +31,7 @@ use tauri_plugin_shell::process::CommandChild;
 use tauri_plugin_shell::ShellExt as _;
 use tauri_plugin_store::StoreExt as _;
 
+use mcp_clients::{desktop_mcp_clients, desktop_mcp_connect, desktop_mcp_disconnect, desktop_mcp_reveal};
 use runner::{
     desktop_get_project_link, desktop_pick_folder, desktop_run_local_tests,
     desktop_set_project_link, desktop_stop_local_tests,
@@ -432,7 +434,11 @@ pub fn run() {
             desktop_set_project_link,
             desktop_run_local_tests,
             desktop_stop_local_tests,
-            desktop_take_pending_open_files
+            desktop_take_pending_open_files,
+            desktop_mcp_clients,
+            desktop_mcp_connect,
+            desktop_mcp_disconnect,
+            desktop_mcp_reveal
         ])
         .manage(ServerProcess::default())
         .manage(runner::LocalRuns::default())
@@ -460,6 +466,12 @@ pub fn run() {
             let port = pick_port();
 
             app.manage(DataDir(data_dir.clone()));
+            app.manage(mcp_clients::ServerInfo { port, token: token.clone() });
+
+            // MCP client configs written on earlier launches embed the URL and
+            // token — bring any that drifted (a different port this launch)
+            // back in line before a client tries the dead address.
+            mcp_clients::heal_configured_clients(app.handle());
 
             // --- publish connection details for the Playwright reporter ---
             match app.path().home_dir().map_err(|e| e.to_string()).and_then(|home| {

--- a/desktop/src-tauri/src/mcp_clients.rs
+++ b/desktop/src-tauri/src/mcp_clients.rs
@@ -1,0 +1,376 @@
+// One-click MCP client configuration.
+//
+// The dashboard's /mcp page shows copy-paste snippets for connecting MCP
+// clients; on this machine the shell can do better and write the client's own
+// config file. Every client is configured the same way: a `piwi` entry inside
+// the client's server map, pointing at this app's /mcp endpoint with the local
+// access token as the Bearer header.
+//
+// Editing another app's config is done conservatively:
+//   - only strict JSON is ever rewritten — a file that does not parse (JSONC
+//     with comments, trailing commas) is reported as `manual` and left alone;
+//   - the previous content is copied to `<file>.piwi-backup` before a write;
+//   - only the `piwi` key is added, updated or removed — everything else in
+//     the file is preserved as parsed.
+//
+// The written URL embeds the port picked at launch, which is not guaranteed
+// across launches — so `heal_configured_clients` runs at startup and rewrites
+// any entry that no longer matches the live URL/token.
+
+use std::path::PathBuf;
+
+use serde_json::{json, Map, Value};
+use tauri::{AppHandle, Manager as _};
+use tauri_plugin_opener::OpenerExt as _;
+
+/// The live connection details every written entry must match.
+pub struct ServerInfo {
+    pub port: u16,
+    pub token: String,
+}
+
+impl ServerInfo {
+    fn mcp_url(&self) -> String {
+        format!("http://127.0.0.1:{}/mcp", self.port)
+    }
+    fn bearer(&self) -> String {
+        format!("Bearer {}", self.token)
+    }
+}
+
+const CLIENT_IDS: [&str; 6] = [
+    "claude-code",
+    "claude-desktop",
+    "cursor",
+    "vscode",
+    "windsurf",
+    "gemini-cli",
+];
+
+/// The key under which clients keep their MCP server map.
+fn container_key(id: &str) -> &'static str {
+    match id {
+        "vscode" => "servers",
+        _ => "mcpServers",
+    }
+}
+
+fn label_of(id: &str) -> &'static str {
+    match id {
+        "claude-code" => "Claude Code",
+        "claude-desktop" => "Claude Desktop",
+        "cursor" => "Cursor",
+        "vscode" => "VS Code",
+        "windsurf" => "Windsurf",
+        "gemini-cli" => "Gemini CLI",
+        _ => "Unknown",
+    }
+}
+
+/// The `piwi` entry in each client's native shape.
+fn entry_for(id: &str, info: &ServerInfo) -> Value {
+    let url = info.mcp_url();
+    let bearer = info.bearer();
+    match id {
+        "cursor" => json!({ "url": url, "headers": { "Authorization": bearer } }),
+        "windsurf" => json!({ "serverUrl": url, "headers": { "Authorization": bearer } }),
+        "gemini-cli" => json!({ "httpUrl": url, "headers": { "Authorization": bearer } }),
+        // Claude Code, Claude Desktop and VS Code share the `type: http` shape.
+        _ => json!({ "type": "http", "url": url, "headers": { "Authorization": bearer } }),
+    }
+}
+
+/// Where the client keeps the config to edit, and the directory whose presence
+/// means "this client is installed on this machine".
+fn paths_of(app: &AppHandle, id: &str) -> Option<(PathBuf, PathBuf)> {
+    let home = app.path().home_dir().ok()?;
+    // ~/Library/Application Support (macOS), %APPDATA% (Windows), ~/.config (Linux).
+    let config = app.path().config_dir().ok()?;
+    match id {
+        "claude-code" => Some((home.join(".claude.json"), home.join(".claude"))),
+        "claude-desktop" => Some((
+            config.join("Claude").join("claude_desktop_config.json"),
+            config.join("Claude"),
+        )),
+        "cursor" => Some((home.join(".cursor").join("mcp.json"), home.join(".cursor"))),
+        "vscode" => Some((
+            config.join("Code").join("User").join("mcp.json"),
+            config.join("Code").join("User"),
+        )),
+        "windsurf" => Some((
+            home.join(".codeium")
+                .join("windsurf")
+                .join("mcp_config.json"),
+            home.join(".codeium").join("windsurf"),
+        )),
+        "gemini-cli" => Some((
+            home.join(".gemini").join("settings.json"),
+            home.join(".gemini"),
+        )),
+        _ => None,
+    }
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct McpClientStatus {
+    id: String,
+    label: String,
+    /// The config file the shell would edit; shown so the user can verify.
+    config_path: String,
+    /// `not_installed` | `not_connected` | `connected` | `stale` | `manual`
+    status: &'static str,
+    /// For `manual`: why the file cannot be edited safely.
+    detail: Option<String>,
+}
+
+/// Pure classification of a client's parsed config against the live entry.
+fn classify(existing: Option<&Value>, container: &str, expected: &Value) -> &'static str {
+    match existing
+        .and_then(|v| v.get(container))
+        .and_then(|c| c.get("piwi"))
+    {
+        None => "not_connected",
+        Some(current) if current == expected => "connected",
+        Some(_) => "stale",
+    }
+}
+
+/// Set or remove the `piwi` entry, preserving everything else. `entry: None`
+/// removes. Returns the new document.
+fn merge_piwi_entry(existing: Value, container: &str, entry: Option<Value>) -> Value {
+    let mut root = match existing {
+        Value::Object(map) => map,
+        // A non-object root would be a broken config; start over rather than
+        // producing invalid nesting. (Reached only for empty/new files.)
+        _ => Map::new(),
+    };
+    let servers = root
+        .entry(container.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !servers.is_object() {
+        *servers = Value::Object(Map::new());
+    }
+    let map = servers.as_object_mut().expect("container is an object");
+    match entry {
+        Some(value) => {
+            map.insert("piwi".to_string(), value);
+        }
+        None => {
+            map.remove("piwi");
+        }
+    }
+    Value::Object(root)
+}
+
+fn read_config(path: &PathBuf) -> Result<Option<Value>, String> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.to_string()),
+    };
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_str::<Value>(&raw).map(Some).map_err(|_| {
+        "the file is not plain JSON (comments or trailing commas?) — add the entry manually"
+            .to_string()
+    })
+}
+
+fn status_of(app: &AppHandle, id: &str, info: &ServerInfo) -> McpClientStatus {
+    let (config_path, detect_dir) = match paths_of(app, id) {
+        Some(paths) => paths,
+        None => {
+            return McpClientStatus {
+                id: id.to_string(),
+                label: label_of(id).to_string(),
+                config_path: String::new(),
+                status: "not_installed",
+                detail: None,
+            };
+        }
+    };
+    let installed = detect_dir.exists() || config_path.is_file();
+    let status = if !installed {
+        "not_installed"
+    } else {
+        match read_config(&config_path) {
+            Err(_) => "manual",
+            Ok(existing) => classify(existing.as_ref(), container_key(id), &entry_for(id, info)),
+        }
+    };
+    McpClientStatus {
+        id: id.to_string(),
+        label: label_of(id).to_string(),
+        config_path: config_path.to_string_lossy().to_string(),
+        status,
+        detail: if status == "manual" {
+            read_config(&config_path).err()
+        } else {
+            None
+        },
+    }
+}
+
+fn write_config(path: &PathBuf, doc: &Value) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    // Keep the previous content recoverable — this is another app's file.
+    if path.is_file() {
+        let _ = std::fs::copy(path, path.with_extension("piwi-backup.json"));
+    }
+    let body = serde_json::to_string_pretty(doc).map_err(|e| e.to_string())? + "\n";
+    std::fs::write(path, body).map_err(|e| e.to_string())
+}
+
+fn set_entry(app: &AppHandle, id: &str, connect: bool) -> Result<McpClientStatus, String> {
+    let info = app
+        .try_state::<ServerInfo>()
+        .ok_or("server details unavailable")?;
+    let (config_path, detect_dir) = paths_of(app, id).ok_or("unknown client")?;
+    if !detect_dir.exists() && !config_path.is_file() {
+        return Err(format!("{} does not appear to be installed", label_of(id)));
+    }
+    let existing = read_config(&config_path)?.unwrap_or_else(|| json!({}));
+    let entry = if connect {
+        Some(entry_for(id, &info))
+    } else {
+        None
+    };
+    let doc = merge_piwi_entry(existing, container_key(id), entry);
+    write_config(&config_path, &doc)?;
+    Ok(status_of(app, id, &info))
+}
+
+/// Rewrite the entry of every already-configured client whose URL or token no
+/// longer matches — the port is not guaranteed across launches. Quietly skips
+/// anything unreadable or manual.
+pub fn heal_configured_clients(app: &AppHandle) {
+    let Some(info) = app.try_state::<ServerInfo>() else {
+        return;
+    };
+    for id in CLIENT_IDS {
+        let status = status_of(app, id, &info);
+        if status.status == "stale" {
+            let _ = set_entry(app, id, true);
+        }
+    }
+}
+
+#[tauri::command]
+pub fn desktop_mcp_clients(app: AppHandle) -> Result<Vec<McpClientStatus>, String> {
+    let info = app
+        .try_state::<ServerInfo>()
+        .ok_or("server details unavailable")?;
+    Ok(CLIENT_IDS
+        .iter()
+        .map(|id| status_of(&app, id, &info))
+        .collect())
+}
+
+#[tauri::command]
+pub fn desktop_mcp_connect(app: AppHandle, client_id: String) -> Result<McpClientStatus, String> {
+    set_entry(&app, &client_id, true)
+}
+
+#[tauri::command]
+pub fn desktop_mcp_disconnect(
+    app: AppHandle,
+    client_id: String,
+) -> Result<McpClientStatus, String> {
+    set_entry(&app, &client_id, false)
+}
+
+/// Reveal a client's config file in the OS file manager. The path is resolved
+/// from the client id — never taken from the caller — so the webview cannot
+/// reveal arbitrary paths.
+#[tauri::command]
+pub fn desktop_mcp_reveal(app: AppHandle, client_id: String) -> Result<(), String> {
+    let (config_path, _) = paths_of(&app, &client_id).ok_or("unknown client")?;
+    if !config_path.is_file() {
+        return Err("the config file does not exist yet".into());
+    }
+    app.opener()
+        .reveal_item_in_dir(&config_path)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info() -> ServerInfo {
+        ServerInfo {
+            port: 3000,
+            token: "pd_test".into(),
+        }
+    }
+
+    #[test]
+    fn entry_shapes_match_each_client() {
+        let i = info();
+        assert_eq!(
+            entry_for("cursor", &i),
+            json!({ "url": "http://127.0.0.1:3000/mcp", "headers": { "Authorization": "Bearer pd_test" } })
+        );
+        assert_eq!(
+            entry_for("windsurf", &i)["serverUrl"],
+            "http://127.0.0.1:3000/mcp"
+        );
+        assert_eq!(
+            entry_for("gemini-cli", &i)["httpUrl"],
+            "http://127.0.0.1:3000/mcp"
+        );
+        for id in ["claude-code", "claude-desktop", "vscode"] {
+            assert_eq!(entry_for(id, &i)["type"], "http");
+        }
+    }
+
+    #[test]
+    fn classify_distinguishes_missing_current_and_stale() {
+        let i = info();
+        let expected = entry_for("cursor", &i);
+        assert_eq!(classify(None, "mcpServers", &expected), "not_connected");
+        let empty = json!({});
+        assert_eq!(
+            classify(Some(&empty), "mcpServers", &expected),
+            "not_connected"
+        );
+        let connected = json!({ "mcpServers": { "piwi": expected } });
+        assert_eq!(
+            classify(Some(&connected), "mcpServers", &expected),
+            "connected"
+        );
+        let stale = json!({ "mcpServers": { "piwi": { "url": "http://127.0.0.1:9999/mcp" } } });
+        assert_eq!(classify(Some(&stale), "mcpServers", &expected), "stale");
+    }
+
+    #[test]
+    fn merge_preserves_unrelated_keys_and_servers() {
+        let existing = json!({
+            "theme": "dark",
+            "mcpServers": { "other": { "command": "npx", "args": ["other-mcp"] } }
+        });
+        let merged = merge_piwi_entry(existing, "mcpServers", Some(json!({ "url": "u" })));
+        assert_eq!(merged["theme"], "dark");
+        assert_eq!(merged["mcpServers"]["other"]["command"], "npx");
+        assert_eq!(merged["mcpServers"]["piwi"]["url"], "u");
+    }
+
+    #[test]
+    fn merge_removes_only_the_piwi_entry() {
+        let existing = json!({
+            "mcpServers": { "piwi": { "url": "u" }, "other": { "command": "npx" } }
+        });
+        let merged = merge_piwi_entry(existing, "mcpServers", None);
+        assert!(merged["mcpServers"].get("piwi").is_none());
+        assert_eq!(merged["mcpServers"]["other"]["command"], "npx");
+    }
+
+    #[test]
+    fn merge_creates_the_container_on_a_fresh_file() {
+        let merged = merge_piwi_entry(json!({}), "servers", Some(json!({ "type": "http" })));
+        assert_eq!(merged["servers"]["piwi"]["type"], "http");
+    }
+}

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -147,6 +147,25 @@ Semantics match the [import page](/importing-runs): idempotent by content
 hash, and imports never trigger notifications, AI diagnosis or regression
 signals.
 
+## Connecting AI assistants
+
+The app exposes the same [MCP server](/mcp) as every Piwi deployment — and on
+this machine it can also do the wiring. The **MCP server** page detects
+installed clients — Claude Code, Claude Desktop, Cursor, VS Code, Windsurf and
+Gemini CLI — and connects each with one click:
+
+- The `piwi` entry is written into the client's **own config file**, with the
+  app's URL and access token filled in; a backup copy is kept next to the file,
+  and only that one entry is ever added, updated or removed.
+- A config that is not plain JSON (comments, trailing commas) is never
+  rewritten — the page says so and shows the copy-paste snippet instead.
+- Written entries embed this app's address, which can change when port 3000 is
+  taken — on every launch the app checks the clients it configured and
+  rewrites any entry that drifted.
+
+Restart the client after connecting; most MCP clients read their config at
+startup.
+
 ## Building from source
 
 See [`desktop/README.md`](https://github.com/PiwiTests/platform/blob/main/desktop/README.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -111,6 +111,11 @@ The server implements the **MCP Streamable HTTP transport**. On `initialize` it 
 
 Replace `<your-piwi-url>` with your dashboard base URL (e.g. `http://localhost:3000`) and `pd_YOUR_API_KEY` with a real API key.
 
+> **Desktop app:** none of this is needed there. The [/mcp page](/desktop#connecting-ai-assistants)
+> detects installed clients (Claude Code, Claude Desktop, Cursor, VS Code,
+> Windsurf, Gemini CLI) and writes the entry into their config files in one
+> click — URL and token included, kept current across launches.
+
 ### Claude Code (CLI)
 
 ```bash


### PR DESCRIPTION
> **Stacked on #333** (which stacks on #332) — merge in order; only the MCP work shows in this diff. GitHub retargets automatically as the stack merges.

## What & why

The `/mcp` page's copy-paste snippets stay, but on the desktop app they become the fallback: a new **"Connect a client on this machine"** card detects installed MCP clients — **Claude Code, Claude Desktop, Cursor, VS Code, Windsurf, Gemini CLI** — and connects each with one click, URL and `pd_` token filled in.

- **Conservative file editing.** Only strict JSON is ever rewritten; the merge touches exactly the `piwi` key inside the client's server map (`mcpServers`, or `servers` for VS Code) and preserves everything else. A backup copy lands next to the file before every write. A JSONC config (comments/trailing commas) is never rewritten — the row reports *Manual setup* and points back to the snippets, so no user config can be destroyed.
- **Self-healing across launches.** Written entries embed the launch port, and port 3000 isn't guaranteed — so on every startup the shell re-checks the clients it configured and rewrites any entry whose URL or token drifted, before a client tries a dead address.
- **No arbitrary paths from the webview.** Detection paths and reveal-in-file-manager targets are resolved shell-side from the client id.
- Each client gets its native entry shape (`url`/`serverUrl`/`httpUrl`/`type: http`), matching the documented snippets.

Follow-up (separate PR, reporter scope): an `npx piwi mcp` stdio bridge reading `~/.piwi/desktop.json`, for stdio-only clients and total port independence.

## How was it tested?

- **Rust unit tests** (5) on the pure core: per-client entry shapes, connected/stale/missing classification, and merge behavior (preserves unrelated keys and sibling servers, removes only `piwi`, creates the container on fresh files). `cargo test` green.
- New `desktop-mcp-clients.spec.ts`: card absent without the bridge; with a faked bridge, all status flavors render and connect/disconnect round-trips update the row and pass the right `clientId`.
- Desktop shell e2e extended: `desktop_mcp_clients` invoked from the real loopback webview returns all six client ids (ACL grant proven at runtime on macOS CI).
- `desktop-acl-consistency` covers the four new commands' three-way wiring; full unit suite 1132 passed; `nuxt typecheck`, oxlint, oxfmt, `cargo check` + rustfmt all clean.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/desktop.md` "Connecting AI assistants", `docs/mcp.md` desktop note, `desktop/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzMq6FrbK7RBHFMWymwkJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzMq6FrbK7RBHFMWymwkJN)_