### PR TITLE
feat(desktop): create projects from local folders with setup detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 .cache
 dist
 
+# Feature screenshots (scripts/take-feature-screenshots.mjs)
+.screens
+
 # Node dependencies
 node_modules
 

--- a/apps/application/AGENTS.md
+++ b/apps/application/AGENTS.md
@@ -111,6 +111,15 @@ either a `md:hidden` card list + `hidden md:block` table (preferred for dense ta
 `TableScroller`. On fixed-height detail layouts the mobile view must scroll as one document — never `overflow-hidden`
 clipping a tall summary; `DetailPageLayout` handles this. **Verify new or changed screens at 375 px before committing.**
 
+### Feature screenshots (MUST follow)
+
+Every change that adds or visibly reworks user-facing UI ends with screenshots of the result: add or update a scene in
+the `SCENES` registry of `scripts/take-feature-screenshots.mjs`, run it (`node scripts/take-feature-screenshots.mjs
+<scene>` — it boots its own desktop-enabled dev server, or pass `--url` to reuse one), and attach the captured images
+to your final report or PR. Desktop-only UI is captured through the script's built-in mocked Tauri bridge — no shell
+build needed; shape the mock per scene (`link`, `inspection`). Output lands in `.screens/` which is **gitignored — the
+images are a report artifact, never committed**; the scene, kept current, is what's committed.
+
 ### Inline help (MUST follow)
 
 Any new **block-level** shared component with a header MUST accept an optional `help?: HelpTopicKey` prop (typed from

--- a/apps/application/app/components/desktop/DesktopFolderChecklist.vue
+++ b/apps/application/app/components/desktop/DesktopFolderChecklist.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: how a local folder stands with Piwi — the Playwright and
+ * `@piwitests/reporter` setup checks from a `DesktopFolderInspection`, one row
+ * per check. Warnings are guidance, not blockers: a project can be created or
+ * linked first and set up after.
+ */
+import type { DesktopFolderInspection } from '~/composables/useDesktopFolderInspect';
+
+const props = defineProps<{ inspection: DesktopFolderInspection }>();
+
+const { copy } = useCopy();
+
+interface Check {
+  ok: boolean;
+  label: string;
+  /** Extra context shown dimmed after the label. */
+  detail?: string;
+}
+
+const checks = computed<Check[]>(() => {
+  const i = props.inspection;
+  return [
+    i.playwrightConfig
+      ? { ok: true, label: 'Playwright config found', detail: i.playwrightConfig }
+      : { ok: false, label: 'No Playwright config at the folder root' },
+    i.playwrightInstalled
+      ? { ok: true, label: 'Playwright is installed' }
+      : { ok: false, label: 'Playwright is not installed', detail: 'run your package manager’s install first' },
+    i.reporterInstalled
+      ? { ok: true, label: 'Piwi reporter is installed', detail: '@piwitests/reporter' }
+      : { ok: false, label: 'Piwi reporter is not installed' },
+    i.reporterConfigured
+      ? {
+          ok: true,
+          label: 'Config sends results to Piwi',
+          detail: i.configuredProjectName ? `projectName: ${i.configuredProjectName}` : undefined,
+        }
+      : { ok: false, label: 'Config does not use the Piwi reporter' },
+  ];
+});
+
+const ready = computed(() => checks.value.every((c) => c.ok));
+
+/** One command fixes both "not installed" and "not configured". */
+const showInitHint = computed(() => !props.inspection.reporterInstalled || !props.inspection.reporterConfigured);
+const INIT_COMMAND = 'npx piwi init';
+</script>
+
+<template>
+  <div class="space-y-2">
+    <ul class="space-y-1.5">
+      <li v-for="check in checks" :key="check.label" class="flex items-center gap-2 text-sm">
+        <UIcon
+          :name="check.ok ? 'i-lucide-circle-check-big' : 'i-lucide-triangle-alert'"
+          class="size-4 shrink-0"
+          :class="check.ok ? 'text-success' : 'text-warning'"
+        />
+        <span :class="check.ok ? '' : 'text-warning'">{{ check.label }}</span>
+        <span v-if="check.detail" class="text-xs text-muted truncate" :title="check.detail">{{ check.detail }}</span>
+      </li>
+    </ul>
+
+    <p v-if="showInitHint" class="flex flex-wrap items-center gap-1.5 text-xs text-muted">
+      <span>Set it up from a terminal in that folder:</span>
+      <code class="px-1.5 py-0.5 rounded bg-elevated font-mono">{{ INIT_COMMAND }}</code>
+      <UButton
+        icon="i-lucide-copy"
+        color="neutral"
+        variant="ghost"
+        size="xs"
+        aria-label="Copy setup command"
+        @click="copy(INIT_COMMAND, { toast: true })"
+      />
+      <DocLink to="reporter" class="text-xs">Reporter docs</DocLink>
+    </p>
+    <p v-else-if="ready" class="flex items-center gap-1.5 text-xs text-muted">
+      <UIcon name="i-lucide-sparkles" class="size-3.5 text-success" />
+      Runs from this folder will report to Piwi.
+    </p>
+  </div>
+</template>

--- a/apps/application/app/components/desktop/DesktopFolderChecklist.vue
+++ b/apps/application/app/components/desktop/DesktopFolderChecklist.vue
@@ -42,9 +42,13 @@ const checks = computed<Check[]>(() => {
 
 const ready = computed(() => checks.value.every((c) => c.ok));
 
-/** One command fixes both "not installed" and "not configured". */
+/**
+ * One command fixes both "not installed" and "not configured". Invoked through
+ * the package name so npx resolves this package even before it is a dependency
+ * — a plain `npx piwi` would fetch an unrelated `piwi` from the registry.
+ */
 const showInitHint = computed(() => !props.inspection.reporterInstalled || !props.inspection.reporterConfigured);
-const INIT_COMMAND = 'npx piwi init';
+const INIT_COMMAND = 'npx @piwitests/reporter init';
 </script>
 
 <template>
@@ -63,15 +67,17 @@ const INIT_COMMAND = 'npx piwi init';
 
     <p v-if="showInitHint" class="flex flex-wrap items-center gap-1.5 text-xs text-muted">
       <span>Set it up from a terminal in that folder:</span>
-      <code class="px-1.5 py-0.5 rounded bg-elevated font-mono">{{ INIT_COMMAND }}</code>
-      <UButton
-        icon="i-lucide-copy"
-        color="neutral"
-        variant="ghost"
-        size="xs"
-        aria-label="Copy setup command"
-        @click="copy(INIT_COMMAND, { toast: true })"
-      />
+      <span class="inline-flex items-center gap-0.5">
+        <code class="px-1.5 py-0.5 rounded bg-elevated font-mono">{{ INIT_COMMAND }}</code>
+        <UButton
+          icon="i-lucide-copy"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          aria-label="Copy setup command"
+          @click="copy(INIT_COMMAND, { toast: true })"
+        />
+      </span>
       <DocLink to="reporter" class="text-xs">Reporter docs</DocLink>
     </p>
     <p v-else-if="ready" class="flex items-center gap-1.5 text-xs text-muted">

--- a/apps/application/app/components/desktop/DesktopNavButtons.vue
+++ b/apps/application/app/components/desktop/DesktopNavButtons.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: back/forward history buttons at the top of the sidebar.
+ * The webview has no browser chrome, so this is the visible counterpart of the
+ * mouse-button and trackpad-swipe navigation the webview already supports.
+ * Renders nothing in a plain browser, which has its own chrome.
+ */
+defineProps<{ collapsed?: boolean }>();
+
+const isDesktop = useIsDesktop();
+const { canGoBack, canGoForward, goBack, goForward } = useDesktopHistoryNav();
+</script>
+
+<template>
+  <div v-if="isDesktop" class="flex gap-0.5" :class="collapsed ? 'flex-col items-stretch' : 'items-center'">
+    <UButton
+      icon="i-lucide-chevron-left"
+      color="neutral"
+      variant="ghost"
+      size="sm"
+      square
+      :disabled="!canGoBack"
+      aria-label="Back"
+      title="Back"
+      @click="goBack"
+    />
+    <UButton
+      icon="i-lucide-chevron-right"
+      color="neutral"
+      variant="ghost"
+      size="sm"
+      square
+      :disabled="!canGoForward"
+      aria-label="Forward"
+      title="Forward"
+      @click="goForward"
+    />
+  </div>
+</template>

--- a/apps/application/app/components/desktop/DesktopNavButtons.vue
+++ b/apps/application/app/components/desktop/DesktopNavButtons.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 /**
- * Desktop shell only: back/forward history buttons at the top of the sidebar.
- * The webview has no browser chrome, so this is the visible counterpart of the
- * mouse-button and trackpad-swipe navigation the webview already supports.
- * Renders nothing in a plain browser, which has its own chrome.
+ * Desktop shell only: back/forward history buttons, joined as one control the
+ * way a native toolbar pairs them. The webview has no browser chrome, so this
+ * is the visible counterpart of the mouse-button and trackpad-swipe navigation
+ * the webview already supports. Sits beside the project switcher at the top of
+ * the sidebar; in the collapsed rail it stacks vertically like every other
+ * rail control. Renders nothing in a plain browser, which has its own chrome.
  */
 defineProps<{ collapsed?: boolean }>();
 
@@ -12,7 +14,7 @@ const { canGoBack, canGoForward, goBack, goForward } = useDesktopHistoryNav();
 </script>
 
 <template>
-  <div v-if="isDesktop" class="flex gap-0.5" :class="collapsed ? 'flex-col items-stretch' : 'items-center'">
+  <UFieldGroup v-if="isDesktop" :orientation="collapsed ? 'vertical' : 'horizontal'" class="shrink-0">
     <UButton
       icon="i-lucide-chevron-left"
       color="neutral"
@@ -35,5 +37,5 @@ const { canGoBack, canGoForward, goBack, goForward } = useDesktopHistoryNav();
       title="Forward"
       @click="goForward"
     />
-  </div>
+  </UFieldGroup>
 </template>

--- a/apps/application/app/components/desktop/DesktopNewProjectFolder.vue
+++ b/apps/application/app/components/desktop/DesktopNewProjectFolder.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: start a new project from a folder on this machine.
+ * Picking a folder inspects it (project name, Playwright/Piwi setup) and emits
+ * the result so the create form can prefill; the parent links the folder to
+ * the project it creates. Renders nothing without the IPC bridge, so the
+ * create modal can mount it unconditionally.
+ */
+import type { DesktopFolderInspection } from '~/composables/useDesktopFolderInspect';
+
+const folder = defineModel<string | null>('folder', { default: null });
+
+const emit = defineEmits<{ detected: [inspection: DesktopFolderInspection] }>();
+
+const toast = useToast();
+
+/** The IPC bridge exists — resolved on mount so SSR renders nothing. */
+const available = ref(false);
+onMounted(() => {
+  available.value = !!tauriCore();
+});
+
+const inspection = ref<DesktopFolderInspection | null>(null);
+const busy = ref(false);
+
+async function choose() {
+  busy.value = true;
+  try {
+    const path = await pickDesktopFolder();
+    if (path) folder.value = path;
+  } catch (error) {
+    toast.add({ title: 'Could not open the folder picker', description: errorMessage(error), color: 'error' });
+  } finally {
+    busy.value = false;
+  }
+}
+
+function clear() {
+  folder.value = null;
+}
+
+watch(
+  folder,
+  async (path) => {
+    inspection.value = path ? await inspectDesktopFolder(path) : null;
+    if (inspection.value) emit('detected', inspection.value);
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <div v-if="available">
+    <div v-if="!folder" class="rounded-lg border border-dashed border-default p-3 flex flex-wrap items-center gap-3">
+      <UIcon name="i-lucide-folder-search" class="size-5 shrink-0 text-muted" />
+      <div class="min-w-0 flex-1 text-sm">
+        <p class="font-medium">Start from a folder on this machine</p>
+        <p class="text-xs text-muted">Detects the project name and checks the Playwright + Piwi reporter setup.</p>
+      </div>
+      <UButton color="neutral" variant="soft" size="sm" icon="i-lucide-folder-open" :loading="busy" @click="choose">
+        Choose folder…
+      </UButton>
+    </div>
+
+    <div v-else class="rounded-lg border border-default p-3 space-y-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2 min-w-0 text-sm">
+          <UIcon name="i-lucide-folder-check" class="size-4 shrink-0 text-primary" />
+          <code class="text-xs break-all">{{ folder }}</code>
+        </div>
+        <div class="flex items-center gap-1.5 shrink-0">
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="soft"
+            icon="i-lucide-folder-search"
+            :loading="busy"
+            @click="choose"
+          >
+            Change
+          </UButton>
+          <UButton size="xs" color="neutral" variant="ghost" icon="i-lucide-x" :disabled="busy" @click="clear">
+            Clear
+          </UButton>
+        </div>
+      </div>
+
+      <DesktopFolderChecklist v-if="inspection" :inspection="inspection" />
+
+      <p class="text-xs text-muted">The folder is linked to the new project for local runs and IDE links.</p>
+    </div>
+  </div>
+</template>

--- a/apps/application/app/components/desktop/DesktopProjectFolderSection.vue
+++ b/apps/application/app/components/desktop/DesktopProjectFolderSection.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+/**
+ * Desktop shell only: the project's linked local folder, managed from the
+ * project edit page alongside the other project settings. Changes apply
+ * immediately — the link lives in the shell's own store on this machine, not
+ * in the server database. Renders nothing without the IPC bridge.
+ */
+import type { DesktopFolderInspection } from '~/composables/useDesktopFolderInspect';
+
+const props = defineProps<{ projectId: string | number }>();
+
+const { available, link, busy, pickAndLink, unlink } = useDesktopProjectLink(() => props.projectId);
+
+const inspection = ref<DesktopFolderInspection | null>(null);
+
+watch(
+  () => link.value?.path,
+  async (path) => {
+    inspection.value = path && link.value?.exists ? await inspectDesktopFolder(path) : null;
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <SectionCard
+    v-if="available"
+    id="local-folder"
+    icon="i-lucide-folder-symlink"
+    title="Local folder"
+    help="project.local-folder"
+  >
+    <template #subtitle>
+      The checkout of this project on this machine — used to run tests locally and open files in your IDE.
+    </template>
+    <template #actions>
+      <UBadge v-if="link && !link.exists" color="warning" variant="subtle" size="sm">missing</UBadge>
+      <UBadge v-else-if="inspection && isFolderPiwiReady(inspection)" color="success" variant="subtle" size="sm">
+        ready
+      </UBadge>
+      <UBadge v-else-if="inspection" color="warning" variant="subtle" size="sm">needs setup</UBadge>
+    </template>
+
+    <div v-if="link" class="space-y-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2 min-w-0 text-sm">
+          <UIcon
+            :name="link.exists ? 'i-lucide-folder-check' : 'i-lucide-folder-x'"
+            class="size-4 shrink-0"
+            :class="link.exists ? 'text-success' : 'text-warning'"
+          />
+          <code class="text-xs break-all">{{ link.path }}</code>
+        </div>
+        <div class="flex items-center gap-1.5 shrink-0">
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="soft"
+            icon="i-lucide-folder-search"
+            :loading="busy"
+            @click="pickAndLink"
+          >
+            Change
+          </UButton>
+          <UButton size="xs" color="neutral" variant="ghost" icon="i-lucide-unlink" :disabled="busy" @click="unlink">
+            Unlink
+          </UButton>
+        </div>
+      </div>
+
+      <p v-if="!link.exists" class="text-sm text-warning">
+        The folder is gone from this machine — pick the checkout again.
+      </p>
+
+      <DesktopFolderChecklist v-if="inspection" :inspection="inspection" />
+    </div>
+
+    <div v-else class="flex items-center justify-between gap-3">
+      <p class="text-sm text-muted">No folder linked on this machine yet.</p>
+      <UButton size="xs" icon="i-lucide-folder-plus" :loading="busy" @click="pickAndLink">Choose folder…</UButton>
+    </div>
+  </SectionCard>
+</template>

--- a/apps/application/app/components/desktop/DesktopProjectLinkCard.vue
+++ b/apps/application/app/components/desktop/DesktopProjectLinkCard.vue
@@ -1,51 +1,60 @@
 <script setup lang="ts">
 /**
- * Desktop shell only: manage the folder on this machine linked to a project.
- * The link powers "run locally" retries and resolves "Open in IDE" paths
- * without manual workspace-root configuration. Renders nothing without the
- * IPC bridge, so the project page can mount it unconditionally.
+ * Desktop shell only: the folder on this machine linked to this project, shown
+ * on the project page as status — the link powers "run locally" and IDE links.
+ * Managing the link (choose, change, unlink) lives with the rest of the
+ * project settings on the edit page; this card only reports and points there.
+ * Renders nothing without the IPC bridge, so the page mounts it unconditionally.
  */
+import type { DesktopFolderInspection } from '~/composables/useDesktopFolderInspect';
+
 const props = defineProps<{ projectId: string | number }>();
 
-const { available, link, busy, pickAndLink, unlink } = useDesktopProjectLink(() => props.projectId);
+const { available, link } = useDesktopProjectLink(() => props.projectId);
+
+const inspection = ref<DesktopFolderInspection | null>(null);
+
+watch(
+  () => link.value?.path,
+  async (path) => {
+    inspection.value = path && link.value?.exists ? await inspectDesktopFolder(path) : null;
+  },
+  { immediate: true },
+);
+
+const ready = computed(() => isFolderPiwiReady(inspection.value));
 </script>
 
 <template>
-  <SectionCard v-if="available" icon="i-lucide-folder-symlink" title="Local folder">
-    <template #subtitle>
-      Link this project to its checkout on this machine to retry failures from here and open files in your IDE.
-    </template>
-
-    <div v-if="link" class="flex items-center justify-between gap-3">
+  <!-- shrink-0: the project page body is a flex column, which would otherwise squash this card -->
+  <UCard v-if="available" class="shrink-0" :ui="{ body: 'p-3 sm:p-3' }">
+    <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-2 min-w-0 text-sm">
         <UIcon
-          :name="link.exists ? 'i-lucide-folder-check' : 'i-lucide-folder-x'"
+          :name="link ? (link.exists ? 'i-lucide-folder-check' : 'i-lucide-folder-x') : 'i-lucide-folder-symlink'"
           class="size-4 shrink-0"
-          :class="link.exists ? 'text-success' : 'text-warning'"
+          :class="link ? (link.exists ? 'text-success' : 'text-warning') : 'text-muted'"
         />
-        <code class="text-xs break-all">{{ link.path }}</code>
-        <UBadge v-if="!link.exists" color="warning" variant="subtle" size="sm">missing</UBadge>
+        <template v-if="link">
+          <code class="text-xs break-all">{{ link.path }}</code>
+          <UBadge v-if="!link.exists" color="warning" variant="subtle" size="sm">missing</UBadge>
+          <UBadge v-else-if="ready" color="success" variant="subtle" size="sm">ready</UBadge>
+          <UBadge v-else-if="inspection" color="warning" variant="subtle" size="sm">needs setup</UBadge>
+        </template>
+        <span v-else class="text-muted">
+          No local folder linked — link this project’s checkout to run tests from here and open files in your IDE.
+        </span>
       </div>
-      <div class="flex items-center gap-1.5 shrink-0">
-        <UButton
-          size="xs"
-          color="neutral"
-          variant="soft"
-          icon="i-lucide-folder-search"
-          :loading="busy"
-          @click="pickAndLink"
-        >
-          Change
-        </UButton>
-        <UButton size="xs" color="neutral" variant="ghost" icon="i-lucide-unlink" :disabled="busy" @click="unlink">
-          Unlink
-        </UButton>
-      </div>
+      <UButton
+        size="xs"
+        color="neutral"
+        variant="soft"
+        :icon="link ? 'i-lucide-settings-2' : 'i-lucide-folder-plus'"
+        :to="`/projects/${projectId}/edit#local-folder`"
+        :title="link ? 'Manage the linked folder in project settings' : 'Link a folder in project settings'"
+      >
+        {{ link ? 'Manage' : 'Link folder' }}
+      </UButton>
     </div>
-
-    <div v-else class="flex items-center justify-between gap-3">
-      <p class="text-sm text-muted">No folder linked yet.</p>
-      <UButton size="xs" icon="i-lucide-folder-plus" :loading="busy" @click="pickAndLink">Choose folder…</UButton>
-    </div>
-  </SectionCard>
+  </UCard>
 </template>

--- a/apps/application/app/composables/useDesktopFolderInspect.ts
+++ b/apps/application/app/composables/useDesktopFolderInspect.ts
@@ -1,0 +1,53 @@
+/**
+ * Read-only inspection of a folder on this machine (desktop shell only): the
+ * Piwi project name it would report under and whether Playwright and the
+ * `@piwitests/reporter` package are set up. Backs "new project from a folder"
+ * and the setup status shown next to a project's linked folder. Every helper
+ * feature-detects the IPC bridge and resolves `null` in a plain browser.
+ */
+
+export interface DesktopFolderInspection {
+  path: string;
+  exists: boolean;
+  packageName: string | null;
+  /** Name the folder would report under: config `projectName` → package name → folder name. */
+  suggestedName: string | null;
+  /** File name of the Playwright config found at the folder root. */
+  playwrightConfig: string | null;
+  playwrightInstalled: boolean;
+  reporterInstalled: boolean;
+  /** The Playwright config references `@piwitests/reporter`. */
+  reporterConfigured: boolean;
+  /** `projectName` parsed out of the Playwright config, when set as a literal. */
+  configuredProjectName: string | null;
+}
+
+/** Open the native folder picker. `null` on cancel or without the bridge. */
+export async function pickDesktopFolder(): Promise<string | null> {
+  const core = tauriCore();
+  if (!core) return null;
+  return await core.invoke<string | null>('desktop_pick_folder');
+}
+
+/** Inspect an absolute folder path; `null` without the bridge or on failure. */
+export async function inspectDesktopFolder(path: string): Promise<DesktopFolderInspection | null> {
+  const core = tauriCore();
+  if (!core || !path) return null;
+  try {
+    return await core.invoke<DesktopFolderInspection>('desktop_inspect_folder', { path });
+  } catch {
+    return null;
+  }
+}
+
+/** A folder is ready when Playwright and the reporter are installed and wired up. */
+export function isFolderPiwiReady(inspection: DesktopFolderInspection | null): boolean {
+  return (
+    !!inspection &&
+    inspection.exists &&
+    inspection.playwrightConfig != null &&
+    inspection.playwrightInstalled &&
+    inspection.reporterInstalled &&
+    inspection.reporterConfigured
+  );
+}

--- a/apps/application/app/composables/useDesktopHistoryNav.ts
+++ b/apps/application/app/composables/useDesktopHistoryNav.ts
@@ -1,0 +1,37 @@
+/**
+ * Back/forward navigation state for the desktop shell's webview.
+ *
+ * A Tauri webview has no browser chrome, so the dashboard renders its own
+ * back/forward buttons there. Mouse side buttons and trackpad gestures already
+ * navigate the webview history natively; these buttons make the same history
+ * visible and clickable.
+ *
+ * Vue Router records `back` / `forward` entry markers in `history.state` on
+ * every navigation, which is what drives the disabled states — the History API
+ * itself exposes no "can go back" flag. The state survives reloads, and
+ * gesture-driven `popstate` navigations still run the router, so `afterEach`
+ * covers every way the position can change.
+ */
+export function useDesktopHistoryNav() {
+  const router = useRouter();
+
+  const canGoBack = ref(false);
+  const canGoForward = ref(false);
+
+  function update() {
+    const state = window.history.state as { back?: string | null; forward?: string | null } | null;
+    canGoBack.value = !!state?.back;
+    canGoForward.value = !!state?.forward;
+  }
+
+  onMounted(update);
+  const stop = router.afterEach(() => nextTick(update));
+  onUnmounted(stop);
+
+  return {
+    canGoBack,
+    canGoForward,
+    goBack: () => router.back(),
+    goForward: () => router.forward(),
+  };
+}

--- a/apps/application/app/composables/useDesktopProjectLink.ts
+++ b/apps/application/app/composables/useDesktopProjectLink.ts
@@ -27,6 +27,13 @@ export async function getDesktopProjectLink(
   }
 }
 
+/** Link a folder to a project outside the composable (e.g. right after creating the project). */
+export async function setDesktopProjectLink(projectId: string | number, path: string): Promise<void> {
+  const core = tauriCore();
+  if (!core) throw new Error('not running inside the desktop shell');
+  await core.invoke('desktop_set_project_link', { projectId: String(projectId), path });
+}
+
 export function useDesktopProjectLink(projectId: MaybeRefOrGetter<string | number | null | undefined>) {
   const toast = useToast();
 
@@ -57,7 +64,7 @@ export function useDesktopProjectLink(projectId: MaybeRefOrGetter<string | numbe
     if (!core || id == null || id === '') return false;
     busy.value = true;
     try {
-      const path = await core.invoke<string | null>('desktop_pick_folder');
+      const path = await pickDesktopFolder();
       if (!path) return false;
       await core.invoke('desktop_set_project_link', { projectId: String(id), path });
       await refresh();

--- a/apps/application/app/layouts/default.vue
+++ b/apps/application/app/layouts/default.vue
@@ -425,6 +425,9 @@ onMounted(async () => {
       </template>
 
       <template #default="{ collapsed }">
+        <!-- Desktop shell only: visible back/forward for the chrome-less webview -->
+        <DesktopNavButtons :collapsed="collapsed" />
+
         <UDashboardSearchButton :collapsed="collapsed" class="bg-transparent ring-default" />
 
         <UNavigationMenu

--- a/apps/application/app/layouts/default.vue
+++ b/apps/application/app/layouts/default.vue
@@ -421,12 +421,18 @@ onMounted(async () => {
       :ui="{ root: 'min-h-full', footer: 'lg:border-t lg:border-default' }"
     >
       <template #header="{ collapsed }">
-        <ProjectsMenu :collapsed="collapsed" />
+        <!-- Desktop shell only: visible back/forward for the chrome-less webview,
+             paired at the top-left corner the way native apps place them. The
+             collapsed rail has no room in the header row, so the pair moves into
+             the rail stack below instead. -->
+        <DesktopNavButtons v-if="!collapsed" />
+        <div class="flex-1 min-w-0">
+          <ProjectsMenu :collapsed="collapsed" />
+        </div>
       </template>
 
       <template #default="{ collapsed }">
-        <!-- Desktop shell only: visible back/forward for the chrome-less webview -->
-        <DesktopNavButtons :collapsed="collapsed" />
+        <DesktopNavButtons v-if="collapsed" collapsed class="self-center" />
 
         <UDashboardSearchButton :collapsed="collapsed" class="bg-transparent ring-default" />
 

--- a/apps/application/app/pages/projects/[id]/edit.vue
+++ b/apps/application/app/pages/projects/[id]/edit.vue
@@ -125,6 +125,10 @@ function onCancel() {
             </div>
           </UForm>
         </UCard>
+
+        <!-- Desktop shell only: the linked folder is a per-machine setting managed here,
+             with the rest of the project settings (renders nothing without the bridge). -->
+        <DesktopProjectFolderSection :project-id="projectId" />
       </div>
     </template>
   </UDashboardPanel>

--- a/apps/application/app/pages/projects/index.vue
+++ b/apps/application/app/pages/projects/index.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { z } from 'zod';
 import type { TableColumn } from '@nuxt/ui';
 import type { ProjectWithStats, TagInfo, TagsResponse } from '~~/types/api';
+import type { DesktopFolderInspection } from '~/composables/useDesktopFolderInspect';
 
 useHead({ title: 'Projects — Piwi Dashboard' });
 
@@ -73,11 +74,33 @@ const newProject = reactive<Partial<NewProjectSchema>>({
 const newProjectTags = ref<TagInfo[]>([]);
 const creatingProject = ref(false);
 
+// Desktop shell only: a folder picked to start the project from. Its inspection
+// prefills the name; the folder is linked to the project once created.
+const newProjectFolder = ref<string | null>(null);
+
+function onFolderDetected(inspection: DesktopFolderInspection) {
+  if (inspection.suggestedName) newProject.name = inspection.suggestedName;
+}
+
+// A folder picked for a dismissed modal must not silently attach to the next
+// project created; the typed fields keep their draft behavior.
+watch(isNewProjectModalOpen, (open) => {
+  if (!open) newProjectFolder.value = null;
+});
+
+function resetNewProjectForm() {
+  newProject.name = '';
+  newProject.label = '';
+  newProject.description = '';
+  newProjectTags.value = [];
+  newProjectFolder.value = null;
+}
+
 async function handleCreateProject() {
   if (!newProject.name?.trim()) return;
   try {
     creatingProject.value = true;
-    await $fetch('/api/projects', {
+    const created = await $fetch<{ project: { id: number } }>('/api/projects', {
       method: 'POST',
       body: {
         name: newProject.name.trim(),
@@ -87,17 +110,38 @@ async function handleCreateProject() {
       },
     });
 
+    const folder = newProjectFolder.value;
+    let folderLinked = false;
+    if (folder && created?.project?.id != null) {
+      try {
+        await setDesktopProjectLink(created.project.id, folder);
+        folderLinked = true;
+      } catch (error) {
+        toast.add({
+          title: 'Project created, but the folder could not be linked',
+          description: errorMessage(error),
+          color: 'warning',
+        });
+      }
+    }
+
     toast.add({
       title: 'Project created',
-      description: `Project "${newProject.name}" has been created`,
+      description: folderLinked
+        ? `Project "${newProject.name}" has been created and linked to its folder`
+        : `Project "${newProject.name}" has been created`,
       color: 'success',
     });
 
     isNewProjectModalOpen.value = false;
-    newProject.name = '';
-    newProject.label = '';
-    newProject.description = '';
-    newProjectTags.value = [];
+    resetNewProjectForm();
+
+    // A folder-backed project continues on its own page, where the linked
+    // folder and reporter setup it just gained are shown.
+    if (folderLinked && created?.project?.id != null) {
+      await navigateTo(`/projects/${created.project.id}`);
+      return;
+    }
 
     await refresh();
   } catch (error: unknown) {
@@ -344,17 +388,22 @@ const columns: TableColumn<ProjectWithStats>[] = [
   <ClientOnly>
     <UModal :open="isNewProjectModalOpen" title="Create new project" @update:open="isNewProjectModalOpen = $event">
       <template #body>
-        <UForm :schema="newProjectSchema" :state="newProject">
-          <ProjectFormFields
-            mode="create"
-            v-model:name="newProject.name"
-            v-model:label="newProject.label"
-            v-model:description="newProject.description"
-            v-model:tags="newProjectTags"
-            :all-tags="allTags"
-            @tag-created="refreshTags()"
-          />
-        </UForm>
+        <div class="space-y-5">
+          <!-- Desktop shell only: prefill from a checkout on this machine (renders nothing without the bridge). -->
+          <DesktopNewProjectFolder v-model:folder="newProjectFolder" @detected="onFolderDetected" />
+
+          <UForm :schema="newProjectSchema" :state="newProject">
+            <ProjectFormFields
+              mode="create"
+              v-model:name="newProject.name"
+              v-model:label="newProject.label"
+              v-model:description="newProject.description"
+              v-model:tags="newProjectTags"
+              :all-tags="allTags"
+              @tag-created="refreshTags()"
+            />
+          </UForm>
+        </div>
       </template>
 
       <template #footer>

--- a/apps/application/app/utils/help-content.ts
+++ b/apps/application/app/utils/help-content.ts
@@ -191,6 +191,11 @@ export const HELP_TOPICS = {
     text: 'A read-only Git host token lets diagnosis pull the actual commit diffs behind a failure for SCM-grounded analysis. Stored encrypted.',
     doc: 'ai-diagnosis#scm-grounded-context',
   },
+  'project.local-folder': {
+    title: 'Linked local folder',
+    text: 'The checkout on this machine that produces this project’s runs. Linking it enables running tests from the app and opening files in your IDE. The link is stored on this machine only — never on the server.',
+    doc: 'desktop#running-tests-from-the-app',
+  },
 
   // ── Test run detail ───────────────────────────────────────────────────
   'run.summary': {

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+/**
+ * Captures screenshots of user-facing features against a real dev server — the
+ * standard closing step for UI work: every change that adds or visibly reworks
+ * a screen gets a scene here, and the captured images go into the final report
+ * (see the "Feature screenshots" rule in AGENTS.md).
+ *
+ * Usage (from application/):
+ *   node scripts/take-feature-screenshots.mjs               # all scenes
+ *   node scripts/take-feature-screenshots.mjs <scene> …     # just these
+ *   node scripts/take-feature-screenshots.mjs --list        # scene names
+ *   node scripts/take-feature-screenshots.mjs --url http://localhost:3002
+ *   node scripts/take-feature-screenshots.mjs <scene> --out ../docs/public/screenshots
+ *
+ * Without --url the script boots its own dev server (desktop UI enabled) on
+ * port 3050 and tears it down at the end; a missing dev DB is created and
+ * seeded first. With --url it drives the server you point it at.
+ *
+ * Desktop-only UI is captured by injecting a mocked Tauri IPC bridge into the
+ * page, so no shell build is needed. Scenes opt in with `desktop: true` and
+ * can shape what the mock answers (linked folder, inspection result).
+ *
+ * Output: .screens/<scene>[-<label>].png — gitignored report artifacts. Docs
+ * illustrations are the exception: `--out` redirects into the docs assets
+ * (which are committed), the only way to picture desktop-only UI the live
+ * demo cannot show.
+ */
+
+import { createRequire } from 'module';
+import { spawn, execSync } from 'child_process';
+import { existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const { chromium } = require('playwright');
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APP_DIR = join(__dirname, '..');
+const OUT_DIR = join(APP_DIR, '.screens');
+const PORT = 3050;
+
+const DEFAULT_VIEWPORT = { width: 1280, height: 860 };
+
+/** What the mocked `desktop_inspect_folder` reports unless a scene overrides it. */
+const READY_INSPECTION = {
+  path: '/home/dev/code/acme-checkout',
+  exists: true,
+  packageName: '@acme/checkout',
+  suggestedName: 'checkout-web',
+  playwrightConfig: 'playwright.config.ts',
+  playwrightInstalled: true,
+  reporterInstalled: true,
+  reporterConfigured: true,
+  configuredProjectName: 'checkout-web',
+};
+
+/**
+ * Scenes: one entry per user-facing feature (or state of it) worth showing.
+ * `run` drives the page and calls `shoot(label?)` for each capture.
+ *
+ * Context passed to `run`:
+ *   page   — Playwright page, already at `base` with hydration settled
+ *   base   — server origin, e.g. http://localhost:3050
+ *   shoot  — (label?, opts?) => save `.screens/<scene>[-<label>].png`;
+ *            opts.clip / opts.fullPage pass through to page.screenshot
+ *   goto   — (path) => navigate + wait for hydration
+ *
+ * Scene options:
+ *   route     — initial path (default '/')
+ *   viewport  — default 1280×860
+ *   desktop   — inject the mocked Tauri bridge
+ *   link      — mocked linked folder for `desktop_get_project_link` (or null)
+ *   inspection— mocked `desktop_inspect_folder` answer (default READY_INSPECTION)
+ */
+const SCENES = [
+  {
+    name: 'desktop-nav',
+    description: 'Back/forward pair in the sidebar header (desktop shell)',
+    desktop: true,
+    route: '/projects',
+    async run({ page, shoot }) {
+      // Navigate away and back — client-side, a reload would reset the router's
+      // history markers — so both directions are enabled in the shot.
+      await page.getByRole('link', { name: 'Analytics' }).click();
+      await page.waitForURL('**/analytics');
+      await page.waitForTimeout(400);
+      await page.getByRole('button', { name: 'Back', exact: true }).click();
+      await page.waitForURL('**/projects');
+      await page.waitForTimeout(400);
+      await shoot();
+      await page.getByRole('button', { name: /collapse sidebar/i }).click();
+      await page.waitForTimeout(500);
+      await shoot('collapsed', { clip: { x: 0, y: 0, width: 320, height: 560 } });
+    },
+  },
+  {
+    name: 'project-from-folder',
+    description: 'New-project modal: start from a local folder (desktop shell)',
+    desktop: true,
+    link: null,
+    inspection: { ...READY_INSPECTION, reporterConfigured: false, configuredProjectName: null },
+    route: '/projects',
+    async run({ page, shoot }) {
+      await page.getByRole('button', { name: 'New project' }).click();
+      await page.getByRole('heading', { name: 'Create new project' }).waitFor();
+      await page.waitForTimeout(300);
+      await shoot('empty');
+      await page.getByRole('button', { name: 'Choose folder…' }).click();
+      await page.getByText(READY_INSPECTION.path).first().waitFor();
+      await page.waitForTimeout(300);
+      await shoot('picked');
+    },
+  },
+  {
+    name: 'project-from-folder-mobile',
+    description: 'The same modal at phone width',
+    desktop: true,
+    link: null,
+    inspection: { ...READY_INSPECTION, reporterConfigured: false, configuredProjectName: null },
+    viewport: { width: 375, height: 812 },
+    route: '/projects',
+    async run({ page, shoot }) {
+      await page.getByRole('button', { name: 'New project' }).click();
+      await page.getByRole('heading', { name: 'Create new project' }).waitFor();
+      await page.getByRole('button', { name: 'Choose folder…' }).click();
+      await page.getByText(READY_INSPECTION.path).first().waitFor();
+      await page.waitForTimeout(300);
+      await shoot();
+    },
+  },
+  {
+    name: 'edit-local-folder',
+    description: 'Project settings: linked folder with setup checks (desktop shell)',
+    desktop: true,
+    link: { path: READY_INSPECTION.path, exists: true },
+    route: '/projects/2/edit',
+    async run({ page, shoot }) {
+      const card = page.locator('#local-folder');
+      await card.waitFor();
+      await page.getByRole('button', { name: 'Unlink' }).waitFor();
+      await card.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(200);
+      await shoot('ready', { clip: await clipFor(card) });
+    },
+  },
+  {
+    name: 'edit-local-folder-needs-setup',
+    description: 'The same card when the folder is missing Piwi wiring',
+    desktop: true,
+    link: { path: READY_INSPECTION.path, exists: true },
+    inspection: {
+      ...READY_INSPECTION,
+      reporterInstalled: false,
+      reporterConfigured: false,
+      configuredProjectName: null,
+    },
+    route: '/projects/2/edit',
+    async run({ page, shoot }) {
+      const card = page.locator('#local-folder');
+      await card.waitFor();
+      await page.getByRole('button', { name: 'Unlink' }).waitFor();
+      await card.scrollIntoViewIfNeeded();
+      await page.waitForTimeout(200);
+      await shoot(undefined, { clip: await clipFor(card) });
+    },
+  },
+  {
+    name: 'project-folder-card',
+    description: 'Project page: compact linked-folder status card (desktop shell)',
+    desktop: true,
+    link: { path: READY_INSPECTION.path, exists: true },
+    route: '/projects/2',
+    async run({ page, shoot }) {
+      await page.getByText(READY_INSPECTION.path).first().waitFor();
+      await page.waitForTimeout(400);
+      await shoot();
+    },
+  },
+];
+
+/** Bounding box of a locator, padded a little, for a tight clipped capture. */
+async function clipFor(locator, pad = 8) {
+  const box = await locator.boundingBox();
+  if (!box) return undefined;
+  return {
+    x: Math.max(0, box.x - pad),
+    y: Math.max(0, box.y - pad),
+    width: box.width + pad * 2,
+    height: box.height + pad * 2,
+  };
+}
+
+/** Mocked Tauri IPC bridge, shaped per scene. Mirrors the real shell's commands. */
+function bridgeScript(scene) {
+  const inspection = scene.inspection ?? READY_INSPECTION;
+  const link = scene.link ?? null;
+  return `
+    window.__mockLink = ${JSON.stringify(link)};
+    window.__TAURI__ = {
+      core: {
+        invoke: (cmd, args) => {
+          switch (cmd) {
+            case 'desktop_pick_folder':
+              return Promise.resolve(${JSON.stringify(inspection.path)});
+            case 'desktop_inspect_folder':
+              return Promise.resolve({ ...${JSON.stringify(inspection)}, path: args.path });
+            case 'desktop_get_project_link':
+              return Promise.resolve(window.__mockLink);
+            case 'desktop_set_project_link':
+              window.__mockLink = args.path ? { path: args.path, exists: true } : null;
+              return Promise.resolve(null);
+            case 'desktop_get_service_settings':
+              return Promise.resolve({ run_in_background: false, start_on_login: false });
+            case 'desktop_check_update':
+              return Promise.resolve({ state: 'unsupported' });
+            case 'desktop_mcp_clients':
+              return Promise.resolve([]);
+            default:
+              return Promise.resolve(null);
+          }
+        },
+      },
+      event: { listen: () => Promise.resolve(() => {}) },
+    };
+  `;
+}
+
+async function waitForHydration(page) {
+  await page.waitForLoadState('load');
+  await page
+    .waitForFunction(() => window.useNuxtApp?.().isHydrating === false, undefined, { timeout: 20000 })
+    .catch(() => page.waitForTimeout(1500));
+}
+
+function ensureDevDb() {
+  if (existsSync(join(APP_DIR, '.data', 'piwi.db'))) return;
+  console.log('No dev DB — creating and seeding one (first run only)…');
+  if (!existsSync(join(APP_DIR, 'public', 'demo', 'seed.sql'))) {
+    execSync('npm run app:seed:demo', { cwd: APP_DIR, stdio: 'inherit' });
+  }
+  mkdirSync(join(APP_DIR, '.data'), { recursive: true });
+  execSync('npm run db:migrate', { cwd: APP_DIR, stdio: 'inherit' });
+  execSync('npm run app:seed:dev', { cwd: APP_DIR, stdio: 'inherit' });
+}
+
+async function waitForHealth(base, timeoutMs = 120_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${base}/api/health`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`server at ${base} did not become healthy within ${timeoutMs / 1000}s`);
+}
+
+/** Boot a dev server with the desktop UI enabled; returns { base, stop }. */
+async function startServer() {
+  ensureDevDb();
+  const child = spawn('npx', ['nuxt', 'dev', '--port', String(PORT)], {
+    cwd: APP_DIR,
+    env: { ...process.env, NUXT_IGNORE_LOCK: '1', NUXT_PUBLIC_DESKTOP: 'true' },
+    stdio: 'ignore',
+    // Detached puts nuxt in its own process group so stop() can kill the whole
+    // tree; on Windows npx needs a shell and group-kill is unsupported anyway.
+    detached: process.platform !== 'win32',
+    shell: process.platform === 'win32',
+  });
+  const stop = () => {
+    // Negative pid kills the whole nuxt process group where supported.
+    try {
+      if (process.platform === 'win32') child.kill();
+      else process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      // already gone
+    }
+  };
+  process.on('SIGINT', () => {
+    stop();
+    process.exit(130);
+  });
+  const base = `http://localhost:${PORT}`;
+  console.log(`Starting dev server at ${base} (desktop UI enabled)…`);
+  try {
+    await waitForHealth(base);
+  } catch (err) {
+    stop();
+    throw err;
+  }
+  return { base, stop };
+}
+
+function resolveChromium() {
+  // The sandboxed environments provide a Chromium via PLAYWRIGHT_BROWSERS_PATH;
+  // a normal checkout uses Playwright's own download.
+  const provided = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (provided && existsSync(join(provided, 'chromium'))) return join(provided, 'chromium');
+  return undefined;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--list')) {
+    for (const scene of SCENES) console.log(`${scene.name.padEnd(34)} ${scene.description}`);
+    return;
+  }
+  const urlIdx = args.indexOf('--url');
+  const externalBase = urlIdx !== -1 ? args[urlIdx + 1] : null;
+  const outIdx = args.indexOf('--out');
+  const outDir = outIdx !== -1 ? join(process.cwd(), args[outIdx + 1]) : OUT_DIR;
+  const flagValues = new Set([urlIdx, outIdx].filter((i) => i !== -1).map((i) => i + 1));
+  const wanted = args.filter((a, i) => !a.startsWith('--') && !flagValues.has(i));
+  const scenes = wanted.length ? SCENES.filter((s) => wanted.includes(s.name)) : SCENES;
+  const unknown = wanted.filter((w) => !SCENES.some((s) => s.name === w));
+  if (unknown.length) throw new Error(`unknown scene(s): ${unknown.join(', ')} — see --list`);
+
+  mkdirSync(outDir, { recursive: true });
+  const server = externalBase ? { base: externalBase, stop: () => {} } : await startServer();
+  const browser = await chromium.launch({
+    executablePath: resolveChromium(),
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  const failures = [];
+  try {
+    for (const scene of scenes) {
+      const context = await browser.newContext({
+        viewport: scene.viewport ?? DEFAULT_VIEWPORT,
+        colorScheme: scene.colorScheme,
+      });
+      if (scene.desktop) await context.addInitScript(bridgeScript(scene));
+      const page = await context.newPage();
+      // A dev server compiles routes on first hit — well past the 30s default.
+      page.setDefaultNavigationTimeout(90_000);
+
+      const goto = async (path) => {
+        await page.goto(`${server.base}${path}`, { waitUntil: 'domcontentloaded' });
+        await waitForHydration(page);
+      };
+      const shoot = async (label, opts = {}) => {
+        const file = join(outDir, `${scene.name}${label ? `-${label}` : ''}.png`);
+        await page.screenshot({ path: file, ...opts });
+        console.log(`-> ${file.replace(`${APP_DIR}/`, '')}`);
+      };
+
+      try {
+        await goto(scene.route ?? '/');
+        await scene.run({ page, base: server.base, shoot, goto });
+      } catch (err) {
+        failures.push(scene.name);
+        console.error(`scene ${scene.name} failed: ${err.message}`);
+      } finally {
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+    server.stop();
+  }
+
+  if (failures.length) throw new Error(`scenes failed: ${failures.join(', ')}`);
+  console.log(`All done! Screenshots written to ${outDir}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/desktop/e2e/tests/shell.spec.ts
+++ b/apps/desktop/e2e/tests/shell.spec.ts
@@ -59,6 +59,16 @@ test('the dashboard can reach the shell IPC commands', async ({ tauriPage }) => 
   expect(rejected.rejected).toBe(true);
   expect(rejected.error).toContain('absolute');
 
+  // The folder inspector is granted, and refuses a relative path from inside
+  // the handler rather than at the ACL.
+  const inspect = (await tauriPage.evaluate(`
+    window.__TAURI__.core.invoke('desktop_inspect_folder', { path: 'not/absolute' })
+      .then(() => ({ rejected: false, error: '' }))
+      .catch((e) => ({ rejected: true, error: String((e && e.message) || e) }))
+  `)) as { rejected: boolean; error: string };
+  expect(inspect.rejected).toBe(true);
+  expect(inspect.error).toContain('absolute');
+
   // The spec pre-flight is granted too, and refuses an unlinked project from
   // inside the handler rather than at the ACL.
   const specs = (await tauriPage.evaluate(`

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "piwi-desktop"
-version = "0.22.1"
+version = "0.24.0"
 dependencies = [
  "rand 0.8.7",
  "serde",

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -20,6 +20,7 @@ fn main() {
             "desktop_notify",
             "desktop_save_download",
             "desktop_pick_folder",
+            "desktop_inspect_folder",
             "desktop_get_project_link",
             "desktop_set_project_link",
             "desktop_run_local_tests",

--- a/apps/desktop/src-tauri/capabilities/remote.json
+++ b/apps/desktop/src-tauri/capabilities/remote.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "remote-desktop-controls",
-  "description": "Let the bundled dashboard, served from the local loopback server, call the app's own IPC commands: read/set the service settings (run in background, start on login), open external links in the OS browser, show native notifications, save downloads, manage per-project linked folders, and run Playwright tests in a linked folder with streamed output. Scoped to the loopback origins the sidecar binds — no external site is granted access, and only the desktop webview has the native bridge.",
+  "description": "Let the bundled dashboard, served from the local loopback server, call the app's own IPC commands: read/set the service settings (run in background, start on login), open external links in the OS browser, show native notifications, save downloads, manage per-project linked folders (including read-only inspection of a chosen folder's Playwright/Piwi setup), and run Playwright tests in a linked folder with streamed output. Scoped to the loopback origins the sidecar binds — no external site is granted access, and only the desktop webview has the native bridge.",
   "windows": ["main"],
   "remote": {
     "urls": ["http://localhost:*", "http://127.0.0.1:*"]
@@ -15,6 +15,7 @@
     "allow-desktop-notify",
     "allow-desktop-save-download",
     "allow-desktop-pick-folder",
+    "allow-desktop-inspect-folder",
     "allow-desktop-get-project-link",
     "allow-desktop-set-project-link",
     "allow-desktop-run-local-tests",

--- a/apps/desktop/src-tauri/src/inspect.rs
+++ b/apps/desktop/src-tauri/src/inspect.rs
@@ -1,0 +1,407 @@
+// Read-only inspection of a folder on this machine, so the dashboard can tell
+// what a checkout is before creating or linking a Piwi project to it: the name
+// it would report under, whether Playwright is present, and whether the
+// `@piwitests/reporter` package is installed and wired into the config.
+//
+// The heuristics deliberately mirror the reporter CLI's own `detect.ts`
+// (`packages/reporter/src/cli/detect.ts`): same config-file lookup order, same
+// name suggestion (unscoped package name, then folder name).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::runner::{resolve_node_module, resolve_playwright_cli};
+
+/// Playwright's own config lookup order.
+const CONFIG_NAMES: [&str; 6] = [
+    "playwright.config.ts",
+    "playwright.config.mts",
+    "playwright.config.cts",
+    "playwright.config.js",
+    "playwright.config.mjs",
+    "playwright.config.cjs",
+];
+
+const REPORTER_PACKAGE: &str = "@piwitests/reporter";
+
+/// Upper bound on how much of a config file is read; a Playwright config
+/// larger than this is not a config file.
+const MAX_CONFIG_BYTES: u64 = 512 * 1024;
+
+#[derive(Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderInspection {
+    /// The absolute folder that was inspected.
+    path: String,
+    /// The folder is a directory on disk. Everything below is `None`/`false`
+    /// when it is not.
+    exists: bool,
+    /// `package.json` `name` as written (scope kept), when present.
+    package_name: Option<String>,
+    /// The Piwi project name this folder would report under: the config's
+    /// `projectName`, else the unscoped package name, else the folder's name.
+    suggested_name: Option<String>,
+    /// File name of the Playwright config found at the folder root.
+    playwright_config: Option<String>,
+    /// A Playwright installation resolves from the folder (own or hoisted).
+    playwright_installed: bool,
+    /// `@piwitests/reporter` resolves from the folder or is a declared dependency.
+    reporter_installed: bool,
+    /// The Playwright config references `@piwitests/reporter`.
+    reporter_configured: bool,
+    /// `projectName` value parsed out of the Playwright config, when set.
+    configured_project_name: Option<String>,
+}
+
+#[derive(Default, serde::Deserialize)]
+struct PackageJson {
+    name: Option<String>,
+    #[serde(default)]
+    dependencies: HashMap<String, String>,
+    #[serde(default, rename = "devDependencies")]
+    dev_dependencies: HashMap<String, String>,
+}
+
+fn read_package_json(folder: &Path) -> Option<PackageJson> {
+    let raw = std::fs::read_to_string(folder.join("package.json")).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn find_config(folder: &Path) -> Option<&'static str> {
+    CONFIG_NAMES
+        .into_iter()
+        .find(|name| folder.join(name).is_file())
+}
+
+/// The config's contents, or `None` when there is no config or it is
+/// unreadable/oversized — in which case nothing can be said about it.
+fn read_config(folder: &Path, config: Option<&str>) -> Option<String> {
+    let path = folder.join(config?);
+    let size = std::fs::metadata(&path).ok()?.len();
+    if size > MAX_CONFIG_BYTES {
+        return None;
+    }
+    std::fs::read_to_string(&path).ok()
+}
+
+/// Pull a literal `projectName: '<value>'` out of the config source. A value
+/// that is not a plain single-line literal (template interpolation, an
+/// expression) is not detectable and yields `None`.
+fn parse_config_project_name(source: &str) -> Option<String> {
+    let bytes = source.as_bytes();
+    let mut from = 0;
+    while let Some(found) = source[from..].find("projectName") {
+        let mut i = from + found + "projectName".len();
+        from = i;
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b':' {
+            continue;
+        }
+        i += 1;
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || !matches!(bytes[i], b'\'' | b'"' | b'`') {
+            continue;
+        }
+        let quote = bytes[i] as char;
+        let start = i + 1;
+        let Some(end) = source[start..].find(quote) else {
+            continue;
+        };
+        let value = &source[start..start + end];
+        if !value.is_empty() && !value.contains('\n') && !value.contains("${") {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Unscoped, filesystem-safe name: `@acme/checkout` → `checkout`.
+fn unscoped(name: &str) -> &str {
+    match name.strip_prefix('@') {
+        Some(rest) => rest.split_once('/').map_or(name, |(_, tail)| tail),
+        None => name,
+    }
+}
+
+fn inspect(folder: &Path) -> FolderInspection {
+    let path = folder.to_string_lossy().to_string();
+    if !folder.is_dir() {
+        return FolderInspection {
+            path,
+            exists: false,
+            package_name: None,
+            suggested_name: None,
+            playwright_config: None,
+            playwright_installed: false,
+            reporter_installed: false,
+            reporter_configured: false,
+            configured_project_name: None,
+        };
+    }
+
+    let package = read_package_json(folder);
+    let config = find_config(folder);
+    let config_source = read_config(folder, config);
+    let configured_project_name = config_source.as_deref().and_then(parse_config_project_name);
+
+    let package_name = package.as_ref().and_then(|p| p.name.clone());
+    let dependency_declared = package.as_ref().is_some_and(|p| {
+        p.dependencies.contains_key(REPORTER_PACKAGE)
+            || p.dev_dependencies.contains_key(REPORTER_PACKAGE)
+    });
+
+    let suggested_name = configured_project_name
+        .clone()
+        .or_else(|| {
+            package_name
+                .as_deref()
+                .map(unscoped)
+                .map(str::trim)
+                .filter(|n| !n.is_empty())
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            folder
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .filter(|n| !n.is_empty())
+        });
+
+    FolderInspection {
+        path,
+        exists: true,
+        package_name,
+        suggested_name,
+        playwright_config: config.map(str::to_string),
+        playwright_installed: resolve_playwright_cli(folder).is_some(),
+        reporter_installed: dependency_declared
+            || resolve_node_module(folder, &["@piwitests/reporter/package.json"]).is_some(),
+        reporter_configured: config_source
+            .as_deref()
+            .is_some_and(|s| s.contains(REPORTER_PACKAGE)),
+        configured_project_name,
+    }
+}
+
+/// What a folder on this machine looks like to Piwi: the project name it would
+/// report under and whether Playwright and the Piwi reporter are set up. A
+/// folder that is gone reports `exists: false` rather than an error, so the
+/// dashboard can render the state.
+#[tauri::command]
+pub fn desktop_inspect_folder(path: String) -> Result<FolderInspection, String> {
+    let folder = PathBuf::from(&path);
+    if !folder.is_absolute() {
+        return Err("the folder path must be absolute".into());
+    }
+    Ok(inspect(&folder))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A temp folder removed when the test ends.
+    struct Folder(PathBuf);
+
+    impl Folder {
+        fn new(label: &str) -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let unique = COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path = std::env::temp_dir().join(format!(
+                "piwi-inspect-{label}-{}-{unique}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("create folder");
+            Self(path)
+        }
+
+        fn write(&self, name: &str, contents: &str) {
+            std::fs::write(self.0.join(name), contents).expect("write file");
+        }
+    }
+
+    impl Drop for Folder {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_missing_folder_reports_not_existing() {
+        let folder = Folder::new("gone");
+        let missing = folder.0.join("not-there");
+
+        let result = inspect(&missing);
+
+        assert!(!result.exists);
+        assert_eq!(result.suggested_name, None);
+        assert_eq!(result.path, missing.to_string_lossy());
+    }
+
+    #[test]
+    fn an_empty_folder_suggests_its_own_name() {
+        let folder = Folder::new("bare");
+
+        let result = inspect(&folder.0);
+
+        assert!(result.exists);
+        assert_eq!(result.package_name, None);
+        assert_eq!(
+            result.suggested_name.as_deref(),
+            folder.0.file_name().map(|n| n.to_str().unwrap()),
+        );
+        assert_eq!(result.playwright_config, None);
+        assert!(!result.playwright_installed);
+        assert!(!result.reporter_installed);
+        assert!(!result.reporter_configured);
+    }
+
+    #[test]
+    fn the_package_name_wins_over_the_folder_name_and_loses_its_scope() {
+        let folder = Folder::new("named");
+        folder.write("package.json", r#"{ "name": "@acme/checkout" }"#);
+
+        let result = inspect(&folder.0);
+
+        assert_eq!(result.package_name.as_deref(), Some("@acme/checkout"));
+        assert_eq!(result.suggested_name.as_deref(), Some("checkout"));
+    }
+
+    #[test]
+    fn the_configured_project_name_wins_over_the_package_name() {
+        let folder = Folder::new("configured-name");
+        folder.write("package.json", r#"{ "name": "checkout" }"#);
+        folder.write(
+            "playwright.config.ts",
+            "export default defineConfig(wrapConfig({\n  reporter: [['@piwitests/reporter', { projectName: 'web-app' }]],\n}));\n",
+        );
+
+        let result = inspect(&folder.0);
+
+        assert_eq!(result.configured_project_name.as_deref(), Some("web-app"));
+        assert_eq!(result.suggested_name.as_deref(), Some("web-app"));
+        assert!(result.reporter_configured);
+    }
+
+    #[test]
+    fn finds_the_config_in_playwrights_lookup_order() {
+        let folder = Folder::new("config-order");
+        folder.write("playwright.config.js", "module.exports = {};\n");
+        folder.write("playwright.config.ts", "export default {};\n");
+
+        let result = inspect(&folder.0);
+
+        assert_eq!(
+            result.playwright_config.as_deref(),
+            Some("playwright.config.ts")
+        );
+        assert!(!result.reporter_configured);
+    }
+
+    #[test]
+    fn a_declared_reporter_dependency_counts_as_installed() {
+        let folder = Folder::new("dependency");
+        folder.write(
+            "package.json",
+            r#"{ "name": "app", "devDependencies": { "@piwitests/reporter": "^1.0.0" } }"#,
+        );
+
+        let result = inspect(&folder.0);
+
+        assert!(result.reporter_installed);
+        assert!(!result.reporter_configured);
+    }
+
+    #[test]
+    fn a_reporter_in_node_modules_counts_as_installed() {
+        let folder = Folder::new("node-modules");
+        let package = folder
+            .0
+            .join("node_modules")
+            .join("@piwitests")
+            .join("reporter");
+        std::fs::create_dir_all(&package).expect("create package");
+        std::fs::write(package.join("package.json"), "{}").expect("write package.json");
+
+        let result = inspect(&folder.0);
+
+        assert!(result.reporter_installed);
+    }
+
+    #[test]
+    fn detects_a_playwright_installation() {
+        let folder = Folder::new("playwright");
+        let package = folder
+            .0
+            .join("node_modules")
+            .join("@playwright")
+            .join("test");
+        std::fs::create_dir_all(&package).expect("create package");
+        std::fs::write(package.join("cli.js"), "").expect("write cli");
+
+        let result = inspect(&folder.0);
+
+        assert!(result.playwright_installed);
+    }
+
+    #[test]
+    fn parses_the_project_name_literal_in_any_quote_style() {
+        for (label, source) in [
+            (
+                "single",
+                "reporter: [['@piwitests/reporter', { projectName: 'web' }]]",
+            ),
+            (
+                "double",
+                "reporter: [[\"@piwitests/reporter\", { projectName: \"web\" }]]",
+            ),
+            (
+                "backtick",
+                "reporter: [['@piwitests/reporter', { projectName: `web` }]]",
+            ),
+            ("spaced", "projectName  :   'web'"),
+        ] {
+            assert_eq!(
+                parse_config_project_name(source).as_deref(),
+                Some("web"),
+                "quote style: {label}",
+            );
+        }
+    }
+
+    #[test]
+    fn skips_project_names_that_are_not_literals() {
+        assert_eq!(
+            parse_config_project_name("projectName: process.env.NAME"),
+            None
+        );
+        assert_eq!(parse_config_project_name("projectName: `app-${env}`"), None);
+        assert_eq!(parse_config_project_name("projectName: ''"), None);
+        assert_eq!(
+            parse_config_project_name("const projectNameHint = 1;"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_later_literal_is_found_after_a_non_literal_mention() {
+        let source = "// projectName comes from the package\nprojectName: 'real-name'";
+        assert_eq!(
+            parse_config_project_name(source).as_deref(),
+            Some("real-name")
+        );
+    }
+
+    #[test]
+    fn unscoped_strips_only_a_leading_scope() {
+        assert_eq!(unscoped("@acme/checkout"), "checkout");
+        assert_eq!(unscoped("checkout"), "checkout");
+        assert_eq!(unscoped("@malformed"), "@malformed");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@
 // and "start on login". Everything binds 127.0.0.1 — nothing is exposed to the
 // network.
 
+mod inspect;
 mod mcp_clients;
 mod mcp_stdio;
 mod runner;
@@ -34,6 +35,7 @@ use tauri_plugin_shell::process::CommandChild;
 use tauri_plugin_shell::ShellExt as _;
 use tauri_plugin_store::StoreExt as _;
 
+use inspect::desktop_inspect_folder;
 use mcp_clients::{desktop_mcp_clients, desktop_mcp_connect, desktop_mcp_disconnect, desktop_mcp_reveal};
 use updates::{desktop_check_update, desktop_install_update, desktop_restart_app};
 use runner::{
@@ -602,6 +604,7 @@ pub fn run() {
             desktop_notify,
             desktop_save_download,
             desktop_pick_folder,
+            desktop_inspect_folder,
             desktop_get_project_link,
             desktop_set_project_link,
             desktop_run_local_tests,

--- a/apps/desktop/src-tauri/src/runner.rs
+++ b/apps/desktop/src-tauri/src/runner.rs
@@ -202,10 +202,10 @@ pub fn desktop_check_local_specs(
     })
 }
 
-/// Find the linked folder's own Playwright CLI entry, walking up so a package
-/// inside a monorepo with a hoisted root `node_modules` still resolves.
-fn resolve_playwright_cli(start: &Path) -> Option<PathBuf> {
-    let candidates = ["@playwright/test/cli.js", "playwright/cli.js"];
+/// Resolve a file inside a `node_modules` reachable from `start`, walking up so
+/// a package inside a monorepo with a hoisted root `node_modules` still
+/// resolves. `candidates` are `node_modules`-relative paths tried at each level.
+pub(crate) fn resolve_node_module(start: &Path, candidates: &[&str]) -> Option<PathBuf> {
     let mut dir = Some(start);
     for _ in 0..MAX_NODE_MODULES_WALK {
         let d = dir?;
@@ -218,6 +218,11 @@ fn resolve_playwright_cli(start: &Path) -> Option<PathBuf> {
         dir = d.parent();
     }
     None
+}
+
+/// Find the linked folder's own Playwright CLI entry.
+pub(crate) fn resolve_playwright_cli(start: &Path) -> Option<PathBuf> {
+    resolve_node_module(start, &["@playwright/test/cli.js", "playwright/cli.js"])
 }
 
 #[derive(serde::Serialize)]

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -116,3 +116,10 @@ split. Capture them against the **live demo** (it already has seed data — no l
 
 Demo *evidence* media (the screenshots, traces and videos shown inside the product) is a different pipeline — see
 [`../application/AGENTS.md`](../application/AGENTS.md#demo-evidence-media-committed-binaries).
+
+**Feature illustrations** (a docs page showing a specific screen, including desktop-only UI the live demo cannot
+render) come from the feature-screenshot harness instead: from `apps/application/`, run
+`node scripts/take-feature-screenshots.mjs <scene> --out ../docs/public/screenshots` — add a scene to its `SCENES`
+registry if none fits (desktop UI is captured through the script's mocked Tauri bridge, no shell build needed). Images
+written into docs assets this way are committed; keep the scene in the script current so the illustration can be
+re-captured when the UI changes.

--- a/apps/docs/desktop.md
+++ b/apps/docs/desktop.md
@@ -15,6 +15,10 @@ standing up a server.
 > Everything binds to `127.0.0.1` — the app is local-only and nothing is exposed
 > to the network.
 
+The window navigates like a browser without looking like one: **back/forward
+buttons** sit at the top of the sidebar, and the mouse side buttons and
+trackpad swipe gestures your OS uses for history work too.
+
 ## Download
 
 Grab the installer for your OS from the [latest release](https://github.com/PiwiTests/platform/releases/latest):
@@ -104,6 +108,24 @@ actual one).
 > *other machines* over the network is intentionally not supported in the desktop
 > build — run the [Docker image](/deployment) for a shared, always-on server.
 
+## Projects from local folders
+
+Runs create projects automatically, but the desktop app can also start from
+the code: **Projects → New project → Choose folder…** picks a checkout on this
+machine, detects the name it would report under (the `projectName` in its
+Playwright config, else the `package.json` name, else the folder name), and
+checks the setup — Playwright config present, Playwright installed, the
+[reporter](/reporter) installed and wired into the config. Anything missing is
+a warning, not a blocker: create the project anyway and run `npx piwi init` in
+the folder when you're ready. The chosen folder is linked to the new project
+automatically.
+
+The link itself is a per-machine setting, managed with the rest of the project
+settings: **project page → Edit → Local folder** shows the folder, the same
+setup checks, and the **Change**/**Unlink** actions. The project page shows the
+link's status — `ready`, `needs setup`, or `missing` when the folder is gone —
+and jumps there. The link never leaves this machine.
+
 ## Running tests from the app
 
 A failing run is one click from a local retry. On a run page (or a single
@@ -113,9 +135,9 @@ immediately, with the options you used last time. The app executes the folder's
 the output streams into the **Local runs** tray in the corner of the window.
 
 - **First use:** a dialog asks you to link the Piwi project to its checkout —
-  the folder that contains the tests. Link it any time on the project page
-  under **Local folder**. The link stays on this machine; it is never sent
-  anywhere.
+  the folder that contains the tests. Link it any time under
+  [**Edit → Local folder**](#projects-from-local-folders). The link stays on
+  this machine; it is never sent anywhere.
 - **The arrow next to the button** holds everything else: run headless, headed,
   under the Playwright inspector or in UI mode; select tests by `file:line`,
   title or file; force trace recording; `--repeat-each` up to 1000× for flake
@@ -148,8 +170,9 @@ pill in the sidebar keeps the tray one click away from every page.
 Two prerequisites, both usually already true for a project that reports to
 Piwi: the linked folder has `@playwright/test` installed (`node_modules`
 present — monorepos with a hoisted root install work too), and its Playwright
-config includes the Piwi reporter. The app checks the first one up front and
-warns before running when no Playwright installation is found.
+config includes the Piwi reporter. Both show in the
+[**Local folder** checks](#projects-from-local-folders), and the run dialog
+warns up front when no Playwright installation is found.
 
 The linked folder also completes [Open in IDE](/ide-integration): when no
 workspace root is configured there, source links resolve against the linked

--- a/apps/docs/desktop.md
+++ b/apps/docs/desktop.md
@@ -116,8 +116,8 @@ machine, detects the name it would report under (the `projectName` in its
 Playwright config, else the `package.json` name, else the folder name), and
 checks the setup — Playwright config present, Playwright installed, the
 [reporter](/reporter) installed and wired into the config. Anything missing is
-a warning, not a blocker: create the project anyway and run `npx piwi init` in
-the folder when you're ready. The chosen folder is linked to the new project
+a warning, not a blocker: create the project anyway and run
+`npx @piwitests/reporter init` in the folder when you're ready. The chosen folder is linked to the new project
 automatically.
 
 The link itself is a per-machine setting, managed with the rest of the project

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
     },
     "apps/application": {
       "name": "@piwitests/dashboard",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -131,7 +131,7 @@
     },
     "apps/extension": {
       "name": "@piwitests/extension",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@piwitests/core": "*",
         "@piwitests/picker-dom": "*"
@@ -160,7 +160,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation-nitro",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -26417,11 +26417,11 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.23.0"
+      "version": "0.24.0"
     },
     "packages/picker-dom": {
       "name": "@piwitests/picker-dom",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@piwitests/core": "*"
       },
@@ -26431,7 +26431,7 @@
     },
     "packages/reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -26450,7 +26450,7 @@
     },
     "packages/server": {
       "name": "@piwitests/server",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.17.4",


### PR DESCRIPTION
## What & why

Adds desktop-shell-only features for creating Piwi projects directly from local folders on the machine:

1. **Folder inspection** (`desktop_inspect_folder` IPC command): Read-only analysis of a folder to detect:
   - The project name it would report under (Playwright config `projectName` → package.json name → folder name)
   - Whether Playwright is installed
   - Whether `@piwitests/reporter` is installed and configured
   - The Playwright config file name

2. **New project from folder**: The "New project" modal now includes a "Choose folder…" option (desktop only) that:
   - Opens the native folder picker
   - Inspects the selected folder to prefill the project name
   - Shows setup status (Playwright/reporter checks) with guidance
   - Links the folder to the newly created project automatically

3. **Project settings**: The project edit page now includes a "Local folder" section (desktop only) to:
   - View the linked folder path and its existence status
   - Change or unlink the folder
   - See setup status inline

4. **Navigation UI**: Added back/forward buttons to the sidebar header (desktop only) for the chrome-less webview, with support for mouse side buttons and trackpad gestures.

The heuristics mirror the reporter CLI's own `detect.ts` for consistency: same config lookup order, same name suggestion logic.

## How was it tested?

- Added comprehensive unit tests for folder inspection logic (config parsing, name detection, dependency checking)
- Added E2E test verifying the `desktop_inspect_folder` command rejects relative paths
- Added feature screenshot scenes for the new UI (new project modal, project settings, navigation)
- Existing tests pass; new composables and components are covered by feature screenshots

## Checklist

- [x] PR title follows Conventional Commits (`feat(desktop): ...`)
- [x] Tests added for behavior changes (unit tests for inspection logic, E2E for IPC validation)
- [x] Docs updated (`apps/docs/desktop.md` — new "Projects from local folders" section, navigation UI)

https://claude.ai/code/session_01VDawfitfQ6Z5G1Mad5REeR