### PR TITLE
fix(reporter): invoke the CLI via npx @piwitests/reporter to avoid the piwi collision

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,22 @@
-(cd application && npm run app:format) && git add -u application/
-(cd reporter && npm run reporter:format) && git add -u reporter/src/
+#!/usr/bin/env sh
+# Keep committed code formatted — but only ever re-stage the files THIS commit
+# already staged. `git add -u <dir>` was wrong: it stages every modified tracked
+# file under the dir, so an unrelated work-in-progress edit gets swept into the
+# commit alongside the files you meant to commit.
+#
+# We still run the same whole-workspace formatter the CI `format:check` gate
+# uses (so formatting coverage can't drift), then hand `git add` the exact list
+# of already-staged files. Files you did not stage are left untouched in the
+# working tree.
+
+# $1: workspace dir to format in   $2: format npm script   $3: pathspec of that
+# workspace's files (matches which staged paths get re-added).
+format_staged() {
+  staged=$(git diff --cached --name-only --diff-filter=ACMR -- "$3")
+  [ -z "$staged" ] && return 0
+  (cd "$1" && npm run "$2") || exit 1
+  printf '%s\n' "$staged" | tr '\n' '\0' | xargs -0 git add --
+}
+
+format_staged application app:format application/
+format_staged reporter reporter:format reporter/src/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 - **Pull-request feedback** — when a run finishes on a branch with an open pull request, Piwi posts a summary comment
   (new failures separated from pre-existing ones, each with its owner and the suggested replacement locator) and a
   commit status. GitHub and GitLab; off by default.
-- **CI gate** — `npx piwi gate` fails a build on the dashboard's analysis rather than on the raw exit code: required
+- **CI gate** — `npx @piwitests/reporter gate` fails a build on the dashboard's analysis rather than on the raw exit code: required
   tags, new regressions, newly flaky tests, or a failure cluster never seen before.
 - **Test tags & ownership** — Playwright's own test tags plus `piwi:owner` / `priority` / `feature` / `link`
   annotations, filterable across the test-case catalog and the flaky leaderboard.

--- a/application/app/pages/mcp.vue
+++ b/application/app/pages/mcp.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { MCP_TOOL_DEFS } from '#shared/mcp-tools';
+import { MCP_PROMPT_DEFS } from '#shared/mcp-prompts';
 
 const config = useRuntimeConfig();
 const isDemo = config.public.demoMode;
@@ -29,6 +30,10 @@ useHead({ title: 'MCP server — Piwi Dashboard' });
 // Single source of truth: the exact catalog the MCP server exposes over
 // `tools/list` (see shared/mcp-tools.ts). New tools appear here automatically.
 const tools = MCP_TOOL_DEFS;
+
+// Same for the prompts the server exposes over `prompts/list`
+// (see shared/mcp-prompts.ts).
+const prompts = MCP_PROMPT_DEFS;
 
 const clientItems = [
   { label: 'Claude Code', slot: 'claude-code' },
@@ -285,6 +290,39 @@ const windsurfSnippet = computed(() =>
               <div class="min-w-0">
                 <p class="text-sm font-mono font-semibold text-foreground">{{ t.name }}</p>
                 <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ t.description }}</p>
+              </div>
+            </div>
+          </div>
+        </SectionCard>
+
+        <!-- Prompts -->
+        <SectionCard icon="i-lucide-sparkles" title="Prompts">
+          <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            Prompts are ready-made instructions your MCP client offers as a slash command — nothing to install.
+            <code class="font-mono">setup_piwi</code> is <strong>server-aware</strong>: it fills in this instance's URL,
+            whether authentication is required, and the projects that already exist, then hands your agent a
+            ready-to-run setup for a Playwright project that is not yet reporting here.
+          </p>
+          <div class="flex flex-col gap-1.5">
+            <div
+              v-for="p in prompts"
+              :key="p.name"
+              class="flex items-start gap-3 px-3 py-2.5 rounded-md bg-elevated/50 border border-default hover:bg-elevated transition-colors"
+            >
+              <UIcon name="i-lucide-square-slash" class="size-4 mt-0.5 shrink-0 text-primary" />
+              <div class="min-w-0">
+                <p class="text-sm font-mono font-semibold text-foreground">{{ p.name }}</p>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{{ p.description }}</p>
+                <div v-if="p.arguments?.length" class="flex flex-wrap gap-1.5 mt-1.5">
+                  <code
+                    v-for="arg in p.arguments"
+                    :key="arg.name"
+                    class="px-1.5 py-0.5 rounded bg-muted text-[11px] font-mono"
+                    :title="arg.description"
+                  >
+                    {{ arg.name }}{{ arg.required ? '' : '?' }}
+                  </code>
+                </div>
               </div>
             </div>
           </div>

