### PR TITLE
feat(reporter): add `piwi init` command and MCP prompts

### DIFF
--- a/application/server/routes/mcp.post.ts
+++ b/application/server/routes/mcp.post.ts
@@ -1,10 +1,14 @@
-import { requireAuth } from '../utils/auth';
+import { getRequestURL, type H3Event } from 'h3';
+import { requireAuth, isAuthEnabled } from '../utils/auth';
 import { getDatabase } from '../database';
 import { MCP_TOOLS, toContent } from '../utils/mcp/tools';
 import type { McpContext } from '../utils/mcp/tools';
+import { getPrompt, isKnownPrompt } from '../utils/mcp/prompts';
 import { getProjectScope } from '../utils/project-access';
+import { resolvePublicBaseUrl } from '../utils/oauth-helpers';
 import { ok, rpcErr, RPC, MCP_SERVER_INFO, negotiateProtocolVersion } from '../utils/mcp/protocol';
 import type { JsonRpcRequest } from '../utils/mcp/protocol';
+import { MCP_PROMPT_DEFS } from '#shared/mcp-prompts';
 
 const TOOL_MAP = new Map(MCP_TOOLS.map((t) => [t.name, t]));
 const MAX_BODY_BYTES = 1_048_576; // 1 MB — reject oversized batches early
