### PR TITLE
feat(app): local run notifications, quit confirmation, and new run-locally entry points

### DIFF
--- a/apps/application/app/components/desktop/DesktopRunLocallyButton.vue
+++ b/apps/application/app/components/desktop/DesktopRunLocallyButton.vue
@@ -17,6 +17,14 @@ const props = defineProps<{
   projectId?: string | number | null;
   projectLabel?: string | null;
   cases: RetryCase[];
+  /** Primary label while idle — entry points like "Reproduce locally". */
+  label?: string;
+  /**
+   * One-off option overrides for runs started from this button (e.g. repeat
+   * ×20 with trace). Applied on top of the project's saved options and kept
+   * out of its saved defaults.
+   */
+  presetOptions?: LocalRunOptions;
 }>();
 
 const available = ref(false);
@@ -50,7 +58,7 @@ watch([available, () => link.value?.path, linked], () => {
   void checkEnv();
 });
 
-const options = computed(() => store.getProjectOptions(props.projectId ?? ''));
+const options = computed(() => ({ ...store.getProjectOptions(props.projectId ?? ''), ...props.presetOptions }));
 const contextRun = computed(() => store.latestForProject(props.projectId));
 const running = computed(() => contextRun.value?.status === 'running');
 
@@ -93,14 +101,14 @@ const face = computed(() => {
   }
   if (!linked.value) {
     return {
-      label: 'Run locally',
+      label: props.label ?? 'Run locally',
       color: 'warning' as const,
       icon: 'i-lucide-monitor-play',
       tooltip: 'Link this project to its local checkout to run tests here',
     };
   }
   return {
-    label: 'Run locally',
+    label: props.label ?? 'Run locally',
     color: 'warning' as const,
     icon: 'i-lucide-monitor-play',
     tooltip: `Run ${testsLabel.value} on this machine · ${runModeLabel.value} · in ${link.value?.path}`,
@@ -113,7 +121,8 @@ function runNow(patch?: LocalRunOptions) {
     projectId: props.projectId,
     projectLabel: props.projectLabel,
     cases: props.cases,
-    options: patch,
+    options: { ...props.presetOptions, ...patch },
+    persistOptions: props.presetOptions ? false : undefined,
   });
 }
 

--- a/apps/application/app/components/run/RunSummary.vue
+++ b/apps/application/app/components/run/RunSummary.vue
@@ -40,6 +40,13 @@ const { copy, copied } = useCopy();
 const retryMode = ref<RetryMode>('file-line');
 const retryCopied = ref(false);
 
