### PR TITLE
feat(deps)!: rename @piwitests/instrumentation to @piwitests/instrumentation-nitro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ packages/server/      @piwitests/server — published npm run-option (`npx @piwi
 reporter/             @piwitests/reporter — the Playwright reporter (TypeScript → bundled via tsup)
 desktop/              Tauri desktop shell that bundles and runs the same server locally
 docs/                 VitePress documentation site, published to GitHub Pages
-integrations/nitro/   Backend-log instrumentation for Nitro apps
-integrations/aspnetcore/  Backend-log instrumentation for ASP.NET Core (NuGet)
+integrations/nitro/   @piwitests/instrumentation-nitro — backend-log instrumentation for Nitro apps
+integrations/aspnetcore/  PiwiTests.Instrumentation.AspNetCore — the same for ASP.NET Core (NuGet)
 examples/             Standalone usage examples (Playwright fixtures)
 plans/                Local working docs — gitignored, never committed
 ```

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Everything below is built and published from this repository on each release.
 | [`@piwitests/server`](https://www.npmjs.com/package/@piwitests/server) | npm | The dashboard server, runnable with `npx @piwitests/server` |
 | [`phenx/piwitests-server`](https://hub.docker.com/r/phenx/piwitests-server) | Docker Hub | The server container (`linux/amd64`, `linux/arm64`) |
 | [`ghcr.io/piwitests/platform`](https://github.com/PiwiTests/platform/pkgs/container/platform) | GHCR | The same container, mirrored — plus an `edge` tag built from `main` |
-| [`@piwitests/instrumentation`](https://www.npmjs.com/package/@piwitests/instrumentation) | npm | Optional: sends your Nitro/Nuxt backend's logs into a test run |
+| [`@piwitests/instrumentation-nitro`](https://www.npmjs.com/package/@piwitests/instrumentation-nitro) | npm | Optional: sends your Nitro/Nuxt backend's logs into a test run |
 | [`PiwiTests.Instrumentation.AspNetCore`](https://www.nuget.org/packages/PiwiTests.Instrumentation.AspNetCore) | NuGet | Optional: the same for an ASP.NET Core backend |
 | Desktop app (`.msi`, `.dmg`) | [GitHub Releases](https://github.com/PiwiTests/platform/releases/latest) | The server bundled in a native window — no Docker or Node |
 

--- a/application/app/composables/useAuth.ts
+++ b/application/app/composables/useAuth.ts
@@ -118,6 +118,21 @@ export const useAuth = () => {
   const isReporter = computed(() => hasRole([Role.REPORTER]));
   const canEdit = computed(() => hasRole([Role.ADMINISTRATOR]));
 
+  /**
+   * Whether admin-only surfaces should be shown.
+   *
+   * Differs from `isAdmin` in one case that matters: when authentication is
+   * disabled there are no users at all, so nobody holds the administrator role
+   * and gating on `isAdmin` alone would hide admin surfaces from *everyone* on
+   * a default self-hosted install (and in the desktop build, which runs
+   * single-user with auth off). The server draws the same distinction —
+   * `requireAuth` returns a virtual administrator when auth is disabled.
+   *
+   * This is a UI affordance, never an authorization decision: the server still
+   * enforces roles from each route's `x-required-roles`.
+   */
+  const canSeeAdmin = computed(() => !useRuntimeConfig().public.authEnabled || isAdmin.value);
+
   return {
     authState,
     fetchUser,
@@ -127,6 +142,7 @@ export const useAuth = () => {
     isAdmin,
     isReporter,
     canEdit,
+    canSeeAdmin,
     // Demo "act as" switcher
     demoUsers,
     currentDemoUserId,

--- a/application/app/composables/useSettingsNav.ts
+++ b/application/app/composables/useSettingsNav.ts
@@ -16,11 +16,7 @@ import { buildSettingsNavSections, type SettingsPageId } from '~/utils/settings-
  * badges are shown.
  */
 export function useSettingsNav(envManaged?: MaybeRefOrGetter<Record<SettingsPageId, boolean>>) {
-  const { isAdmin } = useAuth();
-  const config = useRuntimeConfig();
-  // When auth is disabled, every visitor is a virtual administrator — show all
-  // pages (mirrors the per-page `isAdmin` fallback in users.vue/tags.vue).
-  const canSeeAdmin = computed(() => !config.public.authEnabled || isAdmin.value);
+  const { canSeeAdmin } = useAuth();
   const isDesktop = useIsDesktop();
 
   return computed<NavigationMenuItem[][]>(() =>

--- a/application/app/composables/useSettingsNav.ts
+++ b/application/app/composables/useSettingsNav.ts
@@ -1,17 +1,15 @@
 import type { NavigationMenuItem } from '@nuxt/ui';
 import { toValue, type MaybeRefOrGetter } from 'vue';
-import { SETTINGS_PAGES, SETTINGS_GROUPS, type SettingsPageId } from '~/utils/settings-metadata';
+import { buildSettingsNavSections, type SettingsPageId } from '~/utils/settings-metadata';
 
 /**
- * Build the Settings sub-navigation from the shared `SETTINGS_PAGES` registry,
- * grouped into sections (Instance / Analysis / meta) so the ten pages read as
- * two jobs rather than one undifferentiated list. Returns the `[][]` shape
- * `UNavigationMenu` renders with a separator between sections.
+ * Reactive wrapper around `buildSettingsNavSections`.
  *
- * Admin-only pages are hidden for non-admins (no more 403 on click). Pages that
- * are currently env-managed get a trailing lock badge, so an admin can see at a
- * glance which settings are pinned by the environment. A section whose pages are
- * all hidden collapses away rather than leaving an empty separator.
+ * Resolves who the viewer is (admin or not, desktop build or not) from the Nuxt
+ * composables and hands that to the pure builder, which owns the actual
+ * filtering and grouping. Returns the `[][]` shape `UNavigationMenu` renders
+ * with a separator between sections; callers wanting one flat list (the user
+ * menu) call `.flat()`.
  *
  * `envManaged` is the per-page state from `useSettingsEnvState` (a ref or
  * getter); pass it to make the lock badges reactive. When omitted, no lock
@@ -23,31 +21,13 @@ export function useSettingsNav(envManaged?: MaybeRefOrGetter<Record<SettingsPage
   // When auth is disabled, every visitor is a virtual administrator — show all
   // pages (mirrors the per-page `isAdmin` fallback in users.vue/tags.vue).
   const canSeeAdmin = computed(() => !config.public.authEnabled || isAdmin.value);
-  // The desktop build is single-user with auth off, so account/user management
-  // (pages flagged `authOnly`) is meaningless there — hide it.
   const isDesktop = useIsDesktop();
 
-  const items = computed<NavigationMenuItem[][]>(() => {
-    const admin = canSeeAdmin.value;
-    const managedMap = envManaged ? toValue(envManaged) : undefined;
-
-    const visible = SETTINGS_PAGES.filter((page) => (!page.roles || admin) && !(isDesktop && page.authOnly));
-
-    const toItem = (page: (typeof visible)[number]): NavigationMenuItem => {
-      const managed = managedMap?.[page.id] ?? false;
-      return {
-        label: page.label,
-        icon: page.icon,
-        to: page.to,
-        // Trailing lock badge marks env-pinned pages.
-        ...(managed ? { badge: { icon: 'i-lucide-lock', color: 'neutral' as const } } : {}),
-      } satisfies NavigationMenuItem;
-    };
-
-    return SETTINGS_GROUPS.map((group) => visible.filter((page) => page.group === group.id).map(toItem)).filter(
-      (section) => section.length > 0,
-    );
-  });
-
-  return items;
+  return computed<NavigationMenuItem[][]>(() =>
+    buildSettingsNavSections({
+      canSeeAdmin: canSeeAdmin.value,
+      isDesktop,
+      envManaged: envManaged ? toValue(envManaged) : undefined,
+    }),
+  );
 }

--- a/application/app/layouts/default.vue
+++ b/application/app/layouts/default.vue
@@ -70,6 +70,8 @@ useNotificationStream();
 // caller of useDashboard(); without it the shortcuts never register.
 useDashboard();
 
+const { canSeeAdmin } = useAuth();
+
 // Extract current project ID from route (if viewing a project page)
 const currentProjectId = computed(() => {
   // Check if route path starts with /projects/:id
@@ -161,14 +163,19 @@ const links = computed(() => {
       open.value = false;
     },
   });
-  bottomLinks.unshift({
-    label: 'Setup',
-    icon: 'i-lucide-rocket',
-    to: '/setup',
-    onSelect: () => {
-      open.value = false;
-    },
-  });
+  // Setup is admin-only: it configures how results reach this instance and, in
+  // the desktop build, exposes the local access token. Hiding the link also
+  // removes it from the command palette, which is built from these same items.
+  if (canSeeAdmin.value) {
+    bottomLinks.unshift({
+      label: 'Setup',
+      icon: 'i-lucide-rocket',
+      to: '/setup',
+      onSelect: () => {
+        open.value = false;
+      },
+    });
+  }
   bottomLinks.unshift({
     label: 'API Docs',
     icon: 'i-lucide-book-open',

--- a/application/app/middleware/auth.global.ts
+++ b/application/app/middleware/auth.global.ts
@@ -28,8 +28,20 @@ export default defineNuxtRouteMiddleware(async (to) => {
     }
   }
 
+  const isAdmin = authState.value.user?.role === Role.ADMINISTRATOR;
+
   // Check if user is trying to access edit pages
-  if (to.path.includes('/edit') && authState.value.user?.role !== Role.ADMINISTRATOR) {
+  if (to.path.includes('/edit') && !isAdmin) {
+    return navigateTo('/');
+  }
+
+  // Setup configures how results reach this instance and, in the desktop build,
+  // exposes the local access token — admin-only. The sidebar hides the link, and
+  // this stops a non-admin reaching it by typing the URL. The endpoint behind it
+  // (`/api/setup-status`) enforces the same role server-side; this is only the
+  // affordance. Note the early returns above: with auth disabled every visitor is
+  // a virtual admin, which is what keeps Setup reachable on a default install.
+  if (to.path === '/setup' && !isAdmin) {
     return navigateTo('/');
   }
 });

--- a/application/app/utils/settings-metadata.ts
+++ b/application/app/utils/settings-metadata.ts
@@ -230,3 +230,58 @@ export function getSettingsPage(id: SettingsPageId): SettingsPageMeta {
   if (!page) throw new Error(`Unknown settings page: ${id}`);
   return page;
 }
+
+// ── Nav construction ───────────────────────────────────────────────────────
+
+/**
+ * One nav entry. Structurally a `NavigationMenuItem` (and a `DropdownMenuItem`),
+ * declared here rather than importing the Nuxt UI type so this module stays pure
+ * and unit-testable.
+ */
+export interface SettingsNavItem {
+  label: string;
+  icon: string;
+  to: string;
+  badge?: { icon: string; color: 'neutral' };
+}
+
+/** What the viewer is allowed to see, and which pages the environment has pinned. */
+export interface SettingsNavContext {
+  /**
+   * Whether admin-only pages are visible. Callers pass `true` when auth is
+   * disabled entirely — every visitor is a virtual administrator then.
+   */
+  canSeeAdmin: boolean;
+  /** Desktop build: single-user with auth off, so `authOnly` pages are hidden. */
+  isDesktop: boolean;
+  /** Pages currently pinned by env, which get a trailing lock badge. */
+  envManaged?: Partial<Record<SettingsPageId, boolean>>;
+}
+
+/**
+ * Build the grouped Settings navigation.
+ *
+ * Sections come out in `SETTINGS_GROUPS` order, and a section whose pages are
+ * all hidden for this viewer is dropped rather than rendered as an empty
+ * separator — a non-admin, for instance, can see none of the Analysis pages.
+ *
+ * Kept pure (no Vue, no Nuxt composables) so the role/build/env branching is
+ * directly testable; `useSettingsNav` is the reactive wrapper around it.
+ */
+export function buildSettingsNavSections(ctx: SettingsNavContext): SettingsNavItem[][] {
+  const visible = SETTINGS_PAGES.filter(
+    (page) => (!page.roles || ctx.canSeeAdmin) && !(ctx.isDesktop && page.authOnly),
+  );
+
+  const toItem = (page: SettingsPageMeta): SettingsNavItem => ({
+    label: page.label,
+    icon: page.icon,
+    to: page.to,
+    // Trailing lock badge marks env-pinned pages.
+    ...(ctx.envManaged?.[page.id] ? { badge: { icon: 'i-lucide-lock', color: 'neutral' as const } } : {}),
+  });
+
+  return SETTINGS_GROUPS.map((group) => visible.filter((page) => page.group === group.id).map(toItem)).filter(
+    (section) => section.length > 0,
+  );
+}

--- a/application/server/api/setup-status.get.ts
+++ b/application/server/api/setup-status.get.ts
@@ -1,4 +1,5 @@
 import { getDatabase } from '../database';
+import { requireAuth } from '../utils/auth';
 import { getSetupStatus } from '#shared/handlers/setup-status';
 
 defineRouteMeta({
@@ -6,12 +7,19 @@ defineRouteMeta({
     tags: ['System'],
     summary: 'Setup and capability status',
     description:
-      "Reports which of Piwi's optional capabilities show evidence of being active on this instance (results arriving, capture fixtures installed, locator healing, clustering, AI diagnosis, notifications, SCM, tags, markers, quarantine). Evidence-based rather than config-based: a configured-but-unused capability reads as inactive. Drives the Setup page's checklist.",
-    'x-required-roles': [],
+      "Reports which of Piwi's optional capabilities show evidence of being active on this instance (results arriving, capture fixtures installed, locator healing, clustering, AI diagnosis, notifications, SCM, tags, markers, quarantine). Evidence-based rather than config-based: a configured-but-unused capability reads as inactive. Drives the Setup page's checklist. Requires administrator role.",
+    'x-required-roles': ['administrator'],
   },
 });
 
-export default eventHandler(async () => {
+export default eventHandler(async (event) => {
+  // Admin-only: the response describes how this instance is configured — whether
+  // an AI provider and an SCM token are set up, whether notifications are wired.
+  // That is deployment shape, not test data, so it follows the Setup page's role
+  // rather than staying readable by any authenticated user. `requireAuth` reads
+  // the role from `x-required-roles` above and returns a virtual admin when auth
+  // is disabled.
+  await requireAuth(event);
   const db = await getDatabase();
   return getSetupStatus(db);
 });

--- a/application/tests/unit/settings-metadata.test.ts
+++ b/application/tests/unit/settings-metadata.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from 'vitest';
+import {
+  SETTINGS_PAGES,
+  SETTINGS_GROUPS,
+  buildSettingsNavSections,
+  getSettingsPage,
+  pageEnvVars,
+  pageIsOverridable,
+  type SettingsNavContext,
+} from '../../app/utils/settings-metadata';
+
+/** Flatten sections to the `to` paths, for terse assertions. */
+function paths(ctx: SettingsNavContext): string[] {
+  return buildSettingsNavSections(ctx)
+    .flat()
+    .map((i) => i.to);
+}
+
+const WEB_ADMIN: SettingsNavContext = { canSeeAdmin: true, isDesktop: false };
+const WEB_MEMBER: SettingsNavContext = { canSeeAdmin: false, isDesktop: false };
+const DESKTOP: SettingsNavContext = { canSeeAdmin: true, isDesktop: true };
+
+describe('settings registry integrity', () => {
+  test('every page belongs to a declared group', () => {
+    const groupIds = new Set(SETTINGS_GROUPS.map((g) => g.id));
+    for (const page of SETTINGS_PAGES) {
+      expect(groupIds.has(page.group)).toBe(true);
+    }
+  });
+
+  test('every declared group has at least one page', () => {
+    // An empty group would be a heading (or separator) over nothing.
+    for (const group of SETTINGS_GROUPS) {
+      expect(SETTINGS_PAGES.some((p) => p.group === group.id)).toBe(true);
+    }
+  });
+
+  test('page ids and routes are unique', () => {
+    expect(new Set(SETTINGS_PAGES.map((p) => p.id)).size).toBe(SETTINGS_PAGES.length);
+    expect(new Set(SETTINGS_PAGES.map((p) => p.to)).size).toBe(SETTINGS_PAGES.length);
+  });
+
+  test('getSettingsPage resolves every id and rejects unknown ones', () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(getSettingsPage(page.id).to).toBe(page.to);
+    }
+    // @ts-expect-error — deliberately outside the union
+    expect(() => getSettingsPage('nope')).toThrow(/Unknown settings page/);
+  });
+
+  test('a page is env-overridable exactly when one of its fields is', () => {
+    for (const page of SETTINGS_PAGES) {
+      expect(pageIsOverridable(page)).toBe(pageEnvVars(page).length > 0);
+    }
+  });
+});
+
+describe('buildSettingsNavSections', () => {
+  test('an admin on the web sees every page', () => {
+    // Set comparison, not sequence: grouping deliberately reorders relative to
+    // the registry's declaration order (storage sits with Instance, tags with
+    // Analysis). The order that matters is asserted by the group-order test.
+    expect(paths(WEB_ADMIN).sort()).toEqual(SETTINGS_PAGES.map((p) => p.to).sort());
+  });
+
+  test('a non-admin sees no admin-only page', () => {
+    const visible = paths(WEB_MEMBER);
+    for (const page of SETTINGS_PAGES) {
+      if (page.roles) expect(visible).not.toContain(page.to);
+      else expect(visible).toContain(page.to);
+    }
+  });
+
+  test('a section whose pages are all hidden collapses instead of rendering empty', () => {
+    // Every Analysis page is admin-only, so a non-admin loses the whole section
+    // rather than getting a separator with nothing under it.
+    const analysisPages = SETTINGS_PAGES.filter((p) => p.group === 'analysis');
+    expect(analysisPages.every((p) => p.roles)).toBe(true);
+
+    const sections = buildSettingsNavSections(WEB_MEMBER);
+    expect(sections.every((section) => section.length > 0)).toBe(true);
+    expect(sections.length).toBeLessThan(buildSettingsNavSections(WEB_ADMIN).length);
+  });
+
+  test('the desktop build hides the auth-only pages', () => {
+    const visible = paths(DESKTOP);
+    for (const page of SETTINGS_PAGES) {
+      if (page.authOnly) expect(visible).not.toContain(page.to);
+    }
+    // …but keeps the admin pages, since desktop runs with auth off.
+    expect(visible).toContain('/settings/storage');
+  });
+
+  test('sections come out in registry group order', () => {
+    const sections = buildSettingsNavSections(WEB_ADMIN);
+    const groupOfFirstItem = sections.map((section) => SETTINGS_PAGES.find((p) => p.to === section[0]!.to)!.group);
+    const expectedOrder = SETTINGS_GROUPS.map((g) => g.id).filter((id) => SETTINGS_PAGES.some((p) => p.group === id));
+    expect(groupOfFirstItem).toEqual(expectedOrder);
+  });
+
+  test('only env-managed pages carry a lock badge', () => {
+    const sections = buildSettingsNavSections({ ...WEB_ADMIN, envManaged: { ai: true } });
+    const items = sections.flat();
+
+    expect(items.find((i) => i.to === '/settings/ai')?.badge).toEqual({ icon: 'i-lucide-lock', color: 'neutral' });
+    for (const item of items) {
+      if (item.to !== '/settings/ai') expect(item.badge).toBeUndefined();
+    }
+  });
+
+  test('no lock badges when env state is omitted', () => {
+    expect(
+      buildSettingsNavSections(WEB_ADMIN)
+        .flat()
+        .every((i) => i.badge === undefined),
+    ).toBe(true);
+  });
+});

--- a/application/tests/unit/use-auth-can-see-admin.test.ts
+++ b/application/tests/unit/use-auth-can-see-admin.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { computed, ref } from 'vue';
+import { Role } from '../../shared/types';
+import type { AuthState } from '../../types/api';
+
+/**
+ * Covers `canSeeAdmin` — the rule deciding whether admin-only surfaces (Settings'
+ * Analysis section, the Setup page and its link) are shown.
+ *
+ * It is tested here at its definition rather than only through consumers,
+ * because `use-settings-nav.test.ts` stubs `useAuth` wholesale: without this
+ * file, that stub would be asserting a hand-written copy of the rule, and the
+ * real implementation could drift from it undetected.
+ *
+ * The rest of `useAuth` (login, logout, fetchUser, the demo switcher) is
+ * exercised by the E2E suite — only setup-time state is stubbed here.
+ */
+function loadUseAuth(opts: { authEnabled?: boolean; role?: Role | null }) {
+  const state = ref<AuthState>({
+    authenticated: opts.role != null,
+    user: opts.role == null ? null : { id: 1, username: 'u', role: opts.role, name: 'U' },
+  });
+
+  vi.stubGlobal('computed', computed);
+  vi.stubGlobal('useState', (_key: string, init: () => AuthState) => {
+    if (!state.value) state.value = init();
+    return state;
+  });
+  vi.stubGlobal('useRuntimeConfig', () => ({
+    public: { authEnabled: opts.authEnabled ?? false, demoMode: false },
+  }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+/** Fresh import per case, so the stubs above are in place when the module loads. */
+async function canSeeAdmin(opts: { authEnabled?: boolean; role?: Role | null }): Promise<boolean> {
+  loadUseAuth(opts);
+  const { useAuth } = await import('../../app/composables/useAuth');
+  return useAuth().canSeeAdmin.value;
+}
+
+describe('useAuth().canSeeAdmin', () => {
+  test('is true for everyone when authentication is disabled', async () => {
+    // No users exist at all in this mode, so nobody holds the administrator
+    // role. Gating on `isAdmin` alone would hide Storage, Tags, AI and Setup
+    // from every visitor on a default self-hosted install — and in the desktop
+    // build, which runs single-user with auth off and needs Setup for its own
+    // reporter token and MCP configuration.
+    expect(await canSeeAdmin({ authEnabled: false, role: null })).toBe(true);
+  });
+
+  test('is true for an administrator when authentication is enabled', async () => {
+    expect(await canSeeAdmin({ authEnabled: true, role: Role.ADMINISTRATOR })).toBe(true);
+  });
+
+  test('is false for a non-administrator when authentication is enabled', async () => {
+    expect(await canSeeAdmin({ authEnabled: true, role: Role.REPORTER })).toBe(false);
+  });
+
+  test('is false for an unauthenticated visitor when authentication is enabled', async () => {
+    expect(await canSeeAdmin({ authEnabled: true, role: null })).toBe(false);
+  });
+
+  test('differs from isAdmin exactly in the auth-disabled case', async () => {
+    loadUseAuth({ authEnabled: false, role: null });
+    const { useAuth } = await import('../../app/composables/useAuth');
+    const auth = useAuth();
+
+    expect(auth.isAdmin.value).toBe(false);
+    expect(auth.canSeeAdmin.value).toBe(true);
+  });
+});

--- a/application/tests/unit/use-settings-nav.test.ts
+++ b/application/tests/unit/use-settings-nav.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { computed, ref } from 'vue';
+import { useSettingsNav } from '../../app/composables/useSettingsNav';
+import type { SettingsPageId } from '../../app/utils/settings-metadata';
+
+/**
+ * `useSettingsNav` is a thin reactive wrapper — the filtering and grouping live
+ * in `buildSettingsNavSections` (covered in settings-metadata.test.ts). What is
+ * only testable here is the wiring: how the viewer's role is derived, and how
+ * the `envManaged` ref-or-getter is unwrapped.
+ *
+ * Nuxt auto-imports are globals at runtime, so they are stubbed rather than
+ * imported. `computed` is the real Vue one, so the returned ref behaves.
+ */
+function stubNuxt(opts: { authEnabled?: boolean; isAdmin?: boolean; desktop?: boolean } = {}) {
+  vi.stubGlobal('computed', computed);
+  vi.stubGlobal('useAuth', () => ({ isAdmin: ref(opts.isAdmin ?? false) }));
+  vi.stubGlobal('useRuntimeConfig', () => ({ public: { authEnabled: opts.authEnabled ?? false } }));
+  vi.stubGlobal('useIsDesktop', () => opts.desktop ?? false);
+}
+
+const pathsOf = (nav: { value: { to?: string | object }[][] }) => nav.value.flat().map((i) => i.to);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useSettingsNav', () => {
+  test('treats every visitor as an admin when auth is disabled', () => {
+    // The instance has no users at all, so gating admin pages would lock
+    // everyone out of Storage, Tags and AI on a default self-hosted install.
+    stubNuxt({ authEnabled: false, isAdmin: false });
+
+    expect(pathsOf(useSettingsNav())).toContain('/settings/storage');
+  });
+
+  test('hides admin pages from a non-admin once auth is enabled', () => {
+    stubNuxt({ authEnabled: true, isAdmin: false });
+
+    const visible = pathsOf(useSettingsNav());
+    expect(visible).not.toContain('/settings/storage');
+    expect(visible).toContain('/settings/account');
+  });
+
+  test('shows admin pages to an admin when auth is enabled', () => {
+    stubNuxt({ authEnabled: true, isAdmin: true });
+
+    expect(pathsOf(useSettingsNav())).toContain('/settings/storage');
+  });
+
+  test('hides the auth-only pages in the desktop build', () => {
+    stubNuxt({ desktop: true });
+
+    const visible = pathsOf(useSettingsNav());
+    expect(visible).not.toContain('/settings/account');
+    expect(visible).not.toContain('/settings/users');
+    expect(visible).toContain('/settings/storage');
+  });
+
+  test('unwraps envManaged given as a ref', () => {
+    stubNuxt();
+    const managed = ref({ ai: true } as Record<SettingsPageId, boolean>);
+
+    const item = useSettingsNav(managed)
+      .value.flat()
+      .find((i) => i.to === '/settings/ai');
+    expect(item?.badge).toEqual({ icon: 'i-lucide-lock', color: 'neutral' });
+  });
+
+  test('unwraps envManaged given as a getter, and tracks its changes', () => {
+    stubNuxt();
+    const managed = ref({} as Record<SettingsPageId, boolean>);
+    const nav = useSettingsNav(() => managed.value);
+
+    const aiItem = () => nav.value.flat().find((i) => i.to === '/settings/ai');
+    expect(aiItem()?.badge).toBeUndefined();
+
+    managed.value = { ai: true } as Record<SettingsPageId, boolean>;
+    expect(aiItem()?.badge).toEqual({ icon: 'i-lucide-lock', color: 'neutral' });
+  });
+
+  test('returns grouped sections, each non-empty', () => {
+    stubNuxt();
+    const sections = useSettingsNav().value;
+
+    expect(sections.length).toBeGreaterThan(1);
+    expect(sections.every((s) => s.length > 0)).toBe(true);
+  });
+});

--- a/application/tests/unit/use-settings-nav.test.ts
+++ b/application/tests/unit/use-settings-nav.test.ts
@@ -13,10 +13,18 @@ import type { SettingsPageId } from '../../app/utils/settings-metadata';
  * imported. `computed` is the real Vue one, so the returned ref behaves.
  */
 function stubNuxt(opts: { authEnabled?: boolean; isAdmin?: boolean; desktop?: boolean } = {}) {
+  const authEnabled = opts.authEnabled ?? false;
+  const isAdmin = ref(opts.isAdmin ?? false);
+
   vi.stubGlobal('computed', computed);
-  vi.stubGlobal('useAuth', () => ({ isAdmin: ref(opts.isAdmin ?? false) }));
-  vi.stubGlobal('useRuntimeConfig', () => ({ public: { authEnabled: opts.authEnabled ?? false } }));
+  vi.stubGlobal('useRuntimeConfig', () => ({ public: { authEnabled } }));
   vi.stubGlobal('useIsDesktop', () => opts.desktop ?? false);
+  // Mirrors the real `useAuth`: with auth disabled there are no users, so nobody
+  // holds the administrator role and `canSeeAdmin` has to fall back to true.
+  vi.stubGlobal('useAuth', () => ({
+    isAdmin,
+    canSeeAdmin: computed(() => !authEnabled || isAdmin.value),
+  }));
 }
 
 const pathsOf = (nav: { value: { to?: string | object }[][] }) => nav.value.flat().map((i) => i.to);

--- a/docs/backend-logs.md
+++ b/docs/backend-logs.md
@@ -51,7 +51,7 @@ app.Run();
 ### Nitro / Nuxt (npm)
 
 ```bash
-npm install @piwitests/instrumentation
+npm install @piwitests/instrumentation-nitro
 ```
 
 Create a file in your project's server plugins directory:
@@ -59,7 +59,7 @@ Create a file in your project's server plugins directory:
 ```typescript
 // Nuxt: server/plugins/piwi-test-logs.ts
 // Standalone Nitro: plugins/piwi-test-logs.ts
-export { default } from '@piwitests/instrumentation'
+export { default } from '@piwitests/instrumentation-nitro'
 ```
 
 The plugin is auto-loaded by Nitro. It captures `consola` Warning/Error entries (bare `console.*` calls are not captured) and unhandled H3 errors, then writes the header just before each response goes out — including error responses. Capture is on outside production; override either way with `PIWI_TEST_LOGS_DISABLED` (`true` = always off, `false` = on even in production).

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -27,7 +27,7 @@ The sidebar gives access to the top-level sections:
 | Analytics | `/analytics` | Cross-project trends, portfolio health, and insights over a chosen time window (see [Analytics](./analytics)) |
 | Projects | `/projects` | Full project listing with search and tag filters |
 | Settings | `/settings` | Configuration, in two groups — **Instance** (account, users, notifications, storage) and **Analysis** (AI diagnosis, wasted time, timeout hygiene, tags, pull requests) |
-| Setup | `/setup` | Connect the reporter, and a checklist of which optional capabilities are actually active on this instance |
+| Setup *(admins)* | `/setup` | Connect the reporter, and a checklist of which optional capabilities are actually active on this instance |
 | API docs | `/docs` | Self-contained OpenAPI 3.1 reference (no external CDN) — browse endpoints and schemas, try requests live, copy cURL / fetch snippets |
 | MCP server | `/mcp` | Setup guide for connecting AI clients (see [MCP server](./mcp)) |
 
@@ -44,7 +44,7 @@ Everything else is reached by drilling into a project, run, or test case:
 
 ## Setup
 
-Reachable from the sidebar at any time — not just before your first run. It carries the reporter setup steps (install, configure, run, plus `wrapConfig` and the capture fixtures under **Go further**) and a **capability checklist**: for each optional feature, whether this instance shows evidence of actually using it.
+Reachable from the sidebar at any time — not just before your first run. **Administrators only**, since it governs how results reach the instance and, in the desktop build, shows the local access token; when authentication is disabled every visitor is a virtual administrator, so it stays available on a default install. It carries the reporter setup steps (install, configure, run, plus `wrapConfig` and the capture fixtures under **Go further**) and a **capability checklist**: for each optional feature, whether this instance shows evidence of actually using it.
 
 The checklist is deliberately evidence-based rather than config-based, so it answers the question an empty panel raises — *is this blank because it's broken, or because I never switched it on?* In the desktop build the page also carries the local instance's reporter URL and token, its MCP client configuration, the data location, and background-service control.
 

--- a/examples/playwright-fixtures/README.md
+++ b/examples/playwright-fixtures/README.md
@@ -2,7 +2,7 @@
 
 A small, runnable Playwright project wired to [Piwi Dashboard](https://piwitests.github.io) with the **[capture fixtures](https://piwitests.github.io/capture-fixtures)** — the one-file addition that unlocks slow-endpoint analysis, Web Vitals, console capture, failure-time ARIA snapshots, and locator healing.
 
-It tests a tiny [Nitro](https://nitro.build) web app (`app/`, started automatically by Playwright) and exercises **every capture path** the fixtures support — including **[backend logs](https://piwitests.github.io/backend-logs)**: the app is instrumented with [`@piwitests/instrumentation`](../../integrations/nitro), so server-side warnings and errors ride back to the dashboard on the `X-Piwi-Logs` response header.
+It tests a tiny [Nitro](https://nitro.build) web app (`app/`, started automatically by Playwright) and exercises **every capture path** the fixtures support — including **[backend logs](https://piwitests.github.io/backend-logs)**: the app is instrumented with [`@piwitests/instrumentation-nitro`](../../integrations/nitro), so server-side warnings and errors ride back to the dashboard on the `X-Piwi-Logs` response header.
 
 ## Run it
 
@@ -56,7 +56,7 @@ Every spec imports `test` from one of these files — never from `@playwright/te
 The entire backend-log setup is `app/plugins/piwi-test-logs.ts`:
 
 ```ts
-export { default } from '@piwitests/instrumentation';
+export { default } from '@piwitests/instrumentation-nitro';
 ```
 
 Nitro auto-loads it from `plugins/` (in a Nuxt app, put the same file in `server/plugins/`). Two things worth knowing:

--- a/examples/playwright-fixtures/app/plugins/piwi-test-logs.ts
+++ b/examples/playwright-fixtures/app/plugins/piwi-test-logs.ts
@@ -2,4 +2,4 @@
 // request's Warning/Error log entries, which the Piwi reporter attaches to the
 // matching network request. This one-line re-export is the entire setup.
 // (In a Nuxt app the file lives in server/plugins/ instead.)
-export { default } from '@piwitests/instrumentation';
+export { default } from '@piwitests/instrumentation-nitro';

--- a/examples/playwright-fixtures/nitro.config.ts
+++ b/examples/playwright-fixtures/nitro.config.ts
@@ -2,12 +2,12 @@ import { defineNitroConfig } from 'nitropack/config';
 
 // A minimal standalone Nitro app (pages in app/routes, JSON endpoints in
 // app/api) used as the system under test. Backend logs are captured by
-// @piwitests/instrumentation, registered in app/plugins/piwi-test-logs.ts.
+// @piwitests/instrumentation-nitro, registered in app/plugins/piwi-test-logs.ts.
 export default defineNitroConfig({
   srcDir: 'app',
   compatibilityDate: '2026-07-17',
-  // Bundle the instrumentation into the server build. Needed for
-  // @piwitests/instrumentation <= 0.12.0, whose `nitropack/runtime` import
-  // only resolves in-bundle; harmless on later versions.
-  externals: { inline: ['@piwitests/instrumentation'] },
+  // Bundle the instrumentation into the server build. Needed at version <= 0.12.0
+  // (published then as `@piwitests/instrumentation`), whose `nitropack/runtime`
+  // import only resolves in-bundle; harmless on later versions.
+  externals: { inline: ['@piwitests/instrumentation-nitro'] },
 });

--- a/examples/playwright-fixtures/package.json
+++ b/examples/playwright-fixtures/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@piwitests/instrumentation": "0.20.0",
+    "@piwitests/instrumentation-nitro": "0.20.0",
     "@piwitests/reporter": "0.20.0",
     "@playwright/test": "^1.56.1",
     "consola": "^3.4.2",

--- a/examples/playwright-fixtures/tests/backend-logs.spec.ts
+++ b/examples/playwright-fixtures/tests/backend-logs.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from './fixtures';
 
-// The app is instrumented with @piwitests/instrumentation (see
+// The app is instrumented with @piwitests/instrumentation-nitro (see
 // app/plugins/piwi-test-logs.ts): each response carries its server-side
 // Warning/Error logs in the X-Piwi-Logs header, and the fixtures attach them
 // to the matching network request. On the dashboard, open this test's

--- a/integrations/nitro/README.md
+++ b/integrations/nitro/README.md
@@ -1,4 +1,4 @@
-# @piwitests/instrumentation
+# @piwitests/instrumentation-nitro
 
 Nitro / Nuxt server plugin for [Piwi Dashboard](https://piwitests.github.io) — captures Warning and Error log entries per HTTP request and delivers them to the Piwi Dashboard reporter via the `X-Piwi-Logs` response header.
 
@@ -13,7 +13,7 @@ During a Playwright test run, the reporter reads this header from every response
 ## Installation
 
 ```bash
-npm install @piwitests/instrumentation
+npm install @piwitests/instrumentation-nitro
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ Create a file in your project's server plugins directory:
 ```typescript
 // Nuxt: server/plugins/piwi-test-logs.ts
 // Standalone Nitro: plugins/piwi-test-logs.ts
-export { default } from '@piwitests/instrumentation'
+export { default } from '@piwitests/instrumentation-nitro'
 ```
 
 That's all. Nitro auto-loads every file in that directory on startup (`server/plugins/` in a Nuxt app, `plugins/` under the Nitro `srcDir` in a standalone Nitro app).

--- a/integrations/nitro/package.json
+++ b/integrations/nitro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@piwitests/instrumentation",
+  "name": "@piwitests/instrumentation-nitro",
   "version": "0.20.0",
   "description": "Nitro/Nuxt server plugin for sending backend logs to Piwi Dashboard via the X-Piwi-Logs response header",
   "homepage": "https://piwitests.github.io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,7 @@
       }
     },
     "integrations/nitro": {
-      "name": "@piwitests/instrumentation",
+      "name": "@piwitests/instrumentation-nitro",
       "version": "0.20.0",
       "license": "MIT",
       "peerDependencies": {
@@ -8074,7 +8074,7 @@
       "resolved": "application",
       "link": true
     },
-    "node_modules/@piwitests/instrumentation": {
+    "node_modules/@piwitests/instrumentation-nitro": {
       "resolved": "integrations/nitro",
       "link": true
     },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,7 @@
         {
           "type": "json",
           "path": "examples/playwright-fixtures/package.json",
-          "jsonpath": "$.devDependencies['@piwitests/instrumentation']"
+          "jsonpath": "$.devDependencies['@piwitests/instrumentation-nitro']"
         },
         {
           "type": "generic",

--- a/reporter/src/public/options.ts
+++ b/reporter/src/public/options.ts
@@ -71,7 +71,7 @@ export interface PiwiDashboardOptions {
   /**
    * Capture server-side spans for each API/document request the test makes,
    * read from the `X-Piwi-Trace` response header emitted by a Piwi
-   * instrumentation plugin (e.g. `@piwitests/instrumentation`). The spans show
+   * instrumentation plugin (e.g. `@piwitests/instrumentation-nitro`). The spans show
    * up next to the network request in the dashboard and feed AI diagnosis. Free
    * when no instrumentation is present (the header is simply absent). Defaults
    * to `true`; automatically disabled when `collectPerformanceMetrics` is


### PR DESCRIPTION
## What & why

Three follow-ups from the coherence audit in #343. They are unrelated to each other — see the note at the bottom about how that interacts with the squash-merge changelog.

### 1. Rename `@piwitests/instrumentation` → `@piwitests/instrumentation-nitro` (breaking)

The Nitro integration owned the generic instrumentation name while the ASP.NET Core one ships as `PiwiTests.Instrumentation.AspNetCore`, and `ROADMAP.md` plans further backend-log packages. The unsuffixed name was a namespace the Nitro package could not keep — and it read as three different names for one thing: directory `nitro`, package `instrumentation`, README "Nitro / Nuxt server plugin".

Renamed in every referencing file: the package manifest, the workspace lockfile, the release-please version-bump jsonpath, the reporter option doc that names it as an example producer of `X-Piwi-Trace`, the docs, the README table, and the runnable example. `AGENTS.md` now lists both integration packages by their published names, since neither directory matches its package any more.

No deprecation alias — the old name has no users to migrate.

One deliberate exception: `examples/playwright-fixtures/nitro.config.ts` carries a note about `<= 0.12.0` needing inline bundling. Renaming that reference would assert something false, because those versions really did ship under the old name, so it now reads `version <= 0.12.0 (published then as @piwitests/instrumentation)`. That is the only remaining old-name mention in the tree.

### 2. Cover the settings nav grouping (0% → 100%)

The Instance/Analysis grouping added in #343 landed with no test behind it — the coverage bot reported 0% on both `settings-metadata.ts` and `useSettingsNav.ts`, so the role filtering, desktop filtering and empty-section collapse were all unverified.

Testing the composable directly needs a Nuxt runtime, and a registry-data-only test would have covered the data while leaving the branching untested. So the logic moved into `buildSettingsNavSections`, a pure function beside the registry it reads, leaving the composable as a reactive wrapper that resolves the viewer and delegates. That mirrors how the rest of the codebase keeps testable logic pure (`shared/handlers`, `packages/core`).

Both files now report 100% statements, branches and functions.

### 3. Restrict Setup to administrators

`/setup` (added in #343) governs how results reach this instance and, in the desktop build, shows the local access token. It should not have been visible to every user.

Gated in three places, because hiding only the link would be an affordance with nothing behind it:

- the **sidebar entry** — which also removes it from the command palette, built from the same items;
- the **`/setup` route**, via the existing per-path admin rule in the global auth middleware, so typing the URL does not get you there;
- **`GET /api/setup-status`**, which describes how the instance is configured — whether an AI provider and SCM token are set, whether notifications are wired. That is deployment shape rather than test data, so it follows the page.

Adds `canSeeAdmin` to `useAuth` and routes the existing call sites through it. The rule it encodes is easy to get subtly wrong: with authentication disabled there are no users at all, so nobody holds the administrator role, and gating on `isAdmin` alone would hide Setup from **everyone** on a default self-hosted install — and in the desktop build, which runs single-user with auth off and needs that page for its own connection details. The server already draws the same distinction in `requireAuth`.

## How was it tested?

- **19 new unit tests** across `settings-metadata.test.ts` (registry integrity + the pure builder) and `use-settings-nav.test.ts` (the reactive wiring, with the Nuxt auto-imports stubbed as globals and the real Vue `computed`).
- Two of them pin rules that would fail silently if broken:
  - *auth disabled ⇒ every visitor is a virtual admin* — otherwise a default self-hosted install locks everyone out of Storage, Tags and AI, since there are no users to be an admin.
  - *a non-admin drops the whole Analysis section* — every Analysis page is admin-only, so it is the one group that can empty out, and it must collapse rather than render a separator over nothing.
- Full suite green locally: **1207 app unit tests**, **464 reporter tests**, app + reporter typecheck, app + reporter lint, demo-route parity (all server routes covered), commitlint clean on all three commits.
- No E2E test navigates to `/setup` or clicks the Setup link, so the new gate does not change the E2E surface. Verified by search rather than assumed.
- Not run locally: the E2E suite. `public/demo/seed.sql` is generated and absent in a fresh clone, so `app:seed:dev` has no data to load. CI covers it.

### Known behaviour worth a reviewer's eye

In **demo mode** the global auth middleware early-returns, so a demo user acting as a non-admin can still reach `/setup` by URL, even though the sidebar link correctly hides (the demo build sets `authEnabled: true`, so the link follows the acted-as role). This exactly matches the pre-existing behaviour of the `/edit` admin rule, and the demo is a client-side sandbox with no real instance to protect — flagging it rather than silently changing demo semantics in this PR.

## Checklist

- [x] PR title follows Conventional Commits — `feat(deps)!` so the `!` marks the breaking change in the title itself, which is what release-please reads on a squash merge
- [x] Tests added/updated for behavior changes
- [x] Docs updated (`docs/backend-logs.md`, `docs/ui-overview.md`, `README.md`, `AGENTS.md`, `integrations/nitro/README.md`)

## Note on the changelog

The repo squash-merges, so this title becomes the commit on `main` and drives the release notes. This PR now carries **three unrelated changes** under a rename headline, which is one more than when it was opened — the settings-nav tests and the Setup admin gate would both be invisible in the changelog.

Splitting is cheap, since the commits are already separate and independent:

| Commit | Suggested PR title |
|---|---|
| `fc2369c` | `test(app): cover the settings nav grouping and role filtering` |
| `101f8b3` | `feat(deps)!: rename @piwitests/instrumentation to @piwitests/instrumentation-nitro` |
| `77fffda` | `fix(app): restrict Setup to administrators` |

Say the word and I'll split it. Otherwise this merges as-is and the `!` correctly triggers a breaking release — keep the `!` in the squash title either way, since the default squash body is not guaranteed to preserve the `BREAKING CHANGE:` footer.