### PR TITLE
feat(app): warn when the linked folder holds none of the tests being run

### DIFF
--- a/application/app/components/desktop/DesktopRunLocallyModal.vue
+++ b/application/app/components/desktop/DesktopRunLocallyModal.vue
@@ -40,6 +40,35 @@ const runModeItems = [
 ];
 
 const linked = computed(() => !!link.value?.exists);
+
+// A project linked to the wrong checkout is the likeliest reason a local run
+// dies immediately, and Playwright reports it as a module-resolution stack
+// trace from whatever config that folder happens to hold. Ask the shell which
+// spec files are actually there before anything is spawned.
+const specFiles = computed(() => [...new Set(props.cases.map((c) => c.filePath).filter(Boolean))]);
+const missingSpecs = ref<string[]>([]);
+
+async function checkSpecs() {
+  const core = tauriCore();
+  missingSpecs.value = [];
+  if (!core || !linked.value || specFiles.value.length === 0) return;
+  try {
+    const result = await core.invoke<{ folder: string; missing: string[] }>('desktop_check_local_specs', {
+      projectId: String(props.projectId),
+      files: specFiles.value,
+    });
+    missingSpecs.value = result?.missing ?? [];
+  } catch {
+    // An older shell without the command — the run itself still reports.
+  }
+}
+
+watch([open, () => link.value?.path, linked], () => {
+  if (open.value) void checkSpecs();
+});
+
+/** Every spec absent points at the folder rather than at any one test. */
+const wrongFolder = computed(() => specFiles.value.length > 0 && missingSpecs.value.length === specFiles.value.length);
 const plan = computed(() =>
   buildLocalRunPlan(props.cases, {
     mode: mode.value,
@@ -156,6 +185,43 @@ watch(
               <USwitch v-model="trace" :disabled="running" />
             </UFormField>
           </div>
+
+          <UAlert
+            v-if="missingSpecs.length > 0"
+            color="warning"
+            variant="soft"
+            icon="i-lucide-file-question"
+            :title="
+              wrongFolder ? 'None of these tests are in the linked folder' : 'Some tests are not in the linked folder'
+            "
+          >
+            <template #description>
+              <p>
+                Not found under <code class="text-xs">{{ link?.path }}</code
+                >: <code class="text-xs">{{ missingSpecs[0] }}</code
+                ><span v-if="missingSpecs.length > 1"> and {{ missingSpecs.length - 1 }} more</span>.
+              </p>
+              <p class="mt-1">
+                <template v-if="wrongFolder">
+                  This project is probably linked to a different checkout than the one these tests come from.
+                </template>
+                <template v-else> Running anyway is fine when your Playwright config puts them elsewhere. </template>
+              </p>
+              <UButton
+                v-if="wrongFolder"
+                size="xs"
+                color="warning"
+                variant="soft"
+                icon="i-lucide-folder-search"
+                class="mt-2"
+                :loading="busy"
+                :disabled="running"
+                @click="pickAndLink"
+              >
+                Choose the right folder…
+              </UButton>
+            </template>
+          </UAlert>
 
           <div class="space-y-1">
             <div class="text-xs text-muted">Runs in the linked folder</div>

--- a/application/tests/desktop-local-run.spec.ts
+++ b/application/tests/desktop-local-run.spec.ts
@@ -23,8 +23,8 @@ declare global {
 }
 
 /** Install a fake `window.__TAURI__` before any app script runs. */
-async function installFakeBridge(page: Page, options: { linked: boolean }) {
-  await page.addInitScript((opts: { linked: boolean }) => {
+async function installFakeBridge(page: Page, options: { linked: boolean; missingSpecs?: string[] }) {
+  await page.addInitScript((opts: { linked: boolean; missingSpecs?: string[] }) => {
     const listeners: ((event: { payload: unknown }) => void)[] = [];
     const state = {
       link: opts.linked ? { path: '/home/dev/acme', exists: true } : null,
@@ -44,6 +44,8 @@ async function installFakeBridge(page: Page, options: { linked: boolean }) {
               case 'desktop_set_project_link':
                 state.link = { path: '/home/dev/acme', exists: true };
                 return null;
+              case 'desktop_check_local_specs':
+                return { folder: '/home/dev/acme', missing: opts.missingSpecs ?? [] };
               case 'desktop_run_local_tests':
                 setTimeout(() => {
                   for (const emit of listeners) {
@@ -149,6 +151,23 @@ test.describe('Desktop local run', () => {
     expect(runInvocation).toBeTruthy();
     expect(runInvocation!.args!.args).toEqual(['tests/checkout.spec.ts:42', '--project=chromium']);
     expect(String(runInvocation!.args!.projectId)).toMatch(/^\d+$/);
+  });
+
+  test('warns before running when the linked folder holds none of the tests', async ({ page }) => {
+    await installFakeBridge(page, { linked: true, missingSpecs: ['tests/checkout.spec.ts'] });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    const dialog = page.getByRole('dialog');
+
+    await expect(dialog.getByText('None of these tests are in the linked folder')).toBeVisible();
+    await expect(dialog.getByText('tests/checkout.spec.ts', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('linked to a different checkout')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Choose the right folder…' })).toBeVisible();
+
+    // A warning, never a block: the config may put specs elsewhere.
+    await expect(dialog.getByRole('button', { name: 'Run', exact: true })).toBeEnabled();
   });
 
   test('prompts to link a folder when none is linked yet', async ({ page }) => {

--- a/desktop/e2e/tests/shell.spec.ts
+++ b/desktop/e2e/tests/shell.spec.ts
@@ -59,6 +59,16 @@ test('the dashboard can reach the shell IPC commands', async ({ tauriPage }) => 
   expect(rejected.rejected).toBe(true);
   expect(rejected.error).toContain('absolute');
 
+  // The spec pre-flight is granted too, and refuses an unlinked project from
+  // inside the handler rather than at the ACL.
+  const specs = (await tauriPage.evaluate(`
+    window.__TAURI__.core.invoke('desktop_check_local_specs', { projectId: 'e2e-no-such-project', files: ['tests/a.spec.ts'] })
+      .then(() => ({ rejected: false, error: '' }))
+      .catch((e) => ({ rejected: true, error: String((e && e.message) || e) }))
+  `)) as { rejected: boolean; error: string };
+  expect(specs.rejected).toBe(true);
+  expect(specs.error).toContain('linked');
+
   // The MCP configurator command is granted and reports every known client.
   const mcp = (await tauriPage.evaluate(`
     window.__TAURI__.core.invoke('desktop_mcp_clients')

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -24,6 +24,7 @@ fn main() {
             "desktop_set_project_link",
             "desktop_run_local_tests",
             "desktop_stop_local_tests",
+            "desktop_check_local_specs",
             "desktop_take_pending_open_files",
             "desktop_mcp_clients",
             "desktop_mcp_connect",

--- a/desktop/src-tauri/capabilities/remote.json
+++ b/desktop/src-tauri/capabilities/remote.json
@@ -19,6 +19,7 @@
     "allow-desktop-set-project-link",
     "allow-desktop-run-local-tests",
     "allow-desktop-stop-local-tests",
+    "allow-desktop-check-local-specs",
     "allow-desktop-take-pending-open-files",
     "allow-desktop-mcp-clients",
     "allow-desktop-mcp-connect",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -35,8 +35,8 @@ use tauri_plugin_store::StoreExt as _;
 use mcp_clients::{desktop_mcp_clients, desktop_mcp_connect, desktop_mcp_disconnect, desktop_mcp_reveal};
 use updates::{desktop_check_update, desktop_install_update, desktop_restart_app};
 use runner::{
-    desktop_get_project_link, desktop_pick_folder, desktop_run_local_tests,
-    desktop_set_project_link, desktop_stop_local_tests,
+    desktop_check_local_specs, desktop_get_project_link, desktop_pick_folder,
+    desktop_run_local_tests, desktop_set_project_link, desktop_stop_local_tests,
 };
 
 pub(crate) const STORE_FILE: &str = "settings.json";
@@ -472,6 +472,7 @@ pub fn run() {
             desktop_set_project_link,
             desktop_run_local_tests,
             desktop_stop_local_tests,
+            desktop_check_local_specs,
             desktop_take_pending_open_files,
             desktop_mcp_clients,
             desktop_mcp_connect,

--- a/desktop/src-tauri/src/runner.rs
+++ b/desktop/src-tauri/src/runner.rs
@@ -11,8 +11,8 @@
 // Links live in the shell's own store (`settings.json`), not the server
 // database — a folder path is a fact about this machine, not about the project.
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
 
@@ -138,6 +138,62 @@ pub fn desktop_set_project_link(
     let store = app.store(STORE_FILE).map_err(|e| e.to_string())?;
     store.set(PROJECT_LINKS_KEY, json!(links));
     store.save().map_err(|e| e.to_string())
+}
+
+#[derive(serde::Serialize)]
+pub struct SpecCheck {
+    folder: String,
+    missing: Vec<String>,
+}
+
+/// The given spec paths that are absent from `folder`, in the order given and
+/// without repeats.
+///
+/// A path that is absolute, or that climbs out of the folder, is skipped
+/// rather than reported: it says nothing about whether the right folder is
+/// linked, and the answer here only ever drives a warning.
+fn missing_specs(folder: &Path, files: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut missing = Vec::new();
+    for file in files {
+        let relative = Path::new(file);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|part| matches!(part, Component::ParentDir))
+        {
+            continue;
+        }
+        if !seen.insert(file.as_str()) {
+            continue;
+        }
+        if !folder.join(relative).is_file() {
+            missing.push(file.clone());
+        }
+    }
+    missing
+}
+
+/// Which of a run's spec files the linked folder does not contain — the cheap
+/// way to catch a project linked to the wrong checkout before spawning a run
+/// whose failure would surface as a module-resolution stack trace.
+#[tauri::command]
+pub fn desktop_check_local_specs(
+    app: AppHandle,
+    project_id: String,
+    files: Vec<String>,
+) -> Result<SpecCheck, String> {
+    let folder = read_links(&app)
+        .get(&project_id)
+        .map(PathBuf::from)
+        .ok_or("no folder is linked to this project")?;
+    if !folder.is_dir() {
+        return Err("the linked folder no longer exists — pick it again".into());
+    }
+    Ok(SpecCheck {
+        missing: missing_specs(&folder, &files),
+        folder: folder.to_string_lossy().to_string(),
+    })
 }
 
 /// Find the linked folder's own Playwright CLI entry, walking up so a package
@@ -276,5 +332,84 @@ pub fn desktop_stop_local_tests(app: AppHandle, run_id: u32) -> Result<(), Strin
     match child {
         Some(c) => c.kill().map_err(|e| e.to_string()),
         None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A folder holding `tests/a.spec.ts`, removed when the test ends.
+    struct Checkout(PathBuf);
+
+    impl Checkout {
+        fn new(label: &str) -> Self {
+            use std::sync::atomic::AtomicU32;
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let unique = COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path = std::env::temp_dir()
+                .join(format!("piwi-run-{label}-{}-{unique}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(path.join("tests")).expect("create checkout");
+            std::fs::write(path.join("tests").join("a.spec.ts"), "").expect("write spec");
+            Self(path)
+        }
+    }
+
+    impl Drop for Checkout {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn reports_only_the_specs_the_folder_does_not_hold() {
+        let checkout = Checkout::new("partial");
+
+        let missing = missing_specs(
+            &checkout.0,
+            &["tests/a.spec.ts".into(), "tests/example.spec.ts".into()],
+        );
+
+        assert_eq!(missing, vec!["tests/example.spec.ts".to_string()]);
+    }
+
+    #[test]
+    fn reports_nothing_when_every_spec_is_present() {
+        let checkout = Checkout::new("complete");
+        assert!(missing_specs(&checkout.0, &["tests/a.spec.ts".into()]).is_empty());
+    }
+
+    #[test]
+    fn reports_each_missing_spec_once() {
+        let checkout = Checkout::new("dupes");
+
+        let missing = missing_specs(
+            &checkout.0,
+            &["tests/gone.spec.ts".into(), "tests/gone.spec.ts".into()],
+        );
+
+        assert_eq!(missing, vec!["tests/gone.spec.ts".to_string()]);
+    }
+
+    #[test]
+    fn skips_paths_that_cannot_be_judged_against_the_folder() {
+        let checkout = Checkout::new("outside");
+
+        let missing = missing_specs(
+            &checkout.0,
+            &["../elsewhere/b.spec.ts".into(), "/abs/c.spec.ts".into()],
+        );
+
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn directories_do_not_count_as_specs() {
+        let checkout = Checkout::new("dir");
+        assert_eq!(
+            missing_specs(&checkout.0, &["tests".into()]),
+            vec!["tests".to_string()]
+        );
     }
 }


### PR DESCRIPTION
## What & why

A project linked to the wrong checkout is the likeliest reason a local run dies the instant it starts — and the failure surfaces as whatever the *linked* folder's Playwright config chokes on. In the case that prompted this, a project was linked to a checkout of this repo, so `Run locally` loaded Piwi's own `playwright.config.ts` and the user got:

```
Error: Cannot find package '@piwitests/reporter' imported from …\application\playwright.config.ts
```

…for a run whose tests were `tests/example.spec.ts` in an entirely different project. Nothing in that stack trace points at the actual mistake.

The run dialog now asks the shell which of the run's spec files exist under the linked folder before anything is spawned, and names the ones that don't. When *every* spec is missing — the signal that the folder itself is wrong, rather than one stale test — the alert says so and offers the folder picker inline.

Deliberately **a warning, not a block**: a config whose `testDir` resolves outside the linked folder is perfectly legitimate (monorepos especially), so **Run** stays enabled in both cases and the wording differs accordingly. Paths that are absolute or climb out of the folder are skipped rather than reported — they say nothing about whether the right folder is linked, and skipping them also keeps the shell from stat-ing paths the webview picked.

## How was it tested?

- **5 new Rust unit tests** on the pure `missing_specs` helper (17 in the crate, all green): reports only absent specs, reports nothing when all are present, de-duplicates repeats, skips absolute and `..` paths, and treats a directory as not-a-spec.
- New case in `desktop-local-run.spec.ts`: with a faked bridge reporting a missing spec, the dialog shows the "None of these tests are in the linked folder" alert, names the file, explains the likely cause, offers **Choose the right folder…**, and leaves **Run** enabled. The existing fake bridge learned the new command, so the other three cases still cover the unaffected paths. 4/4 pass (serially and in parallel).
- Desktop shell e2e extended: `desktop_check_local_specs` is refused by the handler, not the ACL, for an unlinked project — the same runtime-grant proof used for the other commands.
- `desktop-acl-consistency` covers the new command's three-way wiring; `cargo test`/`check`/`rustfmt`, `nuxt typecheck`, oxlint and the 1179-test unit suite all green.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing — none needed; this adds a guard inside a flow `docs/desktop.md` already describes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzMq6FrbK7RBHFMWymwkJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzMq6FrbK7RBHFMWymwkJN)_