@@ -51,7 +55,7 @@ export default eventHandler(async (event) => {
   const body = await readBody<JsonRpcRequest | JsonRpcRequest[]>(event);
   const requests = Array.isArray(body) ? body : [body];
 
-  const responses = await Promise.all(requests.map((req) => handleRequest(ctx, req)));
+  const responses = await Promise.all(requests.map((req) => handleRequest(ctx, req, event)));
 
   // Notifications (no id) have no response — filter them out.
   const toSend = responses.filter((r) => r !== null);
@@ -60,7 +64,7 @@ export default eventHandler(async (event) => {
   return Array.isArray(body) ? toSend : (toSend[0] ?? null);
 });
 
-async function handleRequest(ctx: McpContext, req: JsonRpcRequest) {
+async function handleRequest(ctx: McpContext, req: JsonRpcRequest, event: H3Event) {
   if (!req || req.jsonrpc !== '2.0' || !req.method) {
     return rpcErr(req?.id, RPC.INVALID_REQUEST, 'Invalid JSON-RPC request');
   }
@@ -72,7 +76,7 @@ async function handleRequest(ctx: McpContext, req: JsonRpcRequest) {
   }
 
   try {
-    return await dispatch(ctx, req);
+    return await dispatch(ctx, req, event);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error('[MCP] error handling', req.method, message);
@@ -82,7 +86,7 @@ async function handleRequest(ctx: McpContext, req: JsonRpcRequest) {
 
 // ── JSON-RPC dispatcher ───────────────────────────────────────────────────────
 
-async function dispatch(ctx: McpContext, req: JsonRpcRequest) {
+async function dispatch(ctx: McpContext, req: JsonRpcRequest, event: H3Event) {
   const { id, method, params } = req;
 
   switch (method) {
@@ -91,7 +95,7 @@ async function dispatch(ctx: McpContext, req: JsonRpcRequest) {
       const requested = (params as { protocolVersion?: unknown } | undefined)?.protocolVersion;
       return ok(id, {
         protocolVersion: negotiateProtocolVersion(requested),
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, prompts: {} },
         serverInfo: MCP_SERVER_INFO,
         instructions:
           'Piwi Dashboard MCP server — query Playwright test results, failure clusters, AI diagnoses, and SCM diffs. ' +
@@ -99,7 +103,8 @@ async function dispatch(ctx: McpContext, req: JsonRpcRequest) {
           'List tools return {items, nextCursor}; pass nextCursor back (when non-null) to page. ' +
           'IDs: testCaseId = stable test identity; executionId/testRunsCaseId = one per-run execution. ' +
           'Errors are truncated; use get_test_run_case for full error text and explain_failure for a one-call evidence bundle. ' +
-          'Write/triage tools (set_cluster_status, run_cluster_diagnosis, set_cluster_base_commit, submit_diagnosis_feedback) require reporter or admin access.',
+          'Write/triage tools (set_cluster_status, run_cluster_diagnosis, set_cluster_base_commit, submit_diagnosis_feedback) require reporter or admin access. ' +
+          'The setup_piwi prompt (prompts/get) generates a ready-to-run setup for a Playwright project not yet reporting here.',
       });
     }
 
@@ -132,12 +137,41 @@ async function dispatch(ctx: McpContext, req: JsonRpcRequest) {
       return ok(id, toContent(data));
     }
 
-    // ── Resources / prompts (not implemented in v1) ──────────────────────────
+    // ── Prompts ──────────────────────────────────────────────────────────────
+    case 'prompts/list': {
+      return ok(id, {
+        prompts: MCP_PROMPT_DEFS.map((p) => ({
+          name: p.name,
+          description: p.description,
+          arguments: p.arguments ?? [],
+        })),
+      });
+    }
+
+    case 'prompts/get': {
+      const p = params as { name?: string; arguments?: Record<string, string> };
+      if (!p?.name || !isKnownPrompt(p.name)) {
+        return rpcErr(id, RPC.INVALID_PARAMS, `Unknown prompt: ${p?.name}`);
+      }
+      const db = await getDatabase();
+      // The URL the client used to reach this dashboard is the URL its reporter
+      // should point at; PIWI_SITE_URL overrides it when set (reverse proxy).
+      const requestUrl = getRequestURL(event);
+      const siteUrl = (useRuntimeConfig(event).public as { siteUrl?: string })?.siteUrl;
+      const baseUrl = resolvePublicBaseUrl(siteUrl, `${requestUrl.protocol}//${requestUrl.host}`);
+      const result = await getPrompt(p.name, {
+        db,
+        ctx,
+        baseUrl,
+        authEnabled: isAuthEnabled(event),
+        args: p.arguments ?? {},
+      });
+      return ok(id, result);
+    }
+
+    // ── Resources (not implemented) ──────────────────────────────────────────
     case 'resources/list':
       return ok(id, { resources: [] });
-
-    case 'prompts/list':
-      return ok(id, { prompts: [] });
 
     default:
       return rpcErr(id, RPC.METHOD_NOT_FOUND, `Method not found: ${method}`);

--- a/application/server/utils/mcp/prompts.ts
+++ b/application/server/utils/mcp/prompts.ts
@@ -1,0 +1,143 @@
+/**
+ * MCP prompt handlers — the behavior behind the catalog in `shared/mcp-prompts.ts`.
+ *
+ * A prompt returns messages the client drops into the conversation. The value
+ * of serving these from the server (rather than a static template the user
+ * pastes) is that they are filled in with facts only the dashboard knows: its
+ * own public URL, whether authentication is required, and the projects that
+ * already exist. The message-building is a pure function so it is unit-tested
+ * without a database; the async wrapper only fetches the project list.
+ */
+import { getProjectMenu } from '#shared/handlers/projects';
+import { MCP_PROMPT_DEFS } from '#shared/mcp-prompts';
+import type { McpPromptName } from '#shared/mcp-prompts';
+import type { McpContext } from './tools';
+import type { DbClient } from '../../database';
+
+export interface PromptMessage {
+  role: 'user' | 'assistant';
+  content: { type: 'text'; text: string };
+}
+
+export interface PromptResult {
+  description?: string;
+  messages: PromptMessage[];
+}
+
+const PROMPT_NAMES = new Set<string>(MCP_PROMPT_DEFS.map((p) => p.name));
+
+export function isKnownPrompt(name: string): name is McpPromptName {
+  return PROMPT_NAMES.has(name);
+}
+
+export interface SetupPiwiInput {
+  /** Public base URL of this dashboard, e.g. `https://piwi.example.com`. */
+  baseUrl: string;
+  /** Whether the dashboard requires an API key for reporting. */
+  authEnabled: boolean;
+  /** Project name the caller asked for, if any. */
+  projectName?: string | null;
+  /** Names of projects that already exist on this dashboard (scoped to the caller). */
+  existingProjects: string[];
+}
+
+/** Guidance for choosing the project name, given what the caller supplied and what exists. */
+function projectNameGuidance(projectName: string | null | undefined, existing: string[]): string {
+  if (projectName) return `Report under the project "${projectName}".`;
+  if (existing.length) {
+    const sample = existing.slice(0, 20).join(', ');
+    return (
+      `Choose the project name: if this repository already reports to one of the existing projects ` +
+      `(${sample}), reuse that exact name; otherwise derive one from the repository's package.json ` +
+      `"name" or its folder. Replace <project-name> in the command with your choice.`
+    );
+  }
+  return (
+    `Derive the project name from the repository's package.json "name" or its folder — this will be ` +
+    `the first project on the dashboard. Replace <project-name> in the command with it.`
+  );
+}
+
+function authGuidance(authEnabled: boolean): string {
+  if (authEnabled) {
+    return (
+      'This dashboard **requires authentication**, so reporting needs an API key. Create one in the ' +
+      'dashboard UI (Settings → Users → API keys; keys start with `pd_`), add it to `.env` as ' +
+      '`PIWI_API_KEY=pd_...`, and keep `.env` out of git. In CI, pass it as the `PIWI_API_KEY` secret. ' +
+      'Never hardcode the key in `playwright.config`.'
+    );
+  }
+  return 'This dashboard does **not** require authentication, so runs need no API key.';
+}
+
+/** Build the `setup_piwi` prompt messages. Pure — every input is already resolved. */
+export function buildSetupPiwiMessages(input: SetupPiwiInput): PromptResult {
+  const { baseUrl, authEnabled } = input;
+  const projectArg = input.projectName ? input.projectName : '<project-name>';
+  const existing = input.existingProjects.length
+    ? input.existingProjects.slice(0, 20).join(', ') +
+      (input.existingProjects.length > 20 ? `, … (${input.existingProjects.length} total)` : '')
+    : 'none yet';
+
+  const text = [
+    `Set up this Playwright project to report its test results to the Piwi Dashboard at ${baseUrl}.`,
+    '',
+    'Facts about this dashboard (already resolved — do not ask the user for them):',
+    `- URL: ${baseUrl}`,
+    `- Authentication: ${authEnabled ? 'required' : 'not required'}`,
+    `- Projects that already exist: ${existing}`,
+    '',
+    'Steps:',
+    '',
+    '1. From the project root, run the setup command:',
+    '',
+    `   npx piwi init --server-url ${baseUrl} --project ${projectArg}`,
+    '',
+    '   It installs `@piwitests/reporter`, wraps `defineConfig(...)` with `wrapConfig(...)`, creates',
+    '   `tests/fixtures.ts`, and records PIWI_* settings in `.env.example`. Every step is idempotent, so it is',
+    '   safe to re-run. Add `--json` to get a machine-readable plan and finish any step it reports as `manual`',
+    "   using the exact change in that step's `detail`.",
+    `   ${projectNameGuidance(input.projectName, input.existingProjects)}`,
+    '',
+    `2. ${authGuidance(authEnabled)}`,
+    '',
+    '3. Rewire the specs: in each spec, import `test` (and `expect`) from your fixtures file instead of',
+    '   `@playwright/test`, so the capture fixtures (locator healing, slow endpoints, Web Vitals, console,',
+    '   failure-time ARIA) apply. A spec left on the direct import still runs and reports — it just is not captured.',
+    '',
+    '4. Verify a run lands: run `npx playwright test` (one spec is enough) and confirm the run appears at',
+    `   ${baseUrl}. For a deterministic check, set PIWI_OUTPUT_FILE=piwi-run.json when running and read \`runUrl\``,
+    '   from that file afterward — its presence proves the upload.',
+    '',
+    'Report what you changed, the run URL you verified, and anything still to do. Once results are flowing, the',
+    'Piwi MCP tools (list_recent_activity, explain_failure, get_locator_healing, list_flaky_tests, …) let you',
+    'investigate failures and propose fixes from the same evidence the dashboard shows.',
+  ].join('\n');
+
+  return {
+    description: `Set up Piwi reporting for a Playwright project, targeting ${baseUrl}`,
+    messages: [{ role: 'user', content: { type: 'text', text } }],
+  };
+}
+
+export interface ResolvePromptArgs {
+  db: DbClient;
+  ctx: McpContext;
+  baseUrl: string;
+  authEnabled: boolean;
+  args: Record<string, string>;
+}
+
+/** Resolve a prompt by name into its messages, or null when the name is unknown. */
+export async function getPrompt(name: string, opts: ResolvePromptArgs): Promise<PromptResult | null> {
+  if (name === 'setup_piwi') {
+    const menu = await getProjectMenu(opts.db, opts.ctx.scope);
+    return buildSetupPiwiMessages({
+      baseUrl: opts.baseUrl,
+      authEnabled: opts.authEnabled,
+      projectName: opts.args.projectName ?? null,
+      existingProjects: menu.map((m) => m.name),
+    });
+  }
+  return null;
+}

--- a/application/server/utils/mcp/protocol.ts
+++ b/application/server/utils/mcp/protocol.ts
@@ -3,7 +3,7 @@
 // this. Kept broad so older clients (2024-11-05) keep working.
 export const MCP_PROTOCOL_VERSION = '2025-06-18';
 export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'] as const;
-export const MCP_SERVER_INFO = { name: 'piwi-dashboard', version: '1.1.0' };
+export const MCP_SERVER_INFO = { name: 'piwi-dashboard', version: '1.2.0' };
 
 /** Pick the protocol version to advertise: the client's if supported, else ours. */
 export function negotiateProtocolVersion(requested: unknown): string {

--- a/application/shared/mcp-prompts.ts
+++ b/application/shared/mcp-prompts.ts
@@ -1,0 +1,42 @@
+/**
+ * Catalog of MCP **prompts** this server exposes — the slash-command-style
+ * entries an MCP client offers the user (Claude Code, Cursor, Copilot, …).
+ *
+ * Only the catalog (name, description, arguments) lives here, shared so the
+ * server route and the in-app MCP setup page can render the same list — the
+ * same split `mcp-tools.ts` uses for tools. The message text is built
+ * server-side in `server/utils/mcp/prompts.ts`, where it can be filled in with
+ * this dashboard's real URL, whether authentication is required, and the
+ * projects that already exist.
+ */
+
+export interface McpPromptArg {
+  name: string;
+  description: string;
+  required?: boolean;
+}
+
+export interface McpPromptDef {
+  name: string;
+  description: string;
+  // `readonly` so the catalog can be declared `as const` (needed to derive the
+  // `McpPromptName` union) while still satisfying this type.
+  arguments?: readonly McpPromptArg[];
+}
+
+export const MCP_PROMPT_DEFS = [
+  {
+    name: 'setup_piwi',
+    description:
+      "Set up the current Playwright project to report to this Piwi Dashboard: install the reporter, wrap the config, add the capture fixtures, and verify a run lands. Server-aware — fills in this dashboard's URL, whether authentication is required, and the projects that already exist.",
+    arguments: [
+      {
+        name: 'projectName',
+        description: 'Name to report runs under. Omit to reuse an existing project or derive one from the repository.',
+        required: false,
+      },
+    ],
+  },
+] as const satisfies readonly McpPromptDef[];
+
+export type McpPromptName = (typeof MCP_PROMPT_DEFS)[number]['name'];

--- a/application/tests/mcp.spec.ts
+++ b/application/tests/mcp.spec.ts
@@ -62,6 +62,7 @@ test.describe.serial('MCP server', () => {
     expect(body.result.protocolVersion).toBe('2024-11-05');
     expect(body.result.serverInfo.name).toBe('piwi-dashboard');
     expect(body.result.capabilities.tools).toBeDefined();
+    expect(body.result.capabilities.prompts).toBeDefined();
   });
 
   test('ping — returns empty result', async ({ request }) => {
@@ -97,6 +98,37 @@ test.describe.serial('MCP server', () => {
       expect(t).toHaveProperty('description');
       expect(t).toHaveProperty('inputSchema');
     }
+  });
+
+  test('prompts/list — advertises the setup_piwi prompt', async ({ request }) => {
+    const body = await mcp(request, 'prompts/list');
+    const prompts: { name: string; description: string; arguments: unknown[] }[] = body.result.prompts;
+    const setup = prompts.find((p) => p.name === 'setup_piwi');
+    expect(setup).toBeDefined();
+    expect(setup!.description.length).toBeGreaterThan(20);
+    expect(Array.isArray(setup!.arguments)).toBe(true);
+  });
+
+  test('prompts/get setup_piwi — returns server-aware setup messages', async ({ request }) => {
+    const body = await mcp(request, 'prompts/get', {
+      name: 'setup_piwi',
+      arguments: { projectName: PROJECT.MCP_TEST },
+    });
+    const messages: { role: string; content: { type: string; text: string } }[] = body.result.messages;
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages[0].role).toBe('user');
+    const text = messages[0].content.text;
+    // Server-aware: the message names this project and includes a runnable init command.
+    expect(text).toContain(`--project ${PROJECT.MCP_TEST}`);
+    expect(text).toContain('npx piwi init --server-url');
+    // Auth is disabled in the test server, so it should say no key is needed.
+    expect(text).toContain('Authentication: not required');
+  });
+
+  test('prompts/get — unknown prompt returns invalid-params error', async ({ request }) => {
+    const body = await mcp(request, 'prompts/get', { name: 'nope' });
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe(-32602);
   });
 
   test('tools/call list_projects — returns project list with stats', async ({ request }) => {

--- a/application/tests/unit/mcp-prompts.test.ts
+++ b/application/tests/unit/mcp-prompts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildSetupPiwiMessages, isKnownPrompt } from '../../server/utils/mcp/prompts';
+import { MCP_PROMPT_DEFS } from '#shared/mcp-prompts';
+
+describe('isKnownPrompt', () => {
+  it('recognizes every declared prompt and rejects others', () => {
+    for (const def of MCP_PROMPT_DEFS) expect(isKnownPrompt(def.name)).toBe(true);
+    expect(isKnownPrompt('setup_piwi')).toBe(true);
+    expect(isKnownPrompt('nonexistent')).toBe(false);
+  });
+});
+
+describe('buildSetupPiwiMessages', () => {
+  const base = { baseUrl: 'https://piwi.example.com', authEnabled: false, existingProjects: [] as string[] };
+
+  it('returns a single user message and a description naming the dashboard', () => {
+    const result = buildSetupPiwiMessages(base);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('user');
+    expect(result.messages[0].content.type).toBe('text');
+    expect(result.description).toContain('https://piwi.example.com');
+  });
+
+  it('bakes the dashboard URL into the init command', () => {
+    const text = buildSetupPiwiMessages(base).messages[0].content.text;
+    expect(text).toContain('npx piwi init --server-url https://piwi.example.com --project <project-name>');
+    expect(text).toContain('Authentication: not required');
+  });
+
+  it('uses a supplied project name in place of the placeholder', () => {
+    const text = buildSetupPiwiMessages({ ...base, projectName: 'checkout' }).messages[0].content.text;
+    expect(text).toContain('--project checkout');
+    expect(text).not.toContain('<project-name>');
+    expect(text).toContain('project "checkout"');
+  });
+
+  it('spells out the API-key steps when authentication is required', () => {
+    const text = buildSetupPiwiMessages({ ...base, authEnabled: true }).messages[0].content.text;
+    expect(text).toContain('Authentication: required');
+    expect(text).toContain('requires authentication');
+    expect(text).toContain('PIWI_API_KEY');
+    expect(text).toContain('pd_');
+  });
+
+  it('lists existing projects so the agent can reuse a name', () => {
+    const text = buildSetupPiwiMessages({ ...base, existingProjects: ['checkout', 'marketing'] }).messages[0].content
+      .text;
+    expect(text).toContain('Projects that already exist: checkout, marketing');
+    expect(text).toContain('reuse that exact name');
+  });
+
+  it('says so when the dashboard has no projects yet', () => {
+    const text = buildSetupPiwiMessages(base).messages[0].content.text;
+    expect(text).toContain('Projects that already exist: none yet');
+    expect(text).toContain('first project');
+  });
+
+  it('truncates a very long project list and reports the total', () => {
+    const many = Array.from({ length: 25 }, (_, i) => `proj-${i}`);
+    const text = buildSetupPiwiMessages({ ...base, existingProjects: many }).messages[0].content.text;
+    expect(text).toContain('(25 total)');
+  });
+
+  it('always closes with the verification step', () => {
+    const text = buildSetupPiwiMessages(base).messages[0].content.text;
+    expect(text).toContain('npx playwright test');
+    expect(text).toContain('PIWI_OUTPUT_FILE=piwi-run.json');
+  });
+});

--- a/application/tests/unit/piwi-env-vars.test.ts
+++ b/application/tests/unit/piwi-env-vars.test.ts
@@ -181,6 +181,7 @@ describe('PIWI_ENV_VARS registry', () => {
       'PIWI_ENV_CATEGORIES',
       'PIWI_ENV_KEYS',
       'PIWI_API_KEY',
+      'PIWI_OUTPUT_FILE',
     ]);
     const realMissing = missing.filter((v) => !knownFalsePositives.has(v));
     expect(realMissing.sort()).toEqual([]);

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,6 +98,20 @@ The SQLite database is automatically created on the first API call.
 
 The recommended way to integrate is via the custom reporter package — it handles uploading results, HTML reports, and trace files automatically.
 
+### Fast path: `npx piwi init`
+
+From your Playwright project, one command installs the reporter, wraps your `playwright.config`, creates the capture-fixtures file, and records the connection in `.env.example`:
+
+```bash
+npx piwi init --server-url http://localhost:3000 --project my-project
+```
+
+Every step is idempotent, so it is safe to re-run. If it finds a config shape it will not rewrite (or a fixtures file that already exists), it reports that step as `manual` with the exact change to make instead of touching the file. Pass `--dry-run` to preview, or `--json` to get a machine-readable plan — the latter is what lets a coding agent run the setup for you and finish anything left manual. `init` also drops the [Piwi agent skills](./mcp#agent-skills) into the project so your agent can investigate failures, heal locators, and stabilize flaky tests. See `npx piwi init --help` for all options.
+
+Prefer to wire it up by hand? The manual steps are below.
+
+### Manual setup
+
 Install it:
 
 ```bash

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -221,6 +221,16 @@ Agent: [calls list_projects → finds checkout → calls list_runs → calls get
 
 ---
 
+## Prompts
+
+Alongside its tools, the server exposes an MCP **prompt** — a ready-made instruction a client offers as a slash command (Claude Code's `/`, Cursor's prompt picker, …), with no files to install.
+
+| Prompt | What it does |
+|--------|--------------|
+| `setup_piwi` | Generates a complete, ready-to-run setup for a Playwright project that is not yet reporting here. |
+
+`setup_piwi` is **server-aware**: because the dashboard builds it, it fills in *this* instance's real URL, whether authentication is required, and the projects that already exist — facts a static copy-paste prompt can't know. Pick it in your MCP client (optionally passing a `projectName`), and the agent gets a personalized plan: run `npx piwi init` against this dashboard, handle the API key if auth is on, rewire the specs, and verify a run lands. It pairs with the `setup-piwi` skill below — the prompt needs no install but requires the MCP connection; the skill works offline once installed.
+
 ## Agent skills
 
 The MCP server gives an agent read access to your results; **skills** tell it what to *do* with them. A skill is a single `SKILL.md` file — the portable open format (a small front-matter block plus Markdown instructions) that Claude Code and other agents pick up from a project's skills directory. Piwi ships four, installed with the reporter's CLI:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -221,6 +221,27 @@ Agent: [calls list_projects → finds checkout → calls list_runs → calls get
 
 ---
 
+## Agent skills
+
+The MCP server gives an agent read access to your results; **skills** tell it what to *do* with them. A skill is a single `SKILL.md` file — the portable open format (a small front-matter block plus Markdown instructions) that Claude Code and other agents pick up from a project's skills directory. Piwi ships four, installed with the reporter's CLI:
+
+```bash
+npx piwi skills add            # install all of them into .claude/skills/
+npx piwi skills list           # see what each one does
+npx piwi skills add investigate-failure --dir .cursor/skills   # a specific one, elsewhere
+```
+
+`npx piwi init` installs the three workflow skills automatically as part of setup.
+
+| Skill | What it does |
+|------|--------------|
+| `setup-piwi` | Wire a Playwright project up to a dashboard — the same work `npx piwi init` does, driven by an agent. |
+| `investigate-failure` | Investigate a failed run and propose a fix grounded in Piwi's evidence — error, steps, console, network, and the diff since the last green run. |
+| `apply-locator-healing` | Replace a brittle locator with Piwi's ranked healed selector at its call site, then re-run to confirm. |
+| `stabilize-flaky-tests` | Fix the root cause of the highest-impact flaky tests (never by adding retries), then verify with repeated runs. |
+
+The skills are agent-agnostic Markdown — only the destination directory is tool-specific, so `--dir` points the install wherever your agent reads skills from. They pair with this MCP server: each one prefers a connected Piwi MCP tool (`explain_failure`, `get_locator_healing`, `list_flaky_tests`, …) and falls back to the dashboard UI when MCP is not connected.
+
 ## Architecture
 
 The MCP server is implemented as a single Nitro route (`server/routes/mcp.post.ts`) that dispatches JSON-RPC methods to tool handlers in `server/utils/mcp/tools.ts`. Handlers call the same shared DB helpers used by the REST API — no self-HTTP-calls, no extra processes.

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -13,6 +13,8 @@ The `@piwitests/reporter` package is a custom Playwright reporter that automatic
 npm install --save-dev @piwitests/reporter
 ```
 
+Or let `npx piwi init` do the install and wiring for you — see the [one-command setup](./getting-started#fast-path-npx-piwi-init) in Getting started. The rest of this page is the full manual reference.
+
 ## Basic configuration
 
 Add the reporter to your `playwright.config.ts`:

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -10,6 +10,16 @@ A custom Playwright reporter that sends test results to a [Piwi Dashboard](https
 npm install --save-dev @piwitests/reporter
 ```
 
+## Set up in one command
+
+From your Playwright project, `npx piwi init` installs the reporter, wraps your `playwright.config`, creates the capture-fixtures file, and records the connection in `.env.example`:
+
+```bash
+npx piwi init --server-url http://localhost:3000 --project my-project
+```
+
+Every step is idempotent (safe to re-run); a config shape it will not rewrite is reported as `manual` with the exact change to make, never mangled. Add `--dry-run` to preview or `--json` for a machine-readable plan an agent can act on. It also installs the [Piwi agent skills](https://piwitests.github.io/mcp#agent-skills) so your coding agent can investigate failures, heal locators, and stabilize flaky tests. Run `npx piwi init --help` for all options, or wire it up by hand with the steps below.
+
 ## Quick start
 
 `wrapConfig` is the recommended setup. It injects the reporter **and** a global

--- a/reporter/package.json
+++ b/reporter/package.json
@@ -55,7 +55,8 @@
     "prepublishOnly": "npm run reporter:build"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "templates/"
   ],
   "peerDependencies": {
     "@playwright/test": "^1.61.1"

--- a/reporter/src/cli/configure.ts
+++ b/reporter/src/cli/configure.ts
@@ -1,0 +1,174 @@
+/**
+ * The deterministic edits `init` makes to a project: wrapping the Playwright
+ * config, creating the capture-fixtures file, and recording connection details
+ * in `.env` / `.gitignore`.
+ *
+ * Every function here is pure — string in, string out — so the risky part
+ * (rewriting someone's config) is unit-tested without touching disk, and the
+ * command layer only owns reading and writing files. Each transform is
+ * idempotent: running it against already-configured input reports `already`
+ * rather than doubling anything up.
+ */
+
+export interface WrapOptions {
+  /** Written into the config; omitted when empty so the reporter reads the env instead. */
+  serverUrl?: string;
+  projectName: string;
+}
+
+export interface ConfigEdit {
+  text: string;
+  status: 'updated' | 'already' | 'manual';
+  detail: string;
+}
+
+const REPORTER_IMPORT = "import { wrapConfig } from '@piwitests/reporter'";
+
+const MANUAL_HINT =
+  'Could not find `export default defineConfig(...)`. Wrap your exported config by hand: ' +
+  "import { wrapConfig } from '@piwitests/reporter', then " +
+  'export default wrapConfig(defineConfig({ ... }), { serverUrl, projectName }).';
+
+/** Single-quote a value for embedding in a config literal. */
+function quote(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * Index of the `)` that closes the `(` at `openIndex`, or -1 if unbalanced.
+ * Skips parentheses that appear inside strings and comments so a URL or a
+ * commented-out block can't throw the count off.
+ */
+function matchClosingParen(src: string, openIndex: number): number {
+  let depth = 0;
+  let quoteChar: string | null = null;
+  for (let i = openIndex; i < src.length; i++) {
+    const c = src[i];
+    if (quoteChar) {
+      if (c === quoteChar && src[i - 1] !== '\\') quoteChar = null;
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '/') {
+      const nl = src.indexOf('\n', i);
+      if (nl === -1) return -1;
+      i = nl;
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '*') {
+      const end = src.indexOf('*/', i + 2);
+      if (end === -1) return -1;
+      i = end + 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quoteChar = c;
+      continue;
+    }
+    if (c === '(') depth++;
+    else if (c === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** The Piwi options object, printed multi-line to sit inside the wrapped call. */
+function optionsLiteral(opts: WrapOptions): string {
+  const lines: string[] = [];
+  if (opts.serverUrl) lines.push(`    serverUrl: ${quote(opts.serverUrl)},`);
+  lines.push(`    projectName: ${quote(opts.projectName)},`);
+  return `{\n${lines.join('\n')}\n  }`;
+}
+
+/**
+ * Add the `wrapConfig` import next to the file's existing imports — after the
+ * last complete single-line `import ... from '...'` (or side-effect import), so
+ * the two land together. Falls back to prepending when the head has no import
+ * the insertion can safely anchor to (e.g. only multi-line imports).
+ */
+function withReporterImport(head: string): string {
+  const importLine = /^import\b.*$/gm;
+  let insertAt = -1;
+  let match: RegExpExecArray | null;
+  while ((match = importLine.exec(head))) {
+    const line = match[0];
+    const complete = /from\s*['"][^'"]+['"]\s*;?\s*$/.test(line) || /^import\s+['"][^'"]+['"]\s*;?\s*$/.test(line);
+    if (complete) insertAt = match.index + line.length;
+  }
+  if (insertAt === -1) return `${REPORTER_IMPORT}\n${head}`;
+  return `${head.slice(0, insertAt)}\n${REPORTER_IMPORT}${head.slice(insertAt)}`;
+}
+
+/**
+ * Wrap a Playwright config's `export default defineConfig(...)` with
+ * `wrapConfig(...)` and add the import. Returns `already` when the reporter is
+ * present, and `manual` (with the exact snippet in `detail`) when the config
+ * uses a shape this cannot rewrite safely.
+ */
+export function wrapPlaywrightConfig(source: string, opts: WrapOptions): ConfigEdit {
+  if (/@piwitests\/reporter/.test(source)) {
+    return { text: source, status: 'already', detail: 'Piwi reporter is already wired into the config' };
+  }
+
+  const match = /export\s+default\s+defineConfig\s*\(/.exec(source);
+  if (!match) return { text: source, status: 'manual', detail: MANUAL_HINT };
+
+  const openParen = match.index + match[0].length - 1;
+  const closeParen = matchClosingParen(source, openParen);
+  const callStart = source.indexOf('defineConfig', match.index);
+  if (closeParen === -1 || callStart === -1) return { text: source, status: 'manual', detail: MANUAL_HINT };
+
+  const callExpr = source.slice(callStart, closeParen + 1);
+  let before = withReporterImport(source.slice(0, match.index));
+  const after = source.slice(closeParen + 1);
+  if (before.length && !before.endsWith('\n')) before += '\n';
+
+  const wrapped = `export default wrapConfig(\n  ${callExpr},\n  ${optionsLiteral(opts)},\n)`;
+  const text = `${before}${wrapped}${after}`;
+  return { text, status: 'updated', detail: 'Wrapped defineConfig(...) with wrapConfig(...) and added the import' };
+}
+
+/** Contents of the capture-fixtures file — identical for TS and JS projects. */
+export function fixturesContents(): string {
+  return [
+    "import { test as base, expect } from '@playwright/test'",
+    "import { piwiFixtures } from '@piwitests/reporter'",
+    '',
+    'export const test = base.extend(piwiFixtures)',
+    'export { expect }',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Add each `KEY=value` line that is not already present. Existing keys are left
+ * untouched (a value already set by the user is never overwritten).
+ */
+export function upsertEnvKeys(
+  existing: string,
+  entries: ReadonlyArray<readonly [string, string]>,
+): {
+  text: string;
+  added: string[];
+} {
+  let text = existing;
+  const added: string[] = [];
+  for (const [key, value] of entries) {
+    if (new RegExp(`^\\s*${key}=`, 'm').test(text)) continue;
+    if (text.length && !text.endsWith('\n')) text += '\n';
+    text += `${key}=${value}\n`;
+    added.push(key);
+  }
+  return { text, added };
+}
+
+/** Ensure `entry` (default `.env`) appears in a `.gitignore`'s contents. */
+export function ensureGitignoreEntry(existing: string, entry = '.env'): { text: string; added: boolean } {
+  const present = existing.split(/\r?\n/).some((line) => line.trim() === entry);
+  if (present) return { text: existing, added: false };
+  let text = existing;
+  if (text.length && !text.endsWith('\n')) text += '\n';
+  text += `${entry}\n`;
+  return { text, added: true };
+}

--- a/reporter/src/cli/detect.ts
+++ b/reporter/src/cli/detect.ts
@@ -1,0 +1,130 @@
+/**
+ * Read-only inspection of the target project so `init` knows what it is looking
+ * at before it changes anything: which package manager runs there, where the
+ * Playwright config lives, whether the reporter is already a dependency, and a
+ * sensible default project name.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+export type ConfigLang = 'ts' | 'js';
+
+export interface PackageJson {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  packageManager?: string;
+}
+
+export interface ProjectShape {
+  /** Absolute project root the command was pointed at. */
+  root: string;
+  /** Parsed `package.json`, or null when the directory has none. */
+  packageJson: PackageJson | null;
+  packageJsonPath: string | null;
+  packageManager: PackageManager;
+  /** Absolute path to the Playwright config, or null when none is found. */
+  configPath: string | null;
+  configLang: ConfigLang;
+  /** Whether `@piwitests/reporter` is already listed in dependencies. */
+  reporterInstalled: boolean;
+  /** Default `projectName` for the reporter, derived from the package or folder. */
+  suggestedProjectName: string;
+}
+
+const CONFIG_NAMES = [
+  'playwright.config.ts',
+  'playwright.config.mts',
+  'playwright.config.cts',
+  'playwright.config.js',
+  'playwright.config.mjs',
+  'playwright.config.cjs',
+];
+
+/** Lockfile → package manager, in the order a repo's presence should win. */
+const LOCKFILES: ReadonlyArray<readonly [string, PackageManager]> = [
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['bun.lockb', 'bun'],
+  ['bun.lock', 'bun'],
+  ['package-lock.json', 'npm'],
+];
+
+const REPORTER_PACKAGE = '@piwitests/reporter';
+
+function readPackageJson(root: string): { pkg: PackageJson | null; pkgPath: string | null } {
+  const pkgPath = path.join(root, 'package.json');
+  try {
+    return { pkg: JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as PackageJson, pkgPath };
+  } catch {
+    return { pkg: null, pkgPath: null };
+  }
+}
+
+/** Corepack's `packageManager` field wins; then a lockfile; else npm. */
+function detectPackageManager(root: string, pkg: PackageJson | null): PackageManager {
+  const declared = pkg?.packageManager?.split('@')[0];
+  if (declared === 'pnpm' || declared === 'yarn' || declared === 'bun' || declared === 'npm') return declared;
+  for (const [file, manager] of LOCKFILES) {
+    if (fs.existsSync(path.join(root, file))) return manager;
+  }
+  return 'npm';
+}
+
+function findConfig(root: string): string | null {
+  for (const name of CONFIG_NAMES) {
+    const candidate = path.join(root, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** `.js`/`.mjs`/`.cjs` configs are JavaScript; everything else is treated as TypeScript. */
+function langOf(configPath: string | null): ConfigLang {
+  if (!configPath) return 'ts';
+  return /\.[cm]?js$/.test(configPath) ? 'js' : 'ts';
+}
+
+/** Unscoped, filesystem-safe project name: `@acme/checkout` → `checkout`. */
+function suggestProjectName(root: string, pkg: PackageJson | null): string {
+  const fromPkg = pkg?.name?.replace(/^@[^/]+\//, '').trim();
+  return fromPkg || path.basename(root) || 'default-project';
+}
+
+function hasReporter(pkg: PackageJson | null): boolean {
+  if (!pkg) return false;
+  return Boolean(pkg.dependencies?.[REPORTER_PACKAGE] || pkg.devDependencies?.[REPORTER_PACKAGE]);
+}
+
+export function detectProject(root: string): ProjectShape {
+  const absRoot = path.resolve(root);
+  const { pkg, pkgPath } = readPackageJson(absRoot);
+  const configPath = findConfig(absRoot);
+  return {
+    root: absRoot,
+    packageJson: pkg,
+    packageJsonPath: pkgPath,
+    packageManager: detectPackageManager(absRoot, pkg),
+    configPath,
+    configLang: langOf(configPath),
+    reporterInstalled: hasReporter(pkg),
+    suggestedProjectName: suggestProjectName(absRoot, pkg),
+  };
+}
+
+/** The shell command that adds the reporter as a dev dependency, per manager. */
+export function installCommand(manager: PackageManager): string {
+  switch (manager) {
+    case 'pnpm':
+      return `pnpm add -D ${REPORTER_PACKAGE}`;
+    case 'yarn':
+      return `yarn add -D ${REPORTER_PACKAGE}`;
+    case 'bun':
+      return `bun add -d ${REPORTER_PACKAGE}`;
+    case 'npm':
+      return `npm install --save-dev ${REPORTER_PACKAGE}`;
+  }
+}
+
+export { REPORTER_PACKAGE };

--- a/reporter/src/cli/index.ts
+++ b/reporter/src/cli/index.ts
@@ -2,12 +2,14 @@
 /**
  * `piwi` — the reporter package's command-line entry point.
  *
- * Deliberately tiny. The reporter's job is to get results into the dashboard
- * during `playwright test`; this CLI exists only for the things that have to
- * happen *after* a run has landed, where the dashboard's history is what makes
- * the answer possible. Today that is one command.
+ * The reporter's job is to get results into the dashboard during
+ * `playwright test`; the CLI covers the things that happen around a run:
+ * setting a project up in the first place (`init`, `skills`) and acting on the
+ * dashboard's history once a run has landed (`gate`).
  */
 import { runGate } from './gate.js';
+import { runInit } from './init.js';
+import { findTemplatesDir, runSkills } from './skills.js';
 
 const USAGE = `
 piwi — companion commands for the Piwi Dashboard reporter
@@ -16,15 +18,21 @@ Usage:
   npx piwi <command> [options]
 
 Commands:
-  gate    Fail a CI job on the dashboard's analysis of a run
+  init      Wire a Playwright project up to a Piwi Dashboard
+  skills    Install the Piwi agent skills into this project
+  gate      Fail a CI job on the dashboard's analysis of a run
 
-Run \`npx piwi gate --help\` for that command's options.
+Run \`npx piwi <command> --help\` for a command's options.
 `.trim();
 
 async function main(): Promise<number> {
   const [command, ...rest] = process.argv.slice(2);
 
   switch (command) {
+    case 'init':
+      return runInit(rest);
+    case 'skills':
+      return runSkills(rest, findTemplatesDir(__dirname));
     case 'gate':
       return runGate(rest);
     case undefined:

--- a/reporter/src/cli/init.ts
+++ b/reporter/src/cli/init.ts
@@ -1,0 +1,343 @@
+/**
+ * `piwi init` — wire a Playwright project up to a Piwi Dashboard, deterministically.
+ *
+ * The command does the mechanical, error-prone parts of setup so an agent (or a
+ * person) does not have to hand-edit config: install the reporter, wrap the
+ * Playwright config, add the capture fixtures, record the connection in `.env`,
+ * and drop the Piwi agent skills into the repo. Every action is reported as a
+ * `StepResult`; `--json` prints them verbatim so an agent reads the outcomes and
+ * finishes anything left as `manual`.
+ *
+ * It never fails destructively: an unrecognized config shape or a pre-existing
+ * fixtures file becomes a `manual` step carrying the exact snippet to apply, not
+ * a rewrite of a file the tool does not understand.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { formatStep, type StepResult } from './report.js';
+import { detectProject, installCommand, REPORTER_PACKAGE, type PackageManager, type ProjectShape } from './detect.js';
+import { ensureGitignoreEntry, fixturesContents, upsertEnvKeys, wrapPlaywrightConfig } from './configure.js';
+import { ALL_SKILLS, findTemplatesDir, installSkills, WORKFLOW_SKILLS, DEFAULT_SKILLS_DIR } from './skills.js';
+
+const DEFAULT_SERVER_URL = 'http://localhost:3000';
+
+interface InitOptions {
+  root: string;
+  serverUrl: string;
+  projectName: string;
+  apiKey: string | null;
+  skillsDir: string;
+  skillSlugs: ReadonlyArray<string>;
+  install: boolean;
+  force: boolean;
+  dryRun: boolean;
+  json: boolean;
+  /** Only install skills; leave the Playwright config and env untouched. */
+  skillsOnly: boolean;
+  /** Configure the project but install no skills. */
+  noSkills: boolean;
+}
+
+const USAGE = `
+piwi init — wire a Playwright project up to a Piwi Dashboard
+
+Usage:
+  npx piwi init [options]
+
+What it does (each step is idempotent and safe to re-run):
+  - installs @piwitests/reporter as a dev dependency
+  - wraps export default defineConfig(...) with wrapConfig(...)
+  - creates the capture-fixtures file (tests/fixtures.ts)
+  - records PIWI_* connection settings in .env / .env.example and .gitignore
+  - installs the Piwi agent skills so your coding agent can use them
+
+Options:
+  --server-url <url>   Dashboard URL to write into the config (env PIWI_DASHBOARD_URL,
+                       default ${DEFAULT_SERVER_URL})
+  --project <name>     Project name to report under (default: your package/folder name)
+  --api-key <key>      API key to write into .env (env PIWI_API_KEY). Omit to keep it a
+                       .env.example placeholder you fill in yourself.
+  --cwd <path>         Project root to operate on (default: current directory)
+  --skills <list>      Comma-separated skills to install, or "all" / "none"
+                       (default: ${WORKFLOW_SKILLS.join(', ')})
+  --skills-dir <path>  Directory to install skills into (default: ${DEFAULT_SKILLS_DIR})
+  --skills-only        Only install skills; do not touch the config or env
+  --no-skills          Configure the project but install no skills
+  --no-install         Do not run the package manager; record the dependency only
+  --force              Overwrite skill files that already exist
+  --dry-run            Report every change without writing anything
+  --json               Print the plan/result as JSON (for agents)
+  -h, --help           Show this help
+
+Skills: ${ALL_SKILLS.join(', ')}
+`.trim();
+
+function readOption(argv: string[], name: string): string | undefined {
+  const withEquals = argv.find((arg) => arg.startsWith(`${name}=`));
+  if (withEquals) return withEquals.slice(name.length + 1);
+  const index = argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  return value && !value.startsWith('--') ? value : undefined;
+}
+
+/** Resolve `--skills` into a concrete slug list. `all`/`none` are special. */
+function resolveSkillSlugs(raw: string | undefined): ReadonlyArray<string> {
+  if (raw === undefined) return WORKFLOW_SKILLS;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === 'none') return [];
+  if (trimmed === 'all') return ALL_SKILLS;
+  return raw
+    .split(',')
+    .map((slug) => slug.trim())
+    .filter(Boolean);
+}
+
+export function parseInitArgs(argv: string[], env: NodeJS.ProcessEnv, cwd: string): InitOptions {
+  const root = path.resolve(readOption(argv, '--cwd') ?? cwd);
+  const detected = detectProject(root);
+  return {
+    root,
+    serverUrl: (readOption(argv, '--server-url') ?? env.PIWI_DASHBOARD_URL ?? DEFAULT_SERVER_URL).replace(/\/$/, ''),
+    projectName: readOption(argv, '--project') ?? detected.suggestedProjectName,
+    apiKey: readOption(argv, '--api-key') ?? env.PIWI_API_KEY ?? null,
+    skillsDir: readOption(argv, '--skills-dir') ?? DEFAULT_SKILLS_DIR,
+    skillSlugs: resolveSkillSlugs(readOption(argv, '--skills')),
+    install: !argv.includes('--no-install'),
+    force: argv.includes('--force'),
+    dryRun: argv.includes('--dry-run'),
+    json: argv.includes('--json'),
+    skillsOnly: argv.includes('--skills-only'),
+    noSkills: argv.includes('--no-skills'),
+  };
+}
+
+function readFileOr(file: string, fallback: string): string {
+  try {
+    return fs.readFileSync(file, 'utf-8');
+  } catch {
+    return fallback;
+  }
+}
+
+/** Package-manager argv for adding the reporter as a dev dependency. */
+function installArgv(manager: PackageManager): [string, string[]] {
+  switch (manager) {
+    case 'pnpm':
+      return ['pnpm', ['add', '-D', REPORTER_PACKAGE]];
+    case 'yarn':
+      return ['yarn', ['add', '-D', REPORTER_PACKAGE]];
+    case 'bun':
+      return ['bun', ['add', '-d', REPORTER_PACKAGE]];
+    case 'npm':
+      return ['npm', ['install', '--save-dev', REPORTER_PACKAGE]];
+  }
+}
+
+function stepInstallReporter(project: ProjectShape, opts: InitOptions): StepResult {
+  const step = 'dependency';
+  if (project.reporterInstalled)
+    return { step, status: 'already', detail: `${REPORTER_PACKAGE} is already a dependency` };
+  if (!project.packageJson)
+    return {
+      step,
+      status: 'manual',
+      detail: `No package.json here — run \`npm init\`, then \`${installCommand(project.packageManager)}\``,
+    };
+  if (opts.dryRun || !opts.install)
+    return { step, status: 'manual', detail: `Run \`${installCommand(project.packageManager)}\`` };
+
+  const [command, args] = installArgv(project.packageManager);
+  const result = spawnSync(command, args, { cwd: opts.root, stdio: 'inherit' });
+  if (result.status === 0) return { step, status: 'updated', detail: `Installed ${REPORTER_PACKAGE}` };
+  return {
+    step,
+    status: 'error',
+    detail: `\`${installCommand(project.packageManager)}\` failed (exit ${result.status ?? 'unknown'}) — install it by hand`,
+  };
+}
+
+function stepConfig(project: ProjectShape, opts: InitOptions): StepResult {
+  const step = 'config';
+  if (!project.configPath)
+    return {
+      step,
+      status: 'manual',
+      detail: 'No playwright.config found — create one, then re-run `npx piwi init`',
+    };
+
+  const rel = path.relative(project.root, project.configPath) || path.basename(project.configPath);
+  const edit = wrapPlaywrightConfig(readFileOr(project.configPath, ''), {
+    serverUrl: opts.serverUrl,
+    projectName: opts.projectName,
+  });
+  if (edit.status === 'updated' && !opts.dryRun) fs.writeFileSync(project.configPath, edit.text);
+  return { step, file: rel, status: edit.status, detail: edit.detail };
+}
+
+function stepFixtures(project: ProjectShape, opts: InitOptions): StepResult {
+  const step = 'fixtures';
+  const rel = path.join('tests', project.configLang === 'js' ? 'fixtures.js' : 'fixtures.ts');
+  const dest = path.join(project.root, rel);
+
+  if (fs.existsSync(dest)) {
+    const current = readFileOr(dest, '');
+    if (/piwiFixtures/.test(current))
+      return { step, file: rel, status: 'already', detail: 'capture fixtures already set up' };
+    return {
+      step,
+      file: rel,
+      status: 'manual',
+      detail:
+        "A fixtures file exists — extend it: `import { piwiFixtures } from '@piwitests/reporter'` and `base.extend(piwiFixtures)`",
+    };
+  }
+
+  if (!opts.dryRun) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, fixturesContents());
+  }
+  return {
+    step,
+    file: rel,
+    status: 'created',
+    detail: 'Created capture fixtures — import `test` from here in your specs',
+  };
+}
+
+function stepEnv(project: ProjectShape, opts: InitOptions): StepResult[] {
+  const results: StepResult[] = [];
+
+  // Committed template: URL and a placeholder for the key, never a real secret.
+  const examplePath = path.join(project.root, '.env.example');
+  const example = upsertEnvKeys(readFileOr(examplePath, ''), [
+    ['PIWI_DASHBOARD_URL', opts.serverUrl],
+    ['PIWI_API_KEY', ''],
+  ]);
+  if (example.added.length && !opts.dryRun) fs.writeFileSync(examplePath, example.text);
+  results.push({
+    step: 'env',
+    file: '.env.example',
+    status: example.added.length ? 'updated' : 'already',
+    detail: example.added.length ? `Recorded ${example.added.join(', ')}` : 'connection template already present',
+  });
+
+  // Only write a real .env when a key was actually supplied — otherwise the
+  // placeholder in .env.example is the thing to fill in.
+  if (opts.apiKey) {
+    const envPath = path.join(project.root, '.env');
+    const env = upsertEnvKeys(readFileOr(envPath, ''), [
+      ['PIWI_DASHBOARD_URL', opts.serverUrl],
+      ['PIWI_API_KEY', opts.apiKey],
+    ]);
+    if (env.added.length && !opts.dryRun) fs.writeFileSync(envPath, env.text);
+    results.push({
+      step: 'env',
+      file: '.env',
+      status: env.added.length ? 'updated' : 'already',
+      detail: env.added.length ? `Wrote ${env.added.join(', ')} (keep .env out of git)` : 'already set',
+    });
+
+    const gitignorePath = path.join(project.root, '.gitignore');
+    const gitignore = ensureGitignoreEntry(readFileOr(gitignorePath, ''));
+    if (gitignore.added && !opts.dryRun) fs.writeFileSync(gitignorePath, gitignore.text);
+    results.push({
+      step: 'gitignore',
+      file: '.gitignore',
+      status: gitignore.added ? 'updated' : 'already',
+      detail: gitignore.added ? 'Added .env' : '.env already ignored',
+    });
+  }
+
+  return results;
+}
+
+/** Guidance the user acts on after the mechanical steps, tailored to what happened. */
+function nextSteps(opts: InitOptions, steps: StepResult[]): string[] {
+  const out: string[] = [];
+  if (!opts.apiKey) {
+    out.push(
+      'If your dashboard has authentication on, create an API key (Settings → Users → API keys), ' +
+        'put it in .env as PIWI_API_KEY, and keep .env out of git.',
+    );
+  }
+  if (steps.some((s) => s.status === 'manual')) {
+    out.push('Finish the steps marked [manual] above — each one carries the exact change to make.');
+  }
+  out.push('In your specs, import `test` (and `expect`) from your fixtures file instead of `@playwright/test`.');
+  out.push(`Run \`npx playwright test\` — the run should appear at ${opts.serverUrl}.`);
+  out.push(
+    'For a machine-readable check, set PIWI_OUTPUT_FILE=piwi-run.json and read runUrl from that file after the run.',
+  );
+  return out;
+}
+
+/** Run `piwi init`. Returns the process exit code rather than calling exit. */
+export async function runInit(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): Promise<number> {
+  if (argv.includes('-h') || argv.includes('--help')) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const opts = parseInitArgs(argv, env, cwd);
+  const project = detectProject(opts.root);
+  const steps: StepResult[] = [];
+
+  if (!opts.skillsOnly) {
+    steps.push(stepInstallReporter(project, opts));
+    steps.push(stepConfig(project, opts));
+    steps.push(stepFixtures(project, opts));
+    steps.push(...stepEnv(project, opts));
+  }
+
+  if (!opts.noSkills && opts.skillSlugs.length) {
+    steps.push(
+      ...installSkills({
+        templatesDir: findTemplatesDir(__dirname),
+        root: opts.root,
+        skillsDir: opts.skillsDir,
+        slugs: opts.skillSlugs,
+        force: opts.force,
+        dryRun: opts.dryRun,
+      }),
+    );
+  }
+
+  const guidance = nextSteps(opts, steps);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: opts.dryRun,
+          project: {
+            root: project.root,
+            packageManager: project.packageManager,
+            configPath: project.configPath ? path.relative(project.root, project.configPath) : null,
+            projectName: opts.projectName,
+            serverUrl: opts.serverUrl,
+          },
+          steps,
+          nextSteps: guidance,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`\nPiwi setup${opts.dryRun ? ' (dry run — nothing written)' : ''} for "${opts.projectName}":\n`);
+    for (const step of steps) console.log(formatStep(step));
+    console.log('\nNext:');
+    for (const line of guidance) console.log(`  • ${line}`);
+    console.log('');
+  }
+
+  // A tool failure (e.g. the install command erroring) is worth a non-zero exit;
+  // `manual` steps are expected outcomes, not failures.
+  return steps.some((s) => s.status === 'error') ? 1 : 0;
+}

--- a/reporter/src/cli/report.ts
+++ b/reporter/src/cli/report.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared result shape for the `init` / `skills` commands.
+ *
+ * Every step a command performs — wrapping the config, creating fixtures,
+ * writing a skill — reports one `StepResult`. The command prints them as a
+ * human summary by default and as JSON under `--json`, so an agent driving the
+ * command reads the exact same outcomes a person sees in the terminal.
+ */
+
+export type StepStatus =
+  /** A file that did not exist was written. */
+  | 'created'
+  /** An existing file was edited in place. */
+  | 'updated'
+  /** Nothing to do — the desired state was already present. */
+  | 'already'
+  /** The tool could not do it safely; `detail` carries the exact change to apply by hand. */
+  | 'manual'
+  /** Deliberately not done (e.g. a target exists and `--force` was not passed). */
+  | 'skipped'
+  /** The step was attempted and failed; `detail` carries the error. */
+  | 'error';
+
+export interface StepResult {
+  /** Machine id of the step, e.g. `config`, `fixtures`, `env`, `skill:investigate-failure`. */
+  step: string;
+  /** Repo-relative path the step touched, when it maps to a single file. */
+  file?: string;
+  status: StepStatus;
+  /** One-line explanation — always safe to print, never secret-bearing. */
+  detail: string;
+}
+
+const STATUS_MARK: Record<StepStatus, string> = {
+  created: '+',
+  updated: '~',
+  already: '=',
+  manual: '!',
+  skipped: '-',
+  error: 'x',
+};
+
+/** Render one result as a single aligned terminal line. */
+export function formatStep(result: StepResult): string {
+  const where = result.file ? ` ${result.file}` : '';
+  return `  ${STATUS_MARK[result.status]} [${result.status}] ${result.step}${where} — ${result.detail}`;
+}

--- a/reporter/src/cli/skills.ts
+++ b/reporter/src/cli/skills.ts
@@ -1,0 +1,213 @@
+/**
+ * `piwi skills` — install the Piwi agent skills into a project, and the shared
+ * logic `init` reuses to do the same.
+ *
+ * A skill is a single `SKILL.md` file (the portable open format: a YAML
+ * front-matter block naming the skill, then Markdown instructions). Any agent
+ * that reads skills from a directory — Claude Code out of `.claude/skills/`,
+ * others from wherever they look — can pick them up. The files are agent-
+ * agnostic Markdown; only the destination directory is tool-specific, so
+ * `--dir` points the install wherever a given agent reads from.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { StepResult } from './report.js';
+
+/** The setup skill drives this very command; the rest act on a run's results. */
+export const SETUP_SKILL = 'setup-piwi';
+export const WORKFLOW_SKILLS = ['investigate-failure', 'apply-locator-healing', 'stabilize-flaky-tests'] as const;
+export const ALL_SKILLS = [SETUP_SKILL, ...WORKFLOW_SKILLS] as const;
+
+/** Default destination — the directory Claude Code reads project skills from. */
+export const DEFAULT_SKILLS_DIR = path.join('.claude', 'skills');
+
+export interface SkillInfo {
+  slug: string;
+  name: string;
+  description: string;
+}
+
+/**
+ * Locate the package's bundled `templates/` directory by walking up from a
+ * starting directory until `templates/skills/` is found. Works from the
+ * published layout (`dist/cli/`) and from the source tree (`src/cli/`) alike.
+ */
+export function findTemplatesDir(fromDir: string): string {
+  let dir = fromDir;
+  for (let i = 0; i < 6; i++) {
+    if (fs.existsSync(path.join(dir, 'templates', 'skills'))) return path.join(dir, 'templates');
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(fromDir, '..', '..', 'templates');
+}
+
+/** Read `name` and `description` out of a SKILL.md's YAML front matter. */
+function readFrontMatter(markdown: string): { name?: string; description?: string } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(markdown);
+  if (!match) return {};
+  const out: { name?: string; description?: string } = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = /^(name|description):\s*(.*)$/.exec(line);
+    if (kv) out[kv[1] as 'name' | 'description'] = kv[2].trim().replace(/^['"]|['"]$/g, '');
+  }
+  return out;
+}
+
+function templatePath(templatesDir: string, slug: string): string {
+  return path.join(templatesDir, 'skills', slug, 'SKILL.md');
+}
+
+/** Metadata for the given skills (defaults to all), skipping any missing template. */
+export function listSkills(templatesDir: string, slugs: ReadonlyArray<string> = ALL_SKILLS): SkillInfo[] {
+  const infos: SkillInfo[] = [];
+  for (const slug of slugs) {
+    const file = templatePath(templatesDir, slug);
+    if (!fs.existsSync(file)) continue;
+    const front = readFrontMatter(fs.readFileSync(file, 'utf-8'));
+    infos.push({ slug, name: front.name ?? slug, description: front.description ?? '' });
+  }
+  return infos;
+}
+
+export interface InstallSkillsOptions {
+  templatesDir: string;
+  /** Absolute project root the skill directory is created under. */
+  root: string;
+  /** Skill-directory path relative to `root` (e.g. `.claude/skills`). */
+  skillsDir: string;
+  slugs: ReadonlyArray<string>;
+  /** Overwrite an existing SKILL.md instead of skipping it. */
+  force: boolean;
+  /** Compute results without writing anything. */
+  dryRun: boolean;
+}
+
+/** Write each requested skill as `<skillsDir>/<slug>/SKILL.md`. Idempotent. */
+export function installSkills(opts: InstallSkillsOptions): StepResult[] {
+  const results: StepResult[] = [];
+  for (const slug of opts.slugs) {
+    const step = `skill:${slug}`;
+    const source = templatePath(opts.templatesDir, slug);
+    const relDest = path.join(opts.skillsDir, slug, 'SKILL.md');
+    const dest = path.join(opts.root, relDest);
+
+    if (!fs.existsSync(source)) {
+      results.push({ step, status: 'error', detail: `no template found for "${slug}"` });
+      continue;
+    }
+
+    const contents = fs.readFileSync(source, 'utf-8');
+    const exists = fs.existsSync(dest);
+    if (exists && !opts.force) {
+      const identical = fs.readFileSync(dest, 'utf-8') === contents;
+      results.push({
+        step,
+        file: relDest,
+        status: identical ? 'already' : 'skipped',
+        detail: identical ? 'skill already installed' : 'skill exists and differs — pass --force to overwrite',
+      });
+      continue;
+    }
+
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, contents);
+    }
+    results.push({ step, file: relDest, status: exists ? 'updated' : 'created', detail: 'installed skill' });
+  }
+  return results;
+}
+
+const USAGE = `
+piwi skills — install the Piwi agent skills into this project
+
+Usage:
+  npx piwi skills list
+  npx piwi skills add [names...] [options]
+
+Commands:
+  list              Show the available skills and what each one is for
+  add [names...]    Install the named skills (default: all of them)
+
+Options for "add":
+  --dir <path>      Directory to install into (default: ${DEFAULT_SKILLS_DIR})
+  --cwd <path>      Project root to operate on (default: current directory)
+  --force           Overwrite a skill file that already exists
+  --dry-run         Report what would be written without writing
+  --json            Print the results as JSON
+
+Skills: ${ALL_SKILLS.join(', ')}
+`.trim();
+
+function readOption(argv: string[], name: string): string | undefined {
+  const withEquals = argv.find((arg) => arg.startsWith(`${name}=`));
+  if (withEquals) return withEquals.slice(name.length + 1);
+  const index = argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  return value && !value.startsWith('--') ? value : undefined;
+}
+
+/** Slugs passed as positional args (everything before the first `--flag`). */
+function positionalSlugs(argv: string[]): string[] {
+  const slugs: string[] = [];
+  for (const arg of argv) {
+    if (arg.startsWith('--')) break;
+    slugs.push(arg);
+  }
+  return slugs;
+}
+
+/** Run `piwi skills`. Returns the process exit code rather than calling exit. */
+export function runSkills(argv: string[], templatesDir: string, cwd: string = process.cwd()): number {
+  const [sub, ...rest] = argv;
+
+  if (sub === undefined || sub === '-h' || sub === '--help') {
+    console.log(USAGE);
+    return 0;
+  }
+
+  if (sub === 'list') {
+    const infos = listSkills(templatesDir);
+    if (rest.includes('--json')) {
+      console.log(JSON.stringify(infos, null, 2));
+    } else {
+      console.log('Available Piwi skills:\n');
+      for (const info of infos) console.log(`  ${info.slug}\n    ${info.description}\n`);
+    }
+    return 0;
+  }
+
+  if (sub === 'add') {
+    const requested = positionalSlugs(rest);
+    const unknown = requested.filter((slug) => !ALL_SKILLS.includes(slug as (typeof ALL_SKILLS)[number]));
+    if (unknown.length) {
+      console.error(`piwi skills: unknown skill(s): ${unknown.join(', ')}\n`);
+      console.error(USAGE);
+      return 2;
+    }
+
+    const results = installSkills({
+      templatesDir,
+      root: path.resolve(readOption(rest, '--cwd') ?? cwd),
+      skillsDir: readOption(rest, '--dir') ?? DEFAULT_SKILLS_DIR,
+      slugs: requested.length ? requested : ALL_SKILLS,
+      force: rest.includes('--force'),
+      dryRun: rest.includes('--dry-run'),
+    });
+
+    if (rest.includes('--json')) {
+      console.log(JSON.stringify(results, null, 2));
+    } else {
+      for (const result of results)
+        console.log(`  [${result.status}] ${result.file ?? result.step} — ${result.detail}`);
+    }
+    return results.some((r) => r.status === 'error') ? 2 : 0;
+  }
+
+  console.error(`piwi skills: unknown command "${sub}"\n`);
+  console.error(USAGE);
+  return 2;
+}

--- a/reporter/templates/skills/apply-locator-healing/SKILL.md
+++ b/reporter/templates/skills/apply-locator-healing/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: apply-locator-healing
+description: Replace brittle Playwright locators with the healed selector Piwi suggests after a failing run, then re-run to confirm. Use when a test fails because a selector no longer matches, when the user asks to "fix the broken locator", "apply Piwi's suggestion", or "heal the selector".
+---
+
+# Apply Piwi's locator healing
+
+When a locator stops matching, Piwi has already computed a ranked replacement from the locator snapshots it captured on passing runs. This skill applies that suggestion to the real spec file and verifies it — closing the last mile Piwi cannot do on its own (edit your code).
+
+## How you reach Piwi
+
+Prefer the **Piwi MCP server** if it is connected (`get_locator_healing`, `explain_failure`, `get_run`). Otherwise open the failing case in the dashboard — the healing panel shows the suggested locator and its call site — and work from that plus the repo. The reporter also attaches a `piwi-locator-suggestion` annotation to the failing test in the Playwright report.
+
+## Steps
+
+1. **Find the failing case.** From a run the user names, or the latest failed run (`list_recent_activity` → `get_run` with a failed filter). Identify the case whose failure is a locator that matched nothing (a timeout on `click` / `fill` / `expect(locator)`).
+
+2. **Get the healed locator.** Call `get_locator_healing` for that case. It returns the **recommended durable locator** plus ranked alternatives, each stamped with the **call site** (file and line) where the original locator was used. Read the call site — that is the exact spot to edit.
+
+3. **Confirm it's really a locator problem.** The suggestion is only right if the element still exists under a new selector. Skim the error and the ARIA snapshot (`get_test_run_case` / `explain_failure`): if the element is genuinely gone or the page errored before rendering, this is not a healing case — hand it to the `investigate-failure` skill instead.
+
+4. **Edit the spec.** At the call site, replace the brittle locator with the recommended one. Prefer role/label/test-id selectors (what Piwi ranks highest) over CSS/XPath. Keep the change minimal and in the user's existing style. If the same brittle selector appears elsewhere (a page object, a helper), update those too.
+
+5. **Verify.** Re-run just that spec: `npx playwright test <file>`. It should pass. If Piwi is set up to report, confirm the new run is green for that case; if it still fails, try the next-ranked alternative from step 2 before broadening the search.
+
+6. **Report.** Show the before/after locator, the file and line, and the verifying result. If several tests shared the selector, list every place you changed.
+
+## Guardrails
+
+- Change the **locator**, not the assertion's intent — if a test checked for "Sign in" and the button is now "Log in", that is a copy change to confirm with the user, not a locator to heal.
+- Never paste a suggested locator without reading its call site and the surrounding test; apply it where the original was used.
+- One verified green re-run per healed selector. Don't batch-replace across many files without running the affected specs.

--- a/reporter/templates/skills/investigate-failure/SKILL.md
+++ b/reporter/templates/skills/investigate-failure/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: investigate-failure
+description: Investigate a failed test run recorded in Piwi Dashboard and propose a fix grounded in its evidence — error, steps, console, network, locator suggestion, and the diff since the last green run. Use when the user asks "why did the last run fail", "what broke in CI", "diagnose this failure", or points at a Piwi run/cluster.
+---
+
+# Investigate a Piwi failure
+
+Turn a failed run in [Piwi Dashboard](https://piwitests.github.io) into a grounded diagnosis and a concrete fix. Piwi has already gathered the evidence — the error text, the steps that ran, console output, failing network calls, a suggested locator, and the source diff since the last passing run. Use that instead of guessing.
+
+## How you reach Piwi
+
+Prefer the **Piwi MCP server** if it is connected to this agent (tools named `list_recent_activity`, `get_run`, `explain_failure`, `get_cluster_context`, …). If it is not connected, tell the user they can connect it (`npx piwi` does not proxy MCP — see the dashboard's **MCP server** page) or paste the run URL / failure details, and work from those plus the repo.
+
+## Steps
+
+1. **Find the run.** If the user gave a run URL or id, use it. Otherwise call `list_recent_activity` (or `list_runs` for a specific project) and take the most recent failed run. Confirm with the user if several projects are in play.
+
+2. **Get the failures.** Call `get_run` with a failed-status filter to list the failing cases. For a fast single-call evidence bundle on one case, use `explain_failure` (error + steps + console + locator fix + diagnosis context).
+
+3. **Group by cause.** Call `get_failure_groups` (or `list_clusters` / `get_cluster`) — failures that share a root cause are clustered, so you fix one thing, not five. Work cluster by cluster.
+
+4. **Read the evidence per cluster.** Call `get_cluster_context` — the same SCM-grounded context the built-in diagnosis uses: representative errors, test steps, console logs, failing network requests, ARIA snapshots, and the **diff of files changed since the last green run**. If a diagnosis already exists, `get_cluster_diagnosis` returns its root cause and suggested fix.
+
+5. **Form the diagnosis.** Tie the failure to a cause with evidence: a selector that stopped matching, an assertion on changed copy, a slow/500 endpoint (`get_network_requests`), a race, a genuinely flaky test (check `get_test_stability_trend` — if it fails intermittently, treat it as flaky, not a regression). Point at the specific commit/file from the diff when the evidence supports it.
+
+6. **Propose the fix.** Make the smallest change that addresses the root cause, in the actual source or spec files. Prefer Piwi's own suggestions where they exist — for a broken selector, the ranked replacement from `get_locator_healing` (the `apply-locator-healing` skill does exactly this). Show the diff.
+
+7. **Verify.** Re-run the affected spec(s): `npx playwright test <file>`. Confirm they pass and the new run is green in the dashboard (`get_run_insights` compares against the last green run: regressions cleared, nothing new broken).
+
+8. **Close the loop (optional).** With reporter/admin access, `set_cluster_status` marks the cluster resolved with a note so it drops off the triage queue.
+
+## Guardrails
+
+- Ground every claim in evidence you actually read — never invent a stack trace, a commit, or a line number. If the evidence is thin, say so and get the trace (`list_case_traces`) or ask.
+- Distinguish a **regression** (was passing, now failing — fix the cause) from a **flaky** test (intermittent — stabilize it) from an **environmental** failure (dashboard/CI/network). The fix differs for each.
+- Don't mark a cluster resolved until a run proves it. Report the diagnosis, the change, and the verifying run URL.

--- a/reporter/templates/skills/setup-piwi/SKILL.md
+++ b/reporter/templates/skills/setup-piwi/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: setup-piwi
+description: Wire a Playwright project up to a Piwi Dashboard — install the reporter, wrap the config, add capture fixtures, and confirm a run lands. Use when the user asks to "set up Piwi", "connect Playwright to the dashboard", "start reporting test results", or after they mention a Piwi/dashboard server URL.
+---
+
+# Set up Piwi in a Playwright project
+
+Connect a Playwright test suite to a [Piwi Dashboard](https://piwitests.github.io) so every run is uploaded, kept, and analyzed. The mechanical work is done by a deterministic command; your job is to gather the right inputs, run it, finish anything it flags, and prove a run reaches the dashboard.
+
+## Before you start
+
+Find out two things (ask the user only if you cannot infer them):
+
+- **Dashboard URL** — e.g. `http://localhost:3000` for a local server, or a deployed URL. Defaults to `http://localhost:3000`.
+- **Project name** — the label runs are grouped under. Defaults to the package or folder name.
+
+Confirm this is a Playwright project: there should be a `playwright.config.ts|js` and `@playwright/test` in `package.json`. If there is no Playwright at all, set that up first.
+
+## Do it
+
+Run the initializer from the project root. It installs `@piwitests/reporter`, wraps `defineConfig(...)` with `wrapConfig(...)`, creates `tests/fixtures.ts`, and records `PIWI_*` settings in `.env.example`:
+
+```bash
+npx piwi init --server-url <dashboard-url> --project <name> --json
+```
+
+- Preview first with `--dry-run` if you want to see the plan before anything is written.
+- `--json` prints a `steps[]` array. Read it. Each step has a `status`:
+  - `created` / `updated` / `already` — done, nothing more to do.
+  - `manual` — the tool would not edit that file safely. The `detail` field is the exact change to make; apply it yourself (see below).
+  - `error` — something failed (usually the install); the `detail` says what. Fix it and re-run — `init` is idempotent.
+
+### Finishing `manual` steps
+
+- **config** marked `manual`: the config is not a plain `export default defineConfig(...)`. Add `import { wrapConfig } from '@piwitests/reporter'` and wrap the exported config: `export default wrapConfig(defineConfig({ ... }), { serverUrl, projectName })`.
+- **fixtures** marked `manual`: a fixtures file already exists. Merge Piwi in: `import { piwiFixtures } from '@piwitests/reporter'` and compose them into the existing `base.extend(...)` (or use `extendPiwiFixtures(base)`).
+
+### Rewire the specs to the fixtures
+
+The capture fixtures (locator healing, slow-endpoint analysis, Web Vitals, console, failure-time ARIA) only apply to specs that import `test` from the fixtures file. In each spec that currently does:
+
+```ts
+import { test, expect } from '@playwright/test'
+```
+
+change it to import from the fixtures file instead, e.g. `import { test, expect } from './fixtures'` (adjust the relative path). A spec left on the direct import still runs and reports — it just is not captured.
+
+## Authentication
+
+If the dashboard has auth enabled, runs need an API key. Have the user create one in the dashboard (**Settings → Users → API keys**; keys start with `pd_`), then put it in `.env` as `PIWI_API_KEY=pd_...` and make sure `.env` is git-ignored. Never hardcode a key into `playwright.config.ts` or commit it. In CI, pass it as a secret (`PIWI_API_KEY`).
+
+## Verify it worked
+
+Setup is not done until a run reaches the dashboard.
+
+1. Run one spec: `npx playwright test` (or a single file to keep it quick).
+2. Confirm the run landed. Deterministically: set `PIWI_OUTPUT_FILE=piwi-run.json` when running, then read `runUrl`/`status` from that JSON file — its existence with a `runUrl` proves the upload. Otherwise look for the `View run: <url>` line the reporter prints, or open the dashboard and check the project's latest run.
+3. If nothing appears: verify the dashboard is reachable at the URL, that auth (if on) has a valid key, and that traces are enabled (`use: { trace: 'retain-on-failure' }`).
+
+## Wrap up
+
+Tell the user what changed (config, fixtures, `.env.example`), what they still need to do (API key if auth is on; rewire remaining specs), and the run URL you verified. If they use CI, offer to add the reporter's env there too.

--- a/reporter/templates/skills/stabilize-flaky-tests/SKILL.md
+++ b/reporter/templates/skills/stabilize-flaky-tests/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: stabilize-flaky-tests
+description: Find the flakiest Playwright tests from Piwi's flaky analysis and fix the root cause of the intermittency, ranked by impact. Use when the user asks to "fix flaky tests", "reduce flakiness", "why is this test flaky", or wants to clean up an unreliable suite.
+---
+
+# Stabilize flaky tests with Piwi
+
+Piwi scores every test's flakiness over its whole run history and ranks it by impact, so you spend effort on the tests that actually cost the team — not whichever one failed most recently. This skill picks the worst offenders, fixes the *cause* of the intermittency, and confirms the score improves.
+
+## How you reach Piwi
+
+Prefer the **Piwi MCP server** if it is connected (`list_flaky_tests`, `get_test_stability_trend`, `get_test_case`, `get_spec_health`). Otherwise use the dashboard's **Flaky** tab for the project and work from what it shows plus the repo.
+
+## Steps
+
+1. **Rank the flaky tests.** Call `list_flaky_tests` for the project. It returns each test's flaky score, impact ranking, and a **root-cause category**. Take the top few by impact — do not try to fix the whole list at once.
+
+2. **Understand one test's pattern.** For a chosen test, call `get_test_stability_trend` (is it getting worse, or already stable again?) and `get_test_case` (recent pass/fail history). Read a representative failing execution (`get_test_run_case` / `explain_failure`) for the error, steps, console, and network at the moment it flaked.
+
+3. **Identify the cause.** Common categories and their fixes:
+   - **Timing / race** — replace fixed waits and manual sleeps with Playwright web-first assertions (`await expect(locator).toBeVisible()`), await the network/UI state the test depends on, not a timeout.
+   - **Locator instability** — a selector that resolves ambiguously or intermittently; heal it (see the `apply-locator-healing` skill) or scope it.
+   - **Test-order / shared state** — leaking storage, cookies, or a shared backend row; isolate setup, use a fresh context, or a unique fixture per test.
+   - **Slow / unreliable endpoint** — check `get_network_requests`; if a real endpoint is intermittently slow or 500s, that is a product bug, not a test bug — report it rather than papering over it with retries.
+
+4. **Fix the root cause.** Make the change in the spec (or the app, when the flake is a real defect). Do **not** "fix" flakiness by adding retries or increasing timeouts — that hides it; the goal is a test that passes deterministically.
+
+5. **Verify.** Re-run the test several times to shake out intermittency: `npx playwright test <file> --repeat-each=5` (raise the count for stubborn ones). It should pass every time. Over the next runs, confirm the flaky score falls in the dashboard (`get_test_stability_trend`).
+
+6. **Report.** For each test you touched: the root-cause category, the change, and the repeat-run result. List any remaining high-impact flaky tests so the user can decide whether to continue.
+
+## Guardrails
+
+- Fix the cause, never the symptom — no blanket `test.retry`, no bumped global timeout, no `waitForTimeout` sprinkles.
+- A test that flakes because a *real* endpoint is unreliable is a product finding; surface it instead of hiding it in the test.
+- Stabilize a few high-impact tests well rather than lightly touching many. Prove each one with repeated runs before moving on.

--- a/reporter/tests/detect.spec.ts
+++ b/reporter/tests/detect.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { detectProject, installCommand } from '../src/cli/detect.js';
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'piwi-detect-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function write(rel: string, contents = '') {
+  const file = path.join(root, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents);
+}
+
+describe('detectProject', () => {
+  it('finds the TypeScript config and derives an unscoped project name', () => {
+    write('package.json', JSON.stringify({ name: '@acme/checkout' }));
+    write('playwright.config.ts');
+    const shape = detectProject(root);
+    expect(shape.configPath).toBe(path.join(root, 'playwright.config.ts'));
+    expect(shape.configLang).toBe('ts');
+    expect(shape.suggestedProjectName).toBe('checkout');
+  });
+
+  it('treats a .js config as JavaScript', () => {
+    write('package.json', JSON.stringify({ name: 'app' }));
+    write('playwright.config.js');
+    expect(detectProject(root).configLang).toBe('js');
+  });
+
+  it('falls back to the folder name when package.json has no name', () => {
+    write('package.json', JSON.stringify({}));
+    expect(detectProject(root).suggestedProjectName).toBe(path.basename(root));
+  });
+
+  it('detects the reporter across dependencies and devDependencies', () => {
+    write('package.json', JSON.stringify({ devDependencies: { '@piwitests/reporter': '^0.20.0' } }));
+    expect(detectProject(root).reporterInstalled).toBe(true);
+  });
+
+  it('picks the package manager from a lockfile', () => {
+    write('package.json', JSON.stringify({ name: 'app' }));
+    write('pnpm-lock.yaml');
+    expect(detectProject(root).packageManager).toBe('pnpm');
+  });
+
+  it('lets the corepack packageManager field win over a lockfile', () => {
+    write('package.json', JSON.stringify({ name: 'app', packageManager: 'yarn@4.0.0' }));
+    write('package-lock.json');
+    expect(detectProject(root).packageManager).toBe('yarn');
+  });
+
+  it('defaults to npm and reports no config for a bare directory', () => {
+    const shape = detectProject(root);
+    expect(shape.packageManager).toBe('npm');
+    expect(shape.configPath).toBeNull();
+    expect(shape.packageJson).toBeNull();
+  });
+});
+
+describe('installCommand', () => {
+  it('names the reporter as a dev dependency for each manager', () => {
+    expect(installCommand('npm')).toBe('npm install --save-dev @piwitests/reporter');
+    expect(installCommand('pnpm')).toBe('pnpm add -D @piwitests/reporter');
+    expect(installCommand('yarn')).toBe('yarn add -D @piwitests/reporter');
+    expect(installCommand('bun')).toBe('bun add -d @piwitests/reporter');
+  });
+});

--- a/reporter/tests/init-cli.spec.ts
+++ b/reporter/tests/init-cli.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { parseInitArgs, runInit } from '../src/cli/init.js';
+import { WORKFLOW_SKILLS } from '../src/cli/skills.js';
+
+const EMPTY_ENV = {} as NodeJS.ProcessEnv;
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'piwi-init-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function scaffoldProject() {
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: '@acme/checkout' }));
+  fs.writeFileSync(
+    path.join(root, 'playwright.config.ts'),
+    `import { defineConfig } from '@playwright/test'\n\nexport default defineConfig({\n  use: { trace: 'retain-on-failure' },\n})\n`,
+  );
+}
+
+describe('parseInitArgs', () => {
+  it('defaults the server URL, and derives the project name from package.json', () => {
+    scaffoldProject();
+    const opts = parseInitArgs([], EMPTY_ENV, root);
+    expect(opts.serverUrl).toBe('http://localhost:3000');
+    expect(opts.projectName).toBe('checkout');
+    expect(opts.skillSlugs).toEqual([...WORKFLOW_SKILLS]);
+  });
+
+  it('reads the server URL and key from the environment and strips a trailing slash', () => {
+    const opts = parseInitArgs([], { PIWI_DASHBOARD_URL: 'https://piwi.example.com/', PIWI_API_KEY: 'pd_x' } as NodeJS.ProcessEnv, root);
+    expect(opts.serverUrl).toBe('https://piwi.example.com');
+    expect(opts.apiKey).toBe('pd_x');
+  });
+
+  it('resolves --skills all / none', () => {
+    expect(parseInitArgs(['--skills', 'none'], EMPTY_ENV, root).skillSlugs).toEqual([]);
+    expect(parseInitArgs(['--skills', 'all'], EMPTY_ENV, root).skillSlugs.length).toBeGreaterThan(WORKFLOW_SKILLS.length);
+  });
+});
+
+describe('runInit', () => {
+  it('configures a clean project end to end (without installing) and returns 0', async () => {
+    scaffoldProject();
+    const code = await runInit(['--no-install', '--server-url', 'https://piwi.example.com', '--project', 'checkout'], EMPTY_ENV, root);
+    expect(code).toBe(0);
+
+    const config = fs.readFileSync(path.join(root, 'playwright.config.ts'), 'utf-8');
+    expect(config).toContain('wrapConfig(');
+    expect(config).toContain("serverUrl: 'https://piwi.example.com',");
+
+    expect(fs.existsSync(path.join(root, 'tests', 'fixtures.ts'))).toBe(true);
+
+    const example = fs.readFileSync(path.join(root, '.env.example'), 'utf-8');
+    expect(example).toContain('PIWI_DASHBOARD_URL=https://piwi.example.com');
+    expect(example).toContain('PIWI_API_KEY=');
+
+    // Workflow skills land in the repo.
+    for (const slug of WORKFLOW_SKILLS) {
+      expect(fs.existsSync(path.join(root, '.claude', 'skills', slug, 'SKILL.md'))).toBe(true);
+    }
+  });
+
+  it('writes a real .env and gitignores it only when an API key is supplied', async () => {
+    scaffoldProject();
+    await runInit(['--no-install', '--api-key', 'pd_secret'], EMPTY_ENV, root);
+    expect(fs.readFileSync(path.join(root, '.env'), 'utf-8')).toContain('PIWI_API_KEY=pd_secret');
+    expect(fs.readFileSync(path.join(root, '.gitignore'), 'utf-8')).toContain('.env');
+  });
+
+  it('does not create a real .env when no key is given', async () => {
+    scaffoldProject();
+    await runInit(['--no-install'], EMPTY_ENV, root);
+    expect(fs.existsSync(path.join(root, '.env'))).toBe(false);
+  });
+
+  it('under --dry-run writes nothing at all', async () => {
+    scaffoldProject();
+    const before = fs.readFileSync(path.join(root, 'playwright.config.ts'), 'utf-8');
+    await runInit(['--no-install', '--dry-run'], EMPTY_ENV, root);
+    expect(fs.readFileSync(path.join(root, 'playwright.config.ts'), 'utf-8')).toBe(before);
+    expect(fs.existsSync(path.join(root, 'tests', 'fixtures.ts'))).toBe(false);
+    expect(fs.existsSync(path.join(root, '.claude'))).toBe(false);
+    expect(fs.existsSync(path.join(root, '.env.example'))).toBe(false);
+  });
+
+  it('emits a machine-readable plan under --json', async () => {
+    scaffoldProject();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: string) => void logs.push(line));
+    await runInit(['--no-install', '--dry-run', '--json'], EMPTY_ENV, root);
+    const payload = JSON.parse(logs.join('\n'));
+    expect(payload.dryRun).toBe(true);
+    expect(payload.project.projectName).toBe('checkout');
+    expect(Array.isArray(payload.steps)).toBe(true);
+    expect(payload.steps.find((s: { step: string }) => s.step === 'config')).toBeTruthy();
+    expect(Array.isArray(payload.nextSteps)).toBe(true);
+  });
+
+  it('reports config as manual (and does not throw) when there is no defineConfig export', async () => {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    fs.writeFileSync(path.join(root, 'playwright.config.ts'), 'export default { use: {} }\n');
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: string) => void logs.push(line));
+    const code = await runInit(['--no-install', '--json'], EMPTY_ENV, root);
+    expect(code).toBe(0);
+    const payload = JSON.parse(logs.join('\n'));
+    const configStep = payload.steps.find((s: { step: string }) => s.step === 'config');
+    expect(configStep.status).toBe('manual');
+  });
+
+  it('installs only skills under --skills-only, leaving the config untouched', async () => {
+    scaffoldProject();
+    const before = fs.readFileSync(path.join(root, 'playwright.config.ts'), 'utf-8');
+    await runInit(['--skills-only'], EMPTY_ENV, root);
+    expect(fs.readFileSync(path.join(root, 'playwright.config.ts'), 'utf-8')).toBe(before);
+    expect(fs.existsSync(path.join(root, '.env.example'))).toBe(false);
+    expect(fs.existsSync(path.join(root, '.claude', 'skills', WORKFLOW_SKILLS[0], 'SKILL.md'))).toBe(true);
+  });
+
+  it('exits 0 for --help', async () => {
+    expect(await runInit(['--help'], EMPTY_ENV, root)).toBe(0);
+  });
+});

--- a/reporter/tests/init-configure.spec.ts
+++ b/reporter/tests/init-configure.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ensureGitignoreEntry,
+  fixturesContents,
+  upsertEnvKeys,
+  wrapPlaywrightConfig,
+} from '../src/cli/configure.js';
+
+const CLEAN_CONFIG = `import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    trace: 'retain-on-failure',
+  },
+})
+`;
+
+describe('wrapPlaywrightConfig', () => {
+  it('wraps a plain defineConfig export and adds the import', () => {
+    const edit = wrapPlaywrightConfig(CLEAN_CONFIG, { serverUrl: 'http://localhost:3000', projectName: 'checkout' });
+    expect(edit.status).toBe('updated');
+    expect(edit.text).toContain("import { wrapConfig } from '@piwitests/reporter'");
+    expect(edit.text).toContain('export default wrapConfig(');
+    expect(edit.text).toContain('defineConfig({');
+    expect(edit.text).toContain("serverUrl: 'http://localhost:3000',");
+    expect(edit.text).toContain("projectName: 'checkout',");
+    // The original Playwright import survives.
+    expect(edit.text).toContain("import { defineConfig } from '@playwright/test'");
+    // The reporter import lands next to the existing imports, above the export.
+    expect(edit.text).toMatch(
+      /import \{ defineConfig \} from '@playwright\/test'\nimport \{ wrapConfig \} from '@piwitests\/reporter'/,
+    );
+    expect(edit.text.indexOf('wrapConfig }')).toBeLessThan(edit.text.indexOf('export default'));
+  });
+
+  it('produces valid, balanced output for a config that itself contains parens and strings', () => {
+    const tricky = `import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  webServer: { command: 'node server.js', url: 'http://localhost:3000/(health)' },
+  use: { baseURL: process.env.BASE_URL ?? 'http://localhost:3000' },
+})
+`;
+    const edit = wrapPlaywrightConfig(tricky, { serverUrl: 'http://localhost:3000', projectName: 'app' });
+    expect(edit.status).toBe('updated');
+    // Every open paren still has a close paren.
+    const opens = (edit.text.match(/\(/g) ?? []).length;
+    const closes = (edit.text.match(/\)/g) ?? []).length;
+    expect(opens).toBe(closes);
+    expect(edit.text).toContain('wrapConfig(');
+  });
+
+  it('omits serverUrl from the literal when it is not provided', () => {
+    const edit = wrapPlaywrightConfig(CLEAN_CONFIG, { projectName: 'checkout' });
+    expect(edit.status).toBe('updated');
+    expect(edit.text).not.toContain('serverUrl:');
+    expect(edit.text).toContain("projectName: 'checkout',");
+  });
+
+  it('is idempotent — a config that already names the reporter is left alone', () => {
+    const already = wrapPlaywrightConfig(CLEAN_CONFIG, { projectName: 'checkout' }).text;
+    const second = wrapPlaywrightConfig(already, { projectName: 'checkout' });
+    expect(second.status).toBe('already');
+    expect(second.text).toBe(already);
+  });
+
+  it('reports manual (never mangles) when there is no defineConfig default export', () => {
+    const odd = `import { chromium } from '@playwright/test'\nexport default { use: {} }\n`;
+    const edit = wrapPlaywrightConfig(odd, { projectName: 'x' });
+    expect(edit.status).toBe('manual');
+    expect(edit.text).toBe(odd);
+    expect(edit.detail).toMatch(/wrapConfig/);
+  });
+
+  it('escapes a quote in the project name so the literal stays valid', () => {
+    const edit = wrapPlaywrightConfig(CLEAN_CONFIG, { projectName: "o'brien" });
+    expect(edit.text).toContain("projectName: 'o\\'brien',");
+  });
+});
+
+describe('fixturesContents', () => {
+  it('extends the base test with the Piwi fixtures', () => {
+    const contents = fixturesContents();
+    expect(contents).toContain("import { piwiFixtures } from '@piwitests/reporter'");
+    expect(contents).toContain('export const test = base.extend(piwiFixtures)');
+    expect(contents).toContain('export { expect }');
+  });
+});
+
+describe('upsertEnvKeys', () => {
+  it('adds keys that are absent and preserves a trailing newline', () => {
+    const { text, added } = upsertEnvKeys('', [
+      ['PIWI_DASHBOARD_URL', 'http://localhost:3000'],
+      ['PIWI_API_KEY', ''],
+    ]);
+    expect(added).toEqual(['PIWI_DASHBOARD_URL', 'PIWI_API_KEY']);
+    expect(text).toBe('PIWI_DASHBOARD_URL=http://localhost:3000\nPIWI_API_KEY=\n');
+  });
+
+  it('never overwrites a key the user already set', () => {
+    const existing = 'PIWI_API_KEY=pd_existing\n';
+    const { text, added } = upsertEnvKeys(existing, [['PIWI_API_KEY', 'pd_new']]);
+    expect(added).toEqual([]);
+    expect(text).toBe(existing);
+  });
+
+  it('appends a newline before adding when the file lacks one', () => {
+    const { text } = upsertEnvKeys('EXISTING=1', [['PIWI_DASHBOARD_URL', 'http://x']]);
+    expect(text).toBe('EXISTING=1\nPIWI_DASHBOARD_URL=http://x\n');
+  });
+});
+
+describe('ensureGitignoreEntry', () => {
+  it('adds .env when missing', () => {
+    const { text, added } = ensureGitignoreEntry('node_modules\n');
+    expect(added).toBe(true);
+    expect(text).toBe('node_modules\n.env\n');
+  });
+
+  it('does nothing when .env is already ignored', () => {
+    const { text, added } = ensureGitignoreEntry('node_modules\n.env\n');
+    expect(added).toBe(false);
+    expect(text).toBe('node_modules\n.env\n');
+  });
+});

--- a/reporter/tests/skills-cli.spec.ts
+++ b/reporter/tests/skills-cli.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  ALL_SKILLS,
+  findTemplatesDir,
+  installSkills,
+  listSkills,
+  runSkills,
+  SETUP_SKILL,
+  WORKFLOW_SKILLS,
+} from '../src/cli/skills.js';
+
+const TEMPLATES = path.join(import.meta.dirname, '..', 'templates');
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'piwi-skills-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('skill templates ship with the package', () => {
+  it('has a SKILL.md with front matter for every declared skill', () => {
+    const infos = listSkills(TEMPLATES);
+    expect(infos.map((i) => i.slug).sort()).toEqual([...ALL_SKILLS].sort());
+    for (const info of infos) {
+      expect(info.name).toBeTruthy();
+      expect(info.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('separates the setup skill from the workflow skills', () => {
+    expect(ALL_SKILLS).toContain(SETUP_SKILL);
+    expect(WORKFLOW_SKILLS).not.toContain(SETUP_SKILL);
+    expect(WORKFLOW_SKILLS.length).toBe(3);
+  });
+});
+
+describe('findTemplatesDir', () => {
+  it('locates templates/ from a directory inside the package', () => {
+    expect(findTemplatesDir(path.join(import.meta.dirname, '..', 'src', 'cli'))).toBe(TEMPLATES);
+  });
+});
+
+describe('installSkills', () => {
+  it('writes each requested skill as <dir>/<slug>/SKILL.md', () => {
+    const results = installSkills({
+      templatesDir: TEMPLATES,
+      root,
+      skillsDir: '.claude/skills',
+      slugs: WORKFLOW_SKILLS,
+      force: false,
+      dryRun: false,
+    });
+    expect(results.every((r) => r.status === 'created')).toBe(true);
+    for (const slug of WORKFLOW_SKILLS) {
+      const file = path.join(root, '.claude', 'skills', slug, 'SKILL.md');
+      expect(fs.existsSync(file)).toBe(true);
+      expect(fs.readFileSync(file, 'utf-8')).toContain(`name: ${slug}`);
+    }
+  });
+
+  it('writes nothing under --dry-run but still reports what it would create', () => {
+    const results = installSkills({
+      templatesDir: TEMPLATES,
+      root,
+      skillsDir: '.claude/skills',
+      slugs: [SETUP_SKILL],
+      force: false,
+      dryRun: true,
+    });
+    expect(results[0].status).toBe('created');
+    expect(fs.existsSync(path.join(root, '.claude'))).toBe(false);
+  });
+
+  it('is idempotent: an unchanged reinstall reports already, a divergent one is skipped without --force', () => {
+    const opts = { templatesDir: TEMPLATES, root, skillsDir: '.claude/skills', slugs: [SETUP_SKILL], force: false, dryRun: false };
+    installSkills(opts);
+    expect(installSkills(opts)[0].status).toBe('already');
+
+    const file = path.join(root, '.claude', 'skills', SETUP_SKILL, 'SKILL.md');
+    fs.writeFileSync(file, 'edited by hand');
+    expect(installSkills(opts)[0].status).toBe('skipped');
+    expect(fs.readFileSync(file, 'utf-8')).toBe('edited by hand');
+
+    const forced = installSkills({ ...opts, force: true });
+    expect(forced[0].status).toBe('updated');
+    expect(fs.readFileSync(file, 'utf-8')).toContain(`name: ${SETUP_SKILL}`);
+  });
+
+  it('honors a custom skills directory', () => {
+    installSkills({
+      templatesDir: TEMPLATES,
+      root,
+      skillsDir: '.cursor/skills',
+      slugs: [SETUP_SKILL],
+      force: false,
+      dryRun: false,
+    });
+    expect(fs.existsSync(path.join(root, '.cursor', 'skills', SETUP_SKILL, 'SKILL.md'))).toBe(true);
+  });
+});
+
+describe('runSkills', () => {
+  it('rejects an unknown skill name with exit 2', () => {
+    expect(runSkills(['add', 'not-a-skill', '--cwd', root], TEMPLATES)).toBe(2);
+  });
+
+  it('installs all skills when none are named', () => {
+    expect(runSkills(['add', '--cwd', root], TEMPLATES)).toBe(0);
+    for (const slug of ALL_SKILLS) {
+      expect(fs.existsSync(path.join(root, '.claude', 'skills', slug, 'SKILL.md'))).toBe(true);
+    }
+  });
+
+  it('lists skills and exits 0', () => {
+    expect(runSkills(['list'], TEMPLATES)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What & why

This PR adds a deterministic setup command (`npx piwi init`) that wires a Playwright project into a Piwi Dashboard in one go, plus MCP prompts that guide agents through the same setup.

**`piwi init` command** (`reporter/src/cli/init.ts`):
- Installs `@piwitests/reporter` as a dev dependency
- Wraps the Playwright config's `export default defineConfig(...)` with `wrapConfig(...)`
- Creates the capture-fixtures file (`tests/fixtures.ts`)
- Records `PIWI_*` connection settings in `.env` / `.env.example` and `.gitignore`
- Installs agent skills (Claude Code, etc.) into the project
- Every step is idempotent and safe to re-run; unrecognized config shapes become `manual` steps with exact snippets to apply by hand
- Supports `--json` output for agents to read outcomes programmatically

**Supporting modules**:
- `reporter/src/cli/detect.ts`: Inspects the target project (package manager, config location, reporter presence, suggested project name)
- `reporter/src/cli/configure.ts`: Pure string transforms for config wrapping, fixtures creation, and `.env` management — all unit-tested without touching disk
- `reporter/src/cli/skills.ts`: Installs agent skills (Markdown files with YAML front matter) into a project directory
- `reporter/src/cli/report.ts`: Shared `StepResult` shape for both `init` and `skills` commands

**MCP prompts** (`application/server/utils/mcp/prompts.ts`):
- New `setup_piwi` prompt that generates a ready-to-run setup instruction
- Server-aware: fills in the dashboard's real URL, whether authentication is required, and existing projects
- Exposed via the MCP `/prompts/list` endpoint so Claude Code and other agents can offer it as a slash command

**Agent skills** (`reporter/templates/skills/`):
- `setup-piwi`: Drives the `piwi init` command
- `investigate-failure`: Diagnose a failed run from Piwi's evidence
- `apply-locator-healing`: Apply Piwi's suggested locator fix
- `stabilize-flaky-tests`: Fix the flakiest tests ranked by impact

## How was it tested?

- Unit tests for `parseInitArgs`, `wrapPlaywrightConfig`, `ensureGitignoreEntry`, `upsertEnvKeys`, `fixturesContents`, `detectProject`, `installCommand`, `listSkills`, `installSkills`, and `buildSetupPiwiMessages`
- End-to-end test for `runInit` that scaffolds a clean project, runs the full setup, and verifies all outputs
- Tests confirm idempotency (re-running produces `already` status, not duplication)
- Tests verify safe fallback to `manual` steps when config shape is unrecognized
- MCP prompt tests verify the prompt is advertised and messages are built correctly

## Checklist

- [x] PR title follows Conventional Commits (`feat(reporter): ...`)
- [x] Tests added for all new behavior (unit + E2E)
- [x] Docs updated: `docs/getting-started.md`, `docs/reporter.md`, `docs/mcp.md`, and reporter `README.md`
- [x] Skill templates included in package (`package.json` files array updated)

https://claude.ai/code/session_01QbYL4cH1hgC8ok2M85Aaa3