+// Inside the desktop shell the run-locally split button covers copying the
+// command ("Copy as command"), so the copy-only Retry button stays web-only.
+const desktopBridge = ref(false);
+onMounted(() => {
+  desktopBridge.value = !!tauriCore();
+});
+
 const failedCases = computed(() => {
   if (!props.testRun?.testCases) return [];
   return props.testRun.testCases
@@ -324,7 +331,7 @@ function onLabelKeydown(e: KeyboardEvent) {
                   @click="copy(buildRunSummary(), { toast: 'Run summary copied' })"
                 />
               </UTooltip>
-              <UPopover v-if="failedCases.length > 0">
+              <UPopover v-if="failedCases.length > 0 && !desktopBridge">
                 <UButton
                   size="xs"
                   color="warning"

--- a/apps/application/app/composables/useDesktopLocalRuns.ts
+++ b/apps/application/app/composables/useDesktopLocalRuns.ts
@@ -248,6 +248,7 @@ export function useDesktopLocalRuns() {
     const label = run.projectLabel || 'Local run';
     const tests = `${run.cases.length} test${run.cases.length === 1 ? '' : 's'}`;
     const seconds = Math.max(1, Math.round(((run.finishedAt ?? Date.now()) - run.startedAt) / 1000));
+    notifyUnfocused(run, label, tests, seconds);
     const viewOutput = {
       label: 'View output',
       color: 'neutral' as const,
@@ -296,6 +297,32 @@ export function useDesktopLocalRuns() {
     }
   }
 
+  /**
+   * A headless run can take minutes — when the window is hidden or unfocused,
+   * also raise an OS notification. Inside the shell, `window.Notification` is
+   * shimmed onto native notifications (and the dock/taskbar unread badge) by
+   * the desktop plugin.
+   */
+  function notifyUnfocused(run: LocalRun, label: string, tests: string, seconds: number) {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+    if (!document.hidden && document.hasFocus()) return;
+    const title =
+      run.status === 'passed'
+        ? 'Local run passed'
+        : run.status === 'failed'
+          ? 'Local run failed'
+          : 'Local run could not start';
+    const body =
+      run.status === 'failed'
+        ? `${label} — exit ${run.exitCode ?? 1} after ${seconds}s`
+        : `${label} — ${tests} in ${seconds}s`;
+    try {
+      new Notification(title, { body });
+    } catch {
+      // Notifications unavailable in this webview — the toast still shows.
+    }
+  }
+
   function trimFinished() {
     const finished = runs.value.filter((r) => r.status !== 'running');
     if (finished.length <= MAX_FINISHED) return;
@@ -314,12 +341,15 @@ export function useDesktopLocalRuns() {
     projectLabel?: string | null;
     cases: RetryCase[];
     options?: LocalRunOptions;
+    /** `false` keeps the merged options out of the project's saved defaults —
+     * for preset entry points like "Reproduce locally". */
+    persistOptions?: boolean;
   }): LocalRun | null {
     if (!tauriCore() || input.cases.length === 0) return null;
     const options = { ...getProjectOptions(input.projectId), ...input.options };
     const steps = buildLocalRunPlan(input.cases, options);
     if (steps.length === 0) return null;
-    saveProjectOptions(input.projectId, options);
+    if (input.persistOptions !== false) saveProjectOptions(input.projectId, options);
     const run: LocalRun = {
       key: nextKey++,
       projectId: String(input.projectId),
@@ -384,11 +414,14 @@ export function useDesktopLocalRuns() {
   }
 
   function rerun(run: LocalRun): LocalRun | null {
+    // Re-running repeats the run exactly; only explicit choices change the
+    // project's saved defaults.
     return startRun({
       projectId: run.projectId,
       projectLabel: run.projectLabel,
       cases: run.cases,
       options: run.options,
+      persistOptions: false,
     });
   }
 

--- a/apps/application/app/pages/failure-clusters/[id].vue
+++ b/apps/application/app/pages/failure-clusters/[id].vue
@@ -120,16 +120,15 @@ const errorPeek = computed(() => {
 const { scmStatus } = useScmStatusSummary(clusterDiagnosis.coverage);
 
 // Retry command for the test-evidence header (built from all affected cases).
-const retryCommand = computed(() =>
-  buildRetryCommand(
-    (cluster.value?.affectedTestCases ?? []).map((tc) => ({
-      filePath: tc.filePath,
-      title: tc.title,
-      line: null,
-      projectName: null,
-    })),
-  ),
+const affectedRetryCases = computed(() =>
+  (cluster.value?.affectedTestCases ?? []).map((tc) => ({
+    filePath: tc.filePath,
+    title: tc.title,
+    line: null,
+    projectName: null,
+  })),
 );
+const retryCommand = computed(() => buildRetryCommand(affectedRetryCases.value));
 const { copy: copyRetry, copied: retryCopied } = useCopy();
 
 // Reveal-on-citation: a diagnosis evidence citation (right column) can unfold and
@@ -326,6 +325,13 @@ const breadcrumbItems = computed(() => [
                 >
                   Copy retry command
                 </UButton>
+                <DesktopRunLocallyButton
+                  :project-id="cluster.project?.id"
+                  :project-label="cluster.project?.name"
+                  :cases="affectedRetryCases"
+                  label="Run affected locally"
+                  :preset-options="{ mode: 'grep' }"
+                />
                 <UTooltip text="Unlink incorrectly clustered test cases from this group">
                   <UButton
                     size="xs"

--- a/apps/application/app/pages/test-cases/[id].vue
+++ b/apps/application/app/pages/test-cases/[id].vue
@@ -39,6 +39,12 @@ const passRate = computed(() => {
   return Math.round(((t.passedRuns + t.skippedRuns) / t.totalRuns) * 100);
 });
 
+// Desktop shell: reproduce this test on this machine. Selected by title so no
+// line number is needed; repeat ×20 with a trace is the flake-hunting preset.
+const reproduceCases = computed(() =>
+  testCase.value?.filePath ? [{ filePath: testCase.value.filePath, title: testCase.value.title, line: null }] : [],
+);
+
 const clusterColor = (status: string) => {
   return status === 'open' ? 'error' : status === 'resolved' ? 'success' : 'neutral';
 };
@@ -112,6 +118,14 @@ const executionColumns: TableColumn<ExecutionRow>[] = [
           />
         </template>
         <template #right>
+          <DesktopRunLocallyButton
+            :project-id="testCase?.project?.id"
+            :project-label="testCase?.project?.label ?? testCase?.project?.name"
+            :cases="reproduceCases"
+            label="Reproduce locally"
+            :preset-options="{ mode: 'grep', repeatEach: 20, trace: true }"
+            class="mr-2"
+          />
           <NavbarActions :actions="[{ label: 'Refresh', icon: 'i-lucide-refresh-cw', onClick: () => refresh() }]" />
         </template>
       </UDashboardNavbar>

--- a/apps/application/tests/desktop-local-run.spec.ts
+++ b/apps/application/tests/desktop-local-run.spec.ts
@@ -365,6 +365,29 @@ test.describe('Desktop local run', () => {
     expect(saved?.trace ?? false).toBe(false);
   });
 
+  test('raises an OS notification when a run finishes while the window is unfocused', async ({ page }) => {
+    await installFakeBridge(page, { linked: true, autoExit: false });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Run locally' }).click();
+    await expect(tray(page).getByText('Running 0/1…', { exact: true })).toBeVisible();
+
+    // Headless focus reporting is unreliable, so unfocus deterministically;
+    // the subject here is the gate + the shell's Notification shim, which
+    // turns the notification into a desktop_notify invoke.
+    await page.evaluate(() => {
+      document.hasFocus = () => false;
+    });
+    await page.evaluate(() => window.__piwiFakeTauri.finish(1));
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.__piwiFakeTauri.invocations.find((i) => i.cmd === 'desktop_notify')?.args ?? null),
+      )
+      .toMatchObject({ title: 'Local run failed' });
+  });
+
   test('the copy-only Retry button yields to the split button inside the shell', async ({ page }) => {
     await installFakeBridge(page, { linked: true });
     await page.goto(`/test-runs/${runId}`);

--- a/apps/application/tests/desktop-local-run.spec.ts
+++ b/apps/application/tests/desktop-local-run.spec.ts
@@ -90,6 +90,8 @@ async function installFakeBridge(page: Page, options: FakeBridgeOptions) {
                 return id;
               }
               case 'desktop_stop_local_tests':
+              case 'desktop_notify':
+              case 'desktop_set_activity':
                 return null;
               default:
                 throw new Error(`unexpected command: ${cmd}`);
@@ -117,6 +119,8 @@ function runInvocations(page: Page) {
 
 test.describe('Desktop local run', () => {
   let runId: number;
+  let projectId: number;
+  let caseId: number;
 
   test.beforeAll(async ({ request }) => {
     const startTime = Date.now();
@@ -158,6 +162,9 @@ test.describe('Desktop local run', () => {
     const data = await res.json();
     const proj = await (await request.get(`/api/projects/${data.projectId}`)).json();
     runId = proj.testRuns[0].id;
+    projectId = data.projectId;
+    const cases = await (await request.get(`/api/projects/${projectId}/test-cases`)).json();
+    caseId = cases.items.find((c: { title: string; id: number }) => c.title === 'checkout completes')!.id;
   });
 
   test('without the bridge the button does not exist', async ({ page }) => {
@@ -335,6 +342,36 @@ test.describe('Desktop local run', () => {
 
     await page.evaluate(() => window.__piwiFakeTauri.finish(0));
     await expect(tray(page).getByText('Passed', { exact: true })).toBeVisible();
+  });
+
+  test('reproduces a test from its evolution page without touching saved defaults', async ({ page }) => {
+    await installFakeBridge(page, { linked: true });
+    await page.goto(`/test-cases/${caseId}`);
+    await waitForHydration(page);
+
+    await page.getByRole('button', { name: 'Reproduce locally' }).click();
+    await expect(tray(page).getByText('Passed', { exact: true })).toBeVisible();
+
+    const invocations = await runInvocations(page);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]!.args!.args).toEqual(['--grep', 'checkout completes', '--trace=on', '--repeat-each=20']);
+
+    // The preset stays out of the project's saved defaults.
+    const saved = await page.evaluate(
+      (id) => JSON.parse(localStorage.getItem('piwi:desktop-local-run-options') ?? '{}')[String(id)],
+      projectId,
+    );
+    expect(saved?.repeatEach ?? 1).toBe(1);
+    expect(saved?.trace ?? false).toBe(false);
+  });
+
+  test('the copy-only Retry button yields to the split button inside the shell', async ({ page }) => {
+    await installFakeBridge(page, { linked: true });
+    await page.goto(`/test-runs/${runId}`);
+    await waitForHydration(page);
+
+    await expect(page.getByRole('button', { name: 'Run locally' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Retry', exact: true })).toHaveCount(0);
   });
 
   test('warns when the linked folder has no Playwright installation', async ({ page }) => {

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -21,8 +21,9 @@ Targets for v1: **Windows (`.msi`)** and **macOS (`.dmg`)**. Linux is deferred.
    `playwright test` there (`src-tauri/src/runner.rs`): the shell resolves the
    folder's own Playwright package, executes it with the bundled Node sidecar,
    and streams output back to the webview as `piwi:local-run` events. Those
-   processes die with the shell, so closing the window while any of them is
-   still running asks for confirmation first.
+   processes die with the shell, so every way out — closing the window, the
+   tray's Quit, or an update restart — asks for confirmation first while any
+   of them is still running.
 5. Archives the OS hands to the app (drag & drop, "Open with", second-launch
    file arguments, macOS open events) are queued shell-side and drained by the
    dashboard over IPC (`desktop_take_pending_open_files` + a `piwi:open-files`

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -20,7 +20,9 @@ Targets for v1: **Windows (`.msi`)** and **macOS (`.dmg`)**. Linux is deferred.
 4. The dashboard can link a Piwi project to a folder on this machine and run
    `playwright test` there (`src-tauri/src/runner.rs`): the shell resolves the
    folder's own Playwright package, executes it with the bundled Node sidecar,
-   and streams output back to the webview as `piwi:local-run` events.
+   and streams output back to the webview as `piwi:local-run` events. Those
+   processes die with the shell, so closing the window while any of them is
+   still running asks for confirmation first.
 5. Archives the OS hands to the app (drag & drop, "Open with", second-launch
    file arguments, macOS open events) are queued shell-side and drained by the
    dashboard over IPC (`desktop_take_pending_open_files` + a `piwi:open-files`

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "piwi-desktop"
-version = "0.20.0"
+version = "0.22.1"
 dependencies = [
  "rand 0.8.7",
  "serde",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 use serde_json::json;
 use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{Emitter as _, Manager, RunEvent, WindowEvent};
+use tauri::{AppHandle, Emitter as _, Manager, RunEvent, WindowEvent};
 
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_autostart::ManagerExt as _;
@@ -449,15 +449,55 @@ fn desktop_save_download(
     Ok(node_path(&target))
 }
 
-// ── Closing the dashboard window while local test runs are in flight ──────────
+// ── Leaving the app while local test runs are in flight ───────────────────────
 
-/// Quitting kills every local test run (see `LocalRuns::kill_all`), so the user
-/// is asked first while any is still going.
+/// Every way out of the app kills the local test runs (see
+/// `LocalRuns::kill_all`), so each exit path asks first while any is going:
+/// `proceed` runs at once when nothing is active, and only on confirmation
+/// otherwise. `verb` fills the question ("quitting" / "restarting"), and
+/// `confirm_label` names its confirm button.
+///
+/// The callback form keeps the event loop free — a blocking dialog here would
+/// freeze the very window the question is about.
+pub(crate) fn confirm_stopping_local_runs(
+    app: &AppHandle,
+    title: &str,
+    verb: &str,
+    confirm_label: &str,
+    proceed: impl FnOnce() + Send + 'static,
+) {
+    let active = app
+        .try_state::<runner::LocalRuns>()
+        .map(|runs| runs.active_count())
+        .unwrap_or(0);
+    if active == 0 {
+        proceed();
+        return;
+    }
+    app.dialog()
+        .message(format!(
+            "{active} local test run(s) are still running — {verb} stops them."
+        ))
+        .title(title)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            confirm_label.into(),
+            "Cancel".into(),
+        ))
+        .show(move |confirmed| {
+            if confirmed {
+                proceed();
+            }
+        });
+}
+
+/// The window-close variant of the question above.
 ///
 /// Reports whether the close has to be held back: `true` once the question is on
 /// screen, `false` when the close may proceed — nothing is running, or the user
 /// has already agreed to stop it. Confirming closes the window again, which runs
-/// the normal exit path.
+/// the normal exit path; `QuitConfirmed` is what tells that close apart from the
+/// one the user made.
 fn hold_close_for_local_runs(window: &tauri::Window) -> bool {
     let confirmed = window
         .try_state::<QuitConfirmed>()
@@ -474,28 +514,18 @@ fn hold_close_for_local_runs(window: &tauri::Window) -> bool {
     }
 
     let target = window.clone();
-    // The callback form keeps the event loop free — a blocking dialog here would
-    // freeze the very window the question is about.
-    window
-        .dialog()
-        .message(format!(
-            "{active} local test run(s) are still running — quitting stops them."
-        ))
-        .title("Quit Piwi?")
-        .kind(MessageDialogKind::Warning)
-        .buttons(MessageDialogButtons::OkCancelCustom(
-            "Quit".into(),
-            "Cancel".into(),
-        ))
-        .show(move |quit| {
-            if !quit {
-                return;
-            }
+    confirm_stopping_local_runs(
+        window.app_handle(),
+        "Quit Piwi?",
+        "quitting",
+        "Quit",
+        move || {
             if let Some(state) = target.try_state::<QuitConfirmed>() {
                 state.0.store(true, Ordering::SeqCst);
             }
             let _ = target.close();
-        });
+        },
+    );
     true
 }
 
@@ -841,7 +871,12 @@ pub fn run() {
                         let _ = if enabled { mgr.disable() } else { mgr.enable() };
                         let _ = login_i.set_checked(!enabled);
                     }
-                    "quit" => app.exit(0),
+                    "quit" => {
+                        let handle = app.clone();
+                        confirm_stopping_local_runs(app, "Quit Piwi?", "quitting", "Quit", move || {
+                            handle.exit(0);
+                        });
+                    }
                     _ => {}
                 })
                 .build(app)?;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ use tauri::{Emitter as _, Manager, RunEvent, WindowEvent};
 
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_autostart::ManagerExt as _;
+use tauri_plugin_dialog::{DialogExt as _, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt as _;
 use tauri_plugin_opener::OpenerExt as _;
 use tauri_plugin_shell::process::CommandChild;
@@ -59,6 +60,12 @@ struct ServerProcess(Mutex<Option<CommandChild>>);
 
 /// Shared "keep serving after the window closes" flag (tray toggle + close handler).
 struct RunInBackground(Arc<AtomicBool>);
+
+/// Set once the user agrees to quit with local test runs still going. The
+/// confirmed close reaches the close handler as a fresh request, and this is
+/// what tells it apart from the one the user made.
+#[derive(Default)]
+struct QuitConfirmed(AtomicBool);
 
 /// The user's data directory — used by the "Open data folder" tray item.
 struct DataDir(PathBuf);
@@ -442,6 +449,56 @@ fn desktop_save_download(
     Ok(node_path(&target))
 }
 
+// ── Closing the dashboard window while local test runs are in flight ──────────
+
+/// Quitting kills every local test run (see `LocalRuns::kill_all`), so the user
+/// is asked first while any is still going.
+///
+/// Reports whether the close has to be held back: `true` once the question is on
+/// screen, `false` when the close may proceed — nothing is running, or the user
+/// has already agreed to stop it. Confirming closes the window again, which runs
+/// the normal exit path.
+fn hold_close_for_local_runs(window: &tauri::Window) -> bool {
+    let confirmed = window
+        .try_state::<QuitConfirmed>()
+        .is_some_and(|s| s.0.load(Ordering::SeqCst));
+    if confirmed {
+        return false;
+    }
+    let active = window
+        .try_state::<runner::LocalRuns>()
+        .map(|runs| runs.active_count())
+        .unwrap_or(0);
+    if active == 0 {
+        return false;
+    }
+
+    let target = window.clone();
+    // The callback form keeps the event loop free — a blocking dialog here would
+    // freeze the very window the question is about.
+    window
+        .dialog()
+        .message(format!(
+            "{active} local test run(s) are still running — quitting stops them."
+        ))
+        .title("Quit Piwi?")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Quit".into(),
+            "Cancel".into(),
+        ))
+        .show(move |quit| {
+            if !quit {
+                return;
+            }
+            if let Some(state) = target.try_state::<QuitConfirmed>() {
+                state.0.store(true, Ordering::SeqCst);
+            }
+            let _ = target.close();
+        });
+    true
+}
+
 /// e2e-only capability granting the Playwright plugin's `pw_result` callback
 /// command to the loopback origin the dashboard is served from. Added at runtime
 /// (see `add_capability`) so it never ships in production installers.
@@ -533,6 +590,7 @@ pub fn run() {
         ])
         .manage(ServerProcess::default())
         .manage(runner::LocalRuns::default())
+        .manage(QuitConfirmed::default())
         .manage(PendingOpenFiles::default())
         .manage(updates::UpdaterSupport(updater_supported))
         .manage(updates::PendingUpdate::default())
@@ -817,6 +875,10 @@ pub fn run() {
         })
         .on_window_event(|window, event| {
             if let WindowEvent::CloseRequested { api, .. } = event {
+                // The dashboard window is the one whose close ends the app.
+                if window.label() != "main" {
+                    return;
+                }
                 let keep = window
                     .try_state::<RunInBackground>()
                     .map(|s| s.0.load(Ordering::SeqCst))
@@ -824,6 +886,10 @@ pub fn run() {
                 if keep {
                     // Hide to tray and keep the server running.
                     let _ = window.hide();
+                    api.prevent_close();
+                    return;
+                }
+                if hold_close_for_local_runs(window) {
                     api.prevent_close();
                 }
             }

--- a/apps/desktop/src-tauri/src/runner.rs
+++ b/apps/desktop/src-tauri/src/runner.rs
@@ -61,6 +61,12 @@ pub struct LocalRuns {
 }
 
 impl LocalRuns {
+    /// How many test processes are running. A run is tracked only while it
+    /// lives — it drops out of the map as soon as the process terminates.
+    pub fn active_count(&self) -> usize {
+        self.children.lock().unwrap().len()
+    }
+
     /// Kill every process still tracked — called when the app exits so no
     /// orphaned test run outlives the shell.
     pub fn kill_all(&self) {
@@ -378,6 +384,11 @@ pub fn desktop_stop_local_tests(app: AppHandle, run_id: u32) -> Result<(), Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nothing_is_running_before_a_run_starts() {
+        assert_eq!(LocalRuns::default().active_count(), 0);
+    }
 
     /// A folder holding `tests/a.spec.ts`, removed when the test ends.
     struct Checkout(PathBuf);

--- a/apps/desktop/src-tauri/src/updates.rs
+++ b/apps/desktop/src-tauri/src/updates.rs
@@ -107,5 +107,8 @@ pub async fn desktop_install_update(app: AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 pub fn desktop_restart_app(app: AppHandle) {
-    app.restart();
+    let handle = app.clone();
+    crate::confirm_stopping_local_runs(&app, "Restart Piwi?", "restarting", "Restart", move || {
+        handle.restart();
+    });
 }

--- a/apps/docs/desktop.md
+++ b/apps/docs/desktop.md
@@ -127,7 +127,8 @@ the output streams into the **Local runs** tray in the corner of the window.
   while you browse other pages — closing the tray or navigating never kills
   anything. Stopping is always explicit, from the tray; a toast reports the
   result when a run ends, an OS notification does when the window is in the
-  background, and closing the window while runs are active asks first.
+  background, and leaving the app while runs are active — closing the window,
+  quitting from the tray, or restarting for an update — asks first.
 - **More places to run from:** a test case's evolution page has **Reproduce
   locally** (matched by title, ×20 with a trace — the flake-hunting preset,
   without touching your saved defaults), and a failure cluster's test evidence

--- a/apps/docs/desktop.md
+++ b/apps/docs/desktop.md
@@ -125,8 +125,13 @@ the output streams into the **Local runs** tray in the corner of the window.
 - **The button is also the run's status:** it shows progress while tests run
   and the result when they finish; clicking it opens the tray. Runs keep going
   while you browse other pages — closing the tray or navigating never kills
-  anything. Stopping is always explicit, from the tray, and a toast reports
-  the result when a run ends.
+  anything. Stopping is always explicit, from the tray; a toast reports the
+  result when a run ends, an OS notification does when the window is in the
+  background, and closing the window while runs are active asks first.
+- **More places to run from:** a test case's evolution page has **Reproduce
+  locally** (matched by title, ×20 with a trace — the flake-hunting preset,
+  without touching your saved defaults), and a failure cluster's test evidence
+  has **Run affected locally** for every test in the cluster.
 - **Wrong folder?** If none of the tests exist in the linked folder (usually a
   project linked to a different checkout), the button opens the dialog instead
   of spawning a run that would die with a module-resolution error — fix the


### PR DESCRIPTION
## What & why

Phase 3 (final) of the "Run locally" redesign — polish and reach. **Stacked on #372** (which stacks on #371; GitHub retargets as each base merges).

- **OS notification on finish**: when a run ends while the window is hidden or unfocused, the store raises a `Notification` — inside the shell that's already shimmed onto native OS notifications and the dock/taskbar unread badge by the desktop plugin, so no new plumbing was needed.
- **Confirm before stopping runs, on every exit path** (Rust): window close, the tray menu's Quit, and `desktop_restart_app` (the update-restart) all go through a shared `confirm_stopping_local_runs` helper — "N local test run(s) are still running — quitting/restarting stops them" — before the exit path's `kill_all` fires. Non-blocking dialog (callback form), `main`-window-scoped for the close path, run-in-background tray mode keeps precedence, `mcp-stdio` entry unaffected, and with zero active runs every path proceeds exactly as before.
- **New entry points**, reusing the split button with one-off `presetOptions` that never touch the project's saved defaults:
  - Test case evolution page: **Reproduce locally** — title-grep, ×20, trace on. The flake-hunting preset.
  - Failure cluster page: **Run affected locally** — every test in the cluster by title, next to "Copy retry command".
- **Retry folded on desktop**: inside the shell the copy-only Retry popover in the run summary is hidden — the split button's "Copy as command" covers it; the web build is unchanged.
- `rerun` from the tray no longer re-persists options: re-running repeats a run exactly, only explicit choices change defaults.

## How was it tested?

- E2E suite grows to 13, all passing CI-style against the built server — new: reproduce-from-evolution-page (asserts the exact `--grep`/`--trace=on`/`--repeat-each=20` argv **and** that saved defaults stay untouched), Retry-hidden-in-shell, and the unfocused-finish notification (deterministic `document.hasFocus` stub, asserts the shim's `desktop_notify` invoke end to end).
- Rust: `cargo test` — 38 passed, zero warnings (new `LocalRuns::active_count` + test). The confirm dialogs themselves aren't unit-testable (`CommandChild` is unforgeable outside a real spawn); the zero-run pass-through paths are covered and the rest verified by review.
- The `mcp-stdio` entry was smoke-tested headless (no window, no dialog code reached).
- `app:typecheck`, `app:lint`, `app:format:check` clean; unit suite 1300/1300.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/desktop.md`, `apps/desktop/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXuXTYfThzz8cU3J2KwSrw