### PR TITLE
ci: run the desktop crate's unit tests in the desktop workflow

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -1,10 +1,11 @@
 name: Desktop E2E
 
-# Smoke-tests the real desktop shell by driving its webview with Playwright via
-# tauri-plugin-playwright (the app is built with the `e2e-testing` feature, which
-# embeds the control plugin). This boots the whole app — server sidecar + native
-# window — so it is heavier and slower than the unit/integration CI; it runs only
-# on desktop changes and on demand.
+# Runs the Rust crate's unit tests, then smoke-tests the real desktop shell by
+# driving its webview with Playwright via tauri-plugin-playwright (the app is
+# built with the `e2e-testing` feature, which embeds the control plugin). The
+# smoke test boots the whole app — server sidecar + native window — so this is
+# heavier and slower than the unit/integration CI; it runs only on desktop
+# changes and on demand.
 on:
   workflow_dispatch:
   pull_request:
@@ -64,6 +65,14 @@ jobs:
       - name: Install Playwright runtime
         working-directory: apps/desktop
         run: npx playwright install chromium
+
+      # The shell's own unit tests (MCP client entries, the stdio bridge, the
+      # local-run helpers). Runs ahead of the app build so a logic regression
+      # fails here instead of minutes later in the webview. `build.rs` needs the
+      # icons, the Node sidecar and the staged server, all present by this step.
+      - name: Run Rust unit tests
+        working-directory: apps/desktop/src-tauri
+        run: cargo test
 
       # Compile up front so `tauri dev` (launched by the fixture) only has to boot,
       # keeping startup inside the fixture's startTimeout.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -42,4 +42,8 @@ npm run stage        # build the server and stage it into src-tauri/resources
 npm run dev          # tauri dev — run the shell against a staged server
 npm run build        # produce the platform installer
 npm run e2e          # Playwright smoke test of the shell integration
+cargo test --manifest-path src-tauri/Cargo.toml   # the shell's Rust unit tests
 ```
+
+`build.rs` copies the Node sidecar, the staged server and the app icons into the bundle, and fails when any of them is missing — so `cargo test` needs `fetch-node`, `stage` and
+`npx tauri icon ../application/public/logo.svg` to have run first. `desktop-e2e.yml` does all three before it runs the tests.


### PR DESCRIPTION
## What & why

The Rust unit tests in `apps/desktop/src-tauri` — covering the MCP client entries, the MCP stdio bridge and the local-run helpers — only ever ran by hand. `desktop-e2e.yml` runs `cargo build --features e2e-testing` and `desktop-release.yml` runs `tauri build`; neither executes the test profile, so a regression in that logic could compile and reach `main` green.

This adds a `cargo test` step to the desktop workflow:

```yaml
- name: Run Rust unit tests
  working-directory: apps/desktop/src-tauri
  run: cargo test
```

Placement is deliberate. `build.rs` fails outright unless the Node sidecar, the staged server and the app icons are all present, and the earlier steps in this job already stage all three — so the step needs no new setup. It sits ahead of `Pre-build the shell` so a logic regression fails in seconds rather than after the whole app boots. The workflow already triggers on `apps/desktop/**`, which is exactly when these tests matter.

Also documents the command and that `build.rs` prerequisite in `apps/desktop/AGENTS.md`, since running `cargo test` in a fresh checkout fails on the missing sidecar/resources/icons with an error that doesn't point at the fix.

## How was it tested?

- Ran the workflow's exact command locally after staging the same prerequisites the job stages: `cargo test` from `apps/desktop/src-tauri` — **33 passed, 0 failed**.
- Ran the documented form too: `cargo test --manifest-path src-tauri/Cargo.toml` from `apps/desktop` — same result.
- Parsed the workflow YAML and asserted the new step's position in the job: it lands after `Generate app icons` and before `Pre-build the shell (e2e feature)`.

CI on this PR is itself the end-to-end check — the desktop workflow runs on `.github/workflows/desktop-e2e.yml` changes, so the new step executes here on a real macOS runner with real staged artifacts rather than the local stand-ins.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — no behavior change; this makes existing tests gate merges
- [x] Docs updated if user-facing — not user-facing; `apps/desktop/AGENTS.md` documents the command for contributors

Note: commitlint warns `scope may not be empty` on a bare `ci:` title. That matches existing history on `main` (`ci: bump the actions group…`, `ci: run the built demo…`) and is a warning, not an error.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYC8uSaUBk9agxq5J78NZv)_