### PR TITLE
fix: resolve critical, high and medium security audit findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,10 @@ RUN --mount=type=cache,target=/home/nodejs/.npm,uid=1001,gid=1001 \
 # Copy built application — pure-JS deps inlined by Nitro noExternals
 COPY --chown=nodejs:nodejs --from=builder /app/application/.output ./application/.output
 
+# Reconciles operator-facing PIWI_AUTH_* env onto the NUXT_* runtime overrides
+# the prebuilt server reads (see the file for why). Preloaded before the entry.
+COPY --chown=nodejs:nodejs docker-server-env.mjs ./
+
 EXPOSE ${PORT}
 
 # Readiness for compose/k8s/monitors — /api/health verifies DB connectivity
@@ -124,4 +128,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD wget -qO /dev/null "http://127.0.0.1:${PORT}/api/health" || exit 1
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "application/.output/server/index.mjs"]
+CMD ["node", "--import", "./docker-server-env.mjs", "application/.output/server/index.mjs"]

--- a/application/playwright.config.ts
+++ b/application/playwright.config.ts
@@ -11,6 +11,12 @@ const serverCommand = useBuiltServer ? 'node .output/server/index.mjs' : 'npm ru
 /** An already-installed Chromium to use instead of the revision Playwright pins. */
 const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE?.trim() || '';
 
+// Stored third-party secrets (AI keys, webhook secrets) refuse to persist under
+// the built-in default encryption key. Give every test server a real one — it is
+// merged into each webServer via the inherited process.env — so the settings and
+// channel flows the suite exercises can save.
+process.env.PIWI_SECRET_KEY ||= 'test-encryption-secret-key-not-for-production';
+
 // `PIWI_AUTH_*` is resolved into `runtimeConfig` when the Nuxt config is
 // evaluated, which for a production build is build time. Nitro maps the
 // `NUXT_`-prefixed forms onto the same keys at startup, so auth-enabled servers

--- a/application/server/api/auth/change-password.post.ts
+++ b/application/server/api/auth/change-password.post.ts
@@ -1,7 +1,8 @@
 import { eq } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { users } from '../../database/schema';
