### PR TITLE
feat(app): link local runs to Piwi runs, live progress, sidebar pill, env pre-flight

### DIFF
--- a/apps/application/app/components/desktop/DesktopLocalRunsIndicator.vue
+++ b/apps/application/app/components/desktop/DesktopLocalRunsIndicator.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: ambient sidebar pill shown while local test runs are
+ * active, so a run started on one page stays visible (and reachable) from
+ * every other. Clicking opens the Local runs tray. Renders nothing without
+ * the IPC bridge or when no run is active.
+ */
+const props = defineProps<{ collapsed?: boolean }>();
+
+const store = useDesktopLocalRuns();
+
+const available = ref(false);
+onMounted(() => {
+  available.value = !!tauriCore();
+});
+
+const active = computed(() => store.runs.value.filter((r) => r.status === 'running'));
+const label = computed(() => `${active.value.length} local run${active.value.length === 1 ? '' : 's'}`);
+
+/** "7/12" across every active run, when Playwright announced totals. */
+const progress = computed(() => {
+  const withTotals = active.value.filter((r) => r.progressTotal);
+  if (withTotals.length === 0) return '';
+  const done = withTotals.reduce((sum, r) => sum + r.progressDone, 0);
+  const total = withTotals.reduce((sum, r) => sum + (r.progressTotal ?? 0), 0);
+  return `${done}/${total}`;
+});
+</script>
+
+<template>
+  <UTooltip v-if="available && active.length > 0" :text="props.collapsed ? label : 'Open the Local runs tray'">
+    <UButton
+      color="info"
+      variant="soft"
+      size="xs"
+      block
+      :square="props.collapsed"
+      :aria-label="label"
+      :class="props.collapsed ? '' : 'justify-start'"
+      @click="store.trayOpen.value = true"
+    >
+      <span class="relative flex size-2 shrink-0" aria-hidden="true">
+        <span
+          class="absolute inline-flex h-full w-full animate-ping rounded-full bg-info opacity-60 motion-reduce:hidden"
+        />
+        <span class="relative inline-flex size-2 rounded-full bg-info" />
+      </span>
+      <template v-if="!props.collapsed">
+        <span class="truncate">{{ label }}</span>
+        <span v-if="progress" class="text-muted tabular-nums">{{ progress }}</span>
+      </template>
+    </UButton>
+  </UTooltip>
+</template>

--- a/apps/application/app/components/desktop/DesktopLocalRunsTray.vue
+++ b/apps/application/app/components/desktop/DesktopLocalRunsTray.vue
@@ -16,6 +16,11 @@ onMounted(() => {
   available.value = !!tauriCore();
 });
 
+// This component is mounted once in the layout, which makes it the natural
+// owner of the store's Piwi-run correlation: every server run event (the
+// reporter checking in counts) re-checks pending local runs.
+useRunStream(() => store.correlatePiwiRuns());
+
 /** Manual expand/collapse choices; unset falls back to the default below. */
 const expandedByKey = ref<Record<number, boolean>>({});
 
