### PR TITLE
docs: announce Piwi Picker on Chrome Web Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,12 @@ Everything below is built and published from this repository on each release.
 | [`@piwitests/instrumentation-nitro`](https://www.npmjs.com/package/@piwitests/instrumentation-nitro) | npm | Optional: sends your Nitro/Nuxt backend's logs into a test run |
 | [`PiwiTests.Instrumentation.AspNetCore`](https://www.nuget.org/packages/PiwiTests.Instrumentation.AspNetCore) | NuGet | Optional: the same for an ASP.NET Core backend |
 | Desktop app (`.msi`, `.dmg`) | [GitHub Releases](https://github.com/PiwiTests/platform/releases/latest) | The server bundled in a native window — no Docker or Node |
+| [Piwi Picker](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe) | Chrome Web Store | The browser extension — ranked Playwright locators picked from the live page (Chrome, Edge, and other Chromium browsers) |
 
 The two instrumentation packages are optional and only needed for
 [backend log capture](https://piwitests.github.io/backend-logs). Both container registries carry the
-same images; use whichever your organization prefers.
+same images; use whichever your organization prefers. The extension is the one entry uploaded to its
+store by hand rather than by CI, so its listed version can trail a release by a day or two.
 
 ## Project status
 
@@ -231,7 +233,7 @@ Full docs at **[piwitests.github.io](https://piwitests.github.io)**. The usual e
 - [Deployment](https://piwitests.github.io/deployment) and [Configuration](https://piwitests.github.io/configuration) — running your instance
 - [Upgrading](https://piwitests.github.io/upgrading) — what a version bump does, and why downgrading isn't a thing
 - [Privacy & data flow](https://piwitests.github.io/privacy) — exactly what leaves your server (nothing you didn't configure)
-- [Browser extension](https://piwitests.github.io/extension) — pick ranked locators from the live page (standalone, not yet store-published)
+- [Browser extension](https://piwitests.github.io/extension) — pick ranked locators from the live page, standalone ([install from the Chrome Web Store](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe) — works in Edge too)
 
 A running dashboard also serves interactive API docs at `/docs`, rendered in-app from its own OpenAPI
 spec — no external CDN, so they work offline.

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -61,7 +61,7 @@ exists for the long-tail searches that never contain the word "Piwi", so:
 - **Feature pages stay the source of truth.** A recipe links to them; it never becomes a second place
   where the flaky score or the fingerprint algorithm is explained, because that copy will drift.
 - **Always give a route for readers who can't install the thing.** State what a step requires (capture
-  fixtures, an LLM key, an unpacked extension, a signed-installer-less desktop build) and offer the
+  fixtures, an LLM key, a browser extension, a signed-installer-less desktop build) and offer the
   alternative — dashboard, MCP, REST API, or plain trace evidence. Listing a requirement without an
   alternative is the failure mode to avoid.
 - Recipes reuse **existing committed screenshots**; add a scene to the feature-screenshot harness only

--- a/apps/docs/extension.md
+++ b/apps/docs/extension.md
@@ -12,10 +12,19 @@ are fully standalone — nothing is sent anywhere by default. Connecting to a Pi
 optional and adds exactly one thing: matching a recording against your project's own
 page-object methods and helpers, ranked live as you record.
 
-> Not yet published to the Chrome Web Store or Edge Add-ons. Install it unpacked from a local
-> build until it is.
-
 ## Install
+
+**[Piwi Picker on the Chrome Web Store ↗](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe)**
+— click **Add to Chrome** and you're done; updates arrive from the store like any other extension.
+
+That one listing covers **Edge too**, and every other Chromium browser (Brave, Vivaldi, Opera).
+Edge blocks other stores until you say otherwise: the first Chrome Web Store page you open in it
+shows an **Allow extensions from other stores** banner — click **Allow** once, and **Get** installs
+and auto-updates exactly as it does in Chrome. There's no separate Edge Add-ons listing yet.
+
+### From source
+
+Only needed if you want an unreleased build, or you're changing the extension itself.
 
 ```bash
 git clone https://github.com/PiwiTests/platform.git
@@ -29,6 +38,10 @@ Then, in Chrome or Edge:
 1. Open `chrome://extensions` (`edge://extensions` on Edge).
 2. Turn on **Developer mode**.
 3. **Load unpacked** → select `apps/extension/dist`.
+
+A source build doesn't auto-update — rebuild and reload its card on the extensions page to pick up
+changes. If you already have the store version installed, disable one or the other so two copies of
+the picker don't both bind the keyboard shortcut.
 
 ## What it does
 

--- a/apps/docs/recipes/broken-locator.md
+++ b/apps/docs/recipes/broken-locator.md
@@ -65,8 +65,9 @@ don't want mid-release. Three routes that don't need it:
 
 **Pick against the live page.** The [browser extension](../extension) scores locators with the same
 engine the dashboard uses, directly on the page you're looking at. Picking and recording are fully
-standalone — nothing is sent anywhere, and it works without a Piwi instance at all. The cost: it isn't
-in the Chrome Web Store yet, so you install an unpacked build.
+standalone — nothing is sent anywhere, and it works without a Piwi instance at all. The cost: one
+click from the [Chrome Web Store](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe),
+which is also how you install it in Edge.
 
 **Read the failure evidence you already have.** Without fixtures you still get the trace, the
 screenshot, and the failing call stack. Playwright's trace viewer is bundled and served by your own

--- a/apps/docs/recipes/index.md
+++ b/apps/docs/recipes/index.md
@@ -17,8 +17,8 @@ matters.
 | "Our suite is unreliable and I have one afternoon." | [Cut the flakiness that costs the most](./flaky-cleanup) |
 
 Every recipe assumes the [reporter](../reporter) is installed and has sent a few runs — that's the only
-hard requirement. Where a step needs more than that (the capture fixtures, an LLM key, an unpacked
-browser extension), it says so and gives you a route that doesn't.
+hard requirement. Where a step needs more than that (the capture fixtures, an LLM key, a browser
+extension), it says so and gives you a route that doesn't.
 
 ## The tools each recipe draws on
 
@@ -33,7 +33,7 @@ know what exists and what it costs to switch on.
 | **REST API** | Scripts, dashboards of your own, CI steps | Nothing; see the [API docs](https://piwitests.github.io/demo/docs) |
 | **[AI diagnosis](../ai-diagnosis)** | An explanation of a cluster read against your git diff | An LLM you configure. Off by default; a local model works |
 | **[Open in IDE](../ide-integration)** | Jumping from a stack frame to the file | Per-browser config, no install |
-| **[Browser extension](../extension)** | Picking a locator against the live page | An unpacked build — not in the Chrome Web Store yet |
+| **[Browser extension](../extension)** | Picking a locator against the live page | A one-click install from the [Chrome Web Store](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe) (Edge included) |
 | **[Desktop app](../desktop)** | Running all of this without Docker | Windows x64 or Apple-silicon macOS; installers aren't signed yet |
 | **[Notifications](../notifications)** | Being told instead of looking | An email, Slack, or webhook target |
 

--- a/apps/extension/AGENTS.md
+++ b/apps/extension/AGENTS.md
@@ -8,6 +8,12 @@ one-origin-at-a-time `optional_host_permissions` grant recording needs — see b
 **connecting to a Piwi instance is opt-in** and adds exactly one thing: matching a
 recording against a project's own function catalog. See "Connected mode" below.
 
+Published on the Chrome Web Store as
+[Piwi Picker](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe)
+(`pakhnokpjboejcghgcmkjlpnogfjihhe`) — that listing is how Chrome *and* Edge users install it.
+Uploads are manual per release; `PUBLISHING.md` has the loop, and the Edge Add-ons and Firefox
+AMO listings that are still outstanding.
+
 ## What it is
 
 - `manifest.json` — MV3 manifest. Standing permissions stay at `activeTab` + `scripting` +
@@ -215,3 +221,6 @@ While iterating, use `npm run extension:dev` instead — it rebuilds on save. Th
 still needs a manual reload on the `chrome://extensions` card to pick up a new build (MV3
 gives no way to trigger that from outside the browser), so the loop is: save → wait for the
 rebuild line → click reload.
+
+Disable the Chrome Web Store copy while a local build is loaded — two installs both claim the
+`Ctrl+Shift+E` command, and only one of them gets it, which reads as "my change didn't apply".

--- a/apps/extension/PUBLISHING.md
+++ b/apps/extension/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Publishing Piwi Picker to Chrome, Edge, and Firefox
 
-Not yet published anywhere — see `apps/docs/extension.md`'s own note ("install unpacked until it is"). This is what closes that gap.
+**Status: live on the Chrome Web Store**, at [`pakhnokpjboejcghgcmkjlpnogfjihhe`](https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe) — that ID is assigned by the store and is now permanent for this listing. Edge and Firefox are still unsubmitted; §3 and §4 below are the remaining work, and neither blocks an Edge user today (Edge installs Chrome Web Store extensions once the user allows other stores — see §3).
 
 Current state this guide assumes: manifest name `"Piwi Picker"`, version tracked by release-please repo-wide (`apps/extension/manifest.json`'s version is already an `extra-files` target in `release-please-config.json` — no manual version bumps needed), MIT-licensed, icons present at 16/32/48/128px, standing permissions limited to `activeTab` + `scripting` + `storage`, plus `optional_host_permissions` (`http://*/*`, `https://*/*`) — declared but granted nothing until the user clicks "Record actions" and approves a single origin. See `apps/docs/extension.md`'s permissions table for the exact wording, and the note in §2 step 3 below on justifying this one to reviewers.
 
@@ -22,21 +22,25 @@ npm run extension:zip --workspace=apps/extension
 
 Builds, then zips `dist/`'s contents (manifest at the zip root, not nested — what stores expect) into `apps/extension/piwi-picker-v<version>.zip`, dropping `.map` sourcemaps along the way (`apps/extension/scripts/zip.mjs`, via `archiver` — pure JS, no dependency on a system `zip`/`7z` binary, so this works the same on Windows as it does in CI). The zip is gitignored; regenerate it whenever you need a fresh one rather than keeping an old one around. All three stores want this **same built zip**; the manifest is already store-agnostic MV3, so no store-specific rebuild is needed (Firefox's one extra requirement is a manifest key addition, not a different build — see §4).
 
-## 2. Chrome Web Store
+## 2. Chrome Web Store — **done**
+
+Live at <https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe>. The steps below are kept because every version bump repeats them (step 1 onwards, minus the listing fields you don't change).
 
 1. Dashboard → **New item** → upload the zip.
 2. Store listing requires: description, at least one 1280×800 or 640×400 screenshot, a 128×128 icon (already have it), category (Developer Tools), and a **privacy practices** disclosure. Picking and recording are zero-telemetry/zero-network by default; the one exception is the optional Piwi-instance connection (`options.html`), which — only if the user configures it — sends the API key and a project id (one per configured URL-pattern → project mapping) to fetch that project's function catalog, and nothing else (no recorded data, no browsing history). State both halves plainly rather than only the standalone claim.
 3. Permission justification: Chrome's review form asks you to justify each requested permission in plain English. For `activeTab`/`scripting`/`storage`, reuse the exact wording already in `apps/docs/extension.md`'s permissions table — it's already accurate and honest. `optional_host_permissions` needs its own explanation since the two patterns (`http://*/*`, `https://*/*`) look broad on their own: say plainly that this is declared so the extension *can* request a single origin, on demand, only when the user clicks "Record actions" inside that click's own gesture — nothing is granted at install, and the grant is scoped to whichever one site the user is recording, never `<all_urls>` in practice. Reviewers specifically look for this "declared broad, granted narrow, user-gestured" pattern with optional host permissions — state it explicitly rather than assuming the manifest speaks for itself.
 4. Submit for review. First review is typically the slowest (hours to a few days); version updates thereafter are usually faster.
-5. Once approved, note the **extension ID** Chrome assigns — useful for support links and the docs page.
+5. Once approved, note the **extension ID** Chrome assigns — useful for support links and the docs page. It came out as `pakhnokpjboejcghgcmkjlpnogfjihhe`, and `apps/docs/extension.md`, `apps/docs/recipes/`, and the root `README.md` all link the listing by that ID.
 
 ## 3. Edge Add-ons
 
 Structurally the easiest: Edge is Chromium and accepts the **same zip** unmodified.
 
+Not urgent, because Edge users are already served: opening the Chrome Web Store listing in Edge shows an **Allow extensions from other stores** banner, and after one click **Get** installs and auto-updates the extension exactly as in Chrome. That's what `apps/docs/extension.md` tells Edge users to do today. An Edge Add-ons listing buys discoverability inside Edge's own store and skips that banner — worth doing, not blocking.
+
 1. Partner Center → **Create new extension** → upload the same zip from §1.
 2. Edge's review is generally faster than Chrome's and has a lighter privacy-disclosure form — fill it out the same honest way.
-3. Edge can auto-import a listing from an existing Chrome Web Store entry if you link accounts — worth doing if Chrome approves first, to avoid re-typing the listing.
+3. Edge can auto-import a listing from the existing Chrome Web Store entry if you link accounts — do that rather than re-typing the listing, since Chrome is already approved.
 
 ## 4. Firefox AMO — the one with real differences
 
@@ -69,4 +73,4 @@ Submission steps:
 
 ## 5. Ongoing updates
 
-Every store re-review happens on **every version bump**, not just the first. Since release-please already bumps `apps/extension/manifest.json`'s version repo-wide, the practical loop becomes: tag lands → rebuild zip → re-upload to all three dashboards. That's manual today. It's genuinely automatable later — Chrome Web Store, Edge, and AMO all have publish APIs — following the same shape as `.github/workflows/desktop-release.yml`'s already-established pattern (tag-triggered on `v*`, attaches build output to the release release-please created). Not built yet since it wasn't needed until there's a first manual submission to model it after; a natural next step once this has been done by hand a few times.
+Every store re-review happens on **every version bump**, not just the first. Since release-please already bumps `apps/extension/manifest.json`'s version repo-wide, the practical loop becomes: tag lands → rebuild zip → re-upload to every dashboard the extension is listed on — Chrome today, plus Edge and Firefox once §3 and §4 land. That's manual, which is why the store's listed version can trail a release: nothing reminds you, and a skipped upload is invisible from inside the repo. It's genuinely automatable — Chrome Web Store, Edge, and AMO all have publish APIs — following the same shape as `.github/workflows/desktop-release.yml`'s already-established pattern (tag-triggered on `v*`, attaches build output to the release release-please created). The first manual submission it needed as a model has now happened, so this is the natural next step once the by-hand loop has been run a few times and its quirks are known.


### PR DESCRIPTION
## What & why

Piwi Picker has been published to the Chrome Web Store and is now live. This updates all documentation and guides to reflect that the extension is no longer an unpacked development build, but a one-click install from the store.

Changes include:
- **`apps/docs/extension.md`**: Replaces the "not yet published" notice with the Chrome Web Store link and installation instructions. Adds a "From source" section for developers who want to build locally. Clarifies that the same listing works in Edge (via the "Allow extensions from other stores" banner) and other Chromium browsers.
- **`apps/extension/PUBLISHING.md`**: Updates status to "live on the Chrome Web Store" with the permanent extension ID (`pakhnokpjboejcghgcmkjlpnogfjihhe`). Marks §2 as complete and notes that Edge users are already served via the Chrome Web Store. Clarifies the ongoing manual upload loop for version bumps.
- **`apps/extension/AGENTS.md`**: Adds a note about the Chrome Web Store listing and links to the PUBLISHING guide. Adds a developer note about disabling the store copy when testing a local build to avoid keyboard shortcut conflicts.
- **`README.md`**: Adds Piwi Picker to the published artifacts table with a link to the Chrome Web Store. Notes that the extension version can trail releases by a day or two since uploads are manual.
- **`apps/docs/recipes/index.md`** and **`apps/docs/recipes/broken-locator.md`**: Updates references from "unpacked build" to "one-click install from the Chrome Web Store" and adds the store link.
- **`apps/docs/AGENTS.md`**: Updates documentation guidelines to refer to "browser extension" instead of "unpacked extension" in the list of requirements.

## How was it tested?

Documentation review — all links point to the live Chrome Web Store listing, and the installation instructions match the current store behavior.

## Checklist

- [x] PR title follows Conventional Commits (`docs: announce Piwi Picker on Chrome Web Store`)
- [x] Docs updated for user-facing change (extension now published and installable from store)
- [x] No code changes; documentation only

https://claude.ai/code/session_01L8hP52xmNgQbiX4EAF3RyP