--- a/application/server/utils/mcp/prompts.ts
+++ b/application/server/utils/mcp/prompts.ts
@@ -91,7 +91,7 @@ export function buildSetupPiwiMessages(input: SetupPiwiInput): PromptResult {
     '',
     '1. From the project root, run the setup command:',
     '',
-    `   npx piwi init --server-url ${baseUrl} --project ${projectArg}`,
+    `   npx @piwitests/reporter init --server-url ${baseUrl} --project ${projectArg}`,
     '',
     '   It installs `@piwitests/reporter`, wraps `defineConfig(...)` with `wrapConfig(...)`, creates',
     '   `tests/fixtures.ts`, and records PIWI_* settings in `.env.example`. Every step is idempotent, so it is',

--- a/application/tests/mcp.spec.ts
+++ b/application/tests/mcp.spec.ts
@@ -120,7 +120,7 @@ test.describe.serial('MCP server', () => {
     const text = messages[0].content.text;
     // Server-aware: the message names this project and includes a runnable init command.
     expect(text).toContain(`--project ${PROJECT.MCP_TEST}`);
-    expect(text).toContain('npx piwi init --server-url');
+    expect(text).toContain('npx @piwitests/reporter init --server-url');
     // Auth is disabled in the test server, so it should say no key is needed.
     expect(text).toContain('Authentication: not required');
   });

--- a/application/tests/unit/mcp-prompts.test.ts
+++ b/application/tests/unit/mcp-prompts.test.ts
@@ -23,7 +23,9 @@ describe('buildSetupPiwiMessages', () => {
 
   it('bakes the dashboard URL into the init command', () => {
     const text = buildSetupPiwiMessages(base).messages[0].content.text;
-    expect(text).toContain('npx piwi init --server-url https://piwi.example.com --project <project-name>');
+    expect(text).toContain(
+      'npx @piwitests/reporter init --server-url https://piwi.example.com --project <project-name>',
+    );
     expect(text).toContain('Authentication: not required');
   });
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -223,7 +223,7 @@ failure cause appear* — and those need the run history, so the dashboard evalu
     PIWI_DASHBOARD_URL: https://piwi.example.com
     PIWI_OUTPUT_FILE: piwi-run.json      # records which run to gate on
 
-- run: npx piwi gate --require-tag @critical --max-new-regressions 0
+- run: npx @piwitests/reporter gate --require-tag @critical --max-new-regressions 0
   if: always()
   env:
     PIWI_DASHBOARD_URL: https://piwi.example.com
@@ -256,7 +256,7 @@ Three behaviors worth knowing:
 - **A required tag that matches no test in the run is a violation.** A misspelled `--require-tag @critcal` would
   otherwise pass silently, which is the worst outcome for a rule meant to block merges.
 
-`npx piwi gate --help` lists every option. Add `--json` to get the raw result for a pipeline to parse.
+`npx @piwitests/reporter gate --help` lists every option. Add `--json` to get the raw result for a pipeline to parse. (Invoking through the package name keeps npx on this package; a plain `npx piwi gate` also works wherever the reporter is already a dependency, as it is in any job that ran the tests.)
 
 ## Notifying people instead
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,15 +98,17 @@ The SQLite database is automatically created on the first API call.
 
 The recommended way to integrate is via the custom reporter package — it handles uploading results, HTML reports, and trace files automatically.
 
-### Fast path: `npx piwi init`
+### Fast path: one command
 
 From your Playwright project, one command installs the reporter, wraps your `playwright.config`, creates the capture-fixtures file, and records the connection in `.env.example`:
 
 ```bash
-npx piwi init --server-url http://localhost:3000 --project my-project
+npx @piwitests/reporter init --server-url http://localhost:3000 --project my-project
 ```
 
-Every step is idempotent, so it is safe to re-run. If it finds a config shape it will not rewrite (or a fixtures file that already exists), it reports that step as `manual` with the exact change to make instead of touching the file. Pass `--dry-run` to preview, or `--json` to get a machine-readable plan — the latter is what lets a coding agent run the setup for you and finish anything left manual. `init` also drops the [Piwi agent skills](./mcp#agent-skills) into the project so your agent can investigate failures, heal locators, and stabilize flaky tests. See `npx piwi init --help` for all options.
+Every step is idempotent, so it is safe to re-run. If it finds a config shape it will not rewrite (or a fixtures file that already exists), it reports that step as `manual` with the exact change to make instead of touching the file. Pass `--dry-run` to preview, or `--json` to get a machine-readable plan — the latter is what lets a coding agent run the setup for you and finish anything left manual. `init` also drops the [Piwi agent skills](./mcp#agent-skills) into the project so your agent can investigate failures, heal locators, and stabilize flaky tests. See `npx @piwitests/reporter init --help` for all options.
+
+> The reporter is published as `@piwitests/reporter`; its command is `piwi`. Invoke it through the package name — `npx @piwitests/reporter <command>` — so npx always resolves *this* package. (`npx piwi` would fetch an unrelated `piwi` package from npm.) Once the reporter is a dependency of your project, a plain `npx piwi <command>` also works, since it resolves the local binary first.
 
 Prefer to wire it up by hand? The manual steps are below.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -229,23 +229,23 @@ Alongside its tools, the server exposes an MCP **prompt** — a ready-made instr
 |--------|--------------|
 | `setup_piwi` | Generates a complete, ready-to-run setup for a Playwright project that is not yet reporting here. |
 
-`setup_piwi` is **server-aware**: because the dashboard builds it, it fills in *this* instance's real URL, whether authentication is required, and the projects that already exist — facts a static copy-paste prompt can't know. Pick it in your MCP client (optionally passing a `projectName`), and the agent gets a personalized plan: run `npx piwi init` against this dashboard, handle the API key if auth is on, rewire the specs, and verify a run lands. It pairs with the `setup-piwi` skill below — the prompt needs no install but requires the MCP connection; the skill works offline once installed.
+`setup_piwi` is **server-aware**: because the dashboard builds it, it fills in *this* instance's real URL, whether authentication is required, and the projects that already exist — facts a static copy-paste prompt can't know. Pick it in your MCP client (optionally passing a `projectName`), and the agent gets a personalized plan: run `npx @piwitests/reporter init` against this dashboard, handle the API key if auth is on, rewire the specs, and verify a run lands. It pairs with the `setup-piwi` skill below — the prompt needs no install but requires the MCP connection; the skill works offline once installed.
 
 ## Agent skills
 
 The MCP server gives an agent read access to your results; **skills** tell it what to *do* with them. A skill is a single `SKILL.md` file — the portable open format (a small front-matter block plus Markdown instructions) that Claude Code and other agents pick up from a project's skills directory. Piwi ships four, installed with the reporter's CLI:
 
 ```bash
-npx piwi skills add            # install all of them into .claude/skills/
-npx piwi skills list           # see what each one does
-npx piwi skills add investigate-failure --dir .cursor/skills   # a specific one, elsewhere
+npx @piwitests/reporter skills add          # install all of them into .claude/skills/
+npx @piwitests/reporter skills list         # see what each one does
+npx @piwitests/reporter skills add investigate-failure --dir .cursor/skills   # a specific one, elsewhere
 ```
 
-`npx piwi init` installs the three workflow skills automatically as part of setup.
+`npx @piwitests/reporter init` installs the three workflow skills automatically as part of setup. (Invoke the CLI through the package name so npx resolves *this* package, not an unrelated `piwi` on npm; a plain `npx piwi …` works once the reporter is a project dependency.)
 
 | Skill | What it does |
 |------|--------------|
-| `setup-piwi` | Wire a Playwright project up to a dashboard — the same work `npx piwi init` does, driven by an agent. |
+| `setup-piwi` | Wire a Playwright project up to a dashboard — the same work `npx @piwitests/reporter init` does, driven by an agent. |
 | `investigate-failure` | Investigate a failed run and propose a fix grounded in Piwi's evidence — error, steps, console, network, and the diff since the last green run. |
 | `apply-locator-healing` | Replace a brittle locator with Piwi's ranked healed selector at its call site, then re-run to confirm. |
 | `stabilize-flaky-tests` | Fix the root cause of the highest-impact flaky tests (never by adding retries), then verify with repeated runs. |

--- a/docs/reporter.md
+++ b/docs/reporter.md
@@ -13,7 +13,7 @@ The `@piwitests/reporter` package is a custom Playwright reporter that automatic
 npm install --save-dev @piwitests/reporter
 ```
 
-Or let `npx piwi init` do the install and wiring for you — see the [one-command setup](./getting-started#fast-path-npx-piwi-init) in Getting started. The rest of this page is the full manual reference.
+Or let `npx @piwitests/reporter init` do the install and wiring for you — see the [one-command setup](./getting-started#fast-path-one-command) in Getting started. The rest of this page is the full manual reference.
 
 ## Basic configuration
 

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -12,13 +12,15 @@ npm install --save-dev @piwitests/reporter
 
 ## Set up in one command
 
-From your Playwright project, `npx piwi init` installs the reporter, wraps your `playwright.config`, creates the capture-fixtures file, and records the connection in `.env.example`:
+From your Playwright project, `npx @piwitests/reporter init` installs the reporter, wraps your `playwright.config`, creates the capture-fixtures file, and records the connection in `.env.example`:
 
 ```bash
-npx piwi init --server-url http://localhost:3000 --project my-project
+npx @piwitests/reporter init --server-url http://localhost:3000 --project my-project
 ```
 
-Every step is idempotent (safe to re-run); a config shape it will not rewrite is reported as `manual` with the exact change to make, never mangled. Add `--dry-run` to preview or `--json` for a machine-readable plan an agent can act on. It also installs the [Piwi agent skills](https://piwitests.github.io/mcp#agent-skills) so your coding agent can investigate failures, heal locators, and stabilize flaky tests. Run `npx piwi init --help` for all options, or wire it up by hand with the steps below.
+Every step is idempotent (safe to re-run); a config shape it will not rewrite is reported as `manual` with the exact change to make, never mangled. Add `--dry-run` to preview or `--json` for a machine-readable plan an agent can act on. It also installs the [Piwi agent skills](https://piwitests.github.io/mcp#agent-skills) so your coding agent can investigate failures, heal locators, and stabilize flaky tests. Run `npx @piwitests/reporter init --help` for all options, or wire it up by hand with the steps below.
+
+> The package is `@piwitests/reporter`; its command is `piwi`. Invoke it through the package name (`npx @piwitests/reporter <command>`) so npx resolves this package — `npx piwi` would fetch an unrelated `piwi` from npm. Once the reporter is a project dependency, `npx piwi <command>` resolves the local binary and works too.
 
 ## Quick start
 

--- a/reporter/src/cli/gate.ts
+++ b/reporter/src/cli/gate.ts
@@ -33,7 +33,7 @@ const USAGE = `
 piwi gate — fail a CI job on the dashboard's analysis of a run
 
 Usage:
-  npx piwi gate [options]
+  npx @piwitests/reporter gate [options]
 
 Where the run comes from (first match wins):
   --run-id <id>            Run id to evaluate

--- a/reporter/src/cli/index.ts
+++ b/reporter/src/cli/index.ts
@@ -15,14 +15,16 @@ const USAGE = `
 piwi — companion commands for the Piwi Dashboard reporter
 
 Usage:
-  npx piwi <command> [options]
+  npx @piwitests/reporter <command> [options]
 
 Commands:
   init      Wire a Playwright project up to a Piwi Dashboard
   skills    Install the Piwi agent skills into this project
   gate      Fail a CI job on the dashboard's analysis of a run
 
-Run \`npx piwi <command> --help\` for a command's options.
+Run \`npx @piwitests/reporter <command> --help\` for a command's options.
+(The published package is @piwitests/reporter; its command is piwi. Invoke it
+through the package name so npx resolves this package, not an unrelated "piwi".)
 `.trim();
 
 async function main(): Promise<number> {

--- a/reporter/src/cli/init.ts
+++ b/reporter/src/cli/init.ts
@@ -43,7 +43,7 @@ const USAGE = `
 piwi init — wire a Playwright project up to a Piwi Dashboard
 
 Usage:
-  npx piwi init [options]
+  npx @piwitests/reporter init [options]
 
 What it does (each step is idempotent and safe to re-run):
   - installs @piwitests/reporter as a dev dependency
@@ -164,7 +164,7 @@ function stepConfig(project: ProjectShape, opts: InitOptions): StepResult {
     return {
       step,
       status: 'manual',
-      detail: 'No playwright.config found — create one, then re-run `npx piwi init`',
+      detail: 'No playwright.config found — create one, then re-run `npx @piwitests/reporter init`',
     };
 
   const rel = path.relative(project.root, project.configPath) || path.basename(project.configPath);

--- a/reporter/src/cli/skills.ts
+++ b/reporter/src/cli/skills.ts
@@ -124,8 +124,8 @@ const USAGE = `
 piwi skills — install the Piwi agent skills into this project
 
 Usage:
-  npx piwi skills list
-  npx piwi skills add [names...] [options]
+  npx @piwitests/reporter skills list
+  npx @piwitests/reporter skills add [names...] [options]
 
 Commands:
   list              Show the available skills and what each one is for

--- a/reporter/templates/skills/investigate-failure/SKILL.md
+++ b/reporter/templates/skills/investigate-failure/SKILL.md
@@ -9,7 +9,7 @@ Turn a failed run in [Piwi Dashboard](https://piwitests.github.io) into a ground
 
 ## How you reach Piwi
 
-Prefer the **Piwi MCP server** if it is connected to this agent (tools named `list_recent_activity`, `get_run`, `explain_failure`, `get_cluster_context`, …). If it is not connected, tell the user they can connect it (`npx piwi` does not proxy MCP — see the dashboard's **MCP server** page) or paste the run URL / failure details, and work from those plus the repo.
+Prefer the **Piwi MCP server** if it is connected to this agent (tools named `list_recent_activity`, `get_run`, `explain_failure`, `get_cluster_context`, …). If it is not connected, tell the user they can connect it (the reporter CLI does not proxy MCP — see the dashboard's **MCP server** page) or paste the run URL / failure details, and work from those plus the repo.
 
 ## Steps
 

--- a/reporter/templates/skills/setup-piwi/SKILL.md
+++ b/reporter/templates/skills/setup-piwi/SKILL.md
@@ -21,7 +21,7 @@ Confirm this is a Playwright project: there should be a `playwright.config.ts|js
 Run the initializer from the project root. It installs `@piwitests/reporter`, wraps `defineConfig(...)` with `wrapConfig(...)`, creates `tests/fixtures.ts`, and records `PIWI_*` settings in `.env.example`:
 
 ```bash
-npx piwi init --server-url <dashboard-url> --project <name> --json
+npx @piwitests/reporter init --server-url <dashboard-url> --project <name> --json
 ```
 
 - Preview first with `--dry-run` if you want to see the plan before anything is written.


### PR DESCRIPTION
## What & why

Follow-up polish to the agent-setup story shipped in #347. Three related changes:

**1. Fix a real npm collision (the headline).** The package is `@piwitests/reporter` and its bin is named `piwi`, but `npx piwi …` resolves an **unrelated `piwi` package** on the npm registry and offers to install it — so the documented setup command fetched the wrong package for anyone who didn't already have the reporter installed:

```
$ npx piwi init --server-url http://localhost:3000 --project my-project
Need to install the following packages:
piwi@1.0.5          ← not our package
Ok to proceed? (y)
```

Every user-facing invocation now points at the package name — `npx @piwitests/reporter <command>` — which npm resolves to this package and auto-runs its single `piwi` bin (verified on npm 10). Covers the CLI help, README, docs (getting-started, reporter, mcp, ci), ROADMAP, the agent-skill templates, and the server-built `setup_piwi` MCP prompt. A short note records that a bare `npx piwi` still works once the reporter is a project dependency (the local bin wins).

**2. Surface `setup_piwi` on the MCP server page** (`app/pages/mcp.vue`). A new "Prompts" section renders the same `prompts/list` catalog the server exposes (`shared/mcp-prompts.ts`), so a user reading the setup guide sees the prompt, what it does, and its optional `projectName` argument — mirroring how the tools list is already shown.

**3. Fix the pre-commit hook** (`.husky/pre-commit`). `git add -u application/` re-staged *every* modified tracked file under the directory, not just the ones staged for the commit, silently sweeping unrelated work-in-progress into a commit. It now captures the already-staged files, runs the same whole-workspace formatter CI's `format:check` uses, and re-stages exactly that list.

## How was it tested?

- **Reporter:** full unit suite green (498 tests), lint + format clean.
- **Application:** `nuxt typecheck` clean, full unit suite green (1221 tests) including the updated `mcp-prompts` assertions and the `mcp` E2E prompt checks; lint + format clean.
- **npx resolution:** confirmed on npm 10 that `npx @piwitests/reporter init …` auto-runs the package's single `piwi` bin and passes the args through.
- **MCP page:** rendered the live `/mcp` page and verified the Prompts card at desktop and 375 px (no new horizontal overflow — identical markup to the existing tools rows).
- **Pre-commit hook:** modified two tracked app files, staged only one, committed — the commit contained only the staged file and the other stayed unstaged (the old hook would have grabbed both). Test commit cleaned up.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbYL4cH1hgC8ok2M85Aaa3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbYL4cH1hgC8ok2M85Aaa3)_