### PR TITLE
feat(snapshot): inline external stylesheets in DOM picker

### DIFF
--- a/application/app/components/shared/SnapshotLocatorPicker.vue
+++ b/application/app/components/shared/SnapshotLocatorPicker.vue
@@ -58,8 +58,12 @@ async function fetchSnapshot() {
   try {
     // Same endpoint as the read-only DOM snapshot card — trace-derived DOM with
     // an ARIA-tree fallback (or ?source=aria on demand). The picker adds its own
-    // interactive overlay.
-    const query = viewSource.value ? `?source=${viewSource.value}` : '';
+    // interactive overlay and asks the server to inline external stylesheets, so
+    // the opaque-origin iframe (which can never fetch the tested app's CSS)
+    // renders styled instead of as bare markup.
+    const params = new URLSearchParams({ inlineStyles: '1' });
+    if (viewSource.value) params.set('source', viewSource.value);
+    const query = `?${params.toString()}`;
     snapshot.value = await $fetch<DomSnapshotResponse>(
       `/api/test-runs/${props.runId}/cases/${props.testRunsCaseId}/dom-snapshot${query}`,
     );

--- a/application/app/utils/snapshot-picker-overlay.ts
+++ b/application/app/utils/snapshot-picker-overlay.ts
@@ -255,10 +255,11 @@ export function installSnapshotPicker(config) {
     }
   }
   function onKey(e) {
-    if (e.key === 'Escape' || e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-      stop(e);
-      handleKey(e.key);
-    }
+    // Swallow EVERY key while picking so a focused control in the snapshot can't
+    // be activated (Enter/Space), the DOM can't be typed into, and Tab can't
+    // move focus into the page. Esc / ↑ / ↓ still drive the picker itself.
+    stop(e);
+    handleKey(e.key);
   }
 
   // ── Guidance: pre-highlight likely elements + text search ──────────────────
@@ -413,21 +414,68 @@ export function installSnapshotPicker(config) {
     highlight.style.display = 'none';
     clearHints();
     banner.innerHTML = '<div style="text-align:center;color:#9ca3af;">Analyzing element…</div>';
-    removeListeners();
+    freezeAfterPick();
     g.parent.postMessage({ type: 'elementPicked', attrs: attrs }, '*');
   }
 
-  var suppressed = ['mousedown', 'mouseup', 'pointerdown', 'pointerup', 'auxclick', 'dblclick'];
-  function removeListeners() {
+  // Every interaction the snapshot must swallow so it behaves as an inert
+  // picture: a click must never navigate a link, submit a form, activate a
+  // control, type into a field, or start a drag/selection. `mousemove`, `click`
+  // and `keydown` are owned by the picker (hover / pick / tree-walk) and handled
+  // separately below. This list stays installed for the whole picker lifetime.
+  //
+  // NOTE: intentionally STRICTER than the reporter's live picker
+  // (`installPickerOverlay`), which runs on a real page the user may still want
+  // to interact with. Here the page is a dead snapshot, so nothing should react.
+  var INERT_EVENTS = [
+    'mousedown',
+    'mouseup',
+    'pointerdown',
+    'pointerup',
+    'auxclick',
+    'dblclick',
+    'contextmenu',
+    'submit',
+    'beforeinput',
+    'input',
+    'change',
+    'paste',
+    'cut',
+    'drop',
+    'dragstart',
+    'keypress',
+    'keyup',
+    'touchstart',
+    'touchend',
+  ];
+  function addInert() {
+    for (var i = 0; i < INERT_EVENTS.length; i++) doc.addEventListener(INERT_EVENTS[i], stop, true);
+  }
+
+  // Detach the picker's own hover/pick/key handlers. Does NOT re-enable the page.
+  function disarmPicking() {
     doc.removeEventListener('mousemove', onMove, true);
     doc.removeEventListener('click', onClick, true);
     doc.removeEventListener('keydown', onKey, true);
     g.removeEventListener('message', onParentMsg, false);
-    for (var i = 0; i < suppressed.length; i++) doc.removeEventListener(suppressed[i], stop, true);
+  }
+
+  // A pick committed but the snapshot iframe stays on screen through the review
+  // step — keep it fully inert (a stray click/keydown there must do nothing) by
+  // swapping the picker's click/keydown handlers for plain blockers.
+  function freezeAfterPick() {
+    disarmPicking();
+    doc.addEventListener('click', stop, true);
+    doc.addEventListener('keydown', stop, true);
   }
 
   function doClose() {
-    removeListeners();
+    disarmPicking();
+    for (var i = 0; i < INERT_EVENTS.length; i++) doc.removeEventListener(INERT_EVENTS[i], stop, true);
+    // These are only attached after a pick (freezeAfterPick); removeEventListener
+    // is a no-op when they were never added, so this is safe in every state.
+    doc.removeEventListener('click', stop, true);
+    doc.removeEventListener('keydown', stop, true);
     clearHints();
     highlight.remove();
     banner.remove();
@@ -438,7 +486,7 @@ export function installSnapshotPicker(config) {
   doc.addEventListener('click', onClick, true);
   doc.addEventListener('keydown', onKey, true);
   g.addEventListener('message', onParentMsg, false);
-  for (var i = 0; i < suppressed.length; i++) doc.addEventListener(suppressed[i], stop, true);
+  addInert();
 
   // ── Report full content height so the host can size the (opaque-origin)
   // iframe without reading its document. Replaces parent-side measurement. ────

--- a/application/server/api/test-runs/[id]/cases/[caseId]/dom-snapshot.get.ts
+++ b/application/server/api/test-runs/[id]/cases/[caseId]/dom-snapshot.get.ts
@@ -24,6 +24,14 @@ defineRouteMeta({
         schema: { type: 'string', enum: ['dom', 'aria'] },
         description: 'Which representation to render — trace-derived DOM (default) or the ARIA tree',
       },
+      {
+        name: 'inlineStyles',
+        in: 'query',
+        required: false,
+        schema: { type: 'string', enum: ['1', 'true'] },
+        description:
+          "Inline external stylesheets from the trace's resources so the DOM renders styled (used by the locator picker)",
+      },
     ],
     'x-required-roles': ['administrator', 'reporter', 'user'],
   },
@@ -38,8 +46,12 @@ export default eventHandler(async (event) => {
   // another project (the cluster page may pass a caseId from another run).
   const { db } = await requireResolvedProjectAccess(event, caseId, resolveTestRunCaseProjectId, 'Test run case');
 
-  const sourceParam = getQuery(event).source;
+  const query = getQuery(event);
+  const sourceParam = query.source;
   const source = sourceParam === 'aria' || sourceParam === 'dom' ? sourceParam : undefined;
+  // The interactive picker asks to inline external CSS so its iframe renders
+  // styled; the read-only card omits it and gets the HTML-as-text view.
+  const inlineStyles = query.inlineStyles === '1' || query.inlineStyles === 'true';
 
   const [traceRows, caseRows] = await Promise.all([
     db
@@ -61,5 +73,5 @@ export default eventHandler(async (event) => {
     caseRows[0]?.aria ??
     null;
 
-  return resolveCaseDomSnapshot(traceRows[0]?.path ?? null, aria, undefined, { source });
+  return resolveCaseDomSnapshot(traceRows[0]?.path ?? null, aria, undefined, { source, inlineStyles });
 });

--- a/application/server/utils/dom-snapshot-render.ts
+++ b/application/server/utils/dom-snapshot-render.ts
@@ -187,6 +187,17 @@ export function maskSensitiveText(text: string): string {
 }
 
 /**
+ * Mask secrets in a CSS body destined for an inlined `<style>`, but leave
+ * `data:` URIs alone — unlike {@link maskSensitiveText}. The picker deliberately
+ * embeds fonts/images as base64 data URIs, so blanket data-URI masking would
+ * wipe them out; token-shaped secrets (JWTs, long hex) are still scrubbed. Run
+ * this AFTER assets are inlined so the fresh data URIs survive. Pure.
+ */
+export function maskCssText(css: string): string {
+  return css.replace(JWT_RE, '[masked-token]').replace(LONG_HEX_RE, '[masked-hex]');
+}
+
+/**
  * Mask token-shaped strings and cap the rendered HTML. Pure and unit-testable.
  * The renderer already drops `__playwright_*` values, inline handlers, and
  * script bodies — this pass handles secrets baked into ordinary markup.
@@ -238,12 +249,16 @@ export function collectStylesheetLinks(html: string): string[] {
  * server) can never load. `cssByHref` is keyed by each link's ORIGINAL href
  * attribute; links with no entry are left untouched (their href might still
  * resolve, and a broken link is no worse than before). `<style>` bodies are raw
- * text to the HTML parser, so a stray `</style` in the CSS is defanged and
- * token-shaped strings are masked (same posture as the rest of the snapshot).
+ * text to the HTML parser, so a stray `</style` in the CSS is defanged here.
+ *
+ * The caller is responsible for scrubbing secrets from the CSS first (see
+ * `maskCssText`): masking must run BEFORE any `url(...)` assets are embedded, or
+ * it would shred the base64 data URIs it can't tell from real tokens.
+ *
  * Inlining stops once `maxTotalChars` of CSS has been emitted; the remaining
  * links stay as-is rather than emit a half sheet. Pure and unit-testable.
  */
-export function inlineStylesheets(html: string, cssByHref: Record<string, string>, maxTotalChars = 2_000_000): string {
+export function inlineStylesheets(html: string, cssByHref: Record<string, string>, maxTotalChars = 8_000_000): string {
   if (!html || Object.keys(cssByHref).length === 0) return html;
   let budget = maxTotalChars;
   return html.replace(/<link\b[^>]*>/gi, (tag) => {
@@ -253,8 +268,50 @@ export function inlineStylesheets(html: string, cssByHref: Record<string, string
     if (typeof css !== 'string' || css.length === 0 || css.length > budget) return tag;
     budget -= css.length;
     const media = link.media ? ` media="${escapeAttr(link.media)}"` : '';
-    const safeCss = maskSensitiveText(css).replace(/<\/(style)/gi, '<\\/$1');
+    const safeCss = css.replace(/<\/(style)/gi, '<\\/$1');
     return `<style${media}>${safeCss}</style>`;
+  });
+}
+
+// A `url(...)` target: single/double quoted (group 2) or bare (group 3).
+const CSS_URL_RE = /url\(\s*(?:(['"])(.*?)\1|([^)\s'"]+))\s*\)/gi;
+
+/**
+ * Every distinct `url(...)` target in a CSS body worth resolving — quotes
+ * stripped, and already-inline (`data:`) / in-document (`#id`) refs skipped.
+ * Pure; the caller resolves each against the stylesheet's own URL.
+ */
+export function collectCssUrls(css: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = new RegExp(CSS_URL_RE.source, 'gi');
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(css)) !== null) {
+    const raw = (m[2] ?? m[3] ?? '').trim();
+    // Skip already-inline data: URIs and any fragment ref (`#blur` filters,
+    // `sprite.svg#icon`) — a data: URI can't carry the fragment that addresses
+    // the resource, so inlining would break them; leaving them alone is safer.
+    if (!raw || raw.startsWith('data:') || raw.includes('#')) continue;
+    if (!seen.has(raw)) {
+      seen.add(raw);
+      out.push(raw);
+    }
+  }
+  return out;
+}
+
+/**
+ * Rewrite every `url(...)` whose target appears in `replacements` (keyed by the
+ * raw target) to the replacement, double-quoted. Used to swap external asset
+ * refs for `data:` URIs so fonts / background images render offline. Targets
+ * with no replacement are left untouched. Pure.
+ */
+export function inlineCssUrls(css: string, replacements: Record<string, string>): string {
+  if (!css || Object.keys(replacements).length === 0) return css;
+  return css.replace(new RegExp(CSS_URL_RE.source, 'gi'), (full, _q, quoted, bare) => {
+    const raw = (quoted ?? bare ?? '').trim();
+    const repl = replacements[raw];
+    return repl ? `url("${repl}")` : full;
   });
 }
 

--- a/application/server/utils/dom-snapshot-render.ts
+++ b/application/server/utils/dom-snapshot-render.ts
@@ -201,6 +201,63 @@ export function sanitizeDomSnapshot(html: string, capChars: number): { html: str
   return { html: out, truncated };
 }
 
+/**
+ * A `<link rel="stylesheet">` parsed out of rendered snapshot HTML: its original
+ * `href` (the key a resource map is looked up by) and any `media` attribute.
+ */
+function parseStylesheetLink(tag: string): { href: string; media: string | null } | null {
+  // rel may be quoted or bare and carry several tokens (`rel="preload stylesheet"`).
+  if (!/\brel\s*=\s*("|')?[^"'>]*\bstylesheet\b/i.test(tag)) return null;
+  const quoted = /\bhref\s*=\s*("|')(.*?)\1/i.exec(tag);
+  const href = quoted ? quoted[2]! : (/\bhref\s*=\s*([^\s"'>]+)/i.exec(tag)?.[1] ?? null);
+  if (!href) return null;
+  const media = /\bmedia\s*=\s*("|')(.*?)\1/i.exec(tag)?.[2] ?? null;
+  return { href, media };
+}
+
+/** Unique original hrefs of every `<link rel="stylesheet">` in the HTML. Pure. */
+export function collectStylesheetLinks(html: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = /<link\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    const link = parseStylesheetLink(m[0]);
+    if (link && !seen.has(link.href)) {
+      seen.add(link.href);
+      out.push(link.href);
+    }
+  }
+  return out;
+}
+
+/**
+ * Replace external `<link rel="stylesheet">` elements whose CSS we have with an
+ * inline `<style>`, so the snapshot renders styled inside the opaque-origin
+ * picker iframe — where the original href (pointing at the long-gone test
+ * server) can never load. `cssByHref` is keyed by each link's ORIGINAL href
+ * attribute; links with no entry are left untouched (their href might still
+ * resolve, and a broken link is no worse than before). `<style>` bodies are raw
+ * text to the HTML parser, so a stray `</style` in the CSS is defanged and
+ * token-shaped strings are masked (same posture as the rest of the snapshot).
+ * Inlining stops once `maxTotalChars` of CSS has been emitted; the remaining
+ * links stay as-is rather than emit a half sheet. Pure and unit-testable.
+ */
+export function inlineStylesheets(html: string, cssByHref: Record<string, string>, maxTotalChars = 2_000_000): string {
+  if (!html || Object.keys(cssByHref).length === 0) return html;
+  let budget = maxTotalChars;
+  return html.replace(/<link\b[^>]*>/gi, (tag) => {
+    const link = parseStylesheetLink(tag);
+    if (!link) return tag;
+    const css = cssByHref[link.href];
+    if (typeof css !== 'string' || css.length === 0 || css.length > budget) return tag;
+    budget -= css.length;
+    const media = link.media ? ` media="${escapeAttr(link.media)}"` : '';
+    const safeCss = maskSensitiveText(css).replace(/<\/(style)/gi, '<\\/$1');
+    return `<style${media}>${safeCss}</style>`;
+  });
+}
+
 /** The two representations a case can be viewed as: trace-derived DOM or the ARIA tree. */
 export type DomSnapshotSource = 'dom' | 'aria';
 
@@ -214,6 +271,8 @@ export interface DomSnapshotResult {
   action?: string;
   /** The recorded page viewport, for proportion-preserving scaled rendering. */
   viewport?: { width: number; height: number };
+  /** The rendered frame's document URL — the base for resolving `<link href>` when inlining stylesheets. */
+  frameUrl?: string;
   /** Which representation `html` is — the trace DOM (`dom`) or the ARIA tree (`aria`). */
   source?: DomSnapshotSource;
   /**
@@ -261,6 +320,7 @@ export function extractDomSnapshot(data: ParsedTraceData, capChars: number): Dom
       snapshotName: name,
       action: fa?.apiName,
       viewport: rendered?.viewport,
+      frameUrl: rendered?.frameUrl,
     };
   }
   return { status: 'no-snapshot' };

--- a/application/server/utils/dom-snapshot.ts
+++ b/application/server/utils/dom-snapshot.ts
@@ -7,10 +7,14 @@
  * would shadow each other — import the pure API from `dom-snapshot-render.ts`
  * directly.
  */
-import { loadAndParseTrace } from './trace-parser';
+import { getStorage } from '../storage';
+import { parseZip, type ZipEntry } from './trace-zip';
+import { parseTraceTexts, parseResourceSnapshots, traceFileRank } from './trace-events';
 import {
   DOM_SNAPSHOT_CAP_CHARS,
   extractDomSnapshot,
+  collectStylesheetLinks,
+  inlineStylesheets,
   type DomSnapshotResult,
   type DomSnapshotSource,
 } from './dom-snapshot-render';
@@ -18,11 +22,99 @@ import {
 // browser demo can reuse it (the trace path above pulls in node-only zlib).
 import { renderAriaSnapshotHtml } from './dom-snapshot-aria';
 
-/** `extractDomSnapshot` over a stored (slim) trace blob. */
-export async function getTraceDomSnapshot(blobPath: string, capChars: number): Promise<DomSnapshotResult> {
-  const data = await loadAndParseTrace(blobPath);
-  if (!data) return { status: 'no-trace' };
-  return extractDomSnapshot(data, capChars);
+/** Total inlined CSS budget and per-sheet ceiling — a broken app can ship huge bundles. */
+const INLINE_STYLES_BUDGET = 2_000_000;
+const MAX_STYLESHEET_BYTES = 1_000_000;
+
+/** Resolve a `<link href>` (possibly relative) against the frame's document URL. */
+function resolveResourceUrl(href: string, base: string | undefined): string | null {
+  try {
+    return new URL(href, base).href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Inline the snapshot's external stylesheets from the trace's stored resources.
+ * Maps each `<link href>` → absolute URL (via the frame's base) → content hash
+ * (from the `.network` stream) → the CSS body stored under the project's
+ * `trace-resources` pool. Purely additive: any missing piece leaves the `<link>`
+ * untouched, so a page with unreachable CSS is no worse off than before.
+ */
+async function inlineTraceStylesheets(
+  blobPath: string,
+  entries: ZipEntry[],
+  result: DomSnapshotResult,
+): Promise<DomSnapshotResult> {
+  if (result.status !== 'ok' || !result.html) return result;
+  const hrefs = collectStylesheetLinks(result.html);
+  if (hrefs.length === 0) return result;
+
+  const networkTexts = entries.filter((e) => e.name.endsWith('.network')).map((e) => e.data.toString('utf8'));
+  const urlToSha1 = parseResourceSnapshots(networkTexts);
+  if (urlToSha1.size === 0) return result;
+
+  // Resources live in a project-scoped shared pool; the id is in the blob path
+  // (`project-<id>/blobs/<hash>.zip`).
+  const projectId = /^project-(\d+)\//.exec(blobPath)?.[1];
+  if (!projectId) return result;
+  const resourcesDir = `project-${projectId}/trace-resources`;
+  const storage = getStorage();
+
+  const cssByHref: Record<string, string> = {};
+  let budget = INLINE_STYLES_BUDGET;
+  for (const href of hrefs) {
+    if (budget <= 0) break;
+    const abs = resolveResourceUrl(href, result.frameUrl);
+    const sha1 = (abs ? urlToSha1.get(abs) : undefined) ?? urlToSha1.get(href);
+    if (!sha1) continue;
+    try {
+      const bytes = await storage.readFile(`${resourcesDir}/${sha1}`);
+      if (bytes.length === 0 || bytes.length > MAX_STYLESHEET_BYTES || bytes.length > budget) continue;
+      cssByHref[href] = bytes.toString('utf8');
+      budget -= bytes.length;
+    } catch {
+      // Resource missing/unreadable — leave the <link> as-is.
+    }
+  }
+  if (Object.keys(cssByHref).length === 0) return result;
+  return { ...result, html: inlineStylesheets(result.html, cssByHref, INLINE_STYLES_BUDGET) };
+}
+
+/** Options for {@link getTraceDomSnapshot}. */
+export interface TraceDomSnapshotOptions {
+  /** Inline external stylesheets from the trace's resources (the interactive picker only). */
+  inlineStyles?: boolean;
+}
+
+/** `extractDomSnapshot` over a stored (slim) trace blob, optionally inlining external CSS. */
+export async function getTraceDomSnapshot(
+  blobPath: string,
+  capChars: number,
+  options: TraceDomSnapshotOptions = {},
+): Promise<DomSnapshotResult> {
+  let entries: ZipEntry[];
+  try {
+    const data = await getStorage().readFile(blobPath);
+    entries = await parseZip(data);
+  } catch {
+    return { status: 'no-trace' };
+  }
+  const traceTexts = entries
+    .filter((e) => e.name.endsWith('.trace'))
+    .sort((a, b) => traceFileRank(a.name) - traceFileRank(b.name))
+    .map((e) => e.data.toString('utf8'));
+  if (traceTexts.length === 0) return { status: 'no-trace' };
+
+  const result = extractDomSnapshot(parseTraceTexts(traceTexts), capChars);
+  if (!options.inlineStyles) return result;
+  try {
+    return await inlineTraceStylesheets(blobPath, entries, result);
+  } catch {
+    // Inlining is best-effort decoration — never fail the snapshot over it.
+    return result;
+  }
 }
 
 /** Options for {@link resolveCaseDomSnapshot}. */
@@ -33,6 +125,12 @@ export interface ResolveCaseDomSnapshotOptions {
    * even when a trace is available (the view toggle).
    */
   source?: DomSnapshotSource;
+  /**
+   * Inline external stylesheets from the trace so the snapshot renders styled.
+   * Only the interactive picker requests this — the read-only DOM card shows the
+   * HTML as text, where inlined bundles would just be noise.
+   */
+  inlineStyles?: boolean;
 }
 
 /**
@@ -74,7 +172,7 @@ export async function resolveCaseDomSnapshot(
   if (options.source === 'aria' && ariaHtml) return asAria();
 
   if (traceBlobPath) {
-    const result = await getTraceDomSnapshot(traceBlobPath, capChars);
+    const result = await getTraceDomSnapshot(traceBlobPath, capChars, { inlineStyles: options.inlineStyles });
     if (result.status === 'ok' && result.html) {
       return { ...result, source: 'dom', availableSources: sources() };
     }

--- a/application/server/utils/dom-snapshot.ts
+++ b/application/server/utils/dom-snapshot.ts
@@ -9,12 +9,15 @@
  */
 import { getStorage } from '../storage';
 import { parseZip, type ZipEntry } from './trace-zip';
-import { parseTraceTexts, parseResourceSnapshots, traceFileRank } from './trace-events';
+import { parseTraceTexts, parseResourceSnapshots, traceFileRank, type TraceResource } from './trace-events';
 import {
   DOM_SNAPSHOT_CAP_CHARS,
   extractDomSnapshot,
   collectStylesheetLinks,
   inlineStylesheets,
+  collectCssUrls,
+  inlineCssUrls,
+  maskCssText,
   type DomSnapshotResult,
   type DomSnapshotSource,
 } from './dom-snapshot-render';
@@ -22,17 +25,91 @@ import {
 // browser demo can reuse it (the trace path above pulls in node-only zlib).
 import { renderAriaSnapshotHtml } from './dom-snapshot-aria';
 
-/** Total inlined CSS budget and per-sheet ceiling — a broken app can ship huge bundles. */
-const INLINE_STYLES_BUDGET = 2_000_000;
-const MAX_STYLESHEET_BYTES = 1_000_000;
+// Budgets — a broken app can ship huge bundles, and base64 inflates by a third,
+// so cap both the text and the embedded binary.
+const MAX_STYLESHEET_BYTES = 1_000_000; // per external stylesheet
+const INLINE_ASSET_BUDGET = 2_500_000; // total raw bytes embedded as data: URIs across the snapshot
+const MAX_ASSET_BYTES = 512_000; // per font/image
+const INLINE_STYLES_MAX_CHARS = 8_000_000; // ceiling on total inlined CSS text (incl. data: URIs)
 
-/** Resolve a `<link href>` (possibly relative) against the frame's document URL. */
+/** File-extension → MIME fallback when the trace didn't record a usable Content-Type. */
+const EXT_MIME: Record<string, string> = {
+  woff2: 'font/woff2',
+  woff: 'font/woff',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  eot: 'application/vnd.ms-fontobject',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+};
+
+/** Resolve a `<link href>` / CSS `url(...)` (possibly relative) against a base URL. */
 function resolveResourceUrl(href: string, base: string | undefined): string | null {
   try {
     return new URL(href, base).href;
   } catch {
     return null;
   }
+}
+
+/**
+ * The MIME type to stamp on a `data:` URI for a captured asset: the recorded
+ * Content-Type when it's a real type, else inferred from the stored file's or
+ * the reference's extension. Null when nothing plausible is known — the caller
+ * then leaves the reference alone rather than emit a mis-typed data URI.
+ */
+function assetMimeType(res: TraceResource, ref: string): string | null {
+  const recorded = res.mimeType?.split(';')[0]?.trim();
+  if (recorded && recorded.includes('/') && !/x-unknown|octet-stream/i.test(recorded)) return recorded;
+  const ext = (
+    /\.([a-z0-9]+)(?:[?#]|$)/i.exec(res.sha1)?.[1] ?? /\.([a-z0-9]+)(?:[?#]|$)/i.exec(ref)?.[1]
+  )?.toLowerCase();
+  return (ext && EXT_MIME[ext]) || null;
+}
+
+/**
+ * Embed a stylesheet's own `url(...)` assets (fonts, background images) as
+ * base64 `data:` URIs so they render in the offline, opaque-origin iframe. Each
+ * ref resolves against the stylesheet's URL (not the document's), then the same
+ * resource lookup the stylesheets use. Shares one binary budget across the whole
+ * snapshot. Returns the CSS with resolvable refs rewritten; the rest untouched.
+ */
+async function inlineCssAssets(
+  css: string,
+  styleBaseUrl: string,
+  urlToRes: Map<string, TraceResource>,
+  resourcesDir: string,
+  budget: { value: number },
+): Promise<string> {
+  if (budget.value <= 0) return css;
+  const refs = collectCssUrls(css);
+  if (refs.length === 0) return css;
+  const storage = getStorage();
+  const replacements: Record<string, string> = {};
+  for (const ref of refs) {
+    if (budget.value <= 0) break;
+    const abs = resolveResourceUrl(ref, styleBaseUrl);
+    const res = (abs ? urlToRes.get(abs) : undefined) ?? urlToRes.get(ref);
+    if (!res) continue;
+    const mime = assetMimeType(res, ref);
+    if (!mime) continue;
+    try {
+      const bytes = await storage.readFile(`${resourcesDir}/${res.sha1}`);
+      if (bytes.length === 0 || bytes.length > MAX_ASSET_BYTES || bytes.length > budget.value) continue;
+      replacements[ref] = `data:${mime};base64,${bytes.toString('base64')}`;
+      budget.value -= bytes.length;
+    } catch {
+      // Missing/unreadable asset — leave the url() as-is.
+    }
+  }
+  return Object.keys(replacements).length ? inlineCssUrls(css, replacements) : css;
 }
 
 /**
@@ -52,8 +129,8 @@ async function inlineTraceStylesheets(
   if (hrefs.length === 0) return result;
 
   const networkTexts = entries.filter((e) => e.name.endsWith('.network')).map((e) => e.data.toString('utf8'));
-  const urlToSha1 = parseResourceSnapshots(networkTexts);
-  if (urlToSha1.size === 0) return result;
+  const urlToRes = parseResourceSnapshots(networkTexts);
+  if (urlToRes.size === 0) return result;
 
   // Resources live in a project-scoped shared pool; the id is in the blob path
   // (`project-<id>/blobs/<hash>.zip`).
@@ -63,23 +140,26 @@ async function inlineTraceStylesheets(
   const storage = getStorage();
 
   const cssByHref: Record<string, string> = {};
-  let budget = INLINE_STYLES_BUDGET;
+  const assetBudget = { value: INLINE_ASSET_BUDGET };
   for (const href of hrefs) {
-    if (budget <= 0) break;
     const abs = resolveResourceUrl(href, result.frameUrl);
-    const sha1 = (abs ? urlToSha1.get(abs) : undefined) ?? urlToSha1.get(href);
-    if (!sha1) continue;
+    const res = (abs ? urlToRes.get(abs) : undefined) ?? urlToRes.get(href);
+    if (!res) continue;
     try {
-      const bytes = await storage.readFile(`${resourcesDir}/${sha1}`);
-      if (bytes.length === 0 || bytes.length > MAX_STYLESHEET_BYTES || bytes.length > budget) continue;
-      cssByHref[href] = bytes.toString('utf8');
-      budget -= bytes.length;
+      const bytes = await storage.readFile(`${resourcesDir}/${res.sha1}`);
+      if (bytes.length === 0 || bytes.length > MAX_STYLESHEET_BYTES) continue;
+      // Embed the sheet's own url() assets first, THEN mask token-shaped secrets
+      // — masking last leaves the fresh base64 data URIs (and this sheet's
+      // content-hashed filenames) intact. url() refs resolve against the
+      // stylesheet's own URL, not the document's.
+      const css = await inlineCssAssets(bytes.toString('utf8'), abs ?? href, urlToRes, resourcesDir, assetBudget);
+      cssByHref[href] = maskCssText(css);
     } catch {
       // Resource missing/unreadable — leave the <link> as-is.
     }
   }
   if (Object.keys(cssByHref).length === 0) return result;
-  return { ...result, html: inlineStylesheets(result.html, cssByHref, INLINE_STYLES_BUDGET) };
+  return { ...result, html: inlineStylesheets(result.html, cssByHref, INLINE_STYLES_MAX_CHARS) };
 }
 
 /** Options for {@link getTraceDomSnapshot}. */

--- a/application/server/utils/trace-events.ts
+++ b/application/server/utils/trace-events.ts
@@ -147,16 +147,25 @@ export function parseTraceTexts(texts: string[]): ParsedTraceData {
   return extractFromEvents(events);
 }
 
+/** A captured response body: the content hash naming its stored file, plus its recorded MIME type. */
+export interface TraceResource {
+  /** The `_sha1` filename in the project's shared `trace-resources` pool. */
+  sha1: string;
+  /** The recorded `Content-Type` (`response.content.mimeType`), when known — names the data: URI. */
+  mimeType?: string;
+}
+
 /**
- * Map every resource URL captured in a trace's `.network` stream to the content
- * hash (`_sha1`) naming its stored body. Used to inline external stylesheets
- * into a DOM snapshot: a `<link href>` resolves to a URL here, whose `_sha1`
- * names the file in the project's shared `trace-resources` pool. Later snapshots
- * win on duplicate URLs. Node-free (shared with the browser demo, which reads
- * `resources/<sha1>` straight from the ZIP). Unparseable lines are skipped.
+ * Map every resource URL captured in a trace's `.network` stream to the stored
+ * body naming it (`_sha1`) and its MIME type. Used to inline a DOM snapshot's
+ * external assets: a `<link href>` (or a CSS `url(...)`) resolves to a URL here,
+ * whose `_sha1` names the file in the project's shared `trace-resources` pool.
+ * Later snapshots win on duplicate URLs. Node-free (shared with the browser
+ * demo, which reads `resources/<sha1>` straight from the ZIP). Unparseable lines
+ * are skipped.
  */
-export function parseResourceSnapshots(texts: string[]): Map<string, string> {
-  const map = new Map<string, string>();
+export function parseResourceSnapshots(texts: string[]): Map<string, TraceResource> {
+  const map = new Map<string, TraceResource>();
   for (const text of texts) {
     for (const line of text.split('\n')) {
       if (!line) continue;
@@ -169,10 +178,13 @@ export function parseResourceSnapshots(texts: string[]): Map<string, string> {
       if (!evt || evt.type !== 'resource-snapshot') continue;
       const snapshot = evt.snapshot as Record<string, unknown> | undefined;
       const request = snapshot?.request as { url?: unknown } | undefined;
-      const content = (snapshot?.response as { content?: { _sha1?: unknown } } | undefined)?.content;
+      const content = (snapshot?.response as { content?: { _sha1?: unknown; mimeType?: unknown } } | undefined)
+        ?.content;
       const url = request?.url;
       const sha1 = content?._sha1;
-      if (typeof url === 'string' && url && typeof sha1 === 'string' && sha1) map.set(url, sha1);
+      if (typeof url === 'string' && url && typeof sha1 === 'string' && sha1) {
+        map.set(url, { sha1, mimeType: typeof content?.mimeType === 'string' ? content.mimeType : undefined });
+      }
     }
   }
   return map;

--- a/application/server/utils/trace-events.ts
+++ b/application/server/utils/trace-events.ts
@@ -147,6 +147,37 @@ export function parseTraceTexts(texts: string[]): ParsedTraceData {
   return extractFromEvents(events);
 }
 
+/**
+ * Map every resource URL captured in a trace's `.network` stream to the content
+ * hash (`_sha1`) naming its stored body. Used to inline external stylesheets
+ * into a DOM snapshot: a `<link href>` resolves to a URL here, whose `_sha1`
+ * names the file in the project's shared `trace-resources` pool. Later snapshots
+ * win on duplicate URLs. Node-free (shared with the browser demo, which reads
+ * `resources/<sha1>` straight from the ZIP). Unparseable lines are skipped.
+ */
+export function parseResourceSnapshots(texts: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const text of texts) {
+    for (const line of text.split('\n')) {
+      if (!line) continue;
+      let evt: Record<string, unknown>;
+      try {
+        evt = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!evt || evt.type !== 'resource-snapshot') continue;
+      const snapshot = evt.snapshot as Record<string, unknown> | undefined;
+      const request = snapshot?.request as { url?: unknown } | undefined;
+      const content = (snapshot?.response as { content?: { _sha1?: unknown } } | undefined)?.content;
+      const url = request?.url;
+      const sha1 = content?._sha1;
+      if (typeof url === 'string' && url && typeof sha1 === 'string' && sha1) map.set(url, sha1);
+    }
+  }
+  return map;
+}
+
 function extractFromEvents(events: Record<string, unknown>[]): ParsedTraceData {
   const actions: TraceAction[] = [];
   const consoleEntries: TraceConsoleEntry[] = [];

--- a/application/tests/unit/dom-snapshot-inline.test.ts
+++ b/application/tests/unit/dom-snapshot-inline.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Back the storage adapter with an in-memory file map so the whole inlining
+// path (ZIP read → .trace/.network parse → resource reads) runs end to end
+// without touching disk. `vi.hoisted` lets the factory below reach the map.
+const { storageFiles } = vi.hoisted(() => ({ storageFiles: new Map<string, Buffer>() }));
+vi.mock('../../server/storage', () => ({
+  getStorage: () => ({
+    readFile: async (path: string) => {
+      const bytes = storageFiles.get(path);
+      if (!bytes) throw new Error(`ENOENT: ${path}`);
+      return bytes;
+    },
+  }),
+}));
+
+import { getTraceDomSnapshot } from '~~/server/utils/dom-snapshot';
+import { buildZip } from '~~/server/utils/trace-zip';
+
+/**
+ * A minimal slim trace ZIP: one main-frame snapshot linking an external
+ * stylesheet, and a `.network` stream mapping that stylesheet and its
+ * background image to stored resources — the exact shape the picker inlines.
+ */
+function buildTraceZip(): Buffer {
+  const frameSnapshot = {
+    type: 'frame-snapshot',
+    snapshot: {
+      snapshotName: 's1',
+      frameId: 'f1',
+      isMainFrame: true,
+      frameUrl: 'http://app.local/page',
+      doctype: 'html',
+      viewport: { width: 800, height: 600 },
+      html: [
+        'HTML',
+        {},
+        ['HEAD', {}, ['LINK', { rel: 'stylesheet', href: '/app.css' }]],
+        ['BODY', {}, ['DIV', { class: 'logo' }, 'hi']],
+      ],
+    },
+  };
+  const resourceSnap = (url: string, sha1: string, mimeType: string) => ({
+    type: 'resource-snapshot',
+    snapshot: { request: { url }, response: { content: { _sha1: sha1, mimeType } } },
+  });
+  const network = [
+    resourceSnap('http://app.local/app.css', 'css1', 'text/css'),
+    resourceSnap('http://app.local/img/logo.png', 'img1', 'image/png'),
+  ]
+    .map((e) => JSON.stringify(e))
+    .join('\n');
+  return buildZip([
+    { name: '0-trace.trace', data: Buffer.from(JSON.stringify(frameSnapshot), 'utf8') },
+    { name: '0-trace.network', data: Buffer.from(network, 'utf8') },
+  ]);
+}
+
+const BLOB = 'project-7/blobs/abc.zip';
+const HEX_SECRET = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'; // 40 hex chars → masked
+// The stylesheet references a background image by a document-relative url() and
+// also carries a token-shaped secret, so one fixture exercises both concerns.
+const CSS = `.logo{background:url(/img/logo.png)}.k{--t:"${HEX_SECRET}"}`;
+const PNG = Buffer.from('PNGBYTES');
+
+beforeEach(() => {
+  storageFiles.clear();
+  storageFiles.set(BLOB, buildTraceZip());
+  storageFiles.set('project-7/trace-resources/css1', Buffer.from(CSS, 'utf8'));
+  storageFiles.set('project-7/trace-resources/img1', PNG);
+});
+
+describe('getTraceDomSnapshot — stylesheet + asset inlining', () => {
+  test('inlines the stylesheet, embeds its url() image as a data URI, and masks secrets last', async () => {
+    const res = await getTraceDomSnapshot(BLOB, 1_000_000, { inlineStyles: true });
+    expect(res.status).toBe('ok');
+    // The <link> became an inline <style>.
+    expect(res.html).toContain('<style>');
+    expect(res.html).not.toContain('<link rel="stylesheet"');
+    // The CSS url() now points at the base64-embedded image — proving assets are
+    // inlined AND that the later secret-mask left the fresh data URI intact.
+    expect(res.html).toContain(`url("data:image/png;base64,${PNG.toString('base64')}")`);
+    // …while the token-shaped secret in the same sheet is still scrubbed.
+    expect(res.html).toContain('[masked-hex]');
+    expect(res.html).not.toContain(HEX_SECRET);
+  });
+
+  test('leaves the external <link> untouched when inlineStyles is off (the read-only card path)', async () => {
+    const res = await getTraceDomSnapshot(BLOB, 1_000_000);
+    expect(res.status).toBe('ok');
+    expect(res.html).toContain('<link rel="stylesheet" href="/app.css">');
+    expect(res.html).not.toContain('data:image/png');
+  });
+
+  test('keeps the <link> when the stylesheet resource is missing (graceful degradation)', async () => {
+    storageFiles.delete('project-7/trace-resources/css1');
+    const res = await getTraceDomSnapshot(BLOB, 1_000_000, { inlineStyles: true });
+    expect(res.status).toBe('ok');
+    expect(res.html).toContain('<link rel="stylesheet" href="/app.css">');
+  });
+});

--- a/application/tests/unit/dom-snapshot.test.ts
+++ b/application/tests/unit/dom-snapshot.test.ts
@@ -5,6 +5,9 @@ import {
   extractDomSnapshot,
   collectStylesheetLinks,
   inlineStylesheets,
+  collectCssUrls,
+  inlineCssUrls,
+  maskCssText,
 } from '~~/server/utils/dom-snapshot-render';
 import { resolveCaseDomSnapshot } from '~~/server/utils/dom-snapshot';
 import { renderAriaSnapshotHtml } from '~~/server/utils/dom-snapshot-aria';
@@ -184,14 +187,19 @@ describe('inlineStylesheets', () => {
     expect(inlineStylesheets(html, { '/print.css': 'a{}' })).toBe('<style media="print">a{}</style>');
   });
 
-  test('defangs a stray </style> in the CSS and masks token-shaped strings', () => {
-    const css =
-      '.x{content:"</style><script>alert(1)</script>"}.y{background:url(data:image/png;base64,iVBORw0KGgoAAAA==)}';
+  test('defangs a stray </style> in the CSS so it cannot break out of the tag', () => {
+    const css = '.x{content:"</style><script>alert(1)</script>"}';
     const out = inlineStylesheets('<link rel="stylesheet" href="x">', { x: css });
     expect(out).not.toContain('</style><script>'); // the closing tag can't break out
     expect(out).toContain('<\\/style>');
-    expect(out).toContain('data:[masked]'); // secret masking still applies
-    expect(out).not.toContain('iVBORw0KGgo');
+  });
+
+  test('does NOT mask embedded data URIs — masking is the caller-side job before assets are inlined', () => {
+    // inlineStylesheets is purely structural now; a base64 background image the
+    // asset-inliner embedded must survive untouched (maskCssText scrubs secrets
+    // beforehand, leaving data: URIs alone).
+    const css = '.y{background:url("data:image/png;base64,iVBORw0KGgoAAAA==")}';
+    expect(inlineStylesheets('<link rel="stylesheet" href="x">', { x: css })).toContain('iVBORw0KGgoAAAA==');
   });
 
   test('stops inlining once the CSS budget is spent, keeping later links intact', () => {
@@ -209,28 +217,71 @@ describe('inlineStylesheets', () => {
 });
 
 describe('parseResourceSnapshots', () => {
-  const line = (url: string, sha1: string | null) =>
+  const line = (url: string, sha1: string | null, mimeType?: string) =>
     JSON.stringify({
       type: 'resource-snapshot',
-      snapshot: { request: { url }, response: { content: sha1 ? { _sha1: sha1 } : {} } },
+      snapshot: {
+        request: { url },
+        response: { content: sha1 ? { _sha1: sha1, ...(mimeType ? { mimeType } : {}) } : {} },
+      },
     });
 
-  test('maps resource URLs to their content hash, ignoring other events and lines without a hash', () => {
+  test('maps resource URLs to their content hash + MIME, ignoring other events and lines without a hash', () => {
     const text = [
-      line('http://app/main.css', 'aaa.css'),
+      line('http://app/main.css', 'aaa.css', 'text/css'),
       JSON.stringify({ type: 'context-options' }), // unrelated event
       'not json at all',
       line('http://app/no-hash.css', null), // response carries no _sha1
     ].join('\n');
     const map = parseResourceSnapshots([text]);
-    expect(map.get('http://app/main.css')).toBe('aaa.css');
+    expect(map.get('http://app/main.css')).toEqual({ sha1: 'aaa.css', mimeType: 'text/css' });
     expect(map.has('http://app/no-hash.css')).toBe(false);
     expect(map.size).toBe(1);
   });
 
+  test('records an undefined MIME when the response did not carry one', () => {
+    expect(parseResourceSnapshots([line('http://app/x.woff2', 'f.woff2')]).get('http://app/x.woff2')).toEqual({
+      sha1: 'f.woff2',
+      mimeType: undefined,
+    });
+  });
+
   test('later snapshots win for a repeated URL', () => {
     const text = [line('http://app/x.css', 'old.css'), line('http://app/x.css', 'new.css')].join('\n');
-    expect(parseResourceSnapshots([text]).get('http://app/x.css')).toBe('new.css');
+    expect(parseResourceSnapshots([text]).get('http://app/x.css')?.sha1).toBe('new.css');
+  });
+});
+
+describe('collectCssUrls / inlineCssUrls', () => {
+  test('collects distinct url() targets, skipping data:, #fragment and fragment-addressed refs', () => {
+    const css =
+      '@font-face{src:url("/f/inter.woff2") format("woff2")}' +
+      '.a{background:url(/img/bg.png)}' +
+      ".b{background:url('/img/bg.png')}" + // dupe of the same target
+      '.c{background:url(data:image/gif;base64,AAAA)}' + // already inline
+      '.d{filter:url(#blur)}' + // in-document ref
+      '.e{background:url(/img/sprite.svg#star)}'; // fragment-addressed — can't inline faithfully
+    expect(collectCssUrls(css)).toEqual(['/f/inter.woff2', '/img/bg.png']);
+  });
+
+  test('rewrites only the targets present in the replacement map, double-quoting them', () => {
+    const css = ".a{background:url(/img/bg.png)}.b{src:url('/f/x.woff2')}";
+    const out = inlineCssUrls(css, { '/img/bg.png': 'data:image/png;base64,PNG' });
+    expect(out).toContain('url("data:image/png;base64,PNG")');
+    expect(out).toContain("url('/f/x.woff2')"); // untouched — no replacement supplied
+  });
+});
+
+describe('maskCssText', () => {
+  test('scrubs JWT/long-hex secrets but leaves data: URIs alone', () => {
+    const css =
+      '.a{--t:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.SflKxwRJSMeKKF2QT4fwpM"}' +
+      '.b{content:"4a7d1ed414474e4033ac29ccb8653d9b4a7d1ed414474e40"}' +
+      '.c{background:url("data:image/png;base64,iVBORw0KGgoAAAA==")}';
+    const out = maskCssText(css);
+    expect(out).toContain('[masked-token]');
+    expect(out).toContain('[masked-hex]');
+    expect(out).toContain('data:image/png;base64,iVBORw0KGgoAAAA=='); // asset preserved
   });
 });
 

--- a/application/tests/unit/dom-snapshot.test.ts
+++ b/application/tests/unit/dom-snapshot.test.ts
@@ -1,8 +1,14 @@
 import { describe, test, expect } from 'vitest';
-import { renderSnapshotHtml, sanitizeDomSnapshot, extractDomSnapshot } from '~~/server/utils/dom-snapshot-render';
+import {
+  renderSnapshotHtml,
+  sanitizeDomSnapshot,
+  extractDomSnapshot,
+  collectStylesheetLinks,
+  inlineStylesheets,
+} from '~~/server/utils/dom-snapshot-render';
 import { resolveCaseDomSnapshot } from '~~/server/utils/dom-snapshot';
 import { renderAriaSnapshotHtml } from '~~/server/utils/dom-snapshot-aria';
-import type { TraceFrameSnapshot, ParsedTraceData } from '~~/server/utils/trace-events';
+import { parseResourceSnapshots, type TraceFrameSnapshot, type ParsedTraceData } from '~~/server/utils/trace-events';
 
 function snap(overrides: Partial<TraceFrameSnapshot>): TraceFrameSnapshot {
   return { frameId: 'frame@1', isMainFrame: true, html: ['HTML', {}], ...overrides };
@@ -141,6 +147,90 @@ describe('renderSnapshotHtml', () => {
     });
     const main = snap({ snapshotName: 's1', html: ['HTML', {}, ['BODY', {}, 'main content']] });
     expect(renderSnapshotHtml([iframe, main], 's1')).toContain('main content');
+  });
+});
+
+describe('collectStylesheetLinks', () => {
+  test('returns unique stylesheet hrefs and ignores non-stylesheet links', () => {
+    const html =
+      '<head>' +
+      '<link rel="stylesheet" href="/a.css">' +
+      "<link rel='stylesheet' href='/b.css'>" +
+      '<link rel="preload" as="style" href="/c.css">' + // not rel=stylesheet
+      '<link rel="icon" href="/favicon.ico">' +
+      '<link rel="stylesheet" href="/a.css">' + // dupe
+      '<link rel="stylesheet">' + // no href
+      '</head>';
+    expect(collectStylesheetLinks(html)).toEqual(['/a.css', '/b.css']);
+  });
+
+  test('matches a stylesheet token among several rel values and a bare href', () => {
+    expect(collectStylesheetLinks('<link rel="preload stylesheet" href=bare.css>')).toEqual(['bare.css']);
+  });
+});
+
+describe('inlineStylesheets', () => {
+  test('replaces matching stylesheet links in place, leaving unmatched ones alone', () => {
+    const html = '<head><link rel="stylesheet" href="/app.css"><link rel="stylesheet" href="/missing.css"></head>';
+    const out = inlineStylesheets(html, { '/app.css': 'body{color:red}' });
+    expect(out).toContain('<style>body{color:red}</style>');
+    expect(out).not.toContain('href="/app.css"');
+    // Unknown sheet stays as a link (its href may still resolve; no worse off).
+    expect(out).toContain('<link rel="stylesheet" href="/missing.css">');
+  });
+
+  test('preserves the media attribute on the inlined style', () => {
+    const html = '<link rel="stylesheet" href="/print.css" media="print">';
+    expect(inlineStylesheets(html, { '/print.css': 'a{}' })).toBe('<style media="print">a{}</style>');
+  });
+
+  test('defangs a stray </style> in the CSS and masks token-shaped strings', () => {
+    const css =
+      '.x{content:"</style><script>alert(1)</script>"}.y{background:url(data:image/png;base64,iVBORw0KGgoAAAA==)}';
+    const out = inlineStylesheets('<link rel="stylesheet" href="x">', { x: css });
+    expect(out).not.toContain('</style><script>'); // the closing tag can't break out
+    expect(out).toContain('<\\/style>');
+    expect(out).toContain('data:[masked]'); // secret masking still applies
+    expect(out).not.toContain('iVBORw0KGgo');
+  });
+
+  test('stops inlining once the CSS budget is spent, keeping later links intact', () => {
+    const html = '<link rel="stylesheet" href="/a.css"><link rel="stylesheet" href="/b.css">';
+    const out = inlineStylesheets(html, { '/a.css': 'aaaa', '/b.css': 'bbbb' }, 4);
+    expect(out).toContain('<style>aaaa</style>'); // first fits the budget of 4
+    expect(out).toContain('<link rel="stylesheet" href="/b.css">'); // second exceeds it → left as a link
+  });
+
+  test('is a no-op when there is nothing to inline', () => {
+    expect(inlineStylesheets('<link rel="stylesheet" href="/a.css">', {})).toBe(
+      '<link rel="stylesheet" href="/a.css">',
+    );
+  });
+});
+
+describe('parseResourceSnapshots', () => {
+  const line = (url: string, sha1: string | null) =>
+    JSON.stringify({
+      type: 'resource-snapshot',
+      snapshot: { request: { url }, response: { content: sha1 ? { _sha1: sha1 } : {} } },
+    });
+
+  test('maps resource URLs to their content hash, ignoring other events and lines without a hash', () => {
+    const text = [
+      line('http://app/main.css', 'aaa.css'),
+      JSON.stringify({ type: 'context-options' }), // unrelated event
+      'not json at all',
+      line('http://app/no-hash.css', null), // response carries no _sha1
+    ].join('\n');
+    const map = parseResourceSnapshots([text]);
+    expect(map.get('http://app/main.css')).toBe('aaa.css');
+    expect(map.has('http://app/no-hash.css')).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  test('later snapshots win for a repeated URL', () => {
+    const text = [line('http://app/x.css', 'old.css'), line('http://app/x.css', 'new.css')].join('\n');
+    expect(parseResourceSnapshots([text]).get('http://app/x.css')).toBe('new.css');
   });
 });
 
@@ -303,6 +393,17 @@ describe('extractDomSnapshot — styled/lean two-pass', () => {
     expect(res.html).toContain('.x{color:red}'); // styles preserved
     expect(res.html).toContain('<button>Click me</button>');
     expect(res.viewport).toEqual({ width: 1280, height: 720 });
+  });
+
+  test('surfaces the frame URL of the rendered snapshot (the base for stylesheet inlining)', () => {
+    const frames: TraceFrameSnapshot[] = [
+      snap({
+        snapshotName: 'after@call@1',
+        frameUrl: 'http://127.0.0.1:42589/checkout',
+        html: ['HTML', {}, ['BODY', {}, ['BUTTON', {}, 'Pay']]],
+      }),
+    ];
+    expect(extractDomSnapshot(traceData(frames), 1_000_000).frameUrl).toBe('http://127.0.0.1:42589/checkout');
   });
 
   test('falls back to a lean render (styles dropped) so the body survives a tiny cap', () => {

--- a/application/tests/unit/snapshot-picker-script.test.ts
+++ b/application/tests/unit/snapshot-picker-script.test.ts
@@ -68,6 +68,17 @@ describe('snapshotPickerScriptTag / buildPickerDocument', () => {
     expect(tag.match(/<\/script>/g)).toHaveLength(1);
   });
 
+  test('the serialized picker swallows page interaction and re-arms the block after a pick', () => {
+    const tag = snapshotPickerScriptTag({ probedAttrs: [] });
+    // A representative slice of the events a dead snapshot must ignore so a
+    // click never navigates a link, submits a form, or activates a control.
+    for (const evt of ['submit', 'contextmenu', 'auxclick', 'dragstart', 'keypress', 'touchstart']) {
+      expect(tag).toContain(evt);
+    }
+    // The iframe stays inert through the review step (a pick doesn't re-enable it).
+    expect(tag).toContain('freezeAfterPick');
+  });
+
   test('buildPickerDocument strips <base> and appends the script after the HTML', () => {
     const doc = buildPickerDocument('<body><base href="http://x/"><button>Go</button></body>', { probedAttrs: [] });
     expect(doc).not.toContain('<base');


### PR DESCRIPTION
## What & why

Enables the DOM snapshot picker to render styled by inlining external stylesheets from the trace's captured resources. The picker runs in an opaque-origin iframe that cannot fetch the original test server's CSS, so this change embeds stylesheet content directly into the HTML.

Key additions:
- **Stylesheet inlining**: Collects `<link rel="stylesheet">` elements, resolves them against captured network resources, and replaces them with inline `<style>` tags
- **Asset embedding**: Inlines CSS `url()` references (fonts, background images) as base64 `data:` URIs so they render offline
- **Resource parsing**: Extracts content hashes and MIME types from the trace's `.network` stream to locate stored files
- **Security**: Masks token-shaped secrets (JWTs, long hex) in CSS while preserving embedded data URIs
- **Budget controls**: Enforces size limits per stylesheet and across all inlined assets to prevent bloat
- **Graceful degradation**: Missing or oversized resources are left as-is; inlining failures don't break the snapshot

The picker now requests stylesheets via an `inlineStyles` query parameter; the read-only DOM card omits this to avoid noise in the text view.

Also hardens the snapshot picker's event handling to fully suppress page interactions (clicks, form submissions, keyboard input) while picking, preventing accidental navigation or control activation in the dead snapshot.

## How was it tested?

- Added comprehensive unit tests for stylesheet collection, inlining, CSS URL parsing, and resource snapshot parsing
- Added tests for CSS masking that verify secrets are scrubbed while data URIs survive
- Added tests for the picker's event suppression behavior
- Existing snapshot extraction tests updated to verify `frameUrl` is surfaced for stylesheet resolution
- All tests pass; no breaking changes to existing APIs

https://claude.ai/code/session_01FLe67BTKfyM6CUg41J7mWg