### PR TITLE
fix(desktop): update Tauri project path to apps/desktop

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -129,7 +129,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          projectPath: desktop
+          projectPath: apps/desktop
           args: --target ${{ matrix.target }} --bundles ${{ matrix.bundles }} ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' && '--config src-tauri/tauri.updater.conf.json' || '' }}
           # Attach to the release release-please already made for this tag. On a
           # manual dispatch (no tag) tagName is empty, so tauri-action just builds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
     },
     "apps/application": {
       "name": "@piwitests/dashboard",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -131,7 +131,7 @@
     },
     "apps/extension": {
       "name": "@piwitests/extension",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@piwitests/core": "*",
         "@piwitests/picker-dom": "*"
@@ -160,7 +160,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation-nitro",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -7982,8 +7982,7 @@
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.5.6",
@@ -26418,11 +26417,11 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.21.0"
+      "version": "0.22.0"
     },
     "packages/picker-dom": {
       "name": "@piwitests/picker-dom",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@piwitests/core": "*"
       },
@@ -26432,7 +26431,7 @@
     },
     "packages/reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -26451,7 +26450,7 @@
     },
     "packages/server": {
       "name": "@piwitests/server",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.17.4",


### PR DESCRIPTION
## What & why

Updates the `projectPath` in the desktop release workflow from `desktop` to `apps/desktop` to reflect the current monorepo structure where the desktop application is located in the `apps/` directory.

This fixes the Tauri build action to correctly locate the desktop project during the release process.

## How was it tested?

N/A — This is a configuration fix for the CI/CD workflow. The change will be validated when the next release workflow runs.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] No tests needed (configuration change)
- [x] No docs updates needed (internal CI configuration)

https://claude.ai/code/session_01KgMgrS87Q3g1bCicvuYTdS