@@ -39,10 +44,7 @@ function duration(run: LocalRun): string {
 function badge(run: LocalRun): { label: string; color: 'info' | 'success' | 'error' | 'neutral' } {
   switch (run.status) {
     case 'running':
-      return {
-        label: run.steps.length > 1 ? `Running ${run.stepIndex + 1}/${run.steps.length}…` : 'Running…',
-        color: 'info',
-      };
+      return { label: localRunProgressLabel(run), color: 'info' };
     case 'passed':
       return { label: 'Passed', color: 'success' };
     case 'failed':
@@ -134,6 +136,18 @@ const hasFinished = computed(() => runs.value.some((r) => r.status !== 'running'
               :aria-label="isExpanded(run) ? 'Collapse output' : 'Expand output'"
               @click="toggleExpanded(run)"
             />
+          </div>
+          <div v-if="run.piwiRunId != null" class="mt-1.5">
+            <UButton
+              size="xs"
+              color="success"
+              variant="soft"
+              icon="i-lucide-external-link"
+              :to="`/test-runs/${run.piwiRunId}`"
+              @click="trayOpen = false"
+            >
+              Live in Piwi — Run #{{ run.piwiRunId }}
+            </UButton>
           </div>
           <DesktopLocalRunConsole v-if="isExpanded(run)" :lines="run.lines" class="mt-2" />
         </article>

--- a/apps/application/app/components/desktop/DesktopRunLocallyButton.vue
+++ b/apps/application/app/components/desktop/DesktopRunLocallyButton.vue
@@ -30,6 +30,7 @@ const { missingSpecs, wrongFolder, checkSpecs } = useDesktopSpecCheck(
   () => props.projectId,
   () => props.cases,
 );
+const { playwrightMissing, checkEnv } = useDesktopEnvCheck(() => props.projectId);
 const { copy } = useCopy();
 
 const modalOpen = ref(false);
@@ -41,10 +42,12 @@ watch(modalOpen, (isOpen) => {
 
 const canRun = computed(() => available.value && props.projectId != null && props.cases.length > 0);
 const linked = computed(() => !!link.value?.exists);
-const attention = computed(() => !linked.value || wrongFolder.value);
+const attention = computed(() => !linked.value || wrongFolder.value || playwrightMissing.value);
 
 watch([available, () => link.value?.path, linked], () => {
-  if (available.value) void checkSpecs(linked.value);
+  if (!available.value) return;
+  void checkSpecs(linked.value);
+  void checkEnv();
 });
 
 const options = computed(() => store.getProjectOptions(props.projectId ?? ''));
@@ -69,7 +72,7 @@ const face = computed(() => {
   const run = contextRun.value;
   if (run && running.value) {
     return {
-      label: run.steps.length > 1 ? `Running ${run.stepIndex + 1}/${run.steps.length}…` : 'Running…',
+      label: localRunProgressLabel(run),
       color: 'info' as const,
       icon: undefined,
       tooltip: 'A local run is going — view its output',
@@ -119,7 +122,7 @@ function onPrimaryClick() {
     store.trayOpen.value = true;
     return;
   }
-  if (!linked.value || wrongFolder.value) {
+  if (attention.value) {
     modalOpen.value = true;
     return;
   }
@@ -144,6 +147,19 @@ const menuItems = computed<DropdownMenuItem[][]>(() => {
     groups.push([
       { type: 'label', label: 'Tests not found in the linked folder' },
       { label: 'Choose the right folder…', icon: 'i-lucide-folder-search', onSelect: () => void pickAndLink() },
+      { label: 'Run anyway', icon: 'i-lucide-play', onSelect: () => runNow() },
+    ]);
+  } else if (playwrightMissing.value) {
+    groups.push([
+      { type: 'label', label: 'No Playwright found in the linked folder' },
+      {
+        label: 'Re-check after installing',
+        icon: 'i-lucide-refresh-cw',
+        onSelect: (e: Event) => {
+          e.preventDefault();
+          void checkEnv();
+        },
+      },
       { label: 'Run anyway', icon: 'i-lucide-play', onSelect: () => runNow() },
     ]);
   }

--- a/apps/application/app/components/desktop/DesktopRunLocallyModal.vue
+++ b/apps/application/app/components/desktop/DesktopRunLocallyModal.vue
@@ -25,6 +25,7 @@ const { missingSpecs, wrongFolder, checkSpecs } = useDesktopSpecCheck(
   () => props.projectId,
   () => props.cases,
 );
+const { playwrightMissing, checkEnv } = useDesktopEnvCheck(() => props.projectId);
 
 const linked = computed(() => !!link.value?.exists);
 
@@ -55,7 +56,9 @@ const modeItems = RETRY_MODE_ITEMS;
 const runModeItems = LOCAL_RUN_MODE_ITEMS;
 
 watch([open, () => link.value?.path, linked], () => {
-  if (open.value) void checkSpecs(linked.value);
+  if (!open.value) return;
+  void checkSpecs(linked.value);
+  void checkEnv();
 });
 
 const plan = computed(() => buildLocalRunPlan(props.cases, options.value));
@@ -137,6 +140,20 @@ function run() {
               <USwitch v-model="trace" />
             </UFormField>
           </div>
+
+          <UAlert
+            v-if="playwrightMissing"
+            color="warning"
+            variant="soft"
+            icon="i-lucide-package-x"
+            title="No Playwright installation found"
+          >
+            <template #description>
+              Neither <code class="text-xs">{{ link?.path }}</code> nor its parents hold a
+              <code class="text-xs">node_modules</code> with Playwright. Run your package manager's install in the
+              checkout first — the app executes that folder's own Playwright.
+            </template>
+          </UAlert>
 
           <UAlert
             v-if="missingSpecs.length > 0"

--- a/apps/application/app/composables/useDesktopEnvCheck.ts
+++ b/apps/application/app/composables/useDesktopEnvCheck.ts
@@ -1,0 +1,33 @@
+/**
+ * Ask the desktop shell whether a local run could start at all in the folder
+ * linked to a project: does the folder still exist, and does it (or a parent,
+ * for hoisted monorepo installs) hold a Playwright installation? Surfaces the
+ * "run your package manager's install first" case before anything spawns.
+ */
+
+export interface DesktopLocalEnv {
+  folder: string;
+  exists: boolean;
+  playwrightCli: string | null;
+}
+
+export function useDesktopEnvCheck(projectId: MaybeRefOrGetter<string | number | null | undefined>) {
+  const env = ref<DesktopLocalEnv | null>(null);
+
+  const playwrightMissing = computed(() => !!env.value?.exists && env.value.playwrightCli == null);
+
+  async function checkEnv() {
+    const core = tauriCore();
+    const id = toValue(projectId);
+    env.value = null;
+    if (!core || id == null) return;
+    try {
+      env.value = await core.invoke<DesktopLocalEnv>('desktop_check_local_env', { projectId: String(id) });
+    } catch {
+      // No folder linked, or an older shell without the command — the run
+      // itself still reports either way.
+    }
+  }
+
+  return { env, playwrightMissing, checkEnv };
+}

--- a/apps/application/app/composables/useDesktopLocalRuns.ts
+++ b/apps/application/app/composables/useDesktopLocalRuns.ts
@@ -48,6 +48,20 @@ export interface LocalRun {
   /** Shell id of the step currently spawned, for stopping it. */
   shellId: number | null;
   stopRequested: boolean;
+  /** Tests announced by Playwright's "Running N tests" lines, across steps. */
+  progressTotal: number | null;
+  /** Per-test result lines seen so far. */
+  progressDone: number;
+  /** The Piwi run this local process produced, once the reporter checked in. */
+  piwiRunId: number | null;
+  /** Latest Piwi run id for the project at spawn — anything newer is ours. */
+  piwiRunBaseline: number | null;
+}
+
+/** Live label for a running run — test counts when Playwright announced them. */
+export function localRunProgressLabel(run: LocalRun): string {
+  if (run.progressTotal) return `Running ${run.progressDone}/${run.progressTotal}…`;
+  return run.steps.length > 1 ? `Running ${run.stepIndex + 1}/${run.steps.length}…` : 'Running…';
 }
 
 export const DEFAULT_LOCAL_RUN_OPTIONS: SavedLocalRunOptions = {
@@ -92,13 +106,23 @@ let pendingEvents: LocalRunEventPayload[] = [];
 const runByShellId = new Map<number, LocalRun>();
 const exitResolvers = new Map<number, (code: number | null) => void>();
 let toastApi: ReturnType<typeof useToast> | null = null;
+let routerApi: ReturnType<typeof useRouter> | null = null;
 let optionsLoaded = false;
+
+// Playwright's list reporter, as the shell captures it (plain, non-TTY): a
+// "Running N tests using M workers" announcement per step, then one line per
+// finished test starting with a result mark (✓/✘ or the ASCII fallbacks).
+const PROGRESS_TOTAL_RE = /^Running (\d+) tests? using \d+ workers?$/;
+const PROGRESS_RESULT_RE = /^\s{1,6}(?:✓|✘|✗|x|ok|-)\s+\d+\s/;
 
 export function useDesktopLocalRuns() {
   const runs = useState<LocalRun[]>('desktop-local-runs', () => []);
   const trayOpen = useState<boolean>('desktop-local-runs-tray', () => false);
   const optionsByProject = useState<Record<string, SavedLocalRunOptions>>('desktop-local-run-options', () => ({}));
-  if (import.meta.client) toastApi = useToast();
+  if (import.meta.client) {
+    toastApi = useToast();
+    routerApi = useRouter();
+  }
 
   const activeCount = computed(() => runs.value.filter((r) => r.status === 'running').length);
 
@@ -132,6 +156,14 @@ export function useDesktopLocalRuns() {
   function pushLine(run: LocalRun, text: string, error: boolean) {
     run.lines.push({ text, error });
     if (run.lines.length > MAX_LINES) run.lines.splice(0, run.lines.length - MAX_LINES);
+    if (error) return;
+    const total = PROGRESS_TOTAL_RE.exec(text);
+    if (total) {
+      run.progressTotal = (run.progressTotal ?? 0) + Number(total[1]);
+    } else if (PROGRESS_RESULT_RE.test(text)) {
+      // Retried tests print extra result lines, so clamp to the announced total.
+      run.progressDone = Math.min(run.progressDone + 1, run.progressTotal ?? run.progressDone + 1);
+    }
   }
 
   function dispatch(run: LocalRun, payload: LocalRunEventPayload) {
@@ -224,13 +256,26 @@ export function useDesktopLocalRuns() {
         trayOpen.value = true;
       },
     };
+    const openPiwiRun =
+      run.piwiRunId == null
+        ? []
+        : [
+            {
+              label: `Open run #${run.piwiRunId}`,
+              color: 'neutral' as const,
+              variant: 'outline' as const,
+              onClick: () => {
+                void routerApi?.push(`/test-runs/${run.piwiRunId}`);
+              },
+            },
+          ];
     if (run.status === 'passed') {
       toastApi?.add({
         title: 'Local run passed',
         description: `${label} — ${tests} in ${seconds}s`,
         icon: 'i-lucide-check',
         color: 'success',
-        actions: [viewOutput],
+        actions: [viewOutput, ...openPiwiRun],
       });
     } else if (run.status === 'failed') {
       toastApi?.add({
@@ -238,7 +283,7 @@ export function useDesktopLocalRuns() {
         description: `${label} — exit ${run.exitCode ?? 1} after ${seconds}s`,
         icon: 'i-lucide-x',
         color: 'error',
-        actions: [viewOutput],
+        actions: [viewOutput, ...openPiwiRun],
       });
     } else {
       toastApi?.add({
@@ -290,14 +335,52 @@ export function useDesktopLocalRuns() {
       finishedAt: null,
       shellId: null,
       stopRequested: false,
+      progressTotal: null,
+      progressDone: 0,
+      piwiRunId: null,
+      piwiRunBaseline: null,
     };
     runs.value = [run, ...runs.value];
     // Mutations must go through the reactive proxy the array hands back, not
     // the plain object above — the tray and button render from it live.
     const tracked = runs.value[0]!;
     trayOpen.value = true;
+    void captureBaseline(tracked);
     void drive(tracked);
     return tracked;
+  }
+
+  /**
+   * Record the project's newest Piwi run id before our process can report:
+   * any run the server announces later with a higher id is the one this local
+   * process produced (the reporter finds the app via `~/.piwi/desktop.json`).
+   */
+  async function captureBaseline(run: LocalRun) {
+    try {
+      const latest = await $fetch<{ id: number } | null>(`/api/projects/${run.projectId}/latest-run`);
+      run.piwiRunBaseline = latest?.id ?? 0;
+    } catch {
+      // Unknown baseline — this run just won't get a Piwi link.
+    }
+  }
+
+  /**
+   * Match local processes to the Piwi runs they produced. Driven by the shared
+   * SSE stream (the tray subscribes), so the link appears as soon as the
+   * reporter checks in.
+   */
+  async function correlatePiwiRuns() {
+    const cutoff = Date.now() - 2 * 60_000;
+    for (const run of runs.value) {
+      if (run.piwiRunId != null || run.piwiRunBaseline == null) continue;
+      if (run.status !== 'running' && (run.finishedAt ?? 0) < cutoff) continue;
+      try {
+        const latest = await $fetch<{ id: number } | null>(`/api/projects/${run.projectId}/latest-run`);
+        if (latest && latest.id > run.piwiRunBaseline) run.piwiRunId = latest.id;
+      } catch {
+        // Server briefly unavailable — the next stream event retries.
+      }
+    }
   }
 
   function rerun(run: LocalRun): LocalRun | null {
@@ -347,5 +430,6 @@ export function useDesktopLocalRuns() {
     latestForProject,
     getProjectOptions,
     saveProjectOptions,
+    correlatePiwiRuns,
   };
 }

--- a/apps/application/app/layouts/default.vue
+++ b/apps/application/app/layouts/default.vue
@@ -441,6 +441,7 @@ onMounted(async () => {
 
       <template #footer="{ collapsed }">
         <div class="flex flex-col gap-1 w-full">
+          <DesktopLocalRunsIndicator :collapsed="collapsed" />
           <UserMenu :collapsed="collapsed" />
           <ULink
             v-if="!collapsed"

--- a/apps/application/tests/desktop-local-run.spec.ts
+++ b/apps/application/tests/desktop-local-run.spec.ts
@@ -21,6 +21,7 @@ declare global {
     __piwiFakeTauri: {
       invocations: FakeInvocation[];
       finish: (code: number | null) => void;
+      emitLine: (line: string) => void;
     };
   }
 }
@@ -31,6 +32,8 @@ interface FakeBridgeOptions {
   /** Emit two stdout lines and an exit event shortly after each spawn (default true). */
   autoExit?: boolean;
   exitCode?: number;
+  /** Report no Playwright installation from the env pre-flight. */
+  playwrightMissing?: boolean;
 }
 
 /** Install a fake `window.__TAURI__` before any app script runs. */
@@ -46,6 +49,9 @@ async function installFakeBridge(page: Page, options: FakeBridgeOptions) {
       lastRunId: 6,
       finish: (code: number | null) => {
         emit({ id: state.lastRunId, kind: 'exit', line: null, code });
+      },
+      emitLine: (line: string) => {
+        emit({ id: state.lastRunId, kind: 'stdout', line, code: null });
       },
     };
     Object.assign(window, { __piwiFakeTauri: state });
@@ -64,6 +70,14 @@ async function installFakeBridge(page: Page, options: FakeBridgeOptions) {
                 return null;
               case 'desktop_check_local_specs':
                 return { folder: '/home/dev/acme', missing: opts.missingSpecs ?? [] };
+              case 'desktop_check_local_env': {
+                if (!state.link) throw new Error('no folder is linked to this project');
+                return {
+                  folder: state.link.path,
+                  exists: state.link.exists,
+                  playwrightCli: opts.playwrightMissing ? null : '/home/dev/acme/node_modules/@playwright/test/cli.js',
+                };
+              }
               case 'desktop_run_local_tests': {
                 const id = ++state.lastRunId;
                 setTimeout(() => {
@@ -181,12 +195,12 @@ test.describe('Desktop local run', () => {
     await waitForHydration(page);
 
     await page.getByRole('button', { name: 'Run locally' }).click();
-    await expect(tray(page).getByText('Running…', { exact: true })).toBeVisible();
+    await expect(tray(page).getByText('Running 0/1…', { exact: true })).toBeVisible();
 
     // Leave the run page entirely — the store, not the page, owns the run.
     await page.getByRole('link', { name: 'Projects' }).first().click();
     await expect(page).toHaveURL(/\/projects/);
-    await expect(tray(page).getByText('Running…', { exact: true })).toBeVisible();
+    await expect(tray(page).getByText('Running 0/1…', { exact: true })).toBeVisible();
     await expect(tray(page).getByText('Running 1 test using 1 worker')).toBeVisible();
 
     await page.evaluate(() => window.__piwiFakeTauri.finish(0));
@@ -204,7 +218,7 @@ test.describe('Desktop local run', () => {
     await waitForHydration(page);
 
     await page.getByRole('button', { name: 'Run locally' }).click();
-    await expect(tray(page).getByText('Running…', { exact: true })).toBeVisible();
+    await expect(tray(page).getByText('Running 0/1…', { exact: true })).toBeVisible();
 
     await tray(page).getByRole('button', { name: 'Stop' }).click();
     await expect(tray(page).getByText('Stopped', { exact: true })).toBeVisible();
@@ -256,6 +270,87 @@ test.describe('Desktop local run', () => {
     await dialog.getByRole('button', { name: 'Run', exact: true }).click();
     await expect(dialog).toHaveCount(0);
     await expect(tray(page).getByText('Passed', { exact: true })).toBeVisible();
+  });
+
+  test('live test counts reach the button, the tray and the sidebar pill', async ({ page }) => {
+    await installFakeBridge(page, { linked: true, autoExit: false });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    await page.evaluate(() => window.__piwiFakeTauri.emitLine('Running 3 tests using 2 workers'));
+    // The fake spawn already announced 1 test; the second announcement adds 3.
+    await expect(tray(page).getByText('Running 0/4…', { exact: true })).toBeVisible();
+
+    await page.evaluate(() =>
+      window.__piwiFakeTauri.emitLine('  ✓  1 [chromium] › tests/checkout.spec.ts:42:18 › checkout completes (1.2s)'),
+    );
+    await expect(tray(page).getByText('Running 1/4…', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Running 1/4…' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '1 local run' })).toBeVisible();
+
+    await page.evaluate(() => window.__piwiFakeTauri.finish(0));
+    await expect(tray(page).getByText('Passed', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: '1 local run' })).toHaveCount(0);
+  });
+
+  test('links the local process to the Piwi run it produced', async ({ page, request }) => {
+    await installFakeBridge(page, { linked: true, autoExit: false });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    await expect(tray(page).getByText('Running 0/1…', { exact: true })).toBeVisible();
+
+    // The local process reports through the project's own Piwi reporter; here
+    // that check-in is a real submit to the same server, which announces it on
+    // the SSE stream the app correlates from.
+    const res = await retryPost(request, '/api/test-runs/submit', {
+      data: {
+        projectName: PROJECT.DESKTOP_LOCAL_RUN,
+        status: 'passed',
+        startTime: new Date().toISOString(),
+        duration: 2000,
+        totalTests: 1,
+        passedTests: 1,
+        failedTests: 0,
+        skippedTests: 0,
+        testCases: [
+          {
+            title: 'checkout completes',
+            status: 'passed',
+            duration: 2000,
+            location: 'tests/checkout.spec.ts:42:18',
+            browser: { name: 'chromium', projectName: 'chromium' },
+            retries: 0,
+            workerIndex: 0,
+            startedAt: Date.now(),
+          },
+        ],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    await expect(tray(page).getByRole('link', { name: /Live in Piwi — Run #\d+/ })).toBeVisible({ timeout: 15000 });
+
+    await page.evaluate(() => window.__piwiFakeTauri.finish(0));
+    await expect(tray(page).getByText('Passed', { exact: true })).toBeVisible();
+  });
+
+  test('warns when the linked folder has no Playwright installation', async ({ page }) => {
+    await installFakeBridge(page, { linked: true, playwrightMissing: true });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run options' }).click();
+    await expect(page.getByText('No Playwright found in the linked folder')).toBeVisible();
+    await page.keyboard.press('Escape');
+
+    // The primary click demotes to the dialog, which explains — but never blocks.
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('No Playwright installation found')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Run', exact: true })).toBeEnabled();
   });
 
   test('prompts to link a folder when none is linked yet', async ({ page }) => {

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -25,6 +25,7 @@ fn main() {
             "desktop_run_local_tests",
             "desktop_stop_local_tests",
             "desktop_check_local_specs",
+            "desktop_check_local_env",
             "desktop_take_pending_open_files",
             "desktop_mcp_clients",
             "desktop_mcp_connect",

--- a/apps/desktop/src-tauri/capabilities/remote.json
+++ b/apps/desktop/src-tauri/capabilities/remote.json
@@ -20,6 +20,7 @@
     "allow-desktop-run-local-tests",
     "allow-desktop-stop-local-tests",
     "allow-desktop-check-local-specs",
+    "allow-desktop-check-local-env",
     "allow-desktop-take-pending-open-files",
     "allow-desktop-mcp-clients",
     "allow-desktop-mcp-connect",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -36,8 +36,9 @@ use tauri_plugin_store::StoreExt as _;
 use mcp_clients::{desktop_mcp_clients, desktop_mcp_connect, desktop_mcp_disconnect, desktop_mcp_reveal};
 use updates::{desktop_check_update, desktop_install_update, desktop_restart_app};
 use runner::{
-    desktop_check_local_specs, desktop_get_project_link, desktop_pick_folder,
-    desktop_run_local_tests, desktop_set_project_link, desktop_stop_local_tests,
+    desktop_check_local_env, desktop_check_local_specs, desktop_get_project_link,
+    desktop_pick_folder, desktop_run_local_tests, desktop_set_project_link,
+    desktop_stop_local_tests,
 };
 
 pub(crate) const STORE_FILE: &str = "settings.json";
@@ -519,6 +520,7 @@ pub fn run() {
             desktop_run_local_tests,
             desktop_stop_local_tests,
             desktop_check_local_specs,
+            desktop_check_local_env,
             desktop_take_pending_open_files,
             desktop_mcp_clients,
             desktop_mcp_connect,

--- a/apps/desktop/src-tauri/src/runner.rs
+++ b/apps/desktop/src-tauri/src/runner.rs
@@ -214,6 +214,46 @@ fn resolve_playwright_cli(start: &Path) -> Option<PathBuf> {
     None
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalEnvCheck {
+    folder: String,
+    exists: bool,
+    /// Absolute path of the Playwright CLI entry the run would use, when found.
+    playwright_cli: Option<String>,
+}
+
+/// What a local run would find at `folder`: whether the folder is still on disk,
+/// and which Playwright CLI it would execute. A folder that is gone reports no
+/// CLI — its ancestors say nothing about a checkout that is not there.
+fn local_env(folder: &Path) -> LocalEnvCheck {
+    let exists = folder.is_dir();
+    LocalEnvCheck {
+        folder: folder.to_string_lossy().to_string(),
+        exists,
+        playwright_cli: exists
+            .then(|| resolve_playwright_cli(folder))
+            .flatten()
+            .map(|p| p.to_string_lossy().to_string()),
+    }
+}
+
+/// Whether a local run could start at all: the linked folder is still there and
+/// holds a Playwright installation. A missing folder or a missing Playwright is
+/// reported rather than raised, so the dashboard can show the state before
+/// anyone asks for a run.
+#[tauri::command]
+pub fn desktop_check_local_env(
+    app: AppHandle,
+    project_id: String,
+) -> Result<LocalEnvCheck, String> {
+    let folder = read_links(&app)
+        .get(&project_id)
+        .map(PathBuf::from)
+        .ok_or("no folder is linked to this project")?;
+    Ok(local_env(&folder))
+}
+
 fn validate_args(args: &[String]) -> Result<(), String> {
     for arg in args {
         if arg.contains('\0') {
@@ -411,5 +451,69 @@ mod tests {
             missing_specs(&checkout.0, &["tests".into()]),
             vec!["tests".to_string()]
         );
+    }
+
+    /// Put a Playwright package in this folder's own `node_modules`.
+    fn install_playwright(dir: &Path) {
+        let package = dir.join("node_modules").join("@playwright").join("test");
+        std::fs::create_dir_all(&package).expect("create playwright package");
+        std::fs::write(package.join("cli.js"), "").expect("write cli");
+    }
+
+    /// Where `install_playwright` leaves the CLI, in the form the check reports.
+    fn installed_cli(dir: &Path) -> String {
+        dir.join("node_modules")
+            .join("@playwright")
+            .join("test")
+            .join("cli.js")
+            .to_string_lossy()
+            .to_string()
+    }
+
+    #[test]
+    fn finds_the_playwright_installed_in_the_folder() {
+        let checkout = Checkout::new("env-installed");
+        install_playwright(&checkout.0);
+
+        let env = local_env(&checkout.0);
+
+        assert!(env.exists);
+        assert_eq!(env.playwright_cli, Some(installed_cli(&checkout.0)));
+    }
+
+    #[test]
+    fn finds_a_playwright_hoisted_to_a_parent_folder() {
+        let root = Checkout::new("env-hoisted");
+        install_playwright(&root.0);
+        let package = root.0.join("packages").join("web");
+        std::fs::create_dir_all(&package).expect("create package folder");
+
+        let env = local_env(&package);
+
+        assert!(env.exists);
+        assert_eq!(env.playwright_cli, Some(installed_cli(&root.0)));
+    }
+
+    #[test]
+    fn reports_no_cli_when_the_folder_has_no_playwright() {
+        let checkout = Checkout::new("env-bare");
+
+        let env = local_env(&checkout.0);
+
+        assert!(env.exists);
+        assert_eq!(env.playwright_cli, None);
+    }
+
+    #[test]
+    fn reports_a_folder_that_is_not_on_disk() {
+        let checkout = Checkout::new("env-missing");
+        install_playwright(&checkout.0);
+        let gone = checkout.0.join("moved-away");
+
+        let env = local_env(&gone);
+
+        assert!(!env.exists);
+        assert_eq!(env.playwright_cli, None);
+        assert_eq!(env.folder, gone.to_string_lossy());
     }
 }

--- a/apps/docs/desktop.md
+++ b/apps/docs/desktop.md
@@ -135,12 +135,15 @@ the output streams into the **Local runs** tray in the corner of the window.
 Results flow back automatically: the run executes your project's regular
 Playwright config, so the Piwi reporter in it reports to this app through the
 [discovery file](#sending-results-to-it), exactly like a run started from your
-terminal.
+terminal. As soon as the reporter checks in, the run's tray entry links
+straight to the new run — **Live in Piwi** — and while anything is running a
+pill in the sidebar keeps the tray one click away from every page.
 
 Two prerequisites, both usually already true for a project that reports to
 Piwi: the linked folder has `@playwright/test` installed (`node_modules`
 present — monorepos with a hoisted root install work too), and its Playwright
-config includes the Piwi reporter.
+config includes the Piwi reporter. The app checks the first one up front and
+warns before running when no Playwright installation is found.
 
 The linked folder also completes [Open in IDE](/ide-integration): when no
 workspace root is configured there, source links resolve against the linked


### PR DESCRIPTION
## What & why

Phase 2 of the "Run locally" redesign — closes the loop between a spawned local process and the rest of the app. **Stacked on #371** (base is its branch; GitHub will retarget to `main` when #371 merges).

- **"Live in Piwi" correlation**: at spawn the store records the project's newest run id (`latest-run`); when the SSE stream announces a newer one, that's the run our process produced through the project's own Piwi reporter — the tray links straight to it and the finish toast gains an "Open run #N" action. No clock-skew heuristics, just a baseline id.
- **Live test counts**: Playwright's list output ("Running N tests using M workers" + per-test result marks, ASCII fallbacks included) is parsed into `7/12`-style progress shown on the split button, the tray badge, and the pill. Retried tests are clamped to the announced total.
- **Sidebar activity pill** (`DesktopLocalRunsIndicator`): visible from every page while runs are active, with aggregate progress; click opens the tray. Fixes the phase-1 gap where a run started on one page had no affordance elsewhere.
- **Env pre-flight**: new shell command `desktop_check_local_env` reports whether the linked folder is still on disk and which Playwright CLI a run would use (reusing the walk-up resolver). The dashboard surfaces "No Playwright found" in the dropdown and dialog *before* spawning; older shells without the command degrade silently. Registered across all three ACL lists (`generate_handler`, `build.rs` manifest, `capabilities/remote.json`) — the ACL consistency test enforces the trio.

## How was it tested?

- Rust: `cargo test` in `apps/desktop/src-tauri` — 37 passed, zero warnings (4 new tests: in-folder install, hoisted monorepo walk-up, no install, folder gone).
- E2E: `tests/desktop-local-run.spec.ts` grows to 10 tests, all passing CI-style against the built server — including a real correlation test (starts a fake local run, submits an actual run to the server, watches the SSE-driven "Live in Piwi — Run #N" link appear) and a live-progress test driving the button/tray/pill labels.
- `desktop-acl-consistency` unit test green; full unit suite 1300/1300; `app:typecheck`, `app:lint`, `app:format:check` clean.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/desktop.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXuXTYfThzz8cU3J2KwSrw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXuXTYfThzz8cU3J2KwSrw)_