### PR TITLE
fix(extension): recover recording start when permission prompt closes popup

### DIFF
--- a/extension/AGENTS.md
+++ b/extension/AGENTS.md
@@ -29,9 +29,11 @@ recording against a project's own function catalog. See "Connected mode" below.
   itself on every navigation for the lifetime of a recording — see `background/index.ts`.
 - `src/background/` — the service worker. Handles the `chrome.commands` keyboard shortcut
   (the toolbar icon opens the popup instead, which injects content scripts itself) and the
-  recorder's start/stop messages (`piwi-start-recording` / `piwi-recording-stopped`) — the
-  only two places `chrome.scripting.registerContentScripts`/`unregisterContentScripts` and
-  `chrome.action.*` are called from, since content scripts can't reach either API.
+  recorder's start/stop messages (`piwi-start-recording` / `piwi-recording-stopped`, plus the
+  `chrome.permissions.onAdded` fallback that starts a recording when the grant prompt closed
+  the popup — see below) — the only places `chrome.scripting.registerContentScripts`/
+  `unregisterContentScripts` and `chrome.action.*` are called from, since content scripts can't
+  reach either API.
 - `src/popup/` — the toolbar popup. Plain TypeScript + DOM, no UI framework — keep it that
   way unless the popup's own complexity genuinely outgrows it. Has a config (gear) button
   (`chrome.runtime.openOptionsPage()`) and, once connected, an **Active project** select that
@@ -140,11 +142,20 @@ instead of needing a live browser for everything.
 - **The recorder's host permission is requested per-origin, per-recording, from the popup's
   own click handler — never pre-granted, never `<all_urls>`.** `chrome.permissions.request`
   only counts as satisfying a user gesture when called synchronously inside one, so this can't
-  move into `background/index.ts` (see `src/popup/main.ts`'s `startRecordingFlow`). Recording
-  covers the one origin granted at start; navigating to a different origin mid-recording is a
-  known, documented limit (see `docs/extension.md`), not a silent gap — a future phase could
-  detect it and prompt to expand, but that also needs a fresh user gesture, which the HUD (a
-  content script, no `chrome.permissions` access) can't provide on its own either.
+  move into `background/index.ts` (see `src/popup/main.ts`'s `startRecordingFlow`). But the
+  prompt that request shows *takes focus and closes the popup on a first-time grant*, killing
+  the code that would have messaged the worker to start — which is why a first recording used
+  to need a second click. So the popup parks a `RecordIntent` (origin + tab, in session
+  storage) inside that same click, and the worker's `chrome.permissions.onAdded` picks it back
+  up when the grant lands and starts the recording itself. Both starts (the popup's own message
+  when it *does* survive, and the `onAdded` fallback) funnel through `startRecordingOnce`, which
+  dedupes; `decideRecordIntent` (pure, unit-tested) is what keeps the fallback from firing on an
+  unrelated grant — the options page granting the instance origin fires the same event — or on a
+  stale intent. Recording covers the one origin granted at start; navigating to a different
+  origin mid-recording is a known, documented limit (see `docs/extension.md`), not a silent gap
+  — a future phase could detect it and prompt to expand, but that also needs a fresh user
+  gesture, which the HUD (a content script, no `chrome.permissions` access) can't provide on its
+  own either.
 - Reuse `@piwitests/picker-dom`'s exports (`installPickerOverlay`, `showAnchorPicker`,
   probe, role-resolution, syntax highlighting) rather than re-deriving picker logic here —
   that package exists so this workspace doesn't become a third hand-synced copy.

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,4 +1,11 @@
-import { startRecording, getRecordingState, discardRecording } from '../shared/recording-storage.js';
+import {
+  startRecording,
+  getRecordingState,
+  discardRecording,
+  getRecordIntent,
+  clearRecordIntent,
+  decideRecordIntent,
+} from '../shared/recording-storage.js';
 import { getConnectionSettings } from '../shared/connection-settings.js';
 import { fetchCatalog } from '../shared/piwi-client.js';
 import { setCachedCatalog, isCatalogStale } from '../shared/catalog-cache.js';
@@ -94,6 +101,59 @@ async function handleStartRecording(originPattern: string, tabId: number): Promi
 }
 
 /**
+ * Guards against starting the same recording twice.
+ *
+ * A first "Record actions" click resolves its grant down two paths that both
+ * land here: the popup's own `piwi-start-recording` message (when the popup
+ * survives the permission prompt) and `chrome.permissions.onAdded` (when the
+ * prompt closed it). `startInFlight` is set synchronously before the first
+ * await, so a second trigger arriving mid-start sees it and bails; the
+ * persisted `active` flag covers the two arriving far enough apart — or the
+ * worker being torn down between them — that the flag has already reset.
+ */
+let startInFlight = false;
+
+async function startRecordingOnce(originPattern: string, tabId: number): Promise<{ ok: boolean; error?: string }> {
+  if (startInFlight) return { ok: true };
+  startInFlight = true;
+  try {
+    if ((await getRecordingState()).active) return { ok: true };
+    return await handleStartRecording(originPattern, tabId);
+  } finally {
+    startInFlight = false;
+    // The intent has done its job (or failed to) — never leave it to revive a
+    // recording on some later, unrelated grant.
+    await clearRecordIntent().catch(() => undefined);
+  }
+}
+
+/**
+ * Finishes a recording the popup asked for but couldn't start itself.
+ *
+ * The popup requests the host permission inside its click (the only place the
+ * gesture is live), but the prompt takes focus and closes the popup on a
+ * first-time grant — killing the code that would have sent
+ * `piwi-start-recording`. The popup leaves a `RecordIntent` in session storage
+ * before requesting; this fires when the grant lands and picks the intent back
+ * up. `decideRecordIntent` filters out grants that aren't ours (the options
+ * page granting the Piwi instance origin fires the same event) and intents too
+ * old to still be this prompt's answer.
+ */
+async function handlePermissionAdded(addedOrigins: string[]): Promise<void> {
+  const decision = decideRecordIntent(await getRecordIntent(), addedOrigins, Date.now());
+  if (decision.action === 'ignore') return;
+  if (decision.action === 'clear') {
+    await clearRecordIntent().catch(() => undefined);
+    return;
+  }
+  await startRecordingOnce(decision.originPattern, decision.tabId);
+}
+
+chrome.permissions.onAdded.addListener((permissions) => {
+  void handlePermissionAdded(permissions.origins ?? []);
+});
+
+/**
  * Tells every tab still running the recorder that capture is over, so each one
  * drops its HUD and its "this tab is being recorded" border.
  *
@@ -172,7 +232,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
   if (message?.type === 'piwi-start-recording') {
-    void handleStartRecording(message.originPattern, message.tabId).then(sendResponse);
+    // Through the dedupe guard, not `handleStartRecording` directly: on a
+    // first-time grant `chrome.permissions.onAdded` may already be starting the
+    // same recording (see `startRecordingOnce`).
+    void startRecordingOnce(message.originPattern, message.tabId).then(sendResponse);
     return true; // keep the message channel open for the async response
   }
   if (message?.type === 'piwi-refresh-catalog') {

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -1,4 +1,4 @@
-import { getRecordingState, stopRecording } from '../shared/recording-storage.js';
+import { getRecordingState, stopRecording, setRecordIntent, clearRecordIntent } from '../shared/recording-storage.js';
 import { getConnectionSettings, isConnected, type ProjectMapping } from '../shared/connection-settings.js';
 import { getActiveProjectOverride, setActiveProjectOverride, resolveActiveProject } from '../shared/active-project.js';
 
@@ -254,6 +254,9 @@ function recordOriginPattern(url: string | undefined): string | null {
 
 async function startRecordingFlow(originPattern: string, tabId: number, granted: Promise<boolean>): Promise<void> {
   if (!(await granted)) {
+    // Drop the intent the click parked for the worker, so a later unrelated
+    // grant for this same origin can't revive a recording the user declined.
+    await clearRecordIntent().catch(() => undefined);
     statusEl.textContent = 'Permission for this site is needed to record across pages.';
     return;
   }
@@ -307,6 +310,7 @@ recordBtn.addEventListener('click', () => {
     statusEl.textContent = "Can't record on this page.";
     return;
   }
+  const tabId = recordTab.id;
   // Synchronous, before any await: this is the user gesture the request needs.
   let granted: Promise<boolean>;
   try {
@@ -315,7 +319,13 @@ recordBtn.addEventListener('click', () => {
     statusEl.textContent = 'Permission for this site is needed to record across pages.';
     return;
   }
-  void startRecordingFlow(originPattern, recordTab.id, granted);
+  // Park the intent so the background can still start the recording if this
+  // popup is torn down when the prompt takes focus — the first-time grant that
+  // used to leave the recorder needing a second click. Fire-and-forget: it must
+  // not delay the request above, and `startRecordingFlow` still starts things
+  // directly whenever the popup does survive.
+  void setRecordIntent({ originPattern, tabId });
+  void startRecordingFlow(originPattern, tabId, granted);
 });
 
 recordBtn.disabled = true;

--- a/extension/src/shared/recording-storage.ts
+++ b/extension/src/shared/recording-storage.ts
@@ -53,6 +53,82 @@ export async function discardRecording(): Promise<void> {
 }
 
 /**
+ * A "Record actions" click that still needs its host permission, parked in
+ * `chrome.storage.session` so the *background* can finish starting the
+ * recording after the popup is gone.
+ *
+ * The popup can't do it itself: `chrome.permissions.request` shows a prompt
+ * that takes focus and closes the popup on a first-time grant, tearing down the
+ * code that awaited the grant before it can message the worker — which is why a
+ * first recording used to need a second click. The popup writes this intent
+ * inside the same click, then `chrome.permissions.onAdded` in the worker reads
+ * it back when the grant lands (see `decideRecordIntent`).
+ */
+const RECORD_INTENT_KEY = 'piwiRecordIntent';
+
+export interface RecordIntent {
+  /** The origin pattern the popup requested (e.g. `https://app.example.com/*`). */
+  originPattern: string;
+  /** The tab the click applied to — the already-loaded page that needs the one-off inject. */
+  tabId: number;
+  /** When the popup requested the grant; a stale intent is ignored rather than reviving a recording on some later, unrelated grant. */
+  createdAt: number;
+}
+
+/**
+ * How long a parked intent stays actionable. A permission prompt is answered in
+ * seconds; well past that, a matching grant is more likely an unrelated one
+ * (the options page granting the instance origin, say) than a slow answer to
+ * this prompt, so the worker ignores it instead of starting a surprise recording.
+ */
+export const RECORD_INTENT_TTL_MS = 60_000;
+
+export async function setRecordIntent(intent: Omit<RecordIntent, 'createdAt'>): Promise<void> {
+  await chrome.storage.session.set({ [RECORD_INTENT_KEY]: { ...intent, createdAt: Date.now() } });
+}
+
+export async function getRecordIntent(): Promise<RecordIntent | null> {
+  const stored = await chrome.storage.session.get(RECORD_INTENT_KEY);
+  const value = stored[RECORD_INTENT_KEY];
+  if (!value || typeof value !== 'object') return null;
+  const intent = value as Partial<RecordIntent>;
+  if (typeof intent.originPattern !== 'string' || typeof intent.tabId !== 'number') return null;
+  return { originPattern: intent.originPattern, tabId: intent.tabId, createdAt: intent.createdAt ?? 0 };
+}
+
+export async function clearRecordIntent(): Promise<void> {
+  await chrome.storage.session.remove(RECORD_INTENT_KEY);
+}
+
+export type RecordIntentDecision =
+  | { action: 'start'; originPattern: string; tabId: number }
+  | { action: 'clear' }
+  | { action: 'ignore' };
+
+/**
+ * Pure half of the worker's `chrome.permissions.onAdded` handler: given the
+ * parked intent and the origins a grant just added, decide whether to start the
+ * recording, drop a stale intent, or leave everything alone.
+ *
+ * - `ignore` when there's no intent, or the grant didn't include the intent's
+ *   own origin — the options page granting the Piwi instance origin fires the
+ *   same event and must not start a recording.
+ * - `clear` when the intent is older than {@link RECORD_INTENT_TTL_MS}: the
+ *   prompt was left long enough that this grant is unlikely to be its answer.
+ * - `start` otherwise.
+ */
+export function decideRecordIntent(
+  intent: RecordIntent | null,
+  addedOrigins: string[],
+  now: number,
+): RecordIntentDecision {
+  if (!intent) return { action: 'ignore' };
+  if (!addedOrigins.includes(intent.originPattern)) return { action: 'ignore' };
+  if (now - intent.createdAt > RECORD_INTENT_TTL_MS) return { action: 'clear' };
+  return { action: 'start', originPattern: intent.originPattern, tabId: intent.tabId };
+}
+
+/**
  * Serializes appends within one document.
  *
  * An append is read-modify-write against a single storage key, and every DOM

--- a/extension/tests/unit/recording-storage.test.ts
+++ b/extension/tests/unit/recording-storage.test.ts
@@ -5,6 +5,12 @@ import {
   stopRecording,
   discardRecording,
   appendRecordingEvent,
+  setRecordIntent,
+  getRecordIntent,
+  clearRecordIntent,
+  decideRecordIntent,
+  RECORD_INTENT_TTL_MS,
+  type RecordIntent,
 } from '../../src/shared/recording-storage.js';
 import type { RawCaptureEvent } from '@piwitests/core/recording';
 
@@ -131,5 +137,66 @@ describe('recording state', () => {
     const state = await getRecordingState();
     expect(state.active).toBe(false);
     expect(state.events).toEqual([]);
+  });
+});
+
+describe('record intent', () => {
+  it('round-trips the origin pattern and tab, stamping a creation time', async () => {
+    const before = Date.now();
+    await setRecordIntent({ originPattern: 'https://x.test/*', tabId: 7 });
+    const intent = await getRecordIntent();
+    expect(intent).not.toBeNull();
+    expect(intent!.originPattern).toBe('https://x.test/*');
+    expect(intent!.tabId).toBe(7);
+    expect(intent!.createdAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it('reads back null when nothing is parked', async () => {
+    expect(await getRecordIntent()).toBeNull();
+  });
+
+  it('reads back null for a malformed intent rather than a half-populated one', async () => {
+    (globalThis as any).chrome.storage.session.set({ piwiRecordIntent: { originPattern: 'https://x.test/*' } });
+    expect(await getRecordIntent()).toBeNull();
+  });
+
+  it('clearRecordIntent removes it', async () => {
+    await setRecordIntent({ originPattern: 'https://x.test/*', tabId: 7 });
+    await clearRecordIntent();
+    expect(await getRecordIntent()).toBeNull();
+  });
+});
+
+describe('decideRecordIntent', () => {
+  const intent: RecordIntent = { originPattern: 'https://x.test/*', tabId: 7, createdAt: 1_000 };
+
+  it('ignores a grant when nothing is parked', () => {
+    expect(decideRecordIntent(null, ['https://x.test/*'], 1_000)).toEqual({ action: 'ignore' });
+  });
+
+  it('ignores a grant for some other origin — the options page granting the instance origin fires the same event', () => {
+    expect(decideRecordIntent(intent, ['https://piwi.test/*'], 1_000)).toEqual({ action: 'ignore' });
+  });
+
+  it('starts the recording when a fresh intent matches the granted origin', () => {
+    expect(decideRecordIntent(intent, ['https://x.test/*'], 1_500)).toEqual({
+      action: 'start',
+      originPattern: 'https://x.test/*',
+      tabId: 7,
+    });
+  });
+
+  it('starts when the granted set includes the origin among others', () => {
+    expect(decideRecordIntent(intent, ['https://other.test/*', 'https://x.test/*'], 1_500).action).toBe('start');
+  });
+
+  it('clears a stale intent instead of reviving a recording on a much later grant', () => {
+    expect(decideRecordIntent(intent, ['https://x.test/*'], 1_000 + RECORD_INTENT_TTL_MS + 1)).toEqual({
+      action: 'clear',
+    });
+  });
+
+  it('still starts right at the TTL boundary', () => {
+    expect(decideRecordIntent(intent, ['https://x.test/*'], 1_000 + RECORD_INTENT_TTL_MS).action).toBe('start');
   });
 });


### PR DESCRIPTION
## What & why

When a user clicks "Record actions" for the first time on an origin, `chrome.permissions.request` shows a prompt that takes focus and closes the popup on grant. This killed the code path that would message the background worker to start the recording, requiring a second click to actually begin.

This change fixes that by:

1. **Parking a `RecordIntent`** in session storage (origin + tab ID + timestamp) synchronously inside the click handler, before requesting the permission
2. **Listening to `chrome.permissions.onAdded`** in the background worker to detect when the grant lands
3. **Deciding whether to start** via `decideRecordIntent` (pure, unit-tested logic) that:
   - Ignores grants for unrelated origins (e.g., the options page granting the Piwi instance origin fires the same event)
   - Ignores stale intents (older than 60 seconds) to avoid reviving recordings on unrelated later grants
   - Starts the recording if the intent is fresh and matches the granted origin
4. **Deduping starts** via `startRecordingOnce` so both paths (popup's direct message when it survives, and `onAdded` fallback) don't double-start

The popup still starts recordings directly when it survives the prompt; this is a fallback for the first-time grant case.

## How was it tested

- Added comprehensive unit tests for `RecordIntent` storage and `decideRecordIntent` logic covering:
  - Round-tripping intent data with creation timestamps
  - Malformed intent handling
  - Intent clearing
  - Decision logic for matching/non-matching origins, fresh/stale intents, and boundary conditions
- Updated `AGENTS.md` to document the new flow
- Existing tests continue to pass

## Checklist

- [x] PR title follows Conventional Commits (`fix(extension): ...`)
- [x] Tests added for behavior changes (unit tests in `recording-storage.test.ts`)
- [x] Docs updated (`AGENTS.md` explains the new permission flow)

https://claude.ai/code/session_019FUFbtahGuYhUsd5akKwGb