### PR TITLE
feat: add Setup page with capability detection and checklist

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,16 @@
 
 Piwi Dashboard is under active development (pre-1.0). This page shows direction, not promises — priorities shift with feedback, and the best way to influence them is a [GitHub Discussion](https://github.com/PiwiTests/platform/discussions).
 
+## What Piwi is for
+
+Everything below is in service of three things, in this order. When a proposed feature doesn't strengthen one of them, that's the argument against building it.
+
+1. **Keep the history.** CI deletes every report it makes. Piwi keeps every run, trace and report, so "has this always been flaky?" and "did my fix hold?" are answerable at all.
+2. **Explain the failures.** Group them by root cause so forty red tests become three problems, score the flaky ones by what they actually cost, and — optionally — have an LLM explain a cluster against your real diff.
+3. **Hand back a fix.** A ranked replacement locator, a validated patch, an owner, a command that verifies the work. The point is to leave with something to do, not just something to read.
+
+Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the desktop app — is a delivery route for those three. That's the ranking the UI follows too: the dashboard leads with results and failures, and the supporting lenses sit behind them.
+
 ## Recently shipped
 
 - **One-click deploy** — hosting templates for Railway, Render, Fly.io, Koyeb, Coolify and Dokploy, each

--- a/application/app/components/analytics/SlowEndpointsTable.vue
+++ b/application/app/components/analytics/SlowEndpointsTable.vue
@@ -44,10 +44,12 @@ function methodColor(method: string): 'success' | 'info' | 'warning' | 'error' |
         </UButton>
       </template>
     </ErrorState>
-    <EmptyState
+    <FeatureUnavailable
       v-else-if="!slow || slow.endpoints.length === 0"
       icon="i-lucide-network"
-      text="No network requests captured in this period."
+      title="No network requests captured in this period"
+      text="Slow endpoints need the Piwi capture fixtures — extend your Playwright test with piwiFixtures and request timing rides along with every run."
+      doc="capture-fixtures"
     />
     <template v-else>
       <!-- Mobile: card list -->

--- a/application/app/components/cluster/ClusterTestEvidence.vue
+++ b/application/app/components/cluster/ClusterTestEvidence.vue
@@ -181,7 +181,7 @@ const evidenceChips = computed(() => {
       </button>
     </div>
 
-    <!-- Selected case header: title, file location, link to the test run case -->
+    <!-- Selected case header: title, file location, link to the execution -->
     <div v-if="selectedCase" class="flex items-start justify-between gap-2 flex-wrap">
       <div class="min-w-0">
         <p class="text-sm font-medium break-words">{{ selectedCase.title }}</p>
@@ -199,7 +199,7 @@ const evidenceChips = computed(() => {
         color="neutral"
         trailing-icon="i-lucide-arrow-right"
       >
-        Open test run case
+        Open execution
       </UButton>
     </div>
 

--- a/application/app/components/layout/UserMenu.vue
+++ b/application/app/components/layout/UserMenu.vue
@@ -55,7 +55,8 @@ const items = computed<DropdownMenuItem[][]>(() => {
   if (!config.public.authEnabled || (authState.value.authenticated && authState.value.user?.role === 'administrator')) {
     // Nav items are reused as dropdown items (both are link items); the cast
     // bridges the slightly different `type` union between the two Nuxt UI types.
-    configurationMenuItems.push(...(settingsNav.value as unknown as DropdownMenuItem[]));
+    // `settingsNav` is grouped into sections — this menu wants one flat list.
+    configurationMenuItems.push(...(settingsNav.value.flat() as unknown as DropdownMenuItem[]));
   }
 
   const baseItems: DropdownMenuItem[][] = [

--- a/application/app/components/run/SlowEndpoints.vue
+++ b/application/app/components/run/SlowEndpoints.vue
@@ -137,13 +137,13 @@ const endpointColumns: TableColumn<EndpointSummary>[] = [
       </template>
     </UTable>
 
-    <div v-else class="flex-1 flex items-center justify-center text-center text-gray-500">
-      <UIcon name="i-lucide-wifi-off" class="size-8 mx-auto mb-2 text-gray-300 dark:text-gray-600" />
-      <p>
-        No network request data. Add the
-        <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 rounded font-mono">@piwitests/reporter</code>
-        fixtures to your test setup.
-      </p>
-    </div>
+    <FeatureUnavailable
+      v-else
+      class="flex-1"
+      icon="i-lucide-wifi-off"
+      title="No network requests captured"
+      text="Slow endpoints need the Piwi capture fixtures — extend your Playwright test with piwiFixtures and request timing rides along with every run."
+      doc="capture-fixtures"
+    />
   </div>
 </template>

--- a/application/app/components/shared/FeatureUnavailable.vue
+++ b/application/app/components/shared/FeatureUnavailable.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+/**
+ * Empty state for a block whose data depends on an optional capability the user
+ * may simply never have switched on.
+ *
+ * A plain "no data" message is indistinguishable from a broken feature, which
+ * is the fastest way to make a tool feel thin. This says *why* it is empty and
+ * links to the fix. Use it only where emptiness has a known cause — a genuinely
+ * empty-but-working block should keep using `EmptyState`.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** What's missing, e.g. "Network capture". */
+    title: string;
+    /** One line naming the requirement, e.g. "needs the Piwi capture fixtures". */
+    text: string;
+    icon?: string;
+    /** Docs page (+ optional `#anchor`) for the setup instructions. */
+    doc?: string;
+    /** In-app route that switches it on, when one exists. Defaults to /setup. */
+    to?: string;
+    toLabel?: string;
+    padded?: boolean;
+  }>(),
+  { icon: 'i-lucide-plug-zap', to: '/setup', toLabel: 'How to enable', padded: true },
+);
+</script>
+
+<template>
+  <div
+    class="flex flex-col items-center justify-center gap-2 text-center text-gray-500"
+    :class="props.padded && 'py-8'"
+  >
+    <UIcon :name="props.icon" class="size-6 opacity-60" />
+    <p class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ props.title }}</p>
+    <p class="text-sm max-w-md">{{ props.text }}</p>
+    <div class="flex items-center gap-3 mt-1">
+      <UButton :to="props.to" size="xs" variant="soft" icon="i-lucide-rocket">{{ props.toLabel }}</UButton>
+      <DocLink v-if="props.doc" :to="props.doc" class="text-sm">Docs</DocLink>
+    </div>
+    <slot />
+  </div>
+</template>

--- a/application/app/components/test-case/TestCaseEvidenceCard.vue
+++ b/application/app/components/test-case/TestCaseEvidenceCard.vue
@@ -94,7 +94,13 @@ defineExpose({ reveal: () => card.value?.reveal?.() });
         </div>
       </TestEvidenceSection>
 
-      <EmptyState v-if="totalCount === 0" icon="i-lucide-camera-off" text="No screenshots, video or traces captured" />
+      <FeatureUnavailable
+        v-if="totalCount === 0"
+        icon="i-lucide-camera-off"
+        title="No screenshots, video or traces captured"
+        text="Evidence comes from Playwright's own capture settings — set trace, screenshot and video in your config (trace: 'retain-on-failure' is the usual starting point)."
+        doc="reporter"
+      />
     </div>
   </CollapsibleSectionCard>
 </template>

--- a/application/app/composables/useSettingsNav.ts
+++ b/application/app/composables/useSettingsNav.ts
@@ -1,12 +1,17 @@
 import type { NavigationMenuItem } from '@nuxt/ui';
 import { toValue, type MaybeRefOrGetter } from 'vue';
-import { SETTINGS_PAGES, type SettingsPageId } from '~/utils/settings-metadata';
+import { SETTINGS_PAGES, SETTINGS_GROUPS, type SettingsPageId } from '~/utils/settings-metadata';
 
 /**
- * Build the Settings sub-navigation from the shared `SETTINGS_PAGES` registry.
+ * Build the Settings sub-navigation from the shared `SETTINGS_PAGES` registry,
+ * grouped into sections (Instance / Analysis / meta) so the ten pages read as
+ * two jobs rather than one undifferentiated list. Returns the `[][]` shape
+ * `UNavigationMenu` renders with a separator between sections.
+ *
  * Admin-only pages are hidden for non-admins (no more 403 on click). Pages that
  * are currently env-managed get a trailing lock badge, so an admin can see at a
- * glance which settings are pinned by the environment.
+ * glance which settings are pinned by the environment. A section whose pages are
+ * all hidden collapses away rather than leaving an empty separator.
  *
  * `envManaged` is the per-page state from `useSettingsEnvState` (a ref or
  * getter); pass it to make the lock badges reactive. When omitted, no lock
@@ -22,10 +27,13 @@ export function useSettingsNav(envManaged?: MaybeRefOrGetter<Record<SettingsPage
   // (pages flagged `authOnly`) is meaningless there — hide it.
   const isDesktop = useIsDesktop();
 
-  const items = computed<NavigationMenuItem[]>(() => {
+  const items = computed<NavigationMenuItem[][]>(() => {
     const admin = canSeeAdmin.value;
     const managedMap = envManaged ? toValue(envManaged) : undefined;
-    return SETTINGS_PAGES.filter((page) => (!page.roles || admin) && !(isDesktop && page.authOnly)).map((page) => {
+
+    const visible = SETTINGS_PAGES.filter((page) => (!page.roles || admin) && !(isDesktop && page.authOnly));
+
+    const toItem = (page: (typeof visible)[number]): NavigationMenuItem => {
       const managed = managedMap?.[page.id] ?? false;
       return {
         label: page.label,
@@ -34,7 +42,11 @@ export function useSettingsNav(envManaged?: MaybeRefOrGetter<Record<SettingsPage
         // Trailing lock badge marks env-pinned pages.
         ...(managed ? { badge: { icon: 'i-lucide-lock', color: 'neutral' as const } } : {}),
       } satisfies NavigationMenuItem;
-    });
+    };
+
+    return SETTINGS_GROUPS.map((group) => visible.filter((page) => page.group === group.id).map(toItem)).filter(
+      (section) => section.length > 0,
+    );
   });
 
   return items;

--- a/application/app/demo/api/router.ts
+++ b/application/app/demo/api/router.ts
@@ -99,6 +99,7 @@ import {
   updateUserRecord,
 } from '#shared/handlers/users';
 import { searchProjectsTestRunsCases } from '#shared/handlers/search';
+import { getSetupStatus } from '#shared/handlers/setup-status';
 import {
   apiSetupTestRun,
   apiBeginTestRun,
@@ -841,6 +842,14 @@ const routes: RouteEntry[] = [
     method: 'GET',
     pattern: /^\/api\/search$/,
     handler: async (_, __, q, ctx) => searchProjectsTestRunsCases(await getDemoDb(), q?.get('q') || '', ctx?.scope),
+  },
+
+  // Setup status — the same evidence probes as the server, run against the
+  // in-browser demo DB, so the Setup page's checklist reflects the seeded data.
+  {
+    method: 'GET',
+    pattern: /^\/api\/setup-status$/,
+    handler: async () => getSetupStatus(await getDemoDb()),
   },
 
   // Version — demo runs entirely client-side (sql.js in the browser, no Node

--- a/application/app/layouts/default.vue
+++ b/application/app/layouts/default.vue
@@ -162,6 +162,14 @@ const links = computed(() => {
     },
   });
   bottomLinks.unshift({
+    label: 'Setup',
+    icon: 'i-lucide-rocket',
+    to: '/setup',
+    onSelect: () => {
+      open.value = false;
+    },
+  });
+  bottomLinks.unshift({
     label: 'API Docs',
     icon: 'i-lucide-book-open',
     to: '/docs',
@@ -261,14 +269,17 @@ const groups = computed<CommandPaletteGroup[]>(() => {
   // omitted; the project page also tolerates an unknown ?tab= by falling back.
   if (currentProjectId.value) {
     const pid = currentProjectId.value;
+    // Same order as the project page's grouped tab strip (Results → Failures →
+    // Health), so the palette and the page agree on where a tab sits.
     const projectTabs: [value: string, label: string, icon: string][] = [
       ['test-runs', 'Test runs', 'i-lucide-play'],
-      ['failure-clusters', 'Failure clusters', 'i-lucide-layers'],
-      ['flaky-tests', 'Flaky tests', 'i-lucide-shuffle'],
-      ['performance', 'Performance', 'i-lucide-trending-up'],
       ['test-cases', 'Test cases', 'i-lucide-flask-conical'],
       ['compare', 'Compare', 'i-lucide-git-compare-arrows'],
+      ['failure-clusters', 'Failure clusters', 'i-lucide-layers'],
+      ['flaky-tests', 'Flaky tests', 'i-lucide-shuffle'],
+      ['quarantine', 'Quarantine', 'i-lucide-shield-alert'],
       ['spec-health', 'Spec health', 'i-lucide-table-2'],
+      ['performance', 'Performance', 'i-lucide-trending-up'],
       ['timeline', 'Timeline', 'i-lucide-git-commit-horizontal'],
     ];
     staticGroups.unshift({

--- a/application/app/pages/analytics.vue
+++ b/application/app/pages/analytics.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue';
-import { ANALYTICS_WIDGETS, type AnalyticsWidgetId } from '#shared/analytics/registry';
+import { ANALYTICS_WIDGETS, ANALYTICS_BANDS, type AnalyticsWidgetId } from '#shared/analytics/registry';
 import { MAX_ANALYTICS_DAYS } from '#shared/analytics/scope';
 import type { ProjectMenuItem, TestRunForChart } from '~~/types/api';
 import {
@@ -78,6 +78,14 @@ const WIDGET_COMPONENTS: Record<AnalyticsWidgetId, Component> = {
   'browser-matrix': BrowserMatrix,
   'slow-endpoints': SlowEndpointsTable,
 };
+
+/** Widgets grouped into their bands, in registry order, empty bands dropped. */
+const bands = computed(() =>
+  ANALYTICS_BANDS.map((band) => ({
+    ...band,
+    widgets: ANALYTICS_WIDGETS.filter((w) => w.band === band.id),
+  })).filter((band) => band.widgets.length > 0),
+);
 </script>
 
 <template>
@@ -113,15 +121,18 @@ const WIDGET_COMPONENTS: Record<AnalyticsWidgetId, Component> = {
           ]"
         />
 
-        <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
-          <div
-            v-for="widget in ANALYTICS_WIDGETS"
-            :key="widget.id"
-            :class="widget.size === 'full' ? 'xl:col-span-2' : ''"
-          >
-            <component :is="WIDGET_COMPONENTS[widget.id]" :query="scopeQuery" />
+        <section v-for="band in bands" :key="band.id" class="space-y-3">
+          <div>
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-dimmed">{{ band.label }}</h2>
+            <p class="text-sm text-muted">{{ band.description }}</p>
           </div>
-        </div>
+
+          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
+            <div v-for="widget in band.widgets" :key="widget.id" :class="widget.size === 'full' ? 'xl:col-span-2' : ''">
+              <component :is="WIDGET_COMPONENTS[widget.id]" :query="scopeQuery" />
+            </div>
+          </div>
+        </section>
       </div>
     </template>
   </UDashboardPanel>

--- a/application/app/pages/index.vue
+++ b/application/app/pages/index.vue
@@ -378,7 +378,9 @@ const featureHighlights = [
           <p>No runs match the current filters.</p>
         </div>
 
-        <!-- Empty state: setup wizard first (the actionable step), feature highlights after -->
+        <!-- Empty state: setup wizard first (the actionable step), feature highlights after.
+             Once projects exist the wizard moves to /setup, which stays reachable from the
+             sidebar — the steps past "install the reporter" must not vanish on first run. -->
         <template v-if="!hasProjects">
           <GetStartedWizard />
 

--- a/application/app/pages/projects/[id]/index.vue
+++ b/application/app/pages/projects/[id]/index.vue
@@ -195,42 +195,79 @@ watch(activeTab, (tab) => {
 
 const hasFailures = computed(() => project.value?.testRuns?.some((r) => r.failedTests > 0) ?? false);
 
-const tabItems = computed(() => [
+/**
+ * Tabs, grouped by the question they answer rather than listed flat.
+ *
+ * Ten peer tabs made the page read as a pile — "Performance" sat between
+ * "Flaky tests" and "Test cases" for no reason a reader could reconstruct.
+ * The groups run: what happened (Results) → what's broken (Failures) → is the
+ * suite healthy (Health) → administration. The desktop strip renders the
+ * flattened order (adjacency alone carries most of the meaning); the mobile
+ * select and the command palette render the labelled groups.
+ */
+const tabGroups = computed(() => [
   {
-    label: `Test runs (${filteredRuns.value.length})`,
-    icon: 'i-lucide-play-circle',
-    value: 'test-runs',
-    slot: 'test-runs',
+    label: 'Results',
+    items: [
+      {
+        label: `Test runs (${filteredRuns.value.length})`,
+        icon: 'i-lucide-play-circle',
+        value: 'test-runs',
+        slot: 'test-runs',
+      },
+      {
+        label: `Test cases${testCasesTotal.value != null ? ` (${testCasesTotal.value})` : ''}`,
+        icon: 'i-lucide-list-checks',
+        value: 'test-cases',
+        slot: 'test-cases',
+      },
+      { label: 'Compare', icon: 'i-lucide-git-compare-arrows', value: 'compare', slot: 'compare' },
+    ],
   },
-  ...(hasFailures.value
+  {
+    label: 'Failures',
+    items: [
+      ...(hasFailures.value
+        ? [
+            {
+              label: 'Failure clusters',
+              icon: 'i-lucide-layers',
+              value: 'failure-clusters',
+              slot: 'failure-clusters',
+            },
+          ]
+        : []),
+      { label: 'Flaky tests', icon: 'i-lucide-shuffle', value: 'flaky-tests', slot: 'flaky-tests' },
+      { label: 'Quarantine', icon: 'i-lucide-shield-alert', value: 'quarantine', slot: 'quarantine' },
+    ],
+  },
+  {
+    label: 'Health',
+    items: [
+      { label: 'Spec health', icon: 'i-lucide-table-2', value: 'spec-health', slot: 'spec-health' },
+      { label: 'Performance', icon: 'i-lucide-trending-up', value: 'performance', slot: 'performance' },
+      {
+        label: `Timeline${markers.value.length ? ` (${markers.value.length})` : ''}`,
+        icon: 'i-lucide-milestone',
+        value: 'timeline',
+        slot: 'timeline',
+      },
+    ],
+  },
+  ...(isAdmin.value
     ? [
         {
-          label: 'Failure clusters',
-          icon: 'i-lucide-layers',
-          value: 'failure-clusters',
-          slot: 'failure-clusters',
+          label: 'Admin',
+          items: [{ label: 'Members', icon: 'i-lucide-users', value: 'members', slot: 'members' }],
         },
       ]
     : []),
-  { label: 'Flaky tests', icon: 'i-lucide-shuffle', value: 'flaky-tests', slot: 'flaky-tests' },
-  { label: 'Performance', icon: 'i-lucide-trending-up', value: 'performance', slot: 'performance' },
-  {
-    label: `Test cases${testCasesTotal.value != null ? ` (${testCasesTotal.value})` : ''}`,
-    icon: 'i-lucide-list-checks',
-    value: 'test-cases',
-    slot: 'test-cases',
-  },
-  { label: 'Compare', icon: 'i-lucide-git-compare-arrows', value: 'compare', slot: 'compare' },
-  { label: 'Spec health', icon: 'i-lucide-table-2', value: 'spec-health', slot: 'spec-health' },
-  { label: 'Quarantine', icon: 'i-lucide-shield-alert', value: 'quarantine', slot: 'quarantine' },
-  {
-    label: `Timeline${markers.value.length ? ` (${markers.value.length})` : ''}`,
-    icon: 'i-lucide-milestone',
-    value: 'timeline',
-    slot: 'timeline',
-  },
-  ...(isAdmin.value ? [{ label: 'Members', icon: 'i-lucide-users', value: 'members', slot: 'members' }] : []),
 ]);
+
+const tabItems = computed(() => tabGroups.value.flatMap((g) => g.items));
+
+/** Grouped shape for `USelect` (mobile) — array-of-arrays renders as sections. */
+const tabSelectGroups = computed(() => tabGroups.value.map((g) => g.items).filter((items) => items.length > 0));
 
 const activeTabIcon = computed(() => tabItems.value.find((t) => t.value === activeTab.value)?.icon);
 
@@ -694,7 +731,7 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
         <!-- Mobile: a select replaces the cramped tab strip; the strip scrolls from sm up. -->
         <USelect
           v-model="activeTab"
-          :items="tabItems"
+          :items="tabSelectGroups"
           :icon="activeTabIcon"
           size="md"
           class="w-full mx-1 mb-1 sm:hidden"

--- a/application/app/pages/settings.vue
+++ b/application/app/pages/settings.vue
@@ -6,13 +6,15 @@ useHead({ title: 'Settings — Piwi Dashboard' });
 const { envManaged } = useSettingsEnvState();
 const navItems = useSettingsNav(envManaged);
 
+// `navItems` already arrives grouped (Instance / Analysis / meta); the docs link
+// is appended as its own trailing section.
 const links = computed<NavigationMenuItem[][]>(() => [
-  navItems.value,
+  ...navItems.value,
   [
     {
       label: 'Documentation',
       icon: 'i-lucide-book-open',
-      to: 'https://github.com/piwitests/platform',
+      to: 'https://piwitests.github.io',
       target: '_blank',
     },
   ],

--- a/application/app/pages/settings/about.vue
+++ b/application/app/pages/settings/about.vue
@@ -1,22 +1,8 @@
 <script setup lang="ts">
-import type { AdminStats } from '~~/types/api';
-
 const config = useRuntimeConfig();
 const isDesktop = useIsDesktop();
 
 const { data: versionInfo } = await useFetch('/api/version');
-
-// Desktop build only: surface where data lives and how to connect the reporter
-// and MCP clients. These endpoints are admin-scoped / desktop-gated, so only
-// fetch them in the desktop shell (auth is off there → virtual admin).
-const { data: stats } = await useFetch<AdminStats | null>('/api/admin/stats', {
-  immediate: isDesktop,
-  default: () => null,
-});
-const { data: reporterConfig } = await useFetch<{ url: string; token: string } | null>('/api/desktop/reporter-config', {
-  immediate: isDesktop,
-  default: () => null,
-});
 
 const appVersion = config.public.appVersion as string;
 const buildSha = config.public.buildSha as string;
@@ -47,16 +33,20 @@ const dbBackendLabel = computed(() => {
       </StatTileGrid>
     </SectionCard>
 
-    <!-- Desktop shell only (renders nothing without the IPC bridge). -->
+    <!-- Desktop shell only (renders nothing without the IPC bridge). Updates stay
+         here next to the version they act on; connecting the reporter and MCP
+         clients moved to /setup, which is where "how do I hook this up" lives. -->
     <DesktopUpdateCard :current-version="appVersion" />
 
-    <!-- Desktop build only: where data lives + how to connect this local app -->
-    <template v-if="isDesktop">
-      <DataLocationCard v-if="stats" :database="stats.databaseLocation" :storage="stats.storageLocation" />
-      <DesktopReporterCard v-if="reporterConfig" :url="reporterConfig.url" :token="reporterConfig.token" />
-      <DesktopMcpCard v-if="reporterConfig" :url="reporterConfig.url" :token="reporterConfig.token" />
-      <DesktopServiceCard />
-    </template>
+    <UAlert
+      v-if="isDesktop"
+      icon="i-lucide-rocket"
+      color="neutral"
+      variant="subtle"
+      title="Connecting the reporter and AI clients"
+      description="The URL and access token for this local instance, the data location, and background-service control are on the Setup page."
+      :actions="[{ label: 'Open Setup', to: '/setup', color: 'neutral', variant: 'solid', size: 'xs' }]"
+    />
 
     <SectionCard icon="i-lucide-book-open" title="Resources">
       <div class="flex flex-wrap items-center gap-x-6 gap-y-3 text-sm">

--- a/application/app/pages/settings/index.vue
+++ b/application/app/pages/settings/index.vue
@@ -6,22 +6,24 @@
  * It used to render a "General settings" card whose entire body told you to
  * click something in the sidebar, which made the first click into Settings a
  * dead end. The target is computed from the same nav registry rather than
- * hardcoded, because "the first page" differs by role and build: an
- * unauthenticated-but-admin web instance lands on Account, a non-admin lands on
- * Account too, and the desktop build (single-user, auth off, account pages
- * hidden) lands on Notifications.
+ * hardcoded, because "the first page" differs by role and build: a web instance
+ * lands on Account (admin or not), while the desktop build — single-user, auth
+ * off, account pages hidden — lands on Notifications.
+ *
+ * The redirect is issued synchronously in setup so it also happens during SSR
+ * (a real redirect response rather than a flash of this page). `useSettingsNav`
+ * is a pure computed over the static registry plus auth state, so reading it
+ * here needs no await. The template is only what a client sees in the gap
+ * before navigation commits.
  */
 const navItems = useSettingsNav();
 
-const firstPage = computed(
-  () => navItems.value.flat().find((item) => typeof item.to === 'string')?.to as string | undefined,
-);
-
-// `replace` so the Back button returns to wherever the user came from rather
-// than bouncing them through this redirect again.
-watchEffect(() => {
-  if (firstPage.value) navigateTo(firstPage.value, { replace: true });
-});
+// `replace` so Back returns to wherever the user came from rather than bouncing
+// them through this redirect again.
+const firstPage = navItems.value.flat().find((item) => typeof item.to === 'string')?.to as string | undefined;
+if (firstPage) {
+  await navigateTo(firstPage, { replace: true });
+}
 </script>
 
 <template>

--- a/application/app/pages/settings/index.vue
+++ b/application/app/pages/settings/index.vue
@@ -1,43 +1,29 @@
 <script setup lang="ts">
-const runtimeConfig = useRuntimeConfig();
-const isDemoMode = runtimeConfig.public.demoMode;
-const { isResetting, resetDemo } = useDemoReset();
+/**
+ * `/settings` has no content of its own — it redirects to the first settings
+ * page the current user can actually see.
+ *
+ * It used to render a "General settings" card whose entire body told you to
+ * click something in the sidebar, which made the first click into Settings a
+ * dead end. The target is computed from the same nav registry rather than
+ * hardcoded, because "the first page" differs by role and build: an
+ * unauthenticated-but-admin web instance lands on Account, a non-admin lands on
+ * Account too, and the desktop build (single-user, auth off, account pages
+ * hidden) lands on Notifications.
+ */
+const navItems = useSettingsNav();
+
+const firstPage = computed(
+  () => navItems.value.flat().find((item) => typeof item.to === 'string')?.to as string | undefined,
+);
+
+// `replace` so the Back button returns to wherever the user came from rather
+// than bouncing them through this redirect again.
+watchEffect(() => {
+  if (firstPage.value) navigateTo(firstPage.value, { replace: true });
+});
 </script>
 
 <template>
-  <SectionCard icon="i-lucide-settings" title="General settings" help="settings.general">
-    <template #actions>
-      <UButton
-        v-if="isDemoMode"
-        color="error"
-        variant="soft"
-        icon="i-lucide-refresh-cw"
-        :loading="isResetting"
-        @click="resetDemo"
-      >
-        Reset demo
-      </UButton>
-    </template>
-
-    <div v-if="isDemoMode" class="flex max-sm:flex-col justify-between items-start gap-4">
-      <div>
-        <p class="font-medium text-sm">Reset demo data</p>
-        <p class="text-sm text-muted">
-          Wipe the in-browser database and reload with fresh sample data dated to the current moment. All changes made
-          during this demo session will be lost.
-        </p>
-      </div>
-    </div>
-
-    <div v-else class="text-sm text-muted">
-      <p>
-        Appearance and theme are in the top bar. Use the sidebar to manage your account, users, AI diagnosis,
-        notifications, storage, and tags.
-      </p>
-      <p class="mt-2">
-        Settings that can be overridden by <code class="font-mono text-xs">PIWI_*</code> environment variables show a
-        lock badge with the variable name — hover the help icon on any card to see which env var backs a setting.
-      </p>
-    </div>
-  </SectionCard>
+  <LoadingState text="Opening settings…" />
 </template>

--- a/application/app/pages/setup.vue
+++ b/application/app/pages/setup.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+/**
+ * Setup — the permanent home for "how do I connect this, and what else can it do?".
+ *
+ * The connect steps used to live only on Home behind `v-if="!hasProjects"`, so
+ * everything past step one became undiscoverable the moment the first run
+ * landed. This page keeps the wizard reachable forever and pairs it with a
+ * capability ladder that reports which optional features are actually live on
+ * this instance — the answer to "is this empty because it's broken, or because
+ * I never switched it on?".
+ */
+import type { SetupStatus } from '#shared/handlers/setup-status';
+import type { AdminStats } from '~~/types/api';
+import { SETUP_CAPABILITIES } from '~/utils/setup-capabilities';
+
+useHead({ title: 'Setup — Piwi Dashboard' });
+
+const isDesktop = useIsDesktop();
+
+// Desktop build only: where the data lives and how to point the reporter and MCP
+// clients at this local instance. These lived on Settings → About, which is not
+// where anyone looks for "how do I connect to this" — About is for versions.
+const { data: stats } = await useFetch<AdminStats | null>('/api/admin/stats', {
+  immediate: isDesktop,
+  default: () => null,
+});
+const { data: reporterConfig } = await useFetch<{ url: string; token: string } | null>('/api/desktop/reporter-config', {
+  immediate: isDesktop,
+  default: () => null,
+});
+
+const { data: status, status: fetchStatus } = await useFetch<SetupStatus>('/api/setup-status', {
+  lazy: true,
+  default: () => ({ capabilities: [] }) as SetupStatus,
+});
+
+const activeById = computed(() => {
+  const map = new Map<string, boolean>();
+  for (const c of status.value?.capabilities ?? []) map.set(c.id, c.active);
+  return map;
+});
+
+const isLoading = computed(() => fetchStatus.value === 'pending' && !status.value?.capabilities.length);
+
+const rows = computed(() =>
+  SETUP_CAPABILITIES.map((copy) => ({ ...copy, active: activeById.value.get(copy.id) ?? false })),
+);
+
+const activeCount = computed(() => rows.value.filter((r) => r.active).length);
+</script>
+
+<template>
+  <UDashboardPanel id="setup">
+    <template #header>
+      <UDashboardNavbar>
+        <template #leading>
+          <UDashboardSidebarCollapse />
+          <UBreadcrumb :items="[{ label: 'Setup', icon: 'i-lucide-rocket', to: '/setup' }]" />
+        </template>
+      </UDashboardNavbar>
+    </template>
+
+    <template #body>
+      <div class="flex flex-col gap-6 w-full lg:max-w-4xl mx-auto">
+        <!-- Desktop build: connecting to this local instance comes before the
+             generic reporter steps, since the token/URL are specific to it. -->
+        <template v-if="isDesktop">
+          <DesktopReporterCard v-if="reporterConfig" :url="reporterConfig.url" :token="reporterConfig.token" />
+          <DesktopMcpCard v-if="reporterConfig" :url="reporterConfig.url" :token="reporterConfig.token" />
+          <DataLocationCard v-if="stats" :database="stats.databaseLocation" :storage="stats.storageLocation" />
+          <DesktopServiceCard />
+        </template>
+
+        <GetStartedWizard />
+
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-3">
+                <div class="p-2 bg-primary/10 rounded-lg shrink-0">
+                  <UIcon name="i-lucide-list-checks" class="size-5 text-primary" />
+                </div>
+                <div>
+                  <h2 class="text-xl font-semibold">What's switched on</h2>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
+                    Detected from your data, not your config — a capability reads as active once this instance has
+                    actually used it.
+                  </p>
+                </div>
+              </div>
+              <UBadge v-if="!isLoading" color="neutral" variant="subtle" class="shrink-0 max-sm:hidden">
+                {{ activeCount }} / {{ rows.length }}
+              </UBadge>
+            </div>
+          </template>
+
+          <LoadingState v-if="isLoading" />
+
+          <ul v-else class="divide-y divide-default">
+            <li v-for="row in rows" :key="row.id" class="flex gap-4 py-4 first:pt-0 last:pb-0">
+              <div
+                class="flex size-9 shrink-0 items-center justify-center rounded-lg"
+                :class="row.active ? 'bg-success/10 text-success' : 'bg-elevated text-dimmed'"
+              >
+                <UIcon :name="row.icon" class="size-5" />
+              </div>
+
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 flex-wrap mb-1">
+                  <h3 class="font-medium">{{ row.title }}</h3>
+                  <UBadge v-if="row.active" color="success" variant="subtle" size="xs">Active</UBadge>
+                  <UBadge v-else-if="row.optional" color="neutral" variant="subtle" size="xs">Optional</UBadge>
+                  <UBadge v-else color="warning" variant="subtle" size="xs">Not set up</UBadge>
+                </div>
+
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ row.summary }}</p>
+
+                <p v-if="!row.active" class="text-sm text-dimmed mt-1">{{ row.how }}</p>
+
+                <div class="flex items-center gap-3 mt-2 text-sm">
+                  <UButton v-if="row.to && !row.active" :to="row.to" size="xs" variant="soft" icon="i-lucide-settings">
+                    {{ row.toLabel ?? 'Configure' }}
+                  </UButton>
+                  <DocLink v-if="row.doc" :to="row.doc" class="text-sm">Docs</DocLink>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </UCard>
+      </div>
+    </template>
+  </UDashboardPanel>
+</template>

--- a/application/app/pages/test-run-cases/[id].vue
+++ b/application/app/pages/test-run-cases/[id].vue
@@ -37,9 +37,15 @@ const { data: traceData, refresh: refreshTraces } = await useFetch<TraceInfo[]>(
 /** Whether a trace file exists for this execution — unlocks the "go deeper" evidence views. */
 const hasTrace = computed(() => (traceData.value?.length ?? 0) > 0);
 
+// "Execution" is the word `docs/concepts.md` defines for one attempt of one test
+// on one browser — the distinction the whole object model rests on. The UI used
+// to say "Test run case", which is the join-table's name, not a concept anyone
+// was taught. Say the documented word.
 useHead(
   computed(() => ({
-    title: `${testCase.value?.title || `Test run case #${testCaseId}`} — Piwi Dashboard`,
+    title: testCase.value?.title
+      ? `${testCase.value.title} — execution — Piwi Dashboard`
+      : `Execution #${testCaseId} — Piwi Dashboard`,
   })),
 );
 
@@ -474,7 +480,7 @@ provide(clusterSectionLocatorKey, {
                     },
                   ]
                 : [{ label: 'Test run' }]),
-              { label: testCase?.title || `Test run case #${testCaseId}` },
+              { label: testCase?.title || `Execution #${testCaseId}` },
             ]"
           />
         </template>
@@ -1001,15 +1007,13 @@ provide(clusterSectionLocatorKey, {
               </div>
             </SectionCard>
 
-            <EmptyState
+            <FeatureUnavailable
               v-if="performanceHints.length === 0 && !webVitals"
               icon="i-lucide-gauge"
-              text="No performance hints or Web Vitals were captured for this execution."
-            >
-              <p class="text-xs text-gray-400">
-                Web Vitals and timing come from the <DocLink to="capture-fixtures">capture fixtures</DocLink>.
-              </p>
-            </EmptyState>
+              title="No performance hints or Web Vitals for this execution"
+              text="Web Vitals and step timing come from the Piwi capture fixtures — extend your Playwright test with piwiFixtures to collect them."
+              doc="capture-fixtures"
+            />
           </div>
         </template>
 

--- a/application/app/utils/settings-metadata.ts
+++ b/application/app/utils/settings-metadata.ts
@@ -41,11 +41,27 @@ export interface SettingFieldMeta {
   envOnly?: boolean;
 }
 
+/**
+ * Settings splits into two jobs that were previously one flat list of ten:
+ * running the instance, and tuning what Piwi infers from your results. A
+ * newcomer met "Timeout hygiene" before they had seen a timeout, because
+ * nothing said which pages were infrastructure and which were analysis.
+ */
+export type SettingsGroupId = 'instance' | 'analysis' | 'meta';
+
+export const SETTINGS_GROUPS: { id: SettingsGroupId; label: string }[] = [
+  { id: 'instance', label: 'Instance' },
+  { id: 'analysis', label: 'Analysis' },
+  { id: 'meta', label: '' },
+];
+
 export interface SettingsPageMeta {
   id: SettingsPageId;
   label: string;
   icon: string;
   to: string;
+  /** Which section of the Settings nav this page belongs to. */
+  group: SettingsGroupId;
   /** Roles that may access the page; omitted = any authenticated user. */
   roles?: Role[];
   /**
@@ -66,6 +82,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Account',
     icon: 'i-lucide-user-round',
     to: '/settings/account',
+    group: 'instance',
     authOnly: true,
     fields: [
       { id: 'account.display-name', label: 'Display name', help: 'account.display-name' },
@@ -80,6 +97,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Users',
     icon: 'i-lucide-users',
     to: '/settings/users',
+    group: 'instance',
     roles: [Role.ADMINISTRATOR],
     authOnly: true,
     introHelp: 'settings.users',
@@ -93,6 +111,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Notifications',
     icon: 'i-lucide-bell',
     to: '/settings/notifications',
+    group: 'instance',
     fields: [
       { id: 'notifications.smtp', label: 'SMTP email delivery', help: 'settings.smtp', envOnly: true },
       { id: 'notifications.test-email', label: 'Send test email', help: 'notifications.test-email' },
@@ -105,6 +124,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Tags',
     icon: 'i-lucide-tags',
     to: '/settings/tags',
+    group: 'analysis',
     roles: [Role.ADMINISTRATOR],
     introHelp: 'settings.tags',
     fields: [{ id: 'tags.list', label: 'Tags', help: 'settings.tags' }],
@@ -114,6 +134,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Storage',
     icon: 'i-lucide-hard-drive',
     to: '/settings/storage',
+    group: 'instance',
     roles: [Role.ADMINISTRATOR],
     fields: [
       { id: 'storage.backend', label: 'Storage backend', help: 'settings.storage-backend', envOnly: true },
@@ -126,6 +147,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Wasted time',
     icon: 'i-lucide-hourglass',
     to: '/settings/wasted-time',
+    group: 'analysis',
     roles: [Role.ADMINISTRATOR],
     introHelp: 'settings.wasted-time',
     fields: [{ id: 'wasted-time.patterns', label: 'Wasted-time patterns', help: 'settings.wasted-time' }],
@@ -135,6 +157,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Timeout hygiene',
     icon: 'i-lucide-scissors',
     to: '/settings/timeout-hygiene',
+    group: 'analysis',
     roles: [Role.ADMINISTRATOR],
     introHelp: 'settings.timeout-hygiene',
     fields: [{ id: 'timeout-hygiene.thresholds', label: 'Detection thresholds', help: 'settings.timeout-hygiene' }],
@@ -144,6 +167,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'Pull requests',
     icon: 'i-lucide-git-pull-request',
     to: '/settings/pr-feedback',
+    group: 'analysis',
     roles: [Role.ADMINISTRATOR],
     introHelp: 'settings.pr-feedback',
     fields: [{ id: 'pr-feedback.settings', label: 'Pull-request feedback', help: 'settings.pr-feedback' }],
@@ -153,6 +177,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'AI diagnosis',
     icon: 'i-lucide-sparkles',
     to: '/settings/ai',
+    group: 'analysis',
     roles: [Role.ADMINISTRATOR],
     fields: [
       { id: 'ai.diagnosis', label: 'Diagnosis model', help: 'settings.ai-provider' },
@@ -170,6 +195,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
     label: 'About',
     icon: 'i-lucide-info',
     to: '/settings/about',
+    group: 'meta',
     fields: [],
   },
 ];

--- a/application/app/utils/setup-capabilities.ts
+++ b/application/app/utils/setup-capabilities.ts
@@ -1,0 +1,135 @@
+/**
+ * UI copy for the Setup page's capability ladder.
+ *
+ * Single source of truth for what each optional capability is, why you'd want
+ * it, and how to switch it on. Keyed by `SetupCapabilityId` so a capability
+ * added to the detection handler without copy here (or vice versa) is a
+ * compile error.
+ *
+ * Ordered deliberately: the ladder runs from "results arriving at all" through
+ * the capabilities that build on each other (fixtures → locator healing) to
+ * the optional extras. That order is the answer to "what should I do next?",
+ * so it is the order the page renders.
+ */
+import type { SetupCapabilityId } from '#shared/handlers/setup-status';
+
+export interface SetupCapabilityCopy {
+  id: SetupCapabilityId;
+  title: string;
+  /** One line: what it gives you. */
+  summary: string;
+  /** How to switch it on, when inactive. */
+  how: string;
+  icon: string;
+  /** Docs page (+ optional `#anchor`), passed through `DocLink`. */
+  doc?: string;
+  /** In-app route that configures it, when there is one. */
+  to?: string;
+  /** Label for `to`. */
+  toLabel?: string;
+  /** Shown instead of "Not active yet" — some capabilities are genuinely optional. */
+  optional?: boolean;
+}
+
+export const SETUP_CAPABILITIES: SetupCapabilityCopy[] = [
+  {
+    id: 'reporter',
+    title: 'Results arriving',
+    summary: 'Your Playwright runs are reaching this dashboard and their history is being kept.',
+    how: 'Follow the four steps above to add the reporter to your Playwright config.',
+    icon: 'i-lucide-antenna',
+    doc: 'reporter',
+  },
+  {
+    id: 'fixtures',
+    title: 'Capture fixtures',
+    summary:
+      'Network timing, Web Vitals, console errors and ARIA snapshots, captured per test. Powers slow endpoints, performance trends and the richer AI diagnosis context.',
+    how: 'Extend your Playwright `test` with `piwiFixtures` — see "Go further" above.',
+    icon: 'i-lucide-radio',
+    doc: 'capture-fixtures',
+  },
+  {
+    id: 'locator-healing',
+    title: 'Locator healing',
+    summary:
+      'When a selector breaks, ranked replacement locators captured from the last passing run — with a recommended fix.',
+    how: 'Comes with the capture fixtures; enable those and healing data starts accumulating on passing runs.',
+    icon: 'i-lucide-bandage',
+    doc: 'capture-fixtures',
+  },
+  {
+    id: 'clustering',
+    title: 'Failure clustering',
+    summary: 'Forty red tests collapsed into the three root causes behind them, each triaged once.',
+    how: 'Automatic — clusters form as soon as failures with a shared error fingerprint arrive.',
+    icon: 'i-lucide-layers',
+    doc: 'ai-diagnosis',
+  },
+  {
+    id: 'ai',
+    title: 'AI diagnosis',
+    summary:
+      'An LLM you configure explains a cluster against your actual git diff, with its suggested patch validated against your source before you see it.',
+    how: 'Configure a provider in Settings — Anthropic, OpenAI, or any OpenAI-compatible endpoint including local models.',
+    icon: 'i-lucide-sparkles',
+    doc: 'ai-diagnosis',
+    to: '/settings/ai',
+    toLabel: 'Configure AI',
+    optional: true,
+  },
+  {
+    id: 'scm',
+    title: 'Source control',
+    summary:
+      'The commits behind a failure, CODEOWNERS-derived ownership, and pull-request feedback on the branch that broke.',
+    how: 'Add a repository access token on the project, or globally in Settings.',
+    icon: 'i-lucide-git-branch',
+    doc: 'ai-diagnosis',
+    to: '/settings/ai',
+    toLabel: 'Add a token',
+    optional: true,
+  },
+  {
+    id: 'notifications',
+    title: 'Notifications',
+    summary: 'Email, Slack, webhook and browser channels, with per-project subscriptions and digests.',
+    how: 'Add a channel in Settings, then subscribe the projects you care about.',
+    icon: 'i-lucide-bell',
+    doc: 'notifications',
+    to: '/settings/notifications',
+    toLabel: 'Add a channel',
+    optional: true,
+  },
+  {
+    id: 'quarantine',
+    title: 'Quarantine',
+    summary:
+      'A known-bad test keeps running and reporting, but stops failing the CI gate — and earns its way out on a passing streak.',
+    how: "Quarantine a test from its test-case page, or from the project's Quarantine tab.",
+    icon: 'i-lucide-shield-alert',
+    doc: 'flaky-tests',
+    optional: true,
+  },
+  {
+    id: 'tags',
+    title: 'Tags & ownership',
+    summary:
+      "Playwright's own test tags plus `piwi:owner` / `priority` / `feature` annotations, filterable across the catalog and the flaky leaderboard.",
+    how: 'Tag tests in your specs, or define project tags in Settings.',
+    icon: 'i-lucide-tags',
+    doc: 'reporter',
+    to: '/settings/tags',
+    toLabel: 'Manage tags',
+    optional: true,
+  },
+  {
+    id: 'markers',
+    title: 'Timeline markers',
+    summary: 'Your deploys and infrastructure changes overlaid on the trend charts, so a step change has a cause.',
+    how: "Add a marker from a project's Timeline tab.",
+    icon: 'i-lucide-git-commit-horizontal',
+    doc: 'timeline-markers',
+    optional: true,
+  },
+];

--- a/application/server/api/setup-status.get.ts
+++ b/application/server/api/setup-status.get.ts
@@ -1,0 +1,17 @@
+import { getDatabase } from '../database';
+import { getSetupStatus } from '#shared/handlers/setup-status';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['System'],
+    summary: 'Setup and capability status',
+    description:
+      "Reports which of Piwi's optional capabilities show evidence of being active on this instance (results arriving, capture fixtures installed, locator healing, clustering, AI diagnosis, notifications, SCM, tags, markers, quarantine). Evidence-based rather than config-based: a configured-but-unused capability reads as inactive. Drives the Setup page's checklist.",
+    'x-required-roles': [],
+  },
+});
+
+export default eventHandler(async () => {
+  const db = await getDatabase();
+  return getSetupStatus(db);
+});

--- a/application/shared/analytics/registry.ts
+++ b/application/shared/analytics/registry.ts
@@ -6,7 +6,23 @@
  * map in `shared/handlers/analytics`, and the page maps the same `id` to a Vue
  * component — so adding a widget means: one entry here, one handler file, one
  * component. No routing changes on either the server or the demo mirror.
+ *
+ * Widgets are ordered into **bands**, not listed flat. Ten equally-weighted
+ * cards asked the reader to work out for themselves which one to look at
+ * first; the bands answer that — overall health, then where the pain is, then
+ * how it's trending, then the detail you go to once you know what you're
+ * looking for. Adding a widget means choosing its band, which is the useful
+ * question to be forced to answer.
  */
+
+export type AnalyticsBandId = 'health' | 'pain' | 'trends' | 'detail';
+
+export const ANALYTICS_BANDS: { id: AnalyticsBandId; label: string; description: string }[] = [
+  { id: 'health', label: 'Where things stand', description: 'The state of every project right now.' },
+  { id: 'pain', label: 'Where the pain is', description: 'What is costing you the most time and attention.' },
+  { id: 'trends', label: 'Which way it is going', description: 'Movement over the selected period.' },
+  { id: 'detail', label: 'Detail', description: 'Breakdowns to reach for once you know what you are chasing.' },
+];
 
 export interface AnalyticsWidgetMeta {
   id: string;
@@ -16,68 +32,80 @@ export interface AnalyticsWidgetMeta {
   icon: string;
   /** Layout hint: `full` spans the grid, `half` shares a row on wide screens. */
   size: 'full' | 'half';
+  /** Which band the widget belongs to — decides where it renders. */
+  band: AnalyticsBandId;
 }
 
 export const ANALYTICS_WIDGETS = [
+  {
+    id: 'portfolio',
+    title: 'Portfolio health',
+    icon: 'i-lucide-table-properties',
+    size: 'full',
+    band: 'health',
+  },
   {
     id: 'insights',
     title: 'Insights',
     icon: 'i-lucide-lightbulb',
     size: 'half',
+    band: 'health',
   },
   {
     id: 'pass-rate-heatmap',
     title: 'Pass rate heatmap',
     icon: 'i-lucide-grid-3x3',
     size: 'half',
-  },
-  {
-    id: 'portfolio',
-    title: 'Portfolio health',
-    icon: 'i-lucide-table-properties',
-    size: 'full',
-  },
-  {
-    id: 'ci-time-trend',
-    title: 'CI time',
-    icon: 'i-lucide-timer',
-    size: 'half',
-  },
-  {
-    id: 'wasted-time',
-    title: 'Wasted CI time',
-    icon: 'i-lucide-hourglass',
-    size: 'half',
-  },
-  {
-    id: 'flaky-leaderboard',
-    title: 'Flakiest tests',
-    icon: 'i-lucide-repeat',
-    size: 'half',
+    band: 'health',
   },
   {
     id: 'cluster-landscape',
     title: 'Failure clusters',
     icon: 'i-lucide-layers',
     size: 'half',
+    band: 'pain',
+  },
+  {
+    id: 'flaky-leaderboard',
+    title: 'Flakiest tests',
+    icon: 'i-lucide-repeat',
+    size: 'half',
+    band: 'pain',
+  },
+  {
+    id: 'wasted-time',
+    title: 'Wasted CI time',
+    icon: 'i-lucide-hourglass',
+    size: 'half',
+    band: 'pain',
   },
   {
     id: 'regression-velocity',
     title: 'Regression velocity',
     icon: 'i-lucide-git-pull-request-arrow',
     size: 'half',
+    band: 'trends',
+  },
+  {
+    id: 'ci-time-trend',
+    title: 'CI time',
+    icon: 'i-lucide-timer',
+    size: 'half',
+    band: 'trends',
   },
   {
     id: 'browser-matrix',
     title: 'Browser matrix',
     icon: 'i-lucide-monitor-smartphone',
     size: 'half',
+    band: 'detail',
   },
   {
     id: 'slow-endpoints',
     title: 'Slow endpoints',
     icon: 'i-lucide-gauge',
     size: 'full',
+    band: 'detail',
   },
 ] as const satisfies readonly AnalyticsWidgetMeta[];
 

--- a/application/shared/handlers/setup-status.ts
+++ b/application/shared/handlers/setup-status.ts
@@ -1,0 +1,108 @@
+/**
+ * Capability detection for the Setup page.
+ *
+ * Piwi's optional capabilities (capture fixtures, locator healing, AI diagnosis,
+ * notifications, …) are each enabled somewhere else — a reporter option, a
+ * settings page, an env var. Nothing told a user which ones were actually live
+ * on their instance, so a feature they never switched on was indistinguishable
+ * from one that was broken.
+ *
+ * This reports, per capability, whether the instance has ever seen evidence of
+ * it working. It is deliberately evidence-based rather than config-based: a
+ * configured-but-never-used capability reads as inactive, which is the honest
+ * answer to "is this working for me?".
+ *
+ * Cheap by construction — every check is a `limit(1)` existence probe, never a
+ * full count, so the page stays fast on instances with millions of rows.
+ */
+import {
+  testRuns,
+  networkRequests,
+  locatorSnapshots,
+  notificationChannels,
+  tags,
+  markers,
+  projects,
+  appSettings,
+  quarantinedTests,
+  failureClusters,
+} from '../../server/database/schema';
+import { eq, isNotNull } from 'drizzle-orm';
+
+import type { DrizzleDB } from './db';
+
+/** Stable ids — the UI keys its copy off these. */
+export type SetupCapabilityId =
+  | 'reporter'
+  | 'fixtures'
+  | 'locator-healing'
+  | 'clustering'
+  | 'ai'
+  | 'notifications'
+  | 'scm'
+  | 'tags'
+  | 'markers'
+  | 'quarantine';
+
+export interface SetupCapability {
+  id: SetupCapabilityId;
+  /** True when the instance has evidence this capability is doing something. */
+  active: boolean;
+}
+
+export interface SetupStatus {
+  capabilities: SetupCapability[];
+}
+
+/** `true` when the table has at least one row matching the (optional) filter. */
+async function exists(db: DrizzleDB, query: Promise<unknown[]>): Promise<boolean> {
+  const rows = await query;
+  return rows.length > 0;
+}
+
+export async function getSetupStatus(db: DrizzleDB): Promise<SetupStatus> {
+  const [
+    hasRuns,
+    hasNetwork,
+    hasLocators,
+    hasClusters,
+    hasAiSetting,
+    hasChannels,
+    hasScm,
+    hasTags,
+    hasMarkers,
+    hasQuarantine,
+  ] = await Promise.all([
+    exists(db, db.select({ id: testRuns.id }).from(testRuns).limit(1)),
+    exists(db, db.select({ id: networkRequests.id }).from(networkRequests).limit(1)),
+    exists(db, db.select({ id: locatorSnapshots.id }).from(locatorSnapshots).limit(1)),
+    exists(db, db.select({ id: failureClusters.id }).from(failureClusters).limit(1)),
+    exists(db, db.select({ key: appSettings.key }).from(appSettings).where(eq(appSettings.key, 'ai')).limit(1)),
+    exists(db, db.select({ id: notificationChannels.id }).from(notificationChannels).limit(1)),
+    exists(db, db.select({ id: projects.id }).from(projects).where(isNotNull(projects.scmToken)).limit(1)),
+    exists(db, db.select({ id: tags.id }).from(tags).limit(1)),
+    exists(db, db.select({ id: markers.id }).from(markers).limit(1)),
+    exists(db, db.select({ id: quarantinedTests.id }).from(quarantinedTests).limit(1)),
+  ]);
+
+  // AI also counts as active when pinned by environment — an env-configured
+  // instance has no `ai` row in app_settings but is very much switched on.
+  const aiFromEnv = Boolean(
+    typeof process !== 'undefined' && (process.env?.PIWI_AI_API_KEY || process.env?.PIWI_AI_MODEL),
+  );
+
+  const capabilities: SetupCapability[] = [
+    { id: 'reporter', active: hasRuns },
+    { id: 'fixtures', active: hasNetwork },
+    { id: 'locator-healing', active: hasLocators },
+    { id: 'clustering', active: hasClusters },
+    { id: 'ai', active: hasAiSetting || aiFromEnv },
+    { id: 'notifications', active: hasChannels },
+    { id: 'scm', active: hasScm },
+    { id: 'tags', active: hasTags },
+    { id: 'markers', active: hasMarkers },
+    { id: 'quarantine', active: hasQuarantine },
+  ];
+
+  return { capabilities };
+}

--- a/application/tests/cluster-page-layout.spec.ts
+++ b/application/tests/cluster-page-layout.spec.ts
@@ -82,7 +82,7 @@ test.describe('Failure cluster page layout', () => {
     await expect(page.getByRole('heading', { name: 'What changed' })).toBeVisible();
 
     // …but their bodies are folded: the case link (inside the evidence body) is hidden.
-    await expect(page.getByRole('link', { name: 'Open test run case' })).toBeHidden();
+    await expect(page.getByRole('link', { name: 'Open execution' })).toBeHidden();
 
     // The evidence peek carries the key info while folded (the toggle's accessible
     // name includes the peek; occurrence count varies so match loosely).
@@ -94,12 +94,12 @@ test.describe('Failure cluster page layout', () => {
     await waitForHydration(page);
 
     await page.getByRole('heading', { name: 'Test evidence' }).click();
-    await expect(page.getByRole('link', { name: 'Open test run case' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open execution' }).first()).toBeVisible();
 
     await page.reload();
     await waitForHydration(page);
     // Cookie kept it expanded.
-    await expect(page.getByRole('link', { name: 'Open test run case' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Open execution' }).first()).toBeVisible();
   });
 
   test('summary shows Triage and no longer has a Runs card', async ({ page }) => {
@@ -126,7 +126,7 @@ test.describe('Failure cluster page layout', () => {
     await tab2.click();
     await expect(page.getByText('tests/checkout.spec.ts').first()).toBeVisible();
 
-    const link = page.getByRole('link', { name: 'Open test run case' }).first();
+    const link = page.getByRole('link', { name: 'Open execution' }).first();
     await expect(link).toHaveAttribute('href', /\/test-run-cases\/\d+/);
   });
 

--- a/application/tests/unit/analytics-handlers.test.ts
+++ b/application/tests/unit/analytics-handlers.test.ts
@@ -20,7 +20,7 @@ const { getAnalyticsBrowserMatrix } = await import('../../shared/handlers/analyt
 const { getAnalyticsSlowEndpoints } = await import('../../shared/handlers/analytics/slow-endpoints');
 const { evaluateInsightRules } = await import('../../shared/analytics/insight-rules');
 const { parseAnalyticsScope, MAX_ANALYTICS_DAYS } = await import('../../shared/analytics/scope');
-const { ANALYTICS_WIDGETS } = await import('../../shared/analytics/registry');
+const { ANALYTICS_WIDGETS, ANALYTICS_BANDS } = await import('../../shared/analytics/registry');
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS);
@@ -198,6 +198,17 @@ describe('analytics registry', () => {
     for (const widget of ANALYTICS_WIDGETS) {
       const result = await runAnalyticsWidget(db, widget.id, DEFAULT_SCOPE, 'all');
       expect(result).toBeDefined();
+    }
+  });
+
+  test('every widget sits in a declared band, and every band has widgets', () => {
+    const bandIds = new Set(ANALYTICS_BANDS.map((b) => b.id));
+    for (const widget of ANALYTICS_WIDGETS) {
+      expect(bandIds.has(widget.band)).toBe(true);
+    }
+    // An empty band would render a heading over nothing.
+    for (const band of ANALYTICS_BANDS) {
+      expect(ANALYTICS_WIDGETS.some((w) => w.band === band.id)).toBe(true);
     }
   });
 });

--- a/application/tests/unit/setup-status.test.ts
+++ b/application/tests/unit/setup-status.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createClient } from '@libsql/client';
+import * as schema from '../../server/database/schema.sqlite';
+
+// The schema barrel (server/database/schema.ts) picks the PostgreSQL schema at
+// import time when PIWI_DATABASE_URL is set, so clear it before the handler
+// modules (which import the barrel) are loaded.
+delete process.env.PIWI_DATABASE_URL;
+const { getSetupStatus } = await import('../../shared/handlers/setup-status');
+const { SETUP_CAPABILITIES } = await import('../../app/utils/setup-capabilities');
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+let db: Db;
+
+async function freshDb(): Promise<Db> {
+  const next = drizzle(createClient({ url: ':memory:' }), { schema });
+  await migrate(next, {
+    migrationsFolder: fileURLToPath(new URL('../../server/database/migrations', import.meta.url)),
+  });
+  return next;
+}
+
+/** Capability ids that report `active: true`, as a set. */
+async function activeIds(database: Db): Promise<Set<string>> {
+  const { capabilities } = await getSetupStatus(database);
+  return new Set(capabilities.filter((c) => c.active).map((c) => c.id));
+}
+
+beforeEach(async () => {
+  db = await freshDb();
+  delete process.env.PIWI_AI_API_KEY;
+  delete process.env.PIWI_AI_MODEL;
+});
+
+describe('getSetupStatus', () => {
+  test('reports nothing active on a fresh instance', async () => {
+    const { capabilities } = await getSetupStatus(db);
+    expect(capabilities.length).toBeGreaterThan(0);
+    expect(capabilities.every((c) => c.active === false)).toBe(true);
+  });
+
+  test('a submitted run activates only the reporter capability', async () => {
+    await db.insert(schema.projects).values({ id: 1, name: 'checkout' });
+    await db.insert(schema.testRuns).values({
+      projectId: 1,
+      status: 'passed',
+      startTime: new Date(),
+      duration: 1000,
+      totalTests: 1,
+      passedTests: 1,
+    });
+
+    expect(await activeIds(db)).toEqual(new Set(['reporter']));
+  });
+
+  test('captured network requests activate the fixtures capability', async () => {
+    await db.insert(schema.projects).values({ id: 1, name: 'checkout' });
+    const [run] = await db
+      .insert(schema.testRuns)
+      .values({ projectId: 1, status: 'passed', startTime: new Date(), duration: 1, totalTests: 1, passedTests: 1 })
+      .returning({ id: schema.testRuns.id });
+    await db.insert(schema.testCases).values({ id: 1, projectId: 1, filePath: 'a.spec.ts', title: 'a' });
+    const [runCase] = await db
+      .insert(schema.testRunsCases)
+      .values({ testRunId: run!.id, testCaseId: 1, status: 'passed', duration: 1 })
+      .returning({ id: schema.testRunsCases.id });
+    await db.insert(schema.networkRequests).values({
+      testRunsCaseId: runCase!.id,
+      testRunId: run!.id,
+      url: 'https://example.test/api',
+      method: 'GET',
+      status: 200,
+    });
+
+    const active = await activeIds(db);
+    expect(active.has('fixtures')).toBe(true);
+    expect(active.has('locator-healing')).toBe(false);
+  });
+
+  test('detection is evidence-based, not config-based: a defined tag activates tags', async () => {
+    await db.insert(schema.tags).values({ text: 'smoke' });
+
+    expect(await activeIds(db)).toEqual(new Set(['tags']));
+  });
+
+  test('AI counts as active when pinned by environment, with no stored setting', async () => {
+    expect((await activeIds(db)).has('ai')).toBe(false);
+
+    process.env.PIWI_AI_MODEL = 'claude-sonnet-4-5';
+    expect((await activeIds(db)).has('ai')).toBe(true);
+  });
+
+  test('AI counts as active from a stored setting, with no env var', async () => {
+    await db.insert(schema.appSettings).values({ key: 'ai', value: { provider: 'anthropic' }, updatedAt: new Date() });
+
+    expect((await activeIds(db)).has('ai')).toBe(true);
+  });
+});
+
+describe('setup capability copy', () => {
+  test('every detected capability has UI copy, and vice versa', async () => {
+    const { capabilities } = await getSetupStatus(db);
+    const detected = capabilities.map((c) => c.id).sort();
+    const documented = SETUP_CAPABILITIES.map((c) => c.id).sort();
+
+    expect(documented).toEqual(detected);
+  });
+
+  test('a capability that cannot be configured in-app still explains how to enable it', () => {
+    for (const capability of SETUP_CAPABILITIES) {
+      expect(capability.how.length).toBeGreaterThan(0);
+      expect(capability.summary.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -26,7 +26,8 @@ The sidebar gives access to the top-level sections:
 | Home | `/` | Aggregate stats and activity across all projects |
 | Analytics | `/analytics` | Cross-project trends, portfolio health, and insights over a chosen time window (see [Analytics](./analytics)) |
 | Projects | `/projects` | Full project listing with search and tag filters |
-| Settings | `/settings` | Configuration — general, account, users, storage, tags, wasted time, AI, notifications |
+| Settings | `/settings` | Configuration, in two groups — **Instance** (account, users, notifications, storage) and **Analysis** (AI diagnosis, wasted time, timeout hygiene, tags, pull requests) |
+| Setup | `/setup` | Connect the reporter, and a checklist of which optional capabilities are actually active on this instance |
 | API docs | `/docs` | Self-contained OpenAPI 3.1 reference (no external CDN) — browse endpoints and schemas, try requests live, copy cURL / fetch snippets |
 | MCP server | `/mcp` | Setup guide for connecting AI clients (see [MCP server](./mcp)) |
 
@@ -41,6 +42,12 @@ Everything else is reached by drilling into a project, run, or test case:
 | Test run | `/test-runs/:id` |
 | Test case | `/test-cases/:id` |
 
+## Setup
+
+Reachable from the sidebar at any time — not just before your first run. It carries the reporter setup steps (install, configure, run, plus `wrapConfig` and the capture fixtures under **Go further**) and a **capability checklist**: for each optional feature, whether this instance shows evidence of actually using it.
+
+The checklist is deliberately evidence-based rather than config-based, so it answers the question an empty panel raises — *is this blank because it's broken, or because I never switched it on?* In the desktop build the page also carries the local instance's reporter URL and token, its MCP client configuration, the data location, and background-service control.
+
 ## Home
 
 A quick health check across all projects: **stats cards** (projects, runs, active/passing projects, flaky count, slowest project), a **test-results trend chart** (pass/fail/skip/flaky over time), **recent projects**, and a getting-started snippet for teams that haven't wired up the reporter yet.
@@ -49,7 +56,14 @@ A quick health check across all projects: **stats cards** (projects, runs, activ
 
 A cross-project decision view — where Home answers *"what's happening now"*, Analytics answers *"across projects, over time"*. A **scope bar** at the top sets the period (last 7 / 30 / 90 days, last year, or all time), an optional environment, and a full-runs-only toggle; every widget re-aggregates against that scope.
 
-Widgets: an **insights** feed, **portfolio health**, a **pass-rate heatmap**, **CI time** and **wasted CI time**, the global **flakiest tests** leaderboard, open **failure clusters**, **regression velocity**, a **browser matrix**, and cross-project **slow endpoints**. [Timeline markers](./timeline-markers) overlay your deploys and infrastructure changes on the trend charts.
+Widgets are grouped into four bands, in reading order:
+
+- **Where things stand** — portfolio health, the insights feed, the pass-rate heatmap.
+- **Where the pain is** — open failure clusters, the flakiest-tests leaderboard, wasted CI time.
+- **Which way it is going** — regression velocity, CI time.
+- **Detail** — the browser matrix, cross-project slow endpoints.
+
+[Timeline markers](./timeline-markers) overlay your deploys and infrastructure changes on the trend charts.
 
 See [Analytics](./analytics) for what each widget answers and how the periods are compared.
 

--- a/reporter/src/public/options.ts
+++ b/reporter/src/public/options.ts
@@ -20,6 +20,7 @@ export interface ShardInfo {
  * in the reporter entry's options (`['@piwitests/reporter', { … }]`).
  */
 export interface PiwiDashboardOptions {
+  // ── Connection ─────────────────────────────────────────────────────────────
   /** Explicitly enable or disable the reporter. Defaults to `true` when `serverUrl` is set. Set to `false` to disable even if `serverUrl` is provided. */
   enabled?: boolean;
   /** URL of the Piwi Dashboard server */
@@ -28,12 +29,23 @@ export interface PiwiDashboardOptions {
   projectName?: string;
   /** Optional description of the project */
   projectDescription?: string;
+
+  // ── What gets uploaded ─────────────────────────────────────────────────────
   /** Upload trace files to the dashboard. Defaults to `true`. */
   uploadTraces?: boolean;
   /** Upload the Playwright HTML report. Defaults to `true`. */
   uploadReport?: boolean;
   /** Upload each test's trace and attachments as soon as the test finishes (streaming mode only). Defaults to `true`. */
   liveFileUploads?: boolean;
+
+  // ── What gets captured ─────────────────────────────────────────────────────
+  //
+  // Note the dependency: `collectPerformanceMetrics` is a master switch for the
+  // three `capture*` toggles below it. Setting it to `false` forces
+  // `captureLocators`, `capturePageState` and `captureServerTraces` off too,
+  // because the reporter discards their data in that case — it is the one
+  // option here that silently disables others. `collectScmInfo` and
+  // `collectCiInfo` are independent of it.
   /** Auto-collect git commit, branch, author. Defaults to `true`. */
   collectScmInfo?: boolean;
   /** Auto-collect CI environment info. Defaults to `true`. */
@@ -66,6 +78,8 @@ export interface PiwiDashboardOptions {
    * `false`. Can also be forced off with `PIWI_CAPTURE_SERVER_TRACES=false`.
    */
   captureServerTraces?: boolean;
+
+  // ── Local debugging aids (headed runs only, never under CI) ────────────────
   /**
    * Open Piwi's own failure-time overlay on the failing page — for inspecting
    * the page and picking a locator for any element (click an element → confirm
@@ -90,18 +104,24 @@ export interface PiwiDashboardOptions {
    * with `PIWI_PICK_LOCATOR_ON_FAIL=true`.
    */
   pickLocatorOnFailure?: boolean;
+
+  // ── Streaming ──────────────────────────────────────────────────────────────
   /** Enable live streaming of results (falls back to batch if unsupported). Defaults to `true`. */
   streaming?: boolean;
   /** Number of test results to batch before sending during streaming. Defaults to `5`. */
   streamingBatchSize?: number;
   /** Max delay (ms) before flushing pending events during streaming. Defaults to `2000`. */
   streamingBatchDelay?: number;
+
+  // ── Authentication ─────────────────────────────────────────────────────────
   /** Username for dashboard login (use `apiKey` instead when possible) */
   username?: string | null;
   /** Password for dashboard login (used with `username`) */
   password?: string | null;
   /** API key for authentication (preferred over `username`/`password` for CI) */
   apiKey?: string | null;
+
+  // ── Run metadata ───────────────────────────────────────────────────────────
   /** Additional report types to upload. Each entry can specify `type`, optional `dir`, and optional `label`. */
   reports?: Array<{ type: string; dir?: string; label?: string }>;
   /** Stable label that ties shards together (e.g. CI run ID). Auto-detected from CI env; override if needed. */
@@ -118,6 +138,8 @@ export interface PiwiDashboardOptions {
   tags?: string[];
   /** Additional custom metadata as key-value pairs */
   customData?: Record<string, unknown>;
+
+  // ── Output & diagnostics ───────────────────────────────────────────────────
   /**
    * Write a JSON file with the submitted run's dashboard URL, id, project id and
    * status after the run lands, so a CI pipeline can consume it (e.g. feed the


### PR DESCRIPTION
## What & why

Adds a permanent `/setup` page that serves two purposes:

1. **Reporter connection wizard**: The four-step setup guide previously lived only on Home behind a `v-if="!hasProjects"` condition, becoming undiscoverable once the first run landed. This page keeps the wizard reachable forever.

2. **Capability checklist**: Reports which of Piwi's optional features (fixtures, locator healing, AI diagnosis, notifications, SCM, tags, markers, quarantine) are actually active on this instance. Detection is evidence-based (has the feature ever been used?) rather than config-based, answering the critical question: "Is this empty because it's broken, or because I never switched it on?"

The capability detection lives in a new `getSetupStatus` handler that performs cheap existence probes (`limit(1)` queries) on relevant tables, plus environment variable checks for AI configuration. UI copy for each capability is centralized in `SETUP_CAPABILITIES`, keyed by stable IDs that are enforced at compile time to stay in sync with detection logic.

Also reorganizes the Analytics page and Settings navigation into logical groups (Health/Pain/Trends/Detail for analytics; Instance/Analysis for settings) so ten equally-weighted items read as coherent sections answering specific questions rather than an undifferentiated list.

## How was it tested?

- Added comprehensive unit tests (`setup-status.test.ts`) covering:
  - Fresh instance detection (nothing active)
  - Reporter activation on first run
  - Fixtures/locator healing detection from network requests
  - AI detection from both database settings and environment variables
  - Compile-time sync check between detected capabilities and UI copy
- Existing analytics and settings tests updated to reflect grouped structure
- Manual verification of page rendering, capability detection, and navigation

## Checklist

- [x] PR title follows Conventional Commits (`feat(setup): ...`)
- [x] Tests added for capability detection logic and sync validation
- [x] Docs updated (`docs/ui-overview.md` documents new Setup page)
- [x] Settings navigation refactored into groups with updated composable
- [x] Analytics widgets organized into bands with registry updates

https://claude.ai/code/session_01MqHDn4zZqTK66j1yHhcByx