### PR TITLE
fix: restore the lockfile's root name field to "platform"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "p1-conflict",
+  "name": "platform",
   "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,


### PR DESCRIPTION
It read "p1-conflict" — the directory name of a temporary git worktree used to resolve a merge conflict during the extension PR series, which npm wrote into the lockfile and which then rode onto main. Cosmetic, but npm rewrites the field on every install from a normal checkout, so it produces a spurious one-line diff for anyone running npm install until it's corrected.

<!--
Thanks for contributing! Two things to know:

1. PRs are squash-merged, so the PR TITLE becomes the commit on main and drives
   the release changelog. Give it a Conventional Commit title, e.g.
   `feat(reporter): support custom run labels` — see CONTRIBUTING.md.
2. For non-trivial changes, consider opening an issue/discussion first.
-->

## What & why

<!-- What does this change do, and what problem does it solve?
     Link related issues: Fixes #123 -->

## How was it tested?

<!-- Unit tests / E2E tests / manual steps. `npm test` runs the full suite. -->

## Checklist

- [ ] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (`docs/`, README, or reporter README)