-import { requireAuth, hashPassword, verifyPassword } from '../../utils/auth';
+import { requireAuth, hashPassword, verifyPassword, revokeUserSessions, setUserSession } from '../../utils/auth';
+import { Role } from '#shared/types';
 import { z } from 'zod';
 
 defineRouteMeta({
@@ -44,6 +45,16 @@ export default eventHandler(async (event) => {
 
   const hashed = await hashPassword(newPassword);
   await db.update(users).set({ password: hashed, updatedAt: new Date() }).where(eq(users.id, user.id));
+
+  // Revoke every existing session, then re-issue one for the current device so
+  // the password change signs out other devices without signing out this one.
+  const epoch = await revokeUserSessions(user.id);
+  await setUserSession(event, {
+    userId: user.id,
+    username: user.username,
+    role: user.role as Role,
+    sessionEpoch: epoch,
+  });
 
   console.info('[auth/change-password] Password changed for user %d', user.id);
   return { success: true };

--- a/application/server/api/auth/login.post.ts
+++ b/application/server/api/auth/login.post.ts
@@ -1,6 +1,9 @@
 import { Role } from '#shared/types';
 import { verifyUser, setUserSession, isAuthEnabled } from '../../utils/auth';
+import { isRateLimited, recordRateLimitHit, resetRateLimit } from '../../utils/rate-limit';
 import { z } from 'zod';
+
+const WINDOW_MS = 15 * 60 * 1000;
 
 defineRouteMeta({
   openAPI: {
@@ -38,19 +41,34 @@ export default eventHandler(async (event) => {
 
   const { username, password } = validation.data;
 
+  const ip = getRequestIP(event) ?? 'unknown';
+  const ipKey = `login:ip:${ip}`;
+  const accountKey = `login:user:${username.toLowerCase()}`;
+  // Throttle repeated failures — per source and per account — so credentials
+  // can't be brute-forced online. Only failed attempts count; a valid login
+  // clears the account's counter.
+  if (isRateLimited(ipKey, 20) || isRateLimited(accountKey, 5)) {
+    throw createError({ statusCode: 429, message: 'Too many failed attempts. Please wait before trying again.' });
+  }
+
   const user = await verifyUser(username, password);
   if (!user) {
+    recordRateLimitHit(ipKey, WINDOW_MS);
+    recordRateLimitHit(accountKey, WINDOW_MS);
     throw createError({
       statusCode: 401,
       message: 'Invalid username or password',
     });
   }
 
+  resetRateLimit(accountKey);
+
   // Set session
   await setUserSession(event, {
     userId: user.id,
     username: user.username,
     role: user.role as Role,
+    sessionEpoch: user.sessionEpoch,
   });
 
   return {

--- a/application/server/api/auth/oauth/[provider]/unlink.post.ts
+++ b/application/server/api/auth/oauth/[provider]/unlink.post.ts
@@ -1,5 +1,6 @@
-import { requireAuth } from '../../../../utils/auth';
+import { requireAuth, revokeUserSessions, setUserSession } from '../../../../utils/auth';
 import { unlinkProvider } from '../../../../utils/oauth';
+import { Role } from '#shared/types';
 
 defineRouteMeta({
   openAPI: {
@@ -21,6 +22,15 @@ export default eventHandler(async (event) => {
   }
 
   await unlinkProvider(user.id, provider);
+
+  // Removing a sign-in method revokes other sessions; keep the current device in.
+  const epoch = await revokeUserSessions(user.id);
+  await setUserSession(event, {
+    userId: user.id,
+    username: user.username,
+    role: user.role as Role,
+    sessionEpoch: epoch,
+  });
 
   return { success: true };
 });

--- a/application/server/api/auth/reset-password.post.ts
+++ b/application/server/api/auth/reset-password.post.ts
@@ -2,8 +2,9 @@ import { eq } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { users } from '../../database/schema';
 import { validateAccountToken, consumeAccountToken } from '../../utils/account-tokens';
-import { hashPassword } from '../../utils/auth';
+import { hashPassword, revokeUserSessions } from '../../utils/auth';
 import { clearUserSession } from '../../utils/auth';
+import { checkRateLimit } from '../../utils/rate-limit';
 import { z } from 'zod';
 
 defineRouteMeta({
@@ -22,6 +23,11 @@ const schema = z.object({
 });
 
 export default eventHandler(async (event) => {
+  const ip = getRequestIP(event) ?? 'unknown';
+  if (!checkRateLimit(`reset:${ip}`, 10, 15 * 60 * 1000)) {
+    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
+  }
+
   const body = await readBody(event);
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
@@ -51,7 +57,9 @@ export default eventHandler(async (event) => {
 
   await consumeAccountToken(db, validated.tokenId);
 
-  // Clear current session to invalidate it (best-effort; h3 session doesn't support user-wide invalidation)
+  // Revoke every existing session for this account so a stolen session cannot
+  // outlive the reset, then clear the current cookie for good measure.
+  await revokeUserSessions(user.id);
   await clearUserSession(event).catch(() => {});
 
   console.info('[auth/reset-password] Password reset for user %d', user.id);

--- a/application/server/api/auth/send-verify-email.post.ts
+++ b/application/server/api/auth/send-verify-email.post.ts
@@ -2,6 +2,7 @@ import { getDatabase } from '../../database';
 import { requireAuth } from '../../utils/auth';
 import { mintAccountToken } from '../../utils/account-tokens';
 import { isEmailConfigured, sendEmail, renderVerifyEmail } from '../../utils/email';
+import { checkRateLimit } from '../../utils/rate-limit';
 
 defineRouteMeta({
   openAPI: {
@@ -16,6 +17,11 @@ export default eventHandler(async (event) => {
   const user = await requireAuth(event);
   if (!user.email) throw createError({ statusCode: 400, message: 'No email address on this account' });
   if (!isEmailConfigured()) throw createError({ statusCode: 503, message: 'SMTP is not configured' });
+
+  // Bound how often a user can trigger verification emails.
+  if (!checkRateLimit(`verify-email:${user.id}`, 5, 15 * 60 * 1000)) {
+    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
+  }
 
   const db = await getDatabase();
   const token = await mintAccountToken(db, user.id, 'verify');

--- a/application/server/api/auth/setup.post.ts
+++ b/application/server/api/auth/setup.post.ts
@@ -1,5 +1,6 @@
 import { Role } from '#shared/types';
 import { createUser, isAuthEnabled, needsInitialSetup } from '../../utils/auth';
+import { checkRateLimit } from '../../utils/rate-limit';
 import { z } from 'zod';
 
 defineRouteMeta({
@@ -15,7 +16,7 @@ defineRouteMeta({
 
 const createAdminSchema = z.object({
   username: z.string().min(3),
-  password: z.string().min(6),
+  password: z.string().min(8),
   name: z.string().optional(),
 });
 
@@ -25,6 +26,11 @@ export default eventHandler(async (event) => {
       statusCode: 400,
       message: 'Authentication is not enabled',
     });
+  }
+
+  const ip = getRequestIP(event) ?? 'unknown';
+  if (!checkRateLimit(`setup:${ip}`, 5, 15 * 60 * 1000)) {
+    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
   }
 
   if (!(await needsInitialSetup())) {

--- a/application/server/api/auth/setup.post.ts
+++ b/application/server/api/auth/setup.post.ts
@@ -1,5 +1,5 @@
 import { Role } from '#shared/types';
-import { createUser, isAuthEnabled, needsInitialSetup } from '../../utils/auth';
+import { createUser, isAuthEnabled, needsInitialSetup, claimInitialSetup, releaseInitialSetup } from '../../utils/auth';
 import { checkRateLimit } from '../../utils/rate-limit';
 import { z } from 'zod';
 
@@ -53,16 +53,31 @@ export default eventHandler(async (event) => {
 
   const { username, password, name } = validation.data;
 
-  // Create admin user
-  const user = await createUser(username, password, Role.ADMINISTRATOR, name);
+  // Close the check-then-create race: two concurrent setup requests can both
+  // pass the needsInitialSetup() check above and each create an administrator.
+  // claimInitialSetup() lets exactly one of them proceed; the rest are rejected.
+  if (!(await claimInitialSetup())) {
+    throw createError({
+      statusCode: 400,
+      message: 'Users already exist. This endpoint is only for initial setup.',
+    });
+  }
 
-  return {
-    success: true,
-    user: {
-      id: user.id,
-      username: user.username,
-      role: user.role as Role,
-      name: user.name,
-    },
-  };
+  try {
+    const user = await createUser(username, password, Role.ADMINISTRATOR, name);
+
+    return {
+      success: true,
+      user: {
+        id: user.id,
+        username: user.username,
+        role: user.role as Role,
+        name: user.name,
+      },
+    };
+  } catch (err) {
+    // Roll back the claim so a transient failure doesn't permanently lock setup.
+    await releaseInitialSetup();
+    throw err;
+  }
 });

--- a/application/server/api/channels/[id]/test.post.ts
+++ b/application/server/api/channels/[id]/test.post.ts
@@ -4,6 +4,7 @@ import { notificationChannels, users } from '../../../database/schema';
 import { requireAuth, isAuthEnabled } from '../../../utils/auth';
 import { decryptSecret, getEncryptionKey } from '../../../utils/crypto';
 import { sendEmail, renderTestEmail, isEmailConfigured } from '../../../utils/email';
+import { safeFetch } from '../../../utils/safe-fetch';
 import { Role } from '#shared/types';
 
 defineRouteMeta({
@@ -50,7 +51,7 @@ export default eventHandler(async (event) => {
     } else if (channel.type === 'slack') {
       const webhookUrl = config.webhookUrl as string;
       if (!webhookUrl) throw new Error('No Slack webhook URL');
-      const res = await fetch(webhookUrl, {
+      const res = await safeFetch(webhookUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: ':bell: Test notification from Piwi Dashboard' }),
@@ -67,7 +68,7 @@ export default eventHandler(async (event) => {
         const { createHmac } = await import('node:crypto');
         headers['X-Piwi-Signature'] = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
       }
-      const res = await fetch(url, { method: 'POST', headers, body });
+      const res = await safeFetch(url, { method: 'POST', headers, body });
       if (!res.ok) throw new Error(`Webhook returned ${res.status}`);
     } else if (channel.type === 'browser') {
       return { success: true };

--- a/application/server/api/channels/index.get.ts
+++ b/application/server/api/channels/index.get.ts
@@ -60,7 +60,7 @@ export default eventHandler(async (event) => {
       const isOwnPersonal = c.type === 'personal_email' && c.userId === user.id;
       const config = isOwnPersonal
         ? { address: dbUser?.email ?? '' }
-        : sanitizeConfig(c.type, (c.config ?? {}) as Record<string, unknown>);
+        : sanitizeConfig((c.config ?? {}) as Record<string, unknown>);
       const verified = isOwnPersonal ? Boolean(dbUser?.emailVerified) : Boolean(c.verified);
 
       return {
@@ -77,7 +77,19 @@ export default eventHandler(async (event) => {
   };
 });
 
-function sanitizeConfig(type: string, config: Record<string, unknown>): Record<string, unknown> {
-  if (type === 'webhook') return { url: config.url }; // redact secret
-  return config;
+// Config fields that are themselves credentials and must never be returned by
+// the list endpoint: the webhook signing `secret`, and the Slack incoming-
+// webhook URL (`webhookUrl`) — anyone holding that URL can post to the channel.
+// Channels are created/deleted (no edit form re-reads these), and the list UI
+// only renders an email `address` or a webhook `url`, so dropping the secrets
+// doesn't affect the dashboard. Global channels are visible to every user, so
+// this stops a low-privilege user from reading another team's Slack URL.
+const SECRET_CONFIG_FIELDS = new Set(['webhookUrl', 'secret', 'token', 'apiKey', 'password']);
+
+function sanitizeConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const safe: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (!SECRET_CONFIG_FIELDS.has(key)) safe[key] = value;
+  }
+  return safe;
 }

--- a/application/server/api/files/[...path].get.ts
+++ b/application/server/api/files/[...path].get.ts
@@ -49,6 +49,20 @@ async function findInArchive(buffer: Buffer, targetName: string): Promise<Buffer
 
 const COMPRESSIBLE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
 
+// Content types a browser can execute as a scriptable document. Untrusted stored
+// files are never served as one of these on the strength of a caller override.
+const ACTIVE_CONTENT_TYPES = new Set([
+  'text/html',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'application/xml',
+  'text/xml',
+]);
+
+function isActiveContentType(value: string): boolean {
+  return ACTIVE_CONTENT_TYPES.has(value.split(';')[0]!.trim().toLowerCase());
+}
+
 export default eventHandler(async (event) => {
   const path = getRouterParam(event, 'path');
   const query = getQuery(event);
@@ -161,9 +175,13 @@ export default eventHandler(async (event) => {
   }
 
   function resolveContentType(ext: string): string {
-    // If caller provided a content type override, use it for unrecognized extensions
+    // If the caller supplied a content-type for an extension-less attachment,
+    // honor it only for inert types. An override that names an active type
+    // (text/html, image/svg+xml, XML) would turn arbitrary stored bytes into a
+    // scriptable document served from the dashboard origin, so it is ignored —
+    // the file then falls back to octet-stream, which `nosniff` keeps inert.
     const guessed = setContentType(ext);
-    if (guessed === 'application/octet-stream' && overrideContentType) {
+    if (guessed === 'application/octet-stream' && overrideContentType && !isActiveContentType(overrideContentType)) {
       return overrideContentType;
     }
     return guessed;
@@ -171,16 +189,25 @@ export default eventHandler(async (event) => {
 
   /**
    * Apply a Content-Security-Policy sandbox to untrusted HTML responses.
-   * User-uploaded report HTML can contain arbitrary scripts; sandboxing
-   * prevents them from executing in the dashboard's origin.
+   *
+   * Playwright/Monocart reports rely on JavaScript to render, so scripts stay
+   * enabled — but `allow-same-origin` is deliberately omitted, giving the
+   * document a unique opaque origin. Its scripts can no longer read the
+   * dashboard's cookies or localStorage, or make credentialed same-origin calls
+   * to `/api`, so a malicious uploaded report cannot act as the viewer. Bundled
+   * relative resources still load (they are fetched from the dashboard by URL).
    */
   function applyHtmlCsp(): void {
-    // Sandbox with allow-scripts so Playwright/Monocart reports (which rely on
-    // JavaScript to render) are usable.  allow-same-origin is needed for
-    // self-contained resource loads (CSS, JS, fonts, images bundled in the
-    // same directory).  All other sandbox restrictions — no forms, no popups,
-    // no navigation — remain in place.
-    setResponseHeader(event, 'Content-Security-Policy', 'sandbox allow-scripts allow-same-origin');
+    setResponseHeader(event, 'Content-Security-Policy', 'sandbox allow-scripts');
+  }
+
+  /**
+   * SVGs can embed scripts that execute when the file is opened top-level. A
+   * no-scripts sandbox renders it as an inert image and blocks any network
+   * callout, while `<img>` embedding elsewhere in the app is unaffected.
+   */
+  function applySvgCsp(): void {
+    setResponseHeader(event, 'Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; sandbox");
   }
 
   // 1. Try exact path
@@ -242,6 +269,8 @@ export default eventHandler(async (event) => {
     applyInlineDisposition(contentType);
     if (contentType === 'text/html') {
       applyHtmlCsp();
+    } else if (contentType === 'image/svg+xml') {
+      applySvgCsp();
     }
     return fileContent;
   }

--- a/application/server/api/files/[...path].get.ts
+++ b/application/server/api/files/[...path].get.ts
@@ -20,12 +20,20 @@ defineRouteMeta({
 
 const gunzipAsync = promisify(gunzip);
 
+// Cap decompressed archive size to prevent gzip bombs. Stored report archives
+// originate from uploads (open when auth is disabled) and are inflated fully
+// into memory here, so an unbounded ratio could expand a few kilobytes to
+// gigabytes and OOM the server. 1 GiB exceeds any realistic report while
+// stopping bombs; zlib throws ERR_BUFFER_TOO_LARGE past the cap (callers
+// already treat a decompression failure as "not found" and fall through).
+const MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024; // 1 GiB
+
 /**
  * Parse a compressed report archive and find a specific file by name.
  * Archive format: custom binary with LE length-prefixed path+content pairs.
  */
 async function findInArchive(buffer: Buffer, targetName: string): Promise<Buffer | null> {
-  const uncompressed = await gunzipAsync(buffer);
+  const uncompressed = await gunzipAsync(buffer, { maxOutputLength: MAX_ARCHIVE_BYTES });
   let offset = 0;
   while (offset < uncompressed.length) {
     if (offset + 4 > uncompressed.length) break;

--- a/application/server/api/links/[id].delete.ts
+++ b/application/server/api/links/[id].delete.ts
@@ -1,5 +1,4 @@
-import { requireAuth } from '../../utils/auth';
-import { getDatabase } from '../../database';
+import { requireResolvedProjectAccess, resolveLinkProjectId } from '../../utils/project-access';
 import { deleteLink } from '#shared/handlers/links';
 
 defineRouteMeta({
@@ -13,15 +12,14 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
-
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) {
     throw createError({ statusCode: 400, message: 'Invalid link ID' });
   }
 
+  const { db } = await requireResolvedProjectAccess(event, id, resolveLinkProjectId, 'Link');
+
   try {
-    const db = await getDatabase();
     return await deleteLink(db, id);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to delete link';

--- a/application/server/api/links/[id].patch.ts
+++ b/application/server/api/links/[id].patch.ts
@@ -1,5 +1,4 @@
-import { requireAuth } from '../../utils/auth';
-import { getDatabase } from '../../database';
+import { requireResolvedProjectAccess, resolveLinkProjectId } from '../../utils/project-access';
 import { patchLink } from '#shared/handlers/links';
 import { z } from 'zod';
 
@@ -19,12 +18,12 @@ const updateLinkSchema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
-
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) {
     throw createError({ statusCode: 400, message: 'Invalid link ID' });
   }
+
+  const { db } = await requireResolvedProjectAccess(event, id, resolveLinkProjectId, 'Link');
 
   const body = await readBody(event);
   const validation = updateLinkSchema.safeParse(body);
@@ -38,7 +37,6 @@ export default eventHandler(async (event) => {
   }
 
   try {
-    const db = await getDatabase();
     return await patchLink(db, id, validation.data);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to update link';

--- a/application/server/api/links/[id]/refresh.post.ts
+++ b/application/server/api/links/[id]/refresh.post.ts
@@ -1,5 +1,4 @@
-import { requireAuth } from '../../../utils/auth';
-import { getDatabase } from '../../../database';
+import { requireResolvedProjectAccess, resolveLinkProjectId } from '../../../utils/project-access';
 import { entityLinks } from '../../../database/schema';
 import { eq } from 'drizzle-orm';
 import { refreshLinkMeta } from '#shared/handlers/links';
@@ -16,14 +15,12 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
-
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) {
     throw createError({ statusCode: 400, message: 'Invalid link ID' });
   }
 
-  const db = await getDatabase();
+  const { db } = await requireResolvedProjectAccess(event, id, resolveLinkProjectId, 'Link');
 
   let result: { link: any };
   try {

--- a/application/server/api/links/index.get.ts
+++ b/application/server/api/links/index.get.ts
@@ -1,4 +1,4 @@
-import { requireAuth } from '../../utils/auth';
+import { requireProjectAccess, resolveLinkEntityProjectId } from '../../utils/project-access';
 import { getDatabase } from '../../database';
 import { listLinks } from '#shared/handlers/links';
 
@@ -21,8 +21,6 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
-
   const query = getQuery(event);
   const entityType = query.entityType as string;
   const entityId = parseInt(query.entityId as string, 10);
@@ -31,5 +29,10 @@ export default eventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Invalid entityType or entityId' });
   }
 
-  return listLinks(await getDatabase(), entityType, entityId);
+  const db = await getDatabase();
+  const projectId = await resolveLinkEntityProjectId(db, entityType, entityId);
+  if (!projectId) throw createError({ statusCode: 404, message: 'Entity not found' });
+  await requireProjectAccess(event, projectId);
+
+  return listLinks(db, entityType, entityId);
 });

--- a/application/server/api/links/index.post.ts
+++ b/application/server/api/links/index.post.ts
@@ -1,4 +1,4 @@
-import { requireAuth } from '../../utils/auth';
+import { requireProjectAccess, resolveLinkEntityProjectId } from '../../utils/project-access';
 import { getDatabase } from '../../database';
 import { entityLinks } from '../../database/schema';
 import { eq } from 'drizzle-orm';
@@ -24,8 +24,6 @@ const createLinkSchema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
-
   const body = await readBody(event);
   const validation = createLinkSchema.safeParse(body);
 
@@ -39,6 +37,10 @@ export default eventHandler(async (event) => {
 
   const { entityType, entityId, url, title } = validation.data;
   const db = await getDatabase();
+
+  const projectId = await resolveLinkEntityProjectId(db, entityType, entityId);
+  if (!projectId) throw createError({ statusCode: 404, message: 'Entity not found' });
+  await requireProjectAccess(event, projectId);
 
   let result: { link: any };
   try {

--- a/application/server/api/notifications/stream.get.ts
+++ b/application/server/api/notifications/stream.get.ts
@@ -1,5 +1,6 @@
 import { eq, and, or, isNull, lte } from 'drizzle-orm';
 import { requireAuth, isAuthEnabled } from '../../utils/auth';
+import { getProjectScope, scopeAllows } from '../../utils/project-access';
 import { runEventBus } from '../../utils/run-events';
 import { createSSEEndpoint } from '../../utils/sse';
 import { getDatabase } from '../../database';
@@ -8,32 +9,50 @@ import { notificationChannels, subscriptions } from '../../database/schema';
 export default eventHandler(async (event) => {
   const user = await requireAuth(event);
 
-  if (isAuthEnabled()) {
-    const db = await getDatabase();
-    const now = new Date();
-
-    const rows = await db
-      .select({ id: subscriptions.id })
-      .from(subscriptions)
-      .innerJoin(notificationChannels, eq(subscriptions.channelId, notificationChannels.id))
-      .where(
-        and(
-          eq(notificationChannels.type, 'browser'),
-          eq(subscriptions.userId, user.id),
-          eq(subscriptions.active, true),
-          or(isNull(subscriptions.mutedUntil), lte(subscriptions.mutedUntil, now)),
-        ),
-      )
-      .limit(1);
-
-    if (rows.length === 0) {
-      setResponseHeaders(event, { 'Content-Type': 'text/event-stream' });
-      return new Response('', { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
-    }
+  // With auth disabled the instance is single-user, so there is no cross-project
+  // boundary to enforce — stream every notification as before.
+  if (!isAuthEnabled()) {
+    return createSSEEndpoint(event, (controller, encoder) =>
+      runEventBus.subscribeNotifications((notificationEvent) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(notificationEvent)}\n\n`));
+        } catch {
+          // Stream closed — unsubscribe is handled by SSE helper
+        }
+      }),
+    );
   }
+
+  const db = await getDatabase();
+  const now = new Date();
+
+  const rows = await db
+    .select({ id: subscriptions.id })
+    .from(subscriptions)
+    .innerJoin(notificationChannels, eq(subscriptions.channelId, notificationChannels.id))
+    .where(
+      and(
+        eq(notificationChannels.type, 'browser'),
+        eq(subscriptions.userId, user.id),
+        eq(subscriptions.active, true),
+        or(isNull(subscriptions.mutedUntil), lte(subscriptions.mutedUntil, now)),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0) {
+    setResponseHeaders(event, { 'Content-Type': 'text/event-stream' });
+    return new Response('', { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+  }
+
+  // Compute the caller's project scope once for the life of the connection, and
+  // never stream an event for a project they cannot access.
+  const scope = await getProjectScope(db, user);
 
   return createSSEEndpoint(event, (controller, encoder) => {
     return runEventBus.subscribeNotifications((notificationEvent) => {
+      const projectId = notificationEvent.projectId as number | undefined;
+      if (typeof projectId === 'number' && !scopeAllows(scope, projectId)) return;
       try {
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(notificationEvent)}\n\n`));
       } catch {

--- a/application/server/api/stream.get.ts
+++ b/application/server/api/stream.get.ts
@@ -1,4 +1,6 @@
 import { requireAuth } from '../utils/auth';
+import { getDatabase } from '../database';
+import { getProjectScope, scopeAllows } from '../utils/project-access';
 import { runEventBus } from '../utils/run-events';
 import { createSSEEndpoint } from '../utils/sse';
 
@@ -12,9 +14,17 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
+  const user = await requireAuth(event);
+  // The global run bus carries lifecycle events for every project. Compute the
+  // caller's project scope once per connection and filter the fan-out to it, so
+  // a user never receives run metadata (run id, project id, status) for projects
+  // they cannot access. With auth disabled the instance is single-user (scope
+  // 'all'), so nothing is filtered.
+  const db = await getDatabase();
+  const scope = await getProjectScope(db, user);
   return createSSEEndpoint(event, (controller, encoder) => {
     return runEventBus.subscribeGlobal((globalEvent) => {
+      if (!scopeAllows(scope, globalEvent.projectId)) return;
       try {
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(globalEvent)}\n\n`));
       } catch {

--- a/application/server/api/subscriptions/index.post.ts
+++ b/application/server/api/subscriptions/index.post.ts
@@ -1,6 +1,7 @@
 import { getDatabase } from '../../database';
 import { subscriptions, notificationChannels } from '../../database/schema';
 import { requireAuth, isAuthEnabled } from '../../utils/auth';
+import { getProjectScope, scopeAllows } from '../../utils/project-access';
 import { NOTIFICATION_EVENTS } from '#shared/notification-events';
 import { Role } from '#shared/types';
 import { z } from 'zod';
@@ -54,6 +55,22 @@ export default eventHandler(async (event) => {
   const isAdmin = user.role === Role.ADMINISTRATOR;
   if (channel.userId !== null && channel.userId !== user.id && !isAdmin) {
     throw createError({ statusCode: 403, message: "Cannot subscribe to another user's channel" });
+  }
+
+  // Only let the caller subscribe to projects they can access. A null projectId
+  // is a wildcard across every project, so it is reserved for global scope —
+  // otherwise notifications (failing-test titles, files, error excerpts) would
+  // leak from projects the subscriber is not a member of.
+  const scope = await getProjectScope(db, user);
+  if (projectId == null) {
+    if (scope !== 'all') {
+      throw createError({
+        statusCode: 403,
+        message: 'Only users with access to all projects can subscribe to every project',
+      });
+    }
+  } else if (!scopeAllows(scope, projectId)) {
+    throw createError({ statusCode: 403, message: 'No access to this project' });
   }
 
   const [sub] = await db

--- a/application/server/api/test-runs/[id]/begin.post.ts
+++ b/application/server/api/test-runs/[id]/begin.post.ts
@@ -6,6 +6,7 @@ import { cancelInstanceRuns } from '../../../utils/cancel-instance-runs';
 import { sanitizeMetadata } from '../../../utils/sanitize';
 import { runEventBus } from '../../../utils/run-events';
 import { persistShardToken } from '../../../utils/shard-tokens';
+import { timingSafeEqualStr } from '../../../utils/timing-safe';
 
 defineRouteMeta({
   openAPI: {
@@ -80,7 +81,7 @@ export default eventHandler(async (event) => {
   // For sharded runs, accept the setup token from the shardTokens set
   const isValidShardSetupToken = isSharded && runEventBus.isValidShardToken(id, body.setupToken);
 
-  if (testRun.streamToken !== body.setupToken && !isValidShardSetupToken) {
+  if (!timingSafeEqualStr(testRun.streamToken ?? '', body.setupToken) && !isValidShardSetupToken) {
     throw createError({
       statusCode: 403,
       message: 'Invalid setup token',

--- a/application/server/api/traces/check.post.ts
+++ b/application/server/api/traces/check.post.ts
@@ -2,6 +2,7 @@ import { getDatabase } from '../../database';
 import { projects } from '../../database/schema';
 import { eq } from 'drizzle-orm';
 import { requireAuth } from '../../utils/auth';
+import { canAccessProject } from '../../utils/project-access';
 import { checkExistingBlobs } from '../../utils/trace-blobs';
 
 defineRouteMeta({
@@ -15,7 +16,7 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
+  const user = await requireAuth(event);
 
   const body = await readBody(event);
   const projectName = body?.projectName as string | undefined;
@@ -35,8 +36,11 @@ export default eventHandler(async (event) => {
   const projectRows = await db.select({ id: projects.id }).from(projects).where(eq(projects.name, projectName));
   const project = projectRows[0];
 
-  // Unknown project → all hashes are missing
-  if (!project) {
+  // Unknown project — or one the caller cannot access — returns all-missing, so
+  // this endpoint can't be used as a cross-project oracle for blob (or project)
+  // existence. With auth disabled the instance is single-user, so access is
+  // granted and behavior is unchanged.
+  if (!project || !(await canAccessProject(db, user, project.id))) {
     return { existing: [], missing: validHashes };
   }
 

--- a/application/server/api/users/[id].patch.ts
+++ b/application/server/api/users/[id].patch.ts
@@ -1,6 +1,6 @@
 import { getDatabase } from '../../database';
 import { updateUserRecord } from '#shared/handlers/users';
-import { requireAuth } from '../../utils/auth';
+import { requireAuth, revokeUserSessions } from '../../utils/auth';
 import { Role } from '#shared/types';
 import { z } from 'zod';
 
@@ -22,7 +22,7 @@ const schema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  const currentUser = await requireAuth(event, []);
+  const currentUser = await requireAuth(event);
 
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) throw createError({ statusCode: 400, message: 'Invalid user ID' });
@@ -48,6 +48,10 @@ export default eventHandler(async (event) => {
   try {
     const user = await updateUserRecord(await getDatabase(), id, parsed.data);
     if (!user) throw createError({ statusCode: 404, message: 'User not found' });
+    // A role change takes effect immediately by revoking the user's sessions.
+    if (parsed.data.role !== undefined) {
+      await revokeUserSessions(id);
+    }
     return {
       success: true,
       user: { id: user.id, username: user.username, role: user.role as Role, name: user.name, email: user.email },

--- a/application/server/database/migrations-pg/0045_loose_runaways.sql
+++ b/application/server/database/migrations-pg/0045_loose_runaways.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "session_epoch" integer DEFAULT 0 NOT NULL;

--- a/application/server/database/migrations-pg/meta/0045_snapshot.json
+++ b/application/server/database/migrations-pg/meta/0045_snapshot.json
@@ -1,0 +1,4480 @@
+{
+  "id": "c771ddae-f632-4a23-bfaf-99fa617e8076",
+  "prevId": "45a73bc0-3856-4c87-8fd5-54cb9eaf3798",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_tokens": {
+      "name": "account_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_account_tokens_hash": {
+          "name": "idx_account_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_user": {
+          "name": "idx_account_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_tokens_user_id_users_id_fk": {
+          "name": "account_tokens_user_id_users_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_payloads": {
+      "name": "case_payloads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_case_payloads_project_hash": {
+          "name": "idx_case_payloads_project_hash",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_payloads_project_id_projects_id_fk": {
+          "name": "case_payloads_project_id_projects_id_fk",
+          "tableFrom": "case_payloads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_merge_suggestions": {
+      "name": "cluster_merge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_a_id": {
+          "name": "cluster_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_b_id": {
+          "name": "cluster_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_confidence": {
+          "name": "llm_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_reason": {
+          "name": "llm_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_cluster_merge_suggestions_pair": {
+          "name": "idx_cluster_merge_suggestions_pair",
+          "columns": [
+            {
+              "expression": "cluster_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cluster_merge_suggestions_project_status": {
+          "name": "idx_cluster_merge_suggestions_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cluster_merge_suggestions_cluster_b": {
+          "name": "idx_cluster_merge_suggestions_cluster_b",
+          "columns": [
+            {
+              "expression": "cluster_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cluster_merge_suggestions_project_id_projects_id_fk": {
+          "name": "cluster_merge_suggestions_project_id_projects_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_links": {
+      "name": "entity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_text": {
+          "name": "status_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unfurled_at": {
+          "name": "unfurled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_entity_links_run": {
+          "name": "idx_entity_links_run",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entity_links_case_run": {
+          "name": "idx_entity_links_case_run",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entity_links_case": {
+          "name": "idx_entity_links_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entity_links_created_by": {
+          "name": "idx_entity_links_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_links_test_run_id_test_runs_id_fk": {
+          "name": "entity_links_test_run_id_test_runs_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "entity_links_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_case_id_test_cases_id_fk": {
+          "name": "entity_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_created_by_users_id_fk": {
+          "name": "entity_links_created_by_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_cluster_aliases": {
+      "name": "failure_cluster_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_failure_cluster_aliases_project_fingerprint": {
+          "name": "idx_failure_cluster_aliases_project_fingerprint",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_cluster_aliases_cluster": {
+          "name": "idx_failure_cluster_aliases_cluster",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_cluster_aliases_project_id_projects_id_fk": {
+          "name": "failure_cluster_aliases_project_id_projects_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_cluster_aliases_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_cluster_aliases_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_clusters": {
+      "name": "failure_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_error": {
+          "name": "sample_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_run_id": {
+          "name": "first_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "triage_note": {
+          "name": "triage_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_base_commit": {
+          "name": "manual_base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_landed_run_id": {
+          "name": "fix_landed_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_landed_at": {
+          "name": "fix_landed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_commit": {
+          "name": "fix_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_resolution_ms": {
+          "name": "time_to_resolution_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_verification": {
+          "name": "fix_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_failure_clusters_project_fingerprint": {
+          "name": "idx_failure_clusters_project_fingerprint",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_clusters_project_last_seen": {
+          "name": "idx_failure_clusters_project_last_seen",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_clusters_project_status": {
+          "name": "idx_failure_clusters_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_clusters_project_id_projects_id_fk": {
+          "name": "failure_clusters_project_id_projects_id_fk",
+          "tableFrom": "failure_clusters",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_diagnoses": {
+      "name": "failure_diagnoses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_failure_diagnoses_cluster_scope": {
+          "name": "idx_failure_diagnoses_cluster_scope",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_diagnoses_execution": {
+          "name": "idx_failure_diagnoses_execution",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnoses_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnoses_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_diagnosis_versions": {
+      "name": "failure_diagnosis_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_fdv_diagnosis_id": {
+          "name": "idx_fdv_diagnosis_id",
+          "columns": [
+            {
+              "expression": "diagnosis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fdv_cluster_id": {
+          "name": "idx_fdv_cluster_id",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fdv_test_runs_case": {
+          "name": "idx_fdv_test_runs_case",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk": {
+          "name": "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_diagnoses",
+          "columnsFrom": ["diagnosis_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_id": {
+          "name": "blob_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_files_test_run_id": {
+          "name": "idx_files_test_run_id",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_test_runs_case_id": {
+          "name": "idx_files_test_runs_case_id",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_blob_id": {
+          "name": "idx_files_blob_id",
+          "columns": [
+            {
+              "expression": "blob_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_test_run_id_test_runs_id_fk": {
+          "name": "files_test_run_id_test_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "files_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_blob_id_trace_blobs_id_fk": {
+          "name": "files_blob_id_trace_blobs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "trace_blobs",
+          "columnsFrom": ["blob_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locator_snapshots": {
+      "name": "locator_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_method": {
+          "name": "used_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_args": {
+          "name": "used_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_args_fp": {
+          "name": "used_args_fp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_tag": {
+          "name": "element_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element_attrs": {
+          "name": "element_attrs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_text": {
+          "name": "element_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_locator_snapshots_location": {
+          "name": "idx_locator_snapshots_location",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locator_snapshots_fp": {
+          "name": "idx_locator_snapshots_fp",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_args_fp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locator_snapshots_last_seen_run": {
+          "name": "idx_locator_snapshots_last_seen_run",
+          "columns": [
+            {
+              "expression": "last_seen_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locator_snapshots_args_fp": {
+          "name": "idx_locator_snapshots_args_fp",
+          "columns": [
+            {
+              "expression": "used_args_fp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locator_snapshots_test_case_id_test_cases_id_fk": {
+          "name": "locator_snapshots_test_case_id_test_cases_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locator_snapshots_last_seen_run_id_test_runs_id_fk": {
+          "name": "locator_snapshots_last_seen_run_id_test_runs_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_runs",
+          "columnsFrom": ["last_seen_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.markers": {
+      "name": "markers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'event'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_markers_project_id": {
+          "name": "idx_markers_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_markers_project_occurred": {
+          "name": "idx_markers_project_occurred",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_markers_run_id": {
+          "name": "idx_markers_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "markers_project_id_projects_id_fk": {
+          "name": "markers_project_id_projects_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "markers_run_id_test_runs_id_fk": {
+          "name": "markers_run_id_test_runs_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "test_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_requests": {
+      "name": "network_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_logs": {
+          "name": "server_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_traces": {
+          "name": "server_traces",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_nr_run": {
+          "name": "idx_nr_run",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nr_case": {
+          "name": "idx_nr_case",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nr_normalized_url": {
+          "name": "idx_nr_normalized_url",
+          "columns": [
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "network_requests_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "network_requests_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "network_requests_test_run_id_test_runs_id_fk": {
+          "name": "network_requests_test_run_id_test_runs_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_notification_channels_user": {
+          "name": "idx_notification_channels_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_users_id_fk": {
+          "name": "notification_channels_user_id_users_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_status": {
+          "name": "idx_notification_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_dedupe": {
+          "name": "idx_notification_deliveries_dedupe",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_subscription": {
+          "name": "idx_notification_deliveries_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_channel": {
+          "name": "idx_notification_deliveries_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_subscription_id_subscriptions_id_fk": {
+          "name": "notification_deliveries_subscription_id_subscriptions_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_channel_id_notification_channels_id_fk": {
+          "name": "notification_deliveries_channel_id_notification_channels_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_assignments": {
+      "name": "project_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_project_assignments_user": {
+          "name": "idx_project_assignments_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_assignments_project": {
+          "name": "idx_project_assignments_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_assignments_user_project": {
+          "name": "idx_project_assignments_user_project",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_assignments_created_by": {
+          "name": "idx_project_assignments_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_assignments_user_id_users_id_fk": {
+          "name": "project_assignments_user_id_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_project_id_projects_id_fk": {
+          "name": "project_assignments_project_id_projects_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_created_by_users_id_fk": {
+          "name": "project_assignments_created_by_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_tags": {
+      "name": "project_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_project_tags_project_id": {
+          "name": "idx_project_tags_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_tags_tag_id": {
+          "name": "idx_project_tags_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_tags_project_id_projects_id_fk": {
+          "name": "project_tags_project_id_projects_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tags_tag_id_tags_id_fk": {
+          "name": "project_tags_tag_id_tags_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_tags_project_id_tag_id_pk": {
+          "name": "project_tags_project_id_tag_id_pk",
+          "columns": ["project_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_instructions": {
+          "name": "diagnosis_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scm_token": {
+          "name": "scm_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quarantined_tests": {
+      "name": "quarantined_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "quarantined_at_run_id": {
+          "name": "quarantined_at_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_reason": {
+          "name": "released_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_quarantined_tests_project": {
+          "name": "idx_quarantined_tests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quarantined_tests_created_by": {
+          "name": "idx_quarantined_tests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quarantined_tests_active": {
+          "name": "idx_quarantined_tests_active",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "released_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quarantined_tests_project_id_projects_id_fk": {
+          "name": "quarantined_tests_project_id_projects_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_test_case_id_test_cases_id_fk": {
+          "name": "quarantined_tests_test_case_id_test_cases_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_created_by_users_id_fk": {
+          "name": "quarantined_tests_created_by_users_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'realtime'"
+        },
+        "digest_at": {
+          "name": "digest_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_project": {
+          "name": "idx_subscriptions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user": {
+          "name": "idx_subscriptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_channel": {
+          "name": "idx_subscriptions_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_channel_id_notification_channels_id_fk": {
+          "name": "subscriptions_channel_id_notification_channels_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_project_id_projects_id_fk": {
+          "name": "subscriptions_project_id_projects_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tags_updated_at": {
+          "name": "idx_tags_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_text_unique": {
+          "name": "tags_text_unique",
+          "nullsNotDistinct": false,
+          "columns": ["text"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flaky_root_cause": {
+          "name": "flaky_root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_cases_project_id": {
+          "name": "idx_test_cases_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_cases_file_path_title": {
+          "name": "idx_test_cases_file_path_title",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suite_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_cases_suite": {
+          "name": "idx_test_cases_suite",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_cases_owner": {
+          "name": "idx_test_cases_owner",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_suite_id_test_suites_id_fk": {
+          "name": "test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": ["suite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_functions": {
+      "name": "test_functions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver": {
+          "name": "receiver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_name": {
+          "name": "import_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returns_page": {
+          "name": "returns_page",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "url_pattern": {
+          "name": "url_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "param_sources": {
+          "name": "param_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_functions_project_id": {
+          "name": "idx_test_functions_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_functions_project_module_name": {
+          "name": "idx_test_functions_project_module_name",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_functions_project_id_projects_id_fk": {
+          "name": "test_functions_project_id_projects_id_fk",
+          "tableFrom": "test_functions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tests": {
+          "name": "total_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "passed_tests": {
+          "name": "passed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_tests": {
+          "name": "failed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_tests": {
+          "name": "skipped_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "did_not_run_tests": {
+          "name": "did_not_run_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "flaky_tests": {
+          "name": "flaky_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_test_duration": {
+          "name": "avg_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "p90_test_duration": {
+          "name": "p90_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_total": {
+          "name": "shard_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shards_finished": {
+          "name": "shards_finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_full_run": {
+          "name": "is_full_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "filter_details": {
+          "name": "filter_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_steps": {
+          "name": "setup_steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_token": {
+          "name": "stream_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playwright_version": {
+          "name": "playwright_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_version": {
+          "name": "reporter_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_hash": {
+          "name": "import_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_test_runs_project_id": {
+          "name": "idx_test_runs_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_project_start": {
+          "name": "idx_test_runs_project_start",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_start_time": {
+          "name": "idx_test_runs_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_status": {
+          "name": "idx_test_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_import_hash": {
+          "name": "idx_test_runs_import_hash",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs_cases": {
+      "name": "test_runs_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_cluster_id": {
+          "name": "failure_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_events": {
+          "name": "step_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slowest_step": {
+          "name": "slowest_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slowest_step_duration": {
+          "name": "slowest_step_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wasted_time_ms": {
+          "name": "wasted_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_vitals": {
+          "name": "web_vitals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_state": {
+          "name": "page_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_logs": {
+          "name": "console_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aria_snapshot": {
+          "name": "aria_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source": {
+          "name": "test_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source_frames": {
+          "name": "test_source_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aria_snapshot_payload_id": {
+          "name": "aria_snapshot_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source_payload_id": {
+          "name": "test_source_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source_frames_payload_id": {
+          "name": "test_source_frames_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_annotations": {
+          "name": "test_annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_meta": {
+          "name": "test_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_index": {
+          "name": "worker_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_index": {
+          "name": "shard_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_regression": {
+          "name": "is_new_regression",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_flaky": {
+          "name": "is_new_flaky",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_runs_cases_test_run_id": {
+          "name": "idx_test_runs_cases_test_run_id",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_cases_case_created": {
+          "name": "idx_test_runs_cases_case_created",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_cases_failure_cluster_id": {
+          "name": "idx_test_runs_cases_failure_cluster_id",
+          "columns": [
+            {
+              "expression": "failure_cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_cases_run_browser": {
+          "name": "idx_test_runs_cases_run_browser",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retries",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "browser_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trc_aria_payload": {
+          "name": "idx_trc_aria_payload",
+          "columns": [
+            {
+              "expression": "aria_snapshot_payload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "aria_snapshot_payload_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trc_source_payload": {
+          "name": "idx_trc_source_payload",
+          "columns": [
+            {
+              "expression": "test_source_payload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "test_source_payload_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trc_frames_payload": {
+          "name": "idx_trc_frames_payload",
+          "columns": [
+            {
+              "expression": "test_source_frames_payload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "test_source_frames_payload_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_runs_cases_test_run_id_test_runs_id_fk": {
+          "name": "test_runs_cases_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_case_id_test_cases_id_fk": {
+          "name": "test_runs_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_failure_cluster_id_failure_clusters_id_fk": {
+          "name": "test_runs_cases_failure_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["failure_cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["aria_snapshot_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_frames_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_suites_unique": {
+          "name": "idx_test_suites_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suite_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trace_blobs": {
+      "name": "trace_blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trace_blobs_project_hash": {
+          "name": "idx_trace_blobs_project_hash",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trace_blobs_project_id_projects_id_fk": {
+          "name": "trace_blobs_project_id_projects_id_fk",
+          "tableFrom": "trace_blobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trace_resources": {
+      "name": "trace_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trace_resources_project_name": {
+          "name": "idx_trace_resources_project_name",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trace_resources_project_id_projects_id_fk": {
+          "name": "trace_resources_project_id_projects_id_fk",
+          "tableFrom": "trace_resources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_id": {
+          "name": "oauth_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_epoch": {
+          "name": "session_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_users_oauth": {
+          "name": "idx_users_oauth",
+          "columns": [
+            {
+              "expression": "oauth_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/application/server/database/migrations-pg/meta/_journal.json
+++ b/application/server/database/migrations-pg/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1785276301735,
       "tag": "0044_dark_triathlon",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1785430068658,
+      "tag": "0045_loose_runaways",
+      "breakpoints": true
     }
   ]
 }

--- a/application/server/database/migrations/0044_panoramic_eddie_brock.sql
+++ b/application/server/database/migrations/0044_panoramic_eddie_brock.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `session_epoch` integer DEFAULT 0 NOT NULL;

--- a/application/server/database/migrations/meta/0044_snapshot.json
+++ b/application/server/database/migrations/meta/0044_snapshot.json
@@ -1,0 +1,3772 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2eb9ec9b-ad4c-401d-b54d-b9dea2e67cd9",
+  "prevId": "aa26912a-cbc3-4a29-a5e8-92014a5762e3",
+  "tables": {
+    "account_tokens": {
+      "name": "account_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_tokens_hash": {
+          "name": "idx_account_tokens_hash",
+          "columns": ["token_hash"],
+          "isUnique": true
+        },
+        "idx_account_tokens_user": {
+          "name": "idx_account_tokens_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_tokens_user_id_users_id_fk": {
+          "name": "account_tokens_user_id_users_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        },
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "case_payloads": {
+      "name": "case_payloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_case_payloads_project_hash": {
+          "name": "idx_case_payloads_project_hash",
+          "columns": ["project_id", "hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "case_payloads_project_id_projects_id_fk": {
+          "name": "case_payloads_project_id_projects_id_fk",
+          "tableFrom": "case_payloads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cluster_merge_suggestions": {
+      "name": "cluster_merge_suggestions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_a_id": {
+          "name": "cluster_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_b_id": {
+          "name": "cluster_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_confidence": {
+          "name": "llm_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_reason": {
+          "name": "llm_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cluster_merge_suggestions_pair": {
+          "name": "idx_cluster_merge_suggestions_pair",
+          "columns": ["cluster_a_id", "cluster_b_id"],
+          "isUnique": true
+        },
+        "idx_cluster_merge_suggestions_project_status": {
+          "name": "idx_cluster_merge_suggestions_project_status",
+          "columns": ["project_id", "status"],
+          "isUnique": false
+        },
+        "idx_cluster_merge_suggestions_cluster_b": {
+          "name": "idx_cluster_merge_suggestions_cluster_b",
+          "columns": ["cluster_b_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cluster_merge_suggestions_project_id_projects_id_fk": {
+          "name": "cluster_merge_suggestions_project_id_projects_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_links": {
+      "name": "entity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'generic'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_text": {
+          "name": "status_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unfurled_at": {
+          "name": "unfurled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_entity_links_run": {
+          "name": "idx_entity_links_run",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_entity_links_case_run": {
+          "name": "idx_entity_links_case_run",
+          "columns": ["test_runs_case_id"],
+          "isUnique": false
+        },
+        "idx_entity_links_case": {
+          "name": "idx_entity_links_case",
+          "columns": ["test_case_id"],
+          "isUnique": false
+        },
+        "idx_entity_links_created_by": {
+          "name": "idx_entity_links_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_links_test_run_id_test_runs_id_fk": {
+          "name": "entity_links_test_run_id_test_runs_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "entity_links_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_case_id_test_cases_id_fk": {
+          "name": "entity_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_created_by_users_id_fk": {
+          "name": "entity_links_created_by_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_cluster_aliases": {
+      "name": "failure_cluster_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failure_cluster_aliases_project_fingerprint": {
+          "name": "idx_failure_cluster_aliases_project_fingerprint",
+          "columns": ["project_id", "fingerprint"],
+          "isUnique": true
+        },
+        "idx_failure_cluster_aliases_cluster": {
+          "name": "idx_failure_cluster_aliases_cluster",
+          "columns": ["cluster_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_cluster_aliases_project_id_projects_id_fk": {
+          "name": "failure_cluster_aliases_project_id_projects_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_cluster_aliases_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_cluster_aliases_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_clusters": {
+      "name": "failure_clusters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_error": {
+          "name": "sample_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_run_id": {
+          "name": "first_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "triage_note": {
+          "name": "triage_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manual_base_commit": {
+          "name": "manual_base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_landed_run_id": {
+          "name": "fix_landed_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_landed_at": {
+          "name": "fix_landed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_commit": {
+          "name": "fix_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_resolution_ms": {
+          "name": "time_to_resolution_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_verification": {
+          "name": "fix_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failure_clusters_project_fingerprint": {
+          "name": "idx_failure_clusters_project_fingerprint",
+          "columns": ["project_id", "fingerprint"],
+          "isUnique": true
+        },
+        "idx_failure_clusters_project_last_seen": {
+          "name": "idx_failure_clusters_project_last_seen",
+          "columns": ["project_id", "last_seen_run_id"],
+          "isUnique": false
+        },
+        "idx_failure_clusters_project_status": {
+          "name": "idx_failure_clusters_project_status",
+          "columns": ["project_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_clusters_project_id_projects_id_fk": {
+          "name": "failure_clusters_project_id_projects_id_fk",
+          "tableFrom": "failure_clusters",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_diagnoses": {
+      "name": "failure_diagnoses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failure_diagnoses_cluster_scope": {
+          "name": "idx_failure_diagnoses_cluster_scope",
+          "columns": ["cluster_id", "scope"],
+          "isUnique": true
+        },
+        "idx_failure_diagnoses_execution": {
+          "name": "idx_failure_diagnoses_execution",
+          "columns": ["test_runs_case_id", "scope"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnoses_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnoses_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_diagnosis_versions": {
+      "name": "failure_diagnosis_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_fdv_diagnosis_id": {
+          "name": "idx_fdv_diagnosis_id",
+          "columns": ["diagnosis_id"],
+          "isUnique": false
+        },
+        "idx_fdv_cluster_id": {
+          "name": "idx_fdv_cluster_id",
+          "columns": ["cluster_id"],
+          "isUnique": false
+        },
+        "idx_fdv_test_runs_case": {
+          "name": "idx_fdv_test_runs_case",
+          "columns": ["test_runs_case_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk": {
+          "name": "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_diagnoses",
+          "columnsFrom": ["diagnosis_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob_id": {
+          "name": "blob_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_files_test_run_id": {
+          "name": "idx_files_test_run_id",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_files_test_runs_case_id": {
+          "name": "idx_files_test_runs_case_id",
+          "columns": ["test_runs_case_id"],
+          "isUnique": false
+        },
+        "idx_files_blob_id": {
+          "name": "idx_files_blob_id",
+          "columns": ["blob_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "files_test_run_id_test_runs_id_fk": {
+          "name": "files_test_run_id_test_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "files_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_blob_id_trace_blobs_id_fk": {
+          "name": "files_blob_id_trace_blobs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "trace_blobs",
+          "columnsFrom": ["blob_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locator_snapshots": {
+      "name": "locator_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_method": {
+          "name": "used_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_args": {
+          "name": "used_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_args_fp": {
+          "name": "used_args_fp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element_tag": {
+          "name": "element_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "element_attrs": {
+          "name": "element_attrs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element_text": {
+          "name": "element_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_locator_snapshots_location": {
+          "name": "idx_locator_snapshots_location",
+          "columns": ["test_case_id", "location"],
+          "isUnique": true
+        },
+        "idx_locator_snapshots_fp": {
+          "name": "idx_locator_snapshots_fp",
+          "columns": ["test_case_id", "used_method", "used_args_fp"],
+          "isUnique": false
+        },
+        "idx_locator_snapshots_args_fp": {
+          "name": "idx_locator_snapshots_args_fp",
+          "columns": ["used_args_fp"],
+          "isUnique": false
+        },
+        "idx_locator_snapshots_last_seen_run": {
+          "name": "idx_locator_snapshots_last_seen_run",
+          "columns": ["last_seen_run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "locator_snapshots_test_case_id_test_cases_id_fk": {
+          "name": "locator_snapshots_test_case_id_test_cases_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locator_snapshots_last_seen_run_id_test_runs_id_fk": {
+          "name": "locator_snapshots_last_seen_run_id_test_runs_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_runs",
+          "columnsFrom": ["last_seen_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "markers": {
+      "name": "markers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'event'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_markers_project_id": {
+          "name": "idx_markers_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_markers_project_occurred": {
+          "name": "idx_markers_project_occurred",
+          "columns": ["project_id", "occurred_at"],
+          "isUnique": false
+        },
+        "idx_markers_run_id": {
+          "name": "idx_markers_run_id",
+          "columns": ["run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "markers_project_id_projects_id_fk": {
+          "name": "markers_project_id_projects_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "markers_run_id_test_runs_id_fk": {
+          "name": "markers_run_id_test_runs_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "test_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "network_requests": {
+      "name": "network_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_logs": {
+          "name": "server_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_traces": {
+          "name": "server_traces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_nr_run": {
+          "name": "idx_nr_run",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_nr_case": {
+          "name": "idx_nr_case",
+          "columns": ["test_runs_case_id", "status"],
+          "isUnique": false
+        },
+        "idx_nr_normalized_url": {
+          "name": "idx_nr_normalized_url",
+          "columns": ["normalized_url"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "network_requests_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "network_requests_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "network_requests_test_run_id_test_runs_id_fk": {
+          "name": "network_requests_test_run_id_test_runs_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_channels": {
+      "name": "notification_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notification_channels_user": {
+          "name": "idx_notification_channels_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_users_id_fk": {
+          "name": "notification_channels_user_id_users_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_deliveries": {
+      "name": "notification_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_status": {
+          "name": "idx_notification_deliveries_status",
+          "columns": ["status", "scheduled_for"],
+          "isUnique": false
+        },
+        "idx_notification_deliveries_dedupe": {
+          "name": "idx_notification_deliveries_dedupe",
+          "columns": ["dedupe_key"],
+          "isUnique": true
+        },
+        "idx_notification_deliveries_subscription": {
+          "name": "idx_notification_deliveries_subscription",
+          "columns": ["subscription_id"],
+          "isUnique": false
+        },
+        "idx_notification_deliveries_channel": {
+          "name": "idx_notification_deliveries_channel",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_subscription_id_subscriptions_id_fk": {
+          "name": "notification_deliveries_subscription_id_subscriptions_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_channel_id_notification_channels_id_fk": {
+          "name": "notification_deliveries_channel_id_notification_channels_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_assignments": {
+      "name": "project_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_assignments_user": {
+          "name": "idx_project_assignments_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_project_assignments_project": {
+          "name": "idx_project_assignments_project",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_project_assignments_user_project": {
+          "name": "idx_project_assignments_user_project",
+          "columns": ["user_id", "project_id"],
+          "isUnique": true
+        },
+        "idx_project_assignments_created_by": {
+          "name": "idx_project_assignments_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_assignments_user_id_users_id_fk": {
+          "name": "project_assignments_user_id_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_project_id_projects_id_fk": {
+          "name": "project_assignments_project_id_projects_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_created_by_users_id_fk": {
+          "name": "project_assignments_created_by_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_tags": {
+      "name": "project_tags",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_tags_project_id": {
+          "name": "idx_project_tags_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_project_tags_tag_id": {
+          "name": "idx_project_tags_tag_id",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_tags_project_id_projects_id_fk": {
+          "name": "project_tags_project_id_projects_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tags_tag_id_tags_id_fk": {
+          "name": "project_tags_tag_id_tags_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_tags_project_id_tag_id_pk": {
+          "columns": ["project_id", "tag_id"],
+          "name": "project_tags_project_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diagnosis_instructions": {
+          "name": "diagnosis_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scm_token": {
+          "name": "scm_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quarantined_tests": {
+      "name": "quarantined_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "quarantined_at_run_id": {
+          "name": "quarantined_at_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "released_reason": {
+          "name": "released_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quarantined_tests_project": {
+          "name": "idx_quarantined_tests_project",
+          "columns": ["project_id", "released_at"],
+          "isUnique": false
+        },
+        "idx_quarantined_tests_created_by": {
+          "name": "idx_quarantined_tests_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        },
+        "idx_quarantined_tests_active": {
+          "name": "idx_quarantined_tests_active",
+          "columns": ["test_case_id"],
+          "isUnique": true,
+          "where": "released_at IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "quarantined_tests_project_id_projects_id_fk": {
+          "name": "quarantined_tests_project_id_projects_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_test_case_id_test_cases_id_fk": {
+          "name": "quarantined_tests_test_case_id_test_cases_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_created_by_users_id_fk": {
+          "name": "quarantined_tests_created_by_users_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'realtime'"
+        },
+        "digest_at": {
+          "name": "digest_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_project": {
+          "name": "idx_subscriptions_project",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_subscriptions_user": {
+          "name": "idx_subscriptions_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_subscriptions_channel": {
+          "name": "idx_subscriptions_channel",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_channel_id_notification_channels_id_fk": {
+          "name": "subscriptions_channel_id_notification_channels_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_project_id_projects_id_fk": {
+          "name": "subscriptions_project_id_projects_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'neutral'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_text_unique": {
+          "name": "tags_text_unique",
+          "columns": ["text"],
+          "isUnique": true
+        },
+        "idx_tags_updated_at": {
+          "name": "idx_tags_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flaky_root_cause": {
+          "name": "flaky_root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_cases_project_id": {
+          "name": "idx_test_cases_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_test_cases_file_path_title": {
+          "name": "idx_test_cases_file_path_title",
+          "columns": ["project_id", "file_path", "suite_path", "title"],
+          "isUnique": false
+        },
+        "idx_test_cases_suite": {
+          "name": "idx_test_cases_suite",
+          "columns": ["suite_id"],
+          "isUnique": false
+        },
+        "idx_test_cases_owner": {
+          "name": "idx_test_cases_owner",
+          "columns": ["project_id", "owner"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_suite_id_test_suites_id_fk": {
+          "name": "test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": ["suite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_functions": {
+      "name": "test_functions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiver": {
+          "name": "receiver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "import_name": {
+          "name": "import_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "returns_page": {
+          "name": "returns_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_pattern": {
+          "name": "url_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "param_sources": {
+          "name": "param_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_functions_project_id": {
+          "name": "idx_test_functions_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_test_functions_project_module_name": {
+          "name": "idx_test_functions_project_module_name",
+          "columns": ["project_id", "module", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "test_functions_project_id_projects_id_fk": {
+          "name": "test_functions_project_id_projects_id_fk",
+          "tableFrom": "test_functions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_runs": {
+      "name": "test_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tests": {
+          "name": "total_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "passed_tests": {
+          "name": "passed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_tests": {
+          "name": "failed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_tests": {
+          "name": "skipped_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "did_not_run_tests": {
+          "name": "did_not_run_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "flaky_tests": {
+          "name": "flaky_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_test_duration": {
+          "name": "avg_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "p90_test_duration": {
+          "name": "p90_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shard_total": {
+          "name": "shard_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shards_finished": {
+          "name": "shards_finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_full_run": {
+          "name": "is_full_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "filter_details": {
+          "name": "filter_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "setup_steps": {
+          "name": "setup_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_token": {
+          "name": "stream_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playwright_version": {
+          "name": "playwright_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_version": {
+          "name": "reporter_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "import_hash": {
+          "name": "import_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_runs_project_id": {
+          "name": "idx_test_runs_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_test_runs_project_start": {
+          "name": "idx_test_runs_project_start",
+          "columns": ["project_id", "start_time"],
+          "isUnique": false
+        },
+        "idx_test_runs_start_time": {
+          "name": "idx_test_runs_start_time",
+          "columns": ["start_time"],
+          "isUnique": false
+        },
+        "idx_test_runs_status": {
+          "name": "idx_test_runs_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_test_runs_import_hash": {
+          "name": "idx_test_runs_import_hash",
+          "columns": ["project_id", "import_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_runs_cases": {
+      "name": "test_runs_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_cluster_id": {
+          "name": "failure_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_events": {
+          "name": "step_events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slowest_step": {
+          "name": "slowest_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slowest_step_duration": {
+          "name": "slowest_step_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wasted_time_ms": {
+          "name": "wasted_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "web_vitals": {
+          "name": "web_vitals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_state": {
+          "name": "page_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "console_logs": {
+          "name": "console_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aria_snapshot": {
+          "name": "aria_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source": {
+          "name": "test_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source_frames": {
+          "name": "test_source_frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aria_snapshot_payload_id": {
+          "name": "aria_snapshot_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source_payload_id": {
+          "name": "test_source_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source_frames_payload_id": {
+          "name": "test_source_frames_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_annotations": {
+          "name": "test_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_meta": {
+          "name": "test_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker_index": {
+          "name": "worker_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shard_index": {
+          "name": "shard_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new_regression": {
+          "name": "is_new_regression",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new_flaky": {
+          "name": "is_new_flaky",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_runs_cases_test_run_id": {
+          "name": "idx_test_runs_cases_test_run_id",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_test_runs_cases_case_created": {
+          "name": "idx_test_runs_cases_case_created",
+          "columns": ["test_case_id", "created_at"],
+          "isUnique": false
+        },
+        "idx_test_runs_cases_failure_cluster_id": {
+          "name": "idx_test_runs_cases_failure_cluster_id",
+          "columns": ["failure_cluster_id"],
+          "isUnique": false
+        },
+        "idx_test_runs_cases_run_browser": {
+          "name": "idx_test_runs_cases_run_browser",
+          "columns": ["test_run_id", "test_case_id", "retries", "browser_name"],
+          "isUnique": true
+        },
+        "idx_trc_aria_payload": {
+          "name": "idx_trc_aria_payload",
+          "columns": ["aria_snapshot_payload_id"],
+          "isUnique": false,
+          "where": "aria_snapshot_payload_id IS NOT NULL"
+        },
+        "idx_trc_source_payload": {
+          "name": "idx_trc_source_payload",
+          "columns": ["test_source_payload_id"],
+          "isUnique": false,
+          "where": "test_source_payload_id IS NOT NULL"
+        },
+        "idx_trc_frames_payload": {
+          "name": "idx_trc_frames_payload",
+          "columns": ["test_source_frames_payload_id"],
+          "isUnique": false,
+          "where": "test_source_frames_payload_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "test_runs_cases_test_run_id_test_runs_id_fk": {
+          "name": "test_runs_cases_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_case_id_test_cases_id_fk": {
+          "name": "test_runs_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_failure_cluster_id_failure_clusters_id_fk": {
+          "name": "test_runs_cases_failure_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["failure_cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["aria_snapshot_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_frames_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_suites": {
+      "name": "test_suites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_suites_unique": {
+          "name": "idx_test_suites_unique",
+          "columns": ["project_id", "file_path", "suite_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trace_blobs": {
+      "name": "trace_blobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trace_blobs_project_hash": {
+          "name": "idx_trace_blobs_project_hash",
+          "columns": ["project_id", "hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "trace_blobs_project_id_projects_id_fk": {
+          "name": "trace_blobs_project_id_projects_id_fk",
+          "tableFrom": "trace_blobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trace_resources": {
+      "name": "trace_resources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trace_resources_project_name": {
+          "name": "idx_trace_resources_project_name",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "trace_resources_project_id_projects_id_fk": {
+          "name": "trace_resources_project_id_projects_id_fk",
+          "tableFrom": "trace_resources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_id": {
+          "name": "oauth_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_epoch": {
+          "name": "session_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        },
+        "idx_users_oauth": {
+          "name": "idx_users_oauth",
+          "columns": ["oauth_provider", "oauth_provider_id"],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/server/database/migrations/meta/_journal.json
+++ b/application/server/database/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1785273985552,
       "tag": "0043_watery_dragon_lord",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "6",
+      "when": 1785430061283,
+      "tag": "0044_panoramic_eddie_brock",
+      "breakpoints": true
     }
   ]
 }

--- a/application/server/database/schema.pg.ts
+++ b/application/server/database/schema.pg.ts
@@ -715,6 +715,8 @@ export const users = pgTable(
     avatarUrl: text('avatar_url'), // Avatar from OAuth provider
     oauthProvider: text('oauth_provider'), // 'google', 'github', etc.
     oauthProviderId: text('oauth_provider_id'), // User ID from the OAuth provider
+    // Incremented to revoke all of a user's existing sessions (password change/reset, role change, unlink).
+    sessionEpoch: integer('session_epoch').notNull().default(0),
     createdAt: timestamp('created_at', { mode: 'date' })
       .notNull()
       .$defaultFn(() => new Date()),

--- a/application/server/database/schema.sqlite.ts
+++ b/application/server/database/schema.sqlite.ts
@@ -720,6 +720,8 @@ export const users = sqliteTable(
     avatarUrl: text('avatar_url'), // Avatar from OAuth provider
     oauthProvider: text('oauth_provider'), // 'google', 'github', etc.
     oauthProviderId: text('oauth_provider_id'), // User ID from the OAuth provider
+    // Incremented to revoke all of a user's existing sessions (password change/reset, role change, unlink).
+    sessionEpoch: integer('session_epoch').notNull().default(0),
     createdAt: integer('created_at', { mode: 'timestamp' })
       .notNull()
       .$defaultFn(() => new Date()),

--- a/application/server/middleware/desktop-guard.ts
+++ b/application/server/middleware/desktop-guard.ts
@@ -13,6 +13,8 @@
 // Combined with the loopback-only bind, this keeps the bundled server reachable
 // only by the app itself and by tools the user has given the token to — not by
 // other local processes or web pages open in the user's browser.
+import { timingSafeEqualStr } from '../utils/timing-safe';
+
 export default defineEventHandler((event) => {
   const token = process.env.PIWI_DESKTOP_TOKEN;
   if (!token) return; // not the desktop build — no-op
@@ -26,7 +28,7 @@ export default defineEventHandler((event) => {
   const authz = getRequestHeader(event, 'authorization');
   const bearer = authz && authz.startsWith('Bearer ') ? authz.slice('Bearer '.length) : undefined;
   const presented = getCookie(event, 'piwi_token') || getRequestHeader(event, 'x-piwi-token') || bearer;
-  if (presented === token) return;
+  if (presented && timingSafeEqualStr(presented, token)) return;
 
   throw createError({ statusCode: 401, statusMessage: 'Desktop access token required' });
 });

--- a/application/server/plugins/auth-config.ts
+++ b/application/server/plugins/auth-config.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_INSECURE_SECRET } from '../utils/crypto';
+
+// Fail closed at startup when authentication is enabled without a secure secret.
+//
+// An enabled dashboard whose session secret is missing or the built-in default
+// has forgeable administrator sessions, so the server refuses to start rather
+// than serve it. `PIWI_AUTH_*` from the runtime environment is authoritative:
+// on the published image the config is baked at build time (with the variables
+// unset), and server-side enforcement in `utils/auth.ts` reads the same env.
+export default defineNitroPlugin(() => {
+  const config = useRuntimeConfig();
+  const authEnabled = process.env.PIWI_AUTH_ENABLED === 'true' || String(config.authEnabled) === 'true';
+  if (!authEnabled) return;
+
+  const secret = process.env.PIWI_AUTH_SECRET || config.authSecret;
+  if (!secret || secret === DEFAULT_INSECURE_SECRET) {
+    throw new Error(
+      'Authentication is enabled but PIWI_AUTH_SECRET is missing or set to the built-in default. ' +
+        "Generate a strong value with node -e \"console.log(require('node:crypto').randomBytes(32).toString('hex'))\" " +
+        'and set PIWI_AUTH_SECRET before starting the server.',
+    );
+  }
+});

--- a/application/server/plugins/desktop-csp.ts
+++ b/application/server/plugins/desktop-csp.ts
@@ -1,0 +1,43 @@
+import { randomBytes } from 'node:crypto';
+
+// Content-Security-Policy for the desktop (Tauri) build only.
+//
+// The bundled dashboard is served to a webview that carries the native IPC
+// bridge (`window.__TAURI__`), so any script executing in this origin can drive
+// native commands. This policy gives injected script no way to run: inline
+// scripts are allowed only with the per-response nonce, `strict-dynamic` lets
+// the nonced entry load its chunks, and `connect-src 'self'` blocks
+// exfiltration to any other host. It is gated on `PIWI_DESKTOP_TOKEN`, so the
+// server / Docker / npx deployments (which are not in a native webview) are
+// unaffected.
+export default defineNitroPlugin((nitroApp) => {
+  if (!process.env.PIWI_DESKTOP_TOKEN) return;
+
+  nitroApp.hooks.hook('render:html', (html, { event }) => {
+    const nonce = randomBytes(16).toString('base64');
+    const addNonce = (parts: string[]) =>
+      parts.map((part) => part.replace(/<script(?![^>]*\bnonce=)/gi, `<script nonce="${nonce}"`));
+
+    html.head = addNonce(html.head);
+    html.bodyPrepend = addNonce(html.bodyPrepend);
+    html.body = addNonce(html.body);
+    html.bodyAppend = addNonce(html.bodyAppend);
+
+    setResponseHeader(
+      event,
+      'Content-Security-Policy',
+      [
+        "default-src 'self'",
+        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: blob: https:",
+        "font-src 'self' data:",
+        "connect-src 'self'",
+        "object-src 'none'",
+        "base-uri 'none'",
+        "frame-ancestors 'none'",
+        "form-action 'self'",
+      ].join('; '),
+    );
+  });
+});

--- a/application/server/storage/local.ts
+++ b/application/server/storage/local.ts
@@ -1,6 +1,6 @@
 import { readFile as fsReadFile, writeFile as fsWriteFile, mkdir as fsMkdir, existsSync } from 'fs';
 import { rm } from 'fs/promises';
-import { join, dirname } from 'path';
+import { join, dirname, resolve, relative, isAbsolute } from 'path';
 import { promisify } from 'util';
 import type { StorageAdapter } from './types';
 
@@ -19,8 +19,22 @@ export class LocalStorageAdapter implements StorageAdapter {
     this.basePath = basePath;
   }
 
-  async writeFile(path: string, data: Buffer): Promise<void> {
+  /**
+   * Resolve a relative storage path and guarantee it stays inside `basePath`.
+   * Throws on any path that would escape the storage root (e.g. a `..` sequence
+   * from an untrusted archive entry), so traversal can never reach the disk.
+   */
+  private resolvePath(path: string): string {
     const fullPath = join(this.basePath, path);
+    const rel = relative(resolve(this.basePath), resolve(fullPath));
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new Error(`Storage path escapes the storage root: ${path}`);
+    }
+    return fullPath;
+  }
+
+  async writeFile(path: string, data: Buffer): Promise<void> {
+    const fullPath = this.resolvePath(path);
     const dirPath = dirname(fullPath);
 
     // Ensure directory exists
@@ -32,28 +46,28 @@ export class LocalStorageAdapter implements StorageAdapter {
   }
 
   async readFile(path: string): Promise<Buffer> {
-    const fullPath = join(this.basePath, path);
+    const fullPath = this.resolvePath(path);
     return await readFileAsync(fullPath);
   }
 
   async exists(path: string): Promise<boolean> {
-    const fullPath = join(this.basePath, path);
+    const fullPath = this.resolvePath(path);
     return existsSync(fullPath);
   }
 
   async mkdir(path: string): Promise<void> {
-    const fullPath = join(this.basePath, path);
+    const fullPath = this.resolvePath(path);
     if (!existsSync(fullPath)) {
       await mkdirAsync(fullPath, { recursive: true });
     }
   }
 
   getFullPath(path: string): string {
-    return join(this.basePath, path);
+    return this.resolvePath(path);
   }
 
   async deleteFile(path: string): Promise<void> {
-    const fullPath = join(this.basePath, path);
+    const fullPath = this.resolvePath(path);
     try {
       await rm(fullPath, { force: true });
     } catch {
@@ -62,7 +76,7 @@ export class LocalStorageAdapter implements StorageAdapter {
   }
 
   async deleteDirectory(path: string): Promise<void> {
-    const fullPath = join(this.basePath, path);
+    const fullPath = this.resolvePath(path);
     if (existsSync(fullPath)) {
       await rm(fullPath, { recursive: true, force: true });
     }

--- a/application/server/utils/auth.ts
+++ b/application/server/utils/auth.ts
@@ -46,6 +46,33 @@ function getSessionPassword(config: ReturnType<typeof useRuntimeConfig>): string
   return process.env.PIWI_AUTH_SECRET || config.authSecret;
 }
 
+const SESSION_MAX_AGE_SEC = 60 * 60 * 24 * 7; // 7 days
+
+/**
+ * Config for the sealed session cookie, shared by every session operation so its
+ * attributes stay consistent (including on clear).
+ *
+ * `httpOnly` and `secure` keep the cookie out of reach of page scripts and off
+ * plaintext connections. `sameSite: 'lax'` is set explicitly rather than left to
+ * the browser's implicit default so the cookie is withheld from cross-site
+ * subrequests — a CSRF defense for the cookie-authenticated API — while still
+ * riding top-level navigations, which OAuth callbacks and ordinary links into
+ * the dashboard depend on. These are pinned here rather than inherited from h3's
+ * defaults so the posture cannot silently change across h3 versions.
+ */
+function sessionOptions(config: ReturnType<typeof useRuntimeConfig>) {
+  return {
+    password: getSessionPassword(config),
+    maxAge: SESSION_MAX_AGE_SEC,
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax' as const,
+      path: '/',
+    },
+  };
+}
+
 // Get session from cookie
 export async function getUserSession(event: H3Event): Promise<SessionData | null> {
   const config = useRuntimeConfig(event);
@@ -54,10 +81,7 @@ export async function getUserSession(event: H3Event): Promise<SessionData | null
   }
 
   try {
-    const session = await useSession<SessionData>(event, {
-      password: getSessionPassword(config),
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-    });
+    const session = await useSession<SessionData>(event, sessionOptions(config));
 
     if (!session.data || !session.data.userId) {
       return null;
@@ -73,23 +97,13 @@ export async function getUserSession(event: H3Event): Promise<SessionData | null
 // Set session in cookie
 export async function setUserSession(event: H3Event, sessionData: SessionData): Promise<void> {
   const config = useRuntimeConfig(event);
-
-  await updateSession<SessionData>(
-    event,
-    {
-      password: getSessionPassword(config),
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-    },
-    sessionData,
-  );
+  await updateSession<SessionData>(event, sessionOptions(config), sessionData);
 }
 
 // Clear session cookie
 export async function clearUserSession(event: H3Event): Promise<void> {
   const config = useRuntimeConfig(event);
-  await h3ClearSession(event, {
-    password: getSessionPassword(config),
-  });
+  await h3ClearSession(event, sessionOptions(config));
 }
 
 // Get current user from session

--- a/application/server/utils/auth.ts
+++ b/application/server/utils/auth.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3';
 import { useSession, updateSession, clearSession as h3ClearSession } from 'h3';
 import { getDatabase } from '../database';
 import { users, apiKeys } from '../database/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { User } from '../database/schema';
 import { scrypt, randomBytes, timingSafeEqual, createHash } from 'node:crypto';
 import { promisify } from 'node:util';
@@ -33,18 +33,28 @@ export interface SessionData {
   userId: number;
   username: string;
   role: Role;
+  // The user's session epoch at sign-in. A later bump (password/role change,
+  // unlink) makes this stale, which invalidates the session server-side.
+  sessionEpoch?: number;
+}
+
+// The key h3 uses to seal/unseal the session cookie. `PIWI_AUTH_SECRET` from the
+// runtime environment wins over the build-time-baked config value, so the
+// prebuilt image honors a secret supplied at run time (see isAuthEnabled).
+function getSessionPassword(config: ReturnType<typeof useRuntimeConfig>): string {
+  return process.env.PIWI_AUTH_SECRET || config.authSecret;
 }
 
 // Get session from cookie
 export async function getUserSession(event: H3Event): Promise<SessionData | null> {
   const config = useRuntimeConfig(event);
-  if (!config.authEnabled) {
+  if (!isAuthEnabled(event)) {
     return null;
   }
 
   try {
     const session = await useSession<SessionData>(event, {
-      password: config.authSecret,
+      password: getSessionPassword(config),
       maxAge: 60 * 60 * 24 * 7, // 7 days
     });
 
@@ -66,7 +76,7 @@ export async function setUserSession(event: H3Event, sessionData: SessionData): 
   await updateSession<SessionData>(
     event,
     {
-      password: config.authSecret,
+      password: getSessionPassword(config),
       maxAge: 60 * 60 * 24 * 7, // 7 days
     },
     sessionData,
@@ -77,7 +87,7 @@ export async function setUserSession(event: H3Event, sessionData: SessionData): 
 export async function clearUserSession(event: H3Event): Promise<void> {
   const config = useRuntimeConfig(event);
   await h3ClearSession(event, {
-    password: config.authSecret,
+    password: getSessionPassword(config),
   });
 }
 
@@ -90,7 +100,33 @@ export async function getCurrentUser(event: H3Event): Promise<User | null> {
 
   const db = await getDatabase();
   const userResults = await db.select().from(users).where(eq(users.id, session.userId));
-  return userResults[0] || null;
+  const user = userResults[0];
+  if (!user) {
+    return null;
+  }
+
+  // A session minted before the user's epoch was last bumped is revoked.
+  if ((session.sessionEpoch ?? 0) !== (user.sessionEpoch ?? 0)) {
+    return null;
+  }
+
+  return user;
+}
+
+/**
+ * Revoke every existing session for a user by advancing their session epoch.
+ * Sessions carry the epoch they were minted with; `getCurrentUser` rejects any
+ * whose epoch no longer matches. Returns the new epoch so the caller can
+ * immediately re-issue the current device a valid session if desired.
+ */
+export async function revokeUserSessions(userId: number): Promise<number> {
+  const db = await getDatabase();
+  const rows = await db
+    .update(users)
+    .set({ sessionEpoch: sql`${users.sessionEpoch} + 1` })
+    .where(eq(users.id, userId))
+    .returning({ sessionEpoch: users.sessionEpoch });
+  return rows[0]?.sessionEpoch ?? 0;
 }
 
 // Verify user credentials and return user
@@ -154,12 +190,18 @@ export function hasRole(user: User | null, requiredRoles: Role[]): boolean {
   return requiredRoles.includes(user.role as Role);
 }
 
-// Check if authentication is enabled
+// Check if authentication is enabled.
+//
+// `PIWI_AUTH_ENABLED` is read from the runtime environment first: on the
+// prebuilt image the config value is baked at build time (when the variable is
+// unset), so the env check is what lets an operator turn auth on at run time.
+// The baked `config.authEnabled` remains the fallback for source builds and for
+// the `NUXT_AUTH_ENABLED` runtime override.
 export function isAuthEnabled(event?: H3Event): boolean {
+  if (process.env.PIWI_AUTH_ENABLED === 'true') {
+    return true;
+  }
   const config = event ? useRuntimeConfig(event) : useRuntimeConfig();
-  // Nitro overrides runtimeConfig from NUXT_* env vars at startup. Since
-  // environment variables are always strings, a boolean `true` from the
-  // config file becomes the string `"true"` after the override.
   return String(config.authEnabled) === 'true';
 }
 
@@ -262,6 +304,7 @@ export async function requireAuth(event: H3Event, allowedRoles?: Role[]): Promis
       oauthProviderId: null,
       email: null,
       emailVerified: false,
+      sessionEpoch: 0,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/application/server/utils/auth.ts
+++ b/application/server/utils/auth.ts
@@ -144,18 +144,24 @@ export async function revokeUserSessions(userId: number): Promise<number> {
   return rows[0]?.sessionEpoch ?? 0;
 }
 
+// A syntactically-valid scrypt hash (salt:hex) used only to spend the same
+// verification work for a nonexistent or password-less account as for a real
+// one. Its value is irrelevant — the comparison always fails; it exists solely
+// so login response timing can't be used to tell whether a username exists.
+const DUMMY_PASSWORD_HASH = `${'0'.repeat(32)}:${'0'.repeat(128)}`;
+
 // Verify user credentials and return user
 export async function verifyUser(username: string, password: string): Promise<User | null> {
   const db = await getDatabase();
   const userResults = await db.select().from(users).where(eq(users.username, username));
   const user = userResults[0];
 
-  if (!user) {
-    return null;
-  }
-
-  // OAuth-only users have empty password and cannot log in with credentials
-  if (!user.password) {
+  // Equalize response time whether or not the account exists and has a
+  // password: a missing or OAuth-only (password-less) account still spends one
+  // scrypt verification against a dummy hash, so login timing can't be used to
+  // enumerate which usernames are registered (audit L3).
+  if (!user || !user.password) {
+    await verifyPassword(password, DUMMY_PASSWORD_HASH);
     return null;
   }
 

--- a/application/server/utils/auth.ts
+++ b/application/server/utils/auth.ts
@@ -1,12 +1,13 @@
 import type { H3Event } from 'h3';
 import { useSession, updateSession, clearSession as h3ClearSession } from 'h3';
 import { getDatabase } from '../database';
-import { users, apiKeys } from '../database/schema';
+import { users, apiKeys, appSettings } from '../database/schema';
 import { eq, sql } from 'drizzle-orm';
 import type { User } from '../database/schema';
 import { scrypt, randomBytes, timingSafeEqual, createHash } from 'node:crypto';
 import { promisify } from 'node:util';
 import { Role } from '#shared/types';
+import type { DrizzleDB } from '#shared/handlers/db';
 import { getRouteRequiredRoles } from './route-required-roles';
 
 const scryptAsync = promisify(scrypt);
@@ -180,6 +181,44 @@ export async function createUser(username: string, password: string, role: Role,
   }
 
   return user;
+}
+
+/** Sentinel key marking that initial setup has been performed. */
+const INITIAL_SETUP_KEY = 'initial_setup_completed';
+
+/**
+ * Atomically claim the one-time initial-setup slot, returning true for exactly
+ * one caller.
+ *
+ * `needsInitialSetup` (a SELECT) and `createUser` (a later INSERT) are separate
+ * statements, so two concurrent `POST /api/auth/setup` requests could both see
+ * an empty users table and each create an administrator. Claiming a sentinel row
+ * with `INSERT ... ON CONFLICT DO NOTHING` closes that window: SQLite and
+ * Postgres both resolve the primary-key conflict atomically, so only the first
+ * of any set of concurrent callers inserts the row (and goes on to create the
+ * admin) while the rest conflict and get false. Callers must still gate on
+ * `needsInitialSetup()` first, so an instance seeded by other means (OAuth, a
+ * fixture) is never re-opened merely because the sentinel is absent.
+ */
+export async function claimInitialSetup(db?: DrizzleDB): Promise<boolean> {
+  const database = db ?? (await getDatabase());
+  const inserted = await database
+    .insert(appSettings)
+    .values({ key: INITIAL_SETUP_KEY, value: true, updatedAt: new Date() })
+    .onConflictDoNothing({ target: appSettings.key })
+    .returning({ key: appSettings.key });
+  return inserted.length > 0;
+}
+
+/**
+ * Release a claim made by `claimInitialSetup` so setup can be retried. Only the
+ * claim winner calls this, and only when admin creation failed after the claim —
+ * the losing callers were already rejected, so there is no window for a second
+ * admin to slip through.
+ */
+export async function releaseInitialSetup(db?: DrizzleDB): Promise<void> {
+  const database = db ?? (await getDatabase());
+  await database.delete(appSettings).where(eq(appSettings.key, INITIAL_SETUP_KEY));
 }
 
 // Check if user has required role

--- a/application/server/utils/compression.ts
+++ b/application/server/utils/compression.ts
@@ -6,11 +6,22 @@ import { promisify } from 'util';
 const gunzipAsync = promisify(gunzip);
 
 /**
+ * Upper bound on the decompressed size of a report archive. The archive packs
+ * an entire report/trace directory into one gzip stream that is inflated fully
+ * into memory here, and uploads are attacker-controllable (open when auth is
+ * disabled), so an unbounded compression ratio would let a few kilobytes expand
+ * to gigabytes and OOM the server. 1 GiB comfortably exceeds any realistic
+ * report (even a large blob report with hundreds of traced tests) while
+ * stopping decompression bombs. zlib throws ERR_BUFFER_TOO_LARGE past the cap.
+ */
+const MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024; // 1 GiB
+
+/**
  * Decompress a gzip-compressed archive buffer into a target directory.
  */
 export async function decompressDirectory(compressedBuffer: Buffer, targetDir: string): Promise<void> {
   try {
-    const uncompressed = await gunzipAsync(compressedBuffer);
+    const uncompressed = await gunzipAsync(compressedBuffer, { maxOutputLength: MAX_ARCHIVE_BYTES });
 
     await mkdir(targetDir, { recursive: true });
 

--- a/application/server/utils/crypto.ts
+++ b/application/server/utils/crypto.ts
@@ -4,6 +4,14 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_BYTES = 12;
 const PREFIX = 'v1:';
 
+/**
+ * The built-in fallback used for `PIWI_SECRET_KEY` / `PIWI_AUTH_SECRET` when the
+ * operator sets nothing. It is published in this repository, so any data keyed
+ * on it is effectively unprotected — the auth and encryption paths refuse to
+ * rely on it once real secrets are at stake.
+ */
+export const DEFAULT_INSECURE_SECRET = 'default-secret-change-in-production-use-random-string';
+
 function deriveKey(secret: string): Buffer {
   // Purpose-specific derivation so DB encryption keys are distinct from session cookie keys
   return createHash('sha256').update(`piwi-db-encryption:${secret}`).digest();
@@ -14,6 +22,12 @@ function deriveKey(secret: string): Buffer {
  * that can be stored in the database.
  */
 export function encryptSecret(plaintext: string, secret: string): string {
+  if (!secret || secret === DEFAULT_INSECURE_SECRET) {
+    throw new Error(
+      'Refusing to encrypt a secret without a configured PIWI_SECRET_KEY. Set PIWI_SECRET_KEY to a strong ' +
+        "random value (node -e \"console.log(require('node:crypto').randomBytes(32).toString('hex'))\") before saving credentials.",
+    );
+  }
   const key = deriveKey(secret);
   const iv = randomBytes(IV_BYTES);
   const cipher = createCipheriv(ALGORITHM, key, iv);
@@ -46,5 +60,5 @@ export function decryptSecret(ciphertext: string, secret: string): string {
  * works out-of-the-box. Set this in production even when auth is disabled.
  */
 export function getEncryptionKey(): string {
-  return process.env.PIWI_SECRET_KEY || 'default-secret-change-in-production-use-random-string';
+  return process.env.PIWI_SECRET_KEY || DEFAULT_INSECURE_SECRET;
 }

--- a/application/server/utils/notifications/dispatch.ts
+++ b/application/server/utils/notifications/dispatch.ts
@@ -2,6 +2,7 @@ import { and, eq, lte, lt } from 'drizzle-orm';
 import { notificationDeliveries, notificationChannels, users } from '../../database/schema';
 import { sendEmail, renderRunNotificationEmail, renderNewClusterEmail, isEmailConfigured } from '../email';
 import { decryptSecret, getEncryptionKey } from '../crypto';
+import { safeFetch } from '../safe-fetch';
 import type {
   NotificationEvent,
   NotificationPayload,
@@ -87,7 +88,7 @@ async function sendToSlack(config: Record<string, unknown>, event: NotificationE
 
   const body = { text: `${emoji} *${text}*`, blocks };
 
-  const res = await fetch(webhookUrl, {
+  const res = await safeFetch(webhookUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -113,7 +114,7 @@ async function sendToWebhook(config: Record<string, unknown>, event: Notificatio
     headers['X-Piwi-Signature'] = `sha256=${sig}`;
   }
 
-  const res = await fetch(url, { method: 'POST', headers, body });
+  const res = await safeFetch(url, { method: 'POST', headers, body });
   if (!res.ok) throw new Error(`Webhook returned ${res.status}`);
 }
 

--- a/application/server/utils/notifications/match.ts
+++ b/application/server/utils/notifications/match.ts
@@ -1,5 +1,6 @@
 import { and, eq, or, isNull } from 'drizzle-orm';
-import { subscriptions, notificationChannels, notificationDeliveries } from '../../database/schema';
+import { subscriptions, notificationChannels, notificationDeliveries, users } from '../../database/schema';
+import { getProjectScope, scopeAllows, type DrizzleDB } from '../project-access';
 import type { NotificationEvent, NotificationPayload, RunFinishedPayload } from '#shared/notification-events';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 
@@ -87,7 +88,22 @@ export async function matchAndEnqueue(
   let enqueued = 0;
   const now = new Date();
 
+  // Re-check project access at delivery time so a subscription never leaks a
+  // project the subscriber can no longer reach — whether it predates
+  // creation-time scoping or the user was since removed from the project.
+  const accessByUser = new Map<number, boolean>();
+  const subscriberCanAccess = async (userId: number): Promise<boolean> => {
+    const cached = accessByUser.get(userId);
+    if (cached !== undefined) return cached;
+    const [u] = await db.select().from(users).where(eq(users.id, userId));
+    const allowed = u ? scopeAllows(await getProjectScope(db as unknown as DrizzleDB, u), projectId) : false;
+    accessByUser.set(userId, allowed);
+    return allowed;
+  };
+
   for (const { sub, channel } of rows) {
+    if (sub.userId == null || !(await subscriberCanAccess(sub.userId))) continue;
+
     // Check event is subscribed
     const events = (sub.events as string[] | null) ?? [];
     if (!events.includes(event)) continue;

--- a/application/server/utils/oauth.ts
+++ b/application/server/utils/oauth.ts
@@ -573,6 +573,7 @@ export async function handleOAuthCallback(event: H3Event, provider: string): Pro
       userId: user.id,
       username: user.username,
       role: user.role as Role,
+      sessionEpoch: user.sessionEpoch,
     };
     await setUserSession(event, sessionData);
 

--- a/application/server/utils/project-access.ts
+++ b/application/server/utils/project-access.ts
@@ -10,6 +10,7 @@ import {
   failureDiagnoses,
   markers,
   testFunctions,
+  entityLinks,
 } from '../database/schema';
 import { eq } from 'drizzle-orm';
 import { requireAuth, isAuthEnabled } from './auth';
@@ -134,6 +135,29 @@ export async function resolveTestFunctionProjectId(db: DrizzleDB, testFunctionId
     .from(testFunctions)
     .where(eq(testFunctions.id, testFunctionId));
   return rows[0]?.projectId ?? null;
+}
+
+/** Resolve the project owning the entity an entity-link targets (list/create). */
+export async function resolveLinkEntityProjectId(
+  db: DrizzleDB,
+  entityType: string,
+  entityId: number,
+): Promise<number | null> {
+  if (entityType === 'test_run') return resolveRunProjectId(db, entityId);
+  if (entityType === 'test_runs_case') return resolveTestRunCaseProjectId(db, entityId);
+  if (entityType === 'test_case') return resolveCaseProjectId(db, entityId);
+  return null;
+}
+
+/** Resolve the project owning an existing entity link, via its target entity. */
+export async function resolveLinkProjectId(db: DrizzleDB, linkId: number): Promise<number | null> {
+  const rows = await db.select().from(entityLinks).where(eq(entityLinks.id, linkId)).limit(1);
+  const link = rows[0];
+  if (!link) return null;
+  if (link.testRunId != null) return resolveRunProjectId(db, link.testRunId);
+  if (link.testRunsCaseId != null) return resolveTestRunCaseProjectId(db, link.testRunsCaseId);
+  if (link.testCaseId != null) return resolveCaseProjectId(db, link.testCaseId);
+  return null;
 }
 
 export async function resolveDiagnosisProjectId(db: DrizzleDB, diagnosisId: number): Promise<number | null> {

--- a/application/server/utils/rate-limit.ts
+++ b/application/server/utils/rate-limit.ts
@@ -17,3 +17,26 @@ export function checkRateLimit(key: string, limit: number, windowMs: number): bo
   entry.count++;
   return true;
 }
+
+/** Whether `key` has reached `limit` within its current window, without counting this call. */
+export function isRateLimited(key: string, limit: number): boolean {
+  const entry = store.get(key);
+  if (!entry || entry.resetAt < Date.now()) return false;
+  return entry.count >= limit;
+}
+
+/** Record one hit against `key`, starting a fresh window if none is active. Used to count failures. */
+export function recordRateLimitHit(key: string, windowMs: number): void {
+  const now = Date.now();
+  const entry = store.get(key);
+  if (!entry || entry.resetAt < now) {
+    store.set(key, { count: 1, resetAt: now + windowMs });
+  } else {
+    entry.count++;
+  }
+}
+
+/** Clear a key's counter (e.g. after a success), so it no longer counts toward a lockout. */
+export function resetRateLimit(key: string): void {
+  store.delete(key);
+}

--- a/application/server/utils/safe-fetch.ts
+++ b/application/server/utils/safe-fetch.ts
@@ -1,0 +1,100 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * SSRF guards for outbound requests to user-supplied URLs (webhooks, link
+ * unfurling). A hostname is resolved and every address it points at is checked,
+ * so a public name that resolves to a private/loopback/link-local address (a
+ * common SSRF and cloud-metadata vector) is rejected too.
+ */
+
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((n) => Number(n));
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true;
+  const [a, b] = parts as [number, number, number, number];
+  if (a === 0 || a === 10 || a === 127) return true; // "this network", private, loopback
+  if (a === 169 && b === 254) return true; // link-local (incl. 169.254.169.254 metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 168) return true; // private
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT (100.64.0.0/10)
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast + reserved
+  return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const host = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === '::1' || host === '::') return true; // loopback / unspecified
+  if (host.startsWith('fe80') || host.startsWith('fc') || host.startsWith('fd')) return true; // link-local / ULA
+  const mapped = host.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/); // ::ffff:127.0.0.1 etc.
+  if (mapped) return isBlockedIpv4(mapped[1]!);
+  return false;
+}
+
+/** Whether an IP literal is in a private / loopback / link-local / reserved range. */
+export function isBlockedAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isBlockedIpv4(ip);
+  if (family === 6) return isBlockedIpv6(ip);
+  return true; // not a valid IP → refuse
+}
+
+/**
+ * Validate that `rawUrl` is an `http(s)` URL whose host is public. Resolves the
+ * hostname and rejects if any resolved address is blocked. Throws on violation.
+ */
+export async function assertPublicHttpUrl(rawUrl: string): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Only http(s) URLs are allowed');
+  }
+  const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (
+    !host ||
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.internal') ||
+    host.endsWith('.local')
+  ) {
+    throw new Error('URL host is not allowed');
+  }
+  if (isIP(host)) {
+    if (isBlockedAddress(host)) throw new Error('URL host is not allowed');
+    return url;
+  }
+  const resolved = await lookup(host, { all: true });
+  if (resolved.length === 0) throw new Error('URL host did not resolve');
+  for (const { address } of resolved) {
+    if (isBlockedAddress(address)) throw new Error('URL host is not allowed');
+  }
+  return url;
+}
+
+/**
+ * `fetch` for user-supplied URLs: validates the target (and every redirect hop)
+ * against `assertPublicHttpUrl`, following redirects manually so a redirect to
+ * an internal address cannot slip through. Enforces a per-request timeout.
+ */
+export async function safeFetch(
+  rawUrl: string,
+  init: RequestInit = {},
+  maxRedirects = 3,
+  timeoutMs = 5000,
+): Promise<Response> {
+  let current = rawUrl;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    await assertPublicHttpUrl(current);
+    const res = await fetch(current, { ...init, redirect: 'manual', signal: AbortSignal.timeout(timeoutMs) });
+    if (res.status >= 300 && res.status < 400 && res.headers.has('location')) {
+      current = new URL(res.headers.get('location')!, current).toString();
+      continue;
+    }
+    return res;
+  }
+  throw new Error('Too many redirects');
+}

--- a/application/server/utils/sanitize-filename.ts
+++ b/application/server/utils/sanitize-filename.ts
@@ -4,10 +4,13 @@ export function sanitizeFilename(filename: string): string {
   return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
-/** Reduce a (possibly hostile) name to a single safe path segment, or `null`
- * when nothing usable remains. The result contains only `[A-Za-z0-9._-]` and is
- * never `.` or `..`, so appending it to a storage prefix can never escape it. */
+/** Return `name` when it is a single, traversal-free path segment that is safe
+ * to append to a storage prefix, or `null` when it is not (empty, `.`/`..`, or
+ * containing a path separator or NUL). The name is preserved exactly — content
+ * that references a resource by name (e.g. Playwright trace `resources/src@…`
+ * entries) must still resolve — so containment, not rewriting, is the guard. */
 export function safeStorageSegment(name: string): string | null {
-  const safe = sanitizeFilename(name);
-  return safe && safe !== '.' && safe !== '..' ? safe : null;
+  if (!name || name === '.' || name === '..') return null;
+  if (/[/\\\0]/.test(name)) return null;
+  return name;
 }

--- a/application/server/utils/sanitize-filename.ts
+++ b/application/server/utils/sanitize-filename.ts
@@ -3,3 +3,11 @@
 export function sanitizeFilename(filename: string): string {
   return filename.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
+
+/** Reduce a (possibly hostile) name to a single safe path segment, or `null`
+ * when nothing usable remains. The result contains only `[A-Za-z0-9._-]` and is
+ * never `.` or `..`, so appending it to a storage prefix can never escape it. */
+export function safeStorageSegment(name: string): string | null {
+  const safe = sanitizeFilename(name);
+  return safe && safe !== '.' && safe !== '..' ? safe : null;
+}

--- a/application/server/utils/sanitize-filename.ts
+++ b/application/server/utils/sanitize-filename.ts
@@ -11,6 +11,6 @@ export function sanitizeFilename(filename: string): string {
  * entries) must still resolve — so containment, not rewriting, is the guard. */
 export function safeStorageSegment(name: string): string | null {
   if (!name || name === '.' || name === '..') return null;
-  if (/[/\\\0]/.test(name)) return null;
+  if (/[/\\]/.test(name) || name.includes(String.fromCharCode(0))) return null;
   return name;
 }

--- a/application/server/utils/stream-auth.ts
+++ b/application/server/utils/stream-auth.ts
@@ -3,6 +3,7 @@ import { testRuns } from '../database/schema';
 import { runEventBus } from './run-events';
 import { validateAndReviveRun } from './revive-run';
 import { readShardTokensFromMeta } from './shard-tokens';
+import { timingSafeEqualStr } from './timing-safe';
 import type { DbClient as DB } from '../database';
 
 /**
@@ -20,7 +21,8 @@ import type { DbClient as DB } from '../database';
 export async function authorizeStreamToken(db: DB, runId: number, streamToken: string): Promise<{ projectId: number }> {
   const cachedState = runEventBus.getRunState(runId);
   if (cachedState) {
-    const valid = cachedState.streamToken === streamToken || cachedState.shardTokens?.has(streamToken);
+    const valid =
+      timingSafeEqualStr(cachedState.streamToken, streamToken) || (cachedState.shardTokens?.has(streamToken) ?? false);
     if (!valid) throw createError({ statusCode: 403, message: 'Invalid stream token' });
     return { projectId: cachedState.projectId };
   }

--- a/application/server/utils/timing-safe.ts
+++ b/application/server/utils/timing-safe.ts
@@ -1,0 +1,16 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time string equality for comparing secrets such as stream / setup /
+ * desktop access tokens. Both inputs are SHA-256'd first, so the comparison is
+ * always over equal-length buffers and never short-circuits on the first
+ * differing byte the way `===` does — closing the timing side-channel that could
+ * otherwise let an attacker recover a token byte by byte. Hashing also keeps the
+ * inputs' lengths from leaking through the comparison. Inputs are coerced to
+ * strings so a non-string value from an untrusted body can't throw here.
+ */
+export function timingSafeEqualStr(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(String(a)).digest();
+  const hb = createHash('sha256').update(String(b)).digest();
+  return timingSafeEqual(ha, hb);
+}

--- a/application/server/utils/trace-blobs.ts
+++ b/application/server/utils/trace-blobs.ts
@@ -4,6 +4,7 @@ import { eq, and, inArray } from 'drizzle-orm';
 import { getStorage } from '../storage';
 import { parseZipDirectory, decompressEntry, buildZip } from './trace-zip';
 import type { ZipEntry } from './trace-zip';
+import { safeStorageSegment } from './sanitize-filename';
 
 /**
  * Return the set of hashes that already have a stored blob for the given project.
@@ -65,22 +66,27 @@ export async function upsertTraceBlob(
       const resourcesDir = `project-${projectId}/trace-resources`;
       await storage.mkdir(resourcesDir);
 
+      // Resource entry names come from the untrusted ZIP central directory.
+      // Reduce each to a single safe path segment so a crafted name such as
+      // `resources/../../evil` can never be written outside the project prefix.
+      const safeResources: { meta: (typeof resourceMetas)[number]; name: string }[] = [];
+      for (const meta of resourceMetas) {
+        const name = safeStorageSegment(meta.name.slice('resources/'.length));
+        if (name) safeResources.push({ meta, name });
+      }
+
       // 2. Determine which resource names are genuinely new (no decompression needed)
-      const names = resourceMetas.map((e) => e.name.slice('resources/'.length)).filter(Boolean);
+      const names = safeResources.map((r) => r.name);
       const existingRows = await db
         .select({ name: traceResources.name })
         .from(traceResources)
         .where(and(eq(traceResources.projectId, projectId), inArray(traceResources.name, names)));
       const existingNames = new Set(existingRows.map((r) => r.name));
 
-      const newMetas = resourceMetas.filter((e) => {
-        const name = e.name.slice('resources/'.length);
-        return name && !existingNames.has(name);
-      });
+      const newResources = safeResources.filter((r) => !existingNames.has(r.name));
 
       // 3. Decompress and store new resources one at a time to limit peak memory
-      for (const meta of newMetas) {
-        const name = meta.name.slice('resources/'.length);
+      for (const { meta, name } of newResources) {
         const resourceData = await decompressEntry(data, meta);
         const resourcePath = `${resourcesDir}/${name}`;
         await storage.writeFile(resourcePath, resourceData);
@@ -106,8 +112,8 @@ export async function upsertTraceBlob(
         }
       }
 
-      // 5. Collect all resource names (new + pre-existing) for the manifest
-      const resourceNames = resourceMetas.map((e) => e.name.slice('resources/'.length)).filter(Boolean);
+      // 5. All resource names (new + pre-existing) for the manifest
+      const resourceNames = names;
 
       const slimZip = buildZip(eventEntries);
       const manifestJson = Buffer.from(JSON.stringify({ resources: resourceNames }), 'utf8');
@@ -118,7 +124,7 @@ export async function upsertTraceBlob(
       const savedBytes = data.length - slimZip.length;
       console.log(
         `[TraceBlob] ${resourceNames.length} resources extracted for project ${projectId}` +
-          ` (${newMetas.length} new), slim ZIP saves ${Math.round(savedBytes / 1024)} KB`,
+          ` (${newResources.length} new), slim ZIP saves ${Math.round(savedBytes / 1024)} KB`,
       );
     }
   } catch (err) {

--- a/application/server/utils/trace-zip.ts
+++ b/application/server/utils/trace-zip.ts
@@ -3,6 +3,17 @@ import { promisify } from 'util';
 
 const inflateRawAsync = promisify(inflateRaw);
 
+/**
+ * Upper bound on the decompressed size of a single ZIP entry. Deflate can
+ * expand its input by up to ~1000×, so an attacker-supplied trace archive
+ * (uploads are open when auth is disabled) could pair a few kilobytes of
+ * compressed data with gigabytes of output and exhaust server memory. Real
+ * trace files — events, network log, screenshots — never approach this ceiling,
+ * so it stops decompression bombs without affecting legitimate traces. zlib
+ * throws ERR_BUFFER_TOO_LARGE once output would exceed the cap.
+ */
+const MAX_ENTRY_BYTES = 512 * 1024 * 1024; // 512 MiB
+
 export interface ZipEntry {
   name: string;
   data: Buffer;
@@ -121,7 +132,7 @@ export async function decompressEntry(data: Buffer, meta: ZipEntryMeta): Promise
   }
   const compressed = data.subarray(meta.dataStart, meta.dataStart + meta.compressedSize);
   if (meta.method === 0) return Buffer.from(compressed);
-  if (meta.method === 8) return inflateRawAsync(compressed);
+  if (meta.method === 8) return inflateRawAsync(compressed, { maxOutputLength: MAX_ENTRY_BYTES });
   throw new Error(`Unsupported ZIP compression method ${meta.method} for "${meta.name}"`);
 }
 
@@ -231,7 +242,7 @@ export function parseZipSync(data: Buffer): ZipEntry[] {
       if (meta.method === 0) {
         entryData = Buffer.from(compressed);
       } else if (meta.method === 8) {
-        entryData = inflateRawSync(compressed);
+        entryData = inflateRawSync(compressed, { maxOutputLength: MAX_ENTRY_BYTES });
       } else {
         continue;
       }

--- a/application/server/utils/unfurl/UnfurlProvider.ts
+++ b/application/server/utils/unfurl/UnfurlProvider.ts
@@ -26,6 +26,9 @@ const PRIVATE_PATTERNS = [
 
 export function isPrivateHost(hostname: string): boolean {
   const host = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.internal') || host.endsWith('.local')) {
+    return true;
+  }
   return PRIVATE_PATTERNS.some((p) => p.test(host));
 }
 

--- a/application/shared/deploy/koyeb.ts
+++ b/application/shared/deploy/koyeb.ts
@@ -54,8 +54,8 @@ export function emitKoyebDeployUrl(entries: readonly EnvEntry[], opts: EmitOptio
   if (deferred.length) {
     notes.push(
       '#',
-      `# Set in the Koyeb console after the first deploy: ${deferred.join(', ')}.`,
-      '# Generate each secret with: openssl rand -hex 32',
+      `# Set in the Koyeb console: ${deferred.join(', ')}. Generate each secret with: openssl rand -hex 32.`,
+      '# Authentication is enabled above, so the service stays down until PIWI_AUTH_SECRET is set.',
     );
   }
   return commentBlock(opts.header) + `https://app.koyeb.com/deploy?${params.join('&')}\n` + notes.join('\n') + '\n';

--- a/application/tests/unit/env-format.test.ts
+++ b/application/tests/unit/env-format.test.ts
@@ -269,7 +269,7 @@ describe('emitKoyebDeployUrl', () => {
 
   test('spells out the volume caveat and defers what the URL cannot carry', () => {
     expect(out).toContain('koyeb service update piwi/piwi --volumes piwi-data:/app/.data');
-    expect(out).toContain('Set in the Koyeb console after the first deploy: PIWI_SECRET_KEY.');
+    expect(out).toContain('Set in the Koyeb console: PIWI_SECRET_KEY.');
     expect(out).not.toContain('env[PIWI_SECRET_KEY]');
   });
 

--- a/application/tests/unit/initial-setup-claim.test.ts
+++ b/application/tests/unit/initial-setup-claim.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createClient } from '@libsql/client';
+import * as schema from '../../server/database/schema.sqlite';
+
+// The schema barrel (server/database/schema.ts) picks the PostgreSQL schema at
+// import time when PIWI_DATABASE_URL is set, so clear it before auth.ts (which
+// imports the barrel) is loaded.
+delete process.env.PIWI_DATABASE_URL;
+const { claimInitialSetup, releaseInitialSetup } = await import('../../server/utils/auth');
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+let db: Db;
+
+async function freshDb(): Promise<Db> {
+  const next = drizzle(createClient({ url: ':memory:' }), { schema });
+  await migrate(next, {
+    migrationsFolder: fileURLToPath(new URL('../../server/database/migrations', import.meta.url)),
+  });
+  return next;
+}
+
+beforeEach(async () => {
+  db = await freshDb();
+});
+
+describe('claimInitialSetup', () => {
+  test('the first claim wins and a later claim loses', async () => {
+    expect(await claimInitialSetup(db)).toBe(true);
+    // The second claim against the already-claimed state must fail. This is the
+    // guarantee POST /api/auth/setup relies on so only one administrator is ever
+    // created when the check-then-create window is raced.
+    expect(await claimInitialSetup(db)).toBe(false);
+  });
+
+  test('a set of concurrent claims yields exactly one winner', async () => {
+    const results = await Promise.all(Array.from({ length: 8 }, () => claimInitialSetup(db)));
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  test('releasing a claim lets setup be retried', async () => {
+    expect(await claimInitialSetup(db)).toBe(true);
+    await releaseInitialSetup(db);
+    expect(await claimInitialSetup(db)).toBe(true);
+  });
+});

--- a/application/tests/unit/safe-fetch.test.ts
+++ b/application/tests/unit/safe-fetch.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'vitest';
+import { isBlockedAddress, assertPublicHttpUrl } from '../../server/utils/safe-fetch';
+
+describe('isBlockedAddress', () => {
+  test('blocks private / loopback / link-local / reserved addresses', () => {
+    for (const ip of [
+      '127.0.0.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '169.254.169.254', // cloud metadata
+      '100.64.0.1', // CGNAT
+      '198.18.0.1', // benchmarking
+      '0.0.0.0',
+      '::1',
+      'fe80::1',
+      'fc00::1',
+      '::ffff:127.0.0.1', // IPv4-mapped loopback
+      'not-an-ip',
+    ]) {
+      expect(isBlockedAddress(ip)).toBe(true);
+    }
+  });
+
+  test('allows public addresses', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '93.184.216.34', '::ffff:8.8.8.8']) {
+      expect(isBlockedAddress(ip)).toBe(false);
+    }
+  });
+});
+
+describe('assertPublicHttpUrl', () => {
+  test('rejects non-http(s), localhost, and private literals', async () => {
+    await expect(assertPublicHttpUrl('ftp://example.com')).rejects.toThrow();
+    await expect(assertPublicHttpUrl('http://localhost/x')).rejects.toThrow();
+    await expect(assertPublicHttpUrl('http://127.0.0.1/x')).rejects.toThrow();
+    await expect(assertPublicHttpUrl('http://169.254.169.254/latest/meta-data')).rejects.toThrow();
+    await expect(assertPublicHttpUrl('http://[::1]/x')).rejects.toThrow();
+  });
+
+  test('accepts a public literal IP without a DNS lookup', async () => {
+    const url = await assertPublicHttpUrl('https://8.8.8.8/path');
+    expect(url.hostname).toBe('8.8.8.8');
+  });
+});

--- a/application/tests/unit/sanitize-filename.test.ts
+++ b/application/tests/unit/sanitize-filename.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vitest';
+import { safeStorageSegment, sanitizeFilename } from '../../server/utils/sanitize-filename';
+
+describe('safeStorageSegment', () => {
+  test('preserves a legitimate single segment exactly', () => {
+    // Playwright trace source resources are named `src@<sha1>.txt` — the `@`
+    // must survive or the trace events can no longer reference the resource.
+    expect(safeStorageSegment('src@0123456789abcdef.txt')).toBe('src@0123456789abcdef.txt');
+    expect(safeStorageSegment('0123456789abcdef0123456789abcdef01234567')).toBe(
+      '0123456789abcdef0123456789abcdef01234567',
+    );
+    expect(safeStorageSegment('a.b-c_d')).toBe('a.b-c_d');
+    // Dots that are not a whole traversal segment, and spaces, are kept.
+    expect(safeStorageSegment('a..b')).toBe('a..b');
+    expect(safeStorageSegment('a b')).toBe('a b');
+  });
+
+  test('rejects traversal and separator names', () => {
+    expect(safeStorageSegment('')).toBeNull();
+    expect(safeStorageSegment('.')).toBeNull();
+    expect(safeStorageSegment('..')).toBeNull();
+    expect(safeStorageSegment('../../../etc/cron.d/pwn')).toBeNull();
+    expect(safeStorageSegment('foo/bar')).toBeNull();
+    expect(safeStorageSegment('foo\\bar')).toBeNull();
+  });
+});
+
+describe('sanitizeFilename', () => {
+  test('replaces unsafe characters with underscores', () => {
+    expect(sanitizeFilename('a/b c@d')).toBe('a_b_c_d');
+    expect(sanitizeFilename('keep.this-name_1')).toBe('keep.this-name_1');
+  });
+});

--- a/application/tests/unit/timing-safe.test.ts
+++ b/application/tests/unit/timing-safe.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest';
+import { timingSafeEqualStr } from '../../server/utils/timing-safe';
+
+describe('timingSafeEqualStr', () => {
+  test('returns true only for identical strings', () => {
+    expect(timingSafeEqualStr('pd_abc123', 'pd_abc123')).toBe(true);
+    expect(timingSafeEqualStr('', '')).toBe(true);
+  });
+
+  test('returns false for differing strings, including near-misses and length differences', () => {
+    expect(timingSafeEqualStr('token-a', 'token-b')).toBe(false);
+    expect(timingSafeEqualStr('secret', 'secreT')).toBe(false);
+    // Length differences must not throw (the SHA-256 digests are equal-length).
+    expect(timingSafeEqualStr('short', 'a-much-longer-token')).toBe(false);
+    expect(timingSafeEqualStr('prefix', 'prefix-extra')).toBe(false);
+  });
+
+  test('coerces a non-string input instead of throwing', () => {
+    // Untrusted request bodies can carry non-strings; the helper must not throw.
+    expect(() => timingSafeEqualStr(undefined as unknown as string, 'y')).not.toThrow();
+    expect(timingSafeEqualStr('x', undefined as unknown as string)).toBe(false);
+  });
+});

--- a/deploy/koyeb-deploy-url.txt
+++ b/deploy/koyeb-deploy-url.txt
@@ -16,5 +16,5 @@ https://app.koyeb.com/deploy?type=docker&image=docker.io/phenx/piwitests-server:
 #
 #   koyeb service update piwi/piwi --checks 3000:http:/api/health
 #
-# Set in the Koyeb console after the first deploy: PIWI_AUTH_SECRET, PIWI_SECRET_KEY, PIWI_SITE_URL.
-# Generate each secret with: openssl rand -hex 32
+# Set in the Koyeb console: PIWI_AUTH_SECRET, PIWI_SECRET_KEY, PIWI_SITE_URL. Generate each secret with: openssl rand -hex 32.
+# Authentication is enabled above, so the service stays down until PIWI_AUTH_SECRET is set.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -372,9 +372,45 @@ fn decode_base64(input: &str) -> Result<Vec<u8>, String> {
     Ok(out)
 }
 
+/// Write `bytes` into `dir` under `name` without ever overwriting an existing
+/// file. Tries the plain name first, then inserts a ` (n)` counter before the
+/// extension — the disambiguation a browser applies — retrying on collision.
+/// `create_new` makes each attempt atomic (no check-then-write race), so the
+/// caller-controlled bytes of a download can never replace a file already on
+/// disk, e.g. clobber or trojan an installer/DLL the user already trusts.
+fn write_new_download(dir: &Path, name: &str, bytes: &[u8]) -> Result<PathBuf, String> {
+    use std::io::Write as _;
+    let as_path = Path::new(name);
+    let stem = as_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "download".to_string());
+    let ext = as_path.extension().map(|e| e.to_string_lossy().to_string());
+    for n in 0..=1000 {
+        let candidate_name = if n == 0 {
+            name.to_string()
+        } else if let Some(ext) = &ext {
+            format!("{stem} ({n}).{ext}")
+        } else {
+            format!("{stem} ({n})")
+        };
+        let candidate = dir.join(&candidate_name);
+        match std::fs::OpenOptions::new().write(true).create_new(true).open(&candidate) {
+            Ok(mut file) => {
+                file.write_all(bytes).map_err(|e| e.to_string())?;
+                return Ok(candidate);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    Err("could not find an unused download filename".to_string())
+}
+
 /// Write a file the webview fetched to the user's Downloads folder and reveal it.
 /// Returns the saved path. The name is reduced to its base component so a caller
-/// can't traverse out of the Downloads directory.
+/// can't traverse out of the Downloads directory, and an existing file is never
+/// overwritten — a name collision is disambiguated with a ` (n)` suffix.
 ///
 /// `encoding` selects how `contents` is interpreted: omitted or `"utf8"` writes
 /// the string as-is, `"base64"` decodes it first so archives, PDFs and images
@@ -392,13 +428,12 @@ fn desktop_save_download(
         .map(|n| n.to_string_lossy().to_string())
         .filter(|n| !n.is_empty())
         .unwrap_or_else(|| "download".to_string());
-    let target = dir.join(&name);
 
     let bytes = match encoding.as_deref() {
         Some("base64") => decode_base64(&contents)?,
         _ => contents.into_bytes(),
     };
-    std::fs::write(&target, bytes).map_err(|e| e.to_string())?;
+    let target = write_new_download(&dir, &name, &bytes)?;
 
     let _ = app.opener().reveal_item_in_dir(&target);
     Ok(node_path(&target))
@@ -815,4 +850,47 @@ pub fn run() {
             }
             _ => {}
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_new_download;
+    use std::fs;
+
+    #[test]
+    fn does_not_overwrite_an_existing_download() {
+        let dir = std::env::temp_dir().join(format!("piwi-dl-a-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let p1 = write_new_download(&dir, "report.zip", b"one").unwrap();
+        assert_eq!(p1.file_name().unwrap(), "report.zip");
+        // A second download of the same name must not overwrite the first.
+        let p2 = write_new_download(&dir, "report.zip", b"two").unwrap();
+        assert_ne!(p1, p2);
+        assert_eq!(p2.file_name().unwrap(), "report (1).zip");
+        assert_eq!(fs::read(&p1).unwrap(), b"one"); // original bytes intact
+        assert_eq!(fs::read(&p2).unwrap(), b"two");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disambiguates_extensionless_names() {
+        let dir = std::env::temp_dir().join(format!("piwi-dl-b-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let p1 = write_new_download(&dir, "LICENSE", b"a").unwrap();
+        let p2 = write_new_download(&dir, "LICENSE", b"b").unwrap();
+        assert_eq!(p1.file_name().unwrap(), "LICENSE");
+        assert_eq!(p2.file_name().unwrap(), "LICENSE (1)");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn increments_counter_on_repeated_collisions() {
+        let dir = std::env::temp_dir().join(format!("piwi-dl-c-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let _ = write_new_download(&dir, "a.txt", b"1").unwrap();
+        let _ = write_new_download(&dir, "a.txt", b"2").unwrap();
+        let p3 = write_new_download(&dir, "a.txt", b"3").unwrap();
+        assert_eq!(p3.file_name().unwrap(), "a (2).txt");
+        let _ = fs::remove_dir_all(&dir);
+    }
 }

--- a/docker-server-env.mjs
+++ b/docker-server-env.mjs
@@ -1,0 +1,15 @@
+// Preloaded (via `node --import`) before the bundled server starts.
+//
+// The prebuilt server bakes its runtime config at build time and only honors
+// NUXT_*-prefixed overrides at run time. Map the operator-facing PIWI_AUTH_*
+// variables onto those overrides so enabling authentication at run time takes
+// effect on both the server and the browser (public) config. Existing NUXT_*
+// values win, and PIWI_SECRET_KEY / PIWI_AUTH_ENABLED are still read directly by
+// the server, so this only reconciles the pieces baked into the client bundle.
+if (process.env.PIWI_AUTH_ENABLED === 'true') {
+  process.env.NUXT_AUTH_ENABLED ??= 'true';
+  process.env.NUXT_PUBLIC_AUTH_ENABLED ??= 'true';
+}
+if (process.env.PIWI_AUTH_SECRET) {
+  process.env.NUXT_AUTH_SECRET ??= process.env.PIWI_AUTH_SECRET;
+}

--- a/packages/server/bin/piwi-server.mjs
+++ b/packages/server/bin/piwi-server.mjs
@@ -18,6 +18,16 @@ if (!existsSync(entry)) {
   process.exit(1)
 }
 
+// The prebuilt server bakes its runtime config at build time and only honors
+// NUXT_*-prefixed overrides at run time. Map the operator-facing PIWI_AUTH_*
+// variables onto those overrides — before the server loads — so enabling auth at
+// run time takes effect on both the server and the browser (public) config.
+if (process.env.PIWI_AUTH_ENABLED === 'true') {
+  process.env.NUXT_AUTH_ENABLED ??= 'true'
+  process.env.NUXT_PUBLIC_AUTH_ENABLED ??= 'true'
+}
+if (process.env.PIWI_AUTH_SECRET) process.env.NUXT_AUTH_SECRET ??= process.env.PIWI_AUTH_SECRET
+
 const port = process.env.PORT || process.env.NITRO_PORT || '3000'
 console.log(`Starting Piwi Dashboard on http://localhost:${port}`)
 console.log(`Data (SQLite database + file storage) will be stored in ${resolve(process.cwd(), '.data')}`)

--- a/reporter/src/internal/transport/http-client.ts
+++ b/reporter/src/internal/transport/http-client.ts
@@ -70,7 +70,36 @@ export class HttpClient {
     private readonly serverUrl: string,
     private readonly logger: Logger = new Logger(),
     private readonly timeout = 30000,
-  ) {}
+  ) {
+    this.warnIfInsecureTransport();
+  }
+
+  /**
+   * Warn once when the dashboard URL is plaintext `http://` to a non-loopback
+   * host. The reporter sends the API key as a Bearer token — and uploads
+   * captured test data, including request URLs whose query strings the server
+   * only strips after receipt — over this connection, so a non-TLS remote
+   * endpoint exposes the key and payloads on the wire. Loopback (localhost /
+   * 127.0.0.1 / ::1) is exempt: that traffic never leaves the machine. This
+   * warns rather than refuses so internal HTTP deployments (e.g. behind a VPN)
+   * still work, but the exposure is no longer silent.
+   */
+  private warnIfInsecureTransport(): void {
+    let url: URL;
+    try {
+      url = new URL(this.serverUrl);
+    } catch {
+      return; // a malformed URL surfaces on the first request instead
+    }
+    if (url.protocol !== 'http:') return;
+    const host = url.hostname.toLowerCase();
+    const isLoopback =
+      host === 'localhost' || host.endsWith('.localhost') || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+    if (isLoopback) return;
+    this.logger.warn(
+      `Dashboard URL ${this.serverUrl} uses plaintext http:// — the API key and captured test data are transmitted unencrypted. Use https:// for any non-local server.`,
+    );
+  }
 
   /** Base URL of the Piwi Dashboard server this client talks to (used to print run links). */
   get baseUrl(): string {

--- a/reporter/tests/http-client.spec.ts
+++ b/reporter/tests/http-client.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as http from 'node:http';
 import { HttpClient } from '../src/internal/transport/http-client.js';
 import { Logger } from '../src/internal/support/logger.js';
@@ -10,9 +10,11 @@ interface RecordedReq {
   body: string;
 }
 
-function startServer(
-  handler: (req: RecordedReq, res: http.ServerResponse) => void,
-): { server: http.Server; url: string; requests: RecordedReq[] } {
+function startServer(handler: (req: RecordedReq, res: http.ServerResponse) => void): {
+  server: http.Server;
+  url: string;
+  requests: RecordedReq[];
+} {
   const requests: RecordedReq[] = [];
   const server = http.createServer((req, res) => {
     let body = '';
@@ -209,6 +211,33 @@ describe('HttpClient (against fake http.Server)', () => {
         server.close();
         await new Promise<void>((r) => server.on('close', () => r()));
       }
+    });
+  });
+
+  describe('insecure transport warning', () => {
+    function warningsFor(url: string): string[] {
+      const logger = new Logger(false);
+      const spy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      new HttpClient(url, logger);
+      const calls = spy.mock.calls.map((c) => String(c[0]));
+      spy.mockRestore();
+      return calls;
+    }
+
+    it('warns when the dashboard URL is plaintext http:// to a remote host', () => {
+      const w = warningsFor('http://dashboard.example.com:3000');
+      expect(w).toHaveLength(1);
+      expect(w[0]).toMatch(/plaintext http/i);
+    });
+
+    it('does not warn for loopback http:// (localhost / 127.0.0.1 / ::1)', () => {
+      expect(warningsFor('http://localhost:3000')).toHaveLength(0);
+      expect(warningsFor('http://127.0.0.1:3000')).toHaveLength(0);
+      expect(warningsFor('http://[::1]:3000')).toHaveLength(0);
+    });
+
+    it('does not warn for https:// endpoints', () => {
+      expect(warningsFor('https://dashboard.example.com')).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## What & why

Resolves the Critical, High, and actionable Medium findings from a rigorous security audit of the dashboard, reporter, browser extension, and desktop app — plus the server API surface, secrets/crypto at rest, backend integrations, and deploy posture.

### Critical
- **Zip-slip → RCE**: trace-resource ZIP entry names were joined onto the storage path with no containment check, so a crafted `resources/../../…` name wrote attacker-controlled bytes anywhere the server user could reach. Names are now reduced to a safe segment, with a defense-in-depth containment guard in the local storage adapter.
- **Auth silently off on the prebuilt image**: `PIWI_AUTH_ENABLED` was only read at build time, so setting it at runtime on the published image left the dashboard open (virtual admin). Enforcement now reads the env at runtime, and the launcher / Docker image map `PIWI_AUTH_*` onto the `NUXT_*` overrides so the browser config agrees.
- **Default session secret**: a publicly-known fallback secret was only guarded at build time. The server now refuses to start when auth is enabled without a strong `PIWI_AUTH_SECRET`.

### High
- **Default DB-encryption key**: refuses to encrypt stored credentials (AI keys, SCM tokens, webhook secrets) under the built-in default `PIWI_SECRET_KEY` instead of silently using a publicly-known key.
- **Stored XSS via uploaded HTML/SVG**: report HTML now runs in an opaque origin (dropped `allow-same-origin`), SVG is served under a no-scripts sandbox, and a caller content-type override can no longer name an executable type.
- **Cross-project notification leak**: subscriptions are scoped to projects the caller can access (null wildcard reserved for global scope), with a delivery-time re-check.
- **No CSP on the desktop webview**: nonce-based `script-src` + `connect-src 'self'` CSP on the IPC-privileged webview, gated on `PIWI_DESKTOP_TOKEN` (no effect on server / Docker / npx).
- **No login brute-force protection**: rate limiting + per-account lockout on login, plus limits on setup / password-reset / verification-email, and an 8-char setup password floor.
- **No session revocation**: a per-user session epoch, bumped on password change/reset, role change and provider unlink, revokes existing sessions.

Also re-enables `PATCH /api/users/[id]`, which rejected every caller.

### Medium (follow-up commits)
- **Notification SSE stream** scoped to accessible projects (was broadcasting every project's run/cluster events to any subscriber).
- **Entity-links IDOR**: all `/api/links*` routes now authorize by project access, not role only — via the existing `requireProjectAccess` / `requireResolvedProjectAccess` helpers.
- **SSRF** in webhook/Slack channel tests and link unfurling: a shared `assertPublicHttpUrl` / `safeFetch` guard (scheme check + DNS-resolved private/loopback/link-local/metadata block + per-redirect-hop revalidation).
- **Decompression caps** (zip-bomb DoS): explicit `maxOutputLength` on every trace/report inflate & gunzip path (512 MiB/entry, 1 GiB/archive).
- **First-admin setup race**: an atomic `app_settings` sentinel claim so two concurrent `POST /api/auth/setup` requests can't each create an administrator.
- **Session cookie**: explicit `SameSite=Lax` / `HttpOnly` / `Secure`, pinned locally rather than inherited from h3 defaults.
- **Reporter TLS**: warns when the configured dashboard URL is plaintext `http://` to a non-loopback host (the API key and captured payloads would otherwise travel in cleartext).
- **Desktop download**: `desktop_save_download` never overwrites an existing file — atomic `create_new` with browser-style ` (n)` disambiguation, so it can't clobber a trusted file.

### Audited & dispositioned (no code change this PR)
- Reporter request-URL redaction — **already mitigated**: the server strips query strings from network URLs on ingestion, before anything is persisted, exposed via GET, or sent to the LLM.
- Console-text secret scrubbing, backend-log response-header gating, and the desktop navigation lock are noted as deliberate follow-ups (heuristic freeform-text scrubbing and a Tauri window-creation refactor each warrant a separate, GUI-validated change).

## How was it tested?

- `app:typecheck`, `app:lint`, and the full unit suite (**1297 passing**), including new tests for the setup-race claim, decompression caps, the SSRF guard, and the reporter TLS warning; reporter typecheck/lint/tests; the desktop download helper validated with `rustc --test` and compiled in-crate by the desktop e2e workflow.
- Built the app and drove the real server: default boots with no CSP; desktop mode nonces every inline script; auth-enabled-without-a-secret refuses to boot; auth-enabled-with-a-secret enforces auth (`/` → `/login`).
- Full CI green: build, lint/typecheck/unit, 20-shard E2E across {local, s3} × {sqlite, postgres}, demo-generation, and desktop e2e.

**Operational notes**
- Fail-closed is a behavior change: an instance with auth enabled but no secret, or one storing credentials without `PIWI_SECRET_KEY`, now errors instead of using the built-in default key. The shipped one-click manifests already provide both.
- First-admin setup is now strictly one-time — it no longer reopens if every user is later deleted.
- Includes a DB migration (`session_epoch` column, SQLite + Postgres), applied automatically on startup.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (deploy-manifest comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175i656UHuxzpdZGKRKH1WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0175i656UHuxzpdZGKRKH1WJ)_