### PR TITLE
feat(ai): support text-only models and live diagnosis E2E tests

### DIFF
--- a/.github/workflows/ai-live-e2e.yml
+++ b/.github/workflows/ai-live-e2e.yml
@@ -1,11 +1,12 @@
 name: ai-live-e2e
 
-# Live end-to-end test of the AI-step authoring path against a REAL LLM
-# (OpenCode / DeepSeek). It costs tokens, so it is deliberately NOT part of the
-# normal CI matrix — it runs only when triggered on purpose:
+# Live end-to-end tests of both AI surfaces against a REAL LLM (OpenCode /
+# DeepSeek): the AI-step authoring path (reporter) and the failure-diagnosis
+# pipeline (dashboard). They cost tokens, so they are deliberately NOT part of
+# the normal CI matrix — they run only when triggered on purpose:
 #   • manually, via "Run workflow" (workflow_dispatch), or
 #   • when the `ai-live-e2e` label is added to a pull request.
-# The zero-token stub-driven pipeline test runs on every PR in ci.yml instead.
+# The zero-token stub- and mock-driven equivalents run on every PR in ci.yml.
 on:
   workflow_dispatch:
     inputs:
@@ -14,7 +15,7 @@ on:
         default: https://opencode.ai/zen/v1
         required: false
       model:
-        description: Model id to author steps with
+        description: Model id to author steps and diagnose with
         default: deepseek-v4-flash
         required: false
   pull_request:
@@ -22,11 +23,11 @@ on:
 
 jobs:
   live:
-    name: Author AI steps with a real model
+    name: Author AI steps and diagnose a failure with a real model
     runs-on: ubuntu-latest
     # Manual dispatch always runs; on a PR only when the opt-in label is present.
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ai-live-e2e')
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     env:
       # Dispatch inputs win; the label path falls back to these thrifty defaults.
@@ -38,8 +39,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Ensure the provider key is configured
+        env:
+          PROVIDER_KEY: ${{ secrets.OPENCODE_API }}
         run: |
-          if [ -z "${{ secrets.OPENCODE_API }}" ]; then
+          if [ -z "$PROVIDER_KEY" ]; then
             echo "::error::The OPENCODE_API secret is not set for this repository — cannot run the live AI E2E."
             exit 1
           fi
@@ -84,13 +87,15 @@ jobs:
       - name: Start the Piwi server (configured for the real model)
         working-directory: ./apps/application
         # The AI provider is baked into the build above; storage and database are
-        # read straight from process.env at runtime, so they belong here.
+        # read straight from process.env at runtime, so they belong here. This
+        # server backs the reporter's AI-step run; the diagnosis suite starts its
+        # own on port 3102 (tests/live/playwright.config.ts).
         env:
           # Local sqlite + local storage; the server self-migrates on boot but
           # only creates the DB file, not its directory — so make the dir first.
           PIWI_STORAGE_TYPE: local
-          PIWI_STORAGE_PATH: .live-temp/storage
-          PIWI_DATABASE_PATH: .live-temp/live.db
+          PIWI_STORAGE_PATH: .live-temp/steps/storage
+          PIWI_DATABASE_PATH: .live-temp/steps/live.db
           PIWI_SECRET_KEY: ci-live-e2e-encryption-key-not-for-production
           # DeepSeek V4 Flash is a reasoning model: its chain-of-thought counts
           # toward completion tokens, so the 1024-token default step-output cap
@@ -100,7 +105,7 @@ jobs:
           # Auth stays disabled, so the reporter can POST to the resolution
           # endpoint without an API key (requireAuth grants a virtual admin).
         run: |
-          mkdir -p .live-temp/storage
+          mkdir -p .live-temp/steps/storage
           nohup node .output/server/index.mjs > "$GITHUB_WORKSPACE/server.log" 2>&1 &
           echo $! > "$GITHUB_WORKSPACE/server.pid"
 
@@ -120,6 +125,18 @@ jobs:
           # Bound the Ajax settle so a slow/quiet page can never hang the run.
           PIWI_AI_RESPONSE_WAIT_TIMEOUT: '8000'
         run: npm run reporter:test:integration:ai:live
+
+      - name: Run the live AI diagnosis E2E
+        # Both surfaces get reported in one run even when the other one fails.
+        if: ${{ !cancelled() }}
+        working-directory: ./apps/application
+        # Starts its own server on port 3102 with the provider and the
+        # image-free context the model needs — see tests/live/playwright.config.ts.
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API }}
+          PIWI_AI_BASE_URL: ${{ env.BASE_URL }}
+          PIWI_AI_MODEL: ${{ env.MODEL }}
+        run: npm run app:test:ai:live
 
       - name: Server logs
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@ coverage/
 .test-temp-gzip/
 .temp-dashboard/
 
+# Live AI E2E scratch: the throwaway server state and the artifacts the
+# authoring run writes instead of committing.
+.live-temp/
+.ai-live-artifacts/
+
 
 # Playwright artifacts
 .playwright-cli/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ From `apps/application/`:
 | `npm run app:format` / `app:format:check` | oxfmt |
 | `npm run app:test:unit` | Unit tests (Vitest) — add `:coverage` for coverage |
 | `npm run app:test` | E2E tests (Playwright) — add `:ui` / `:report` |
+| `npm run app:test:ai:live` | Diagnosis E2E against a **real** model (`tests/live/`) — needs `OPENCODE_API_KEY`, spends tokens |
 | `npm test` | Everything: unit first, then E2E |
 | `npm run db:generate` / `db:migrate` / `db:push` / `db:studio` | Drizzle, SQLite — append `:pg` for PostgreSQL |
 | `npm run app:seed:demo` | Regenerate demo seed data (`public/demo/seed.sql`) |

--- a/apps/application/AGENTS.md
+++ b/apps/application/AGENTS.md
@@ -239,6 +239,10 @@ same files load unchanged in Vite, Vitest and plain Node (the generator script r
   must be unique repo-wide; follow the reuse and responsive rules below.
 - **Unit test** — `tests/unit/*.test.ts` (Vitest). **E2E test** — `tests/*.spec.ts` (Playwright), with any project name
   registered in `shared/test-project-names.ts`.
+- **AI test** — an E2E that needs a model goes against the mock OpenAI-compatible server in `tests/ai-diagnosis.spec.ts`,
+  so the main suite stays at zero tokens. `tests/live/` is the only place that talks to a real provider: it is excluded
+  from `playwright.config.ts`, has its own config, and runs from `npm run app:test:ai:live` or the `ai-live-e2e`
+  workflow. Assume the live model is text-only — that suite pins `PIWI_AI_MAX_IMAGES=0`.
 
 ## Extension points
 

--- a/apps/application/app/composables/useAttachments.ts
+++ b/apps/application/app/composables/useAttachments.ts
@@ -1,3 +1,4 @@
+import { SUPPORTED_IMAGE_MEDIA_TYPES } from '#shared/file-classify';
 import type { DiagnoseImage } from './useClusterDiagnosis';
 
 /**
@@ -20,7 +21,6 @@ export interface AttachedImage extends DiagnoseImage {
 
 const MAX_TEXT_BYTES = 200 * 1024;
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
-const SUPPORTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 
 function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -44,7 +44,7 @@ export function useAttachments() {
 
   async function processFiles(list: FileList | File[]) {
     for (const file of Array.from(list)) {
-      if (SUPPORTED_IMAGE_TYPES.includes(file.type)) {
+      if ((SUPPORTED_IMAGE_MEDIA_TYPES as readonly string[]).includes(file.type)) {
         if (file.size > MAX_IMAGE_BYTES) {
           toast.add({ title: 'Image too large', description: `${file.name} exceeds 5 MB`, color: 'error' });
           continue;

--- a/apps/application/package.json
+++ b/apps/application/package.json
@@ -22,6 +22,7 @@
     "app:typecheck": "nuxt typecheck",
     "test": "vitest run && playwright test",
     "app:test": "playwright test",
+    "app:test:ai:live": "playwright test --config=tests/live/playwright.config.ts",
     "app:test:unit": "vitest run",
     "app:test:unit:coverage": "vitest run --coverage",
     "app:test:ui": "playwright test --ui",

--- a/apps/application/playwright.config.ts
+++ b/apps/application/playwright.config.ts
@@ -46,6 +46,9 @@ const reporters: ReporterDescription[] = process.env.CI
 const baseConfig = defineConfig({
   testDir: './tests',
   testMatch: '**/*.spec.ts',
+  // `tests/live/` talks to a real LLM and has its own config + npm script; a
+  // normal run must never spend tokens.
+  testIgnore: '**/live/**',
 
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/apps/application/server/utils/ai-context.ts
+++ b/apps/application/server/utils/ai-context.ts
@@ -46,6 +46,7 @@ import { getLocatorHealing } from './locator-healing';
 import { getEnvironmentDiff } from './environment-diff';
 import { renderEnvironmentDiffMarkdown } from '#shared/environment-diff';
 import { selectCaseScreenshots } from './case-screenshots';
+import { supportedImageMediaType } from '#shared/file-classify';
 import { getOrComputeVisualDiff } from './visual-diff';
 import { parseAriaCandidates, textSimilarity } from '#shared/locator-fingerprint';
 import type {
@@ -1025,19 +1026,13 @@ async function resolveScreenshots(
 
   for (const f of screenshotRows) {
     if (images.length >= limits.maxImages) break;
+    const mediaType = supportedImageMediaType(f);
+    if (!mediaType) continue;
     try {
       const buf = await storage.readFile(f.path);
-      const ext = f.path.toLowerCase().split('.').pop() || 'png';
-      const mediaType =
-        ext === 'jpg' || ext === 'jpeg'
-          ? ('image/jpeg' as const)
-          : ext === 'gif'
-            ? ('image/gif' as const)
-            : ext === 'webp'
-              ? ('image/webp' as const)
-              : ('image/png' as const);
       images.push({
-        name: f.label || f.path.split('/').pop() || 'screenshot',
+        // `subtype` is the Playwright attachment name; `label` is its content type.
+        name: f.subtype || f.path.split('/').pop() || 'screenshot',
         mediaType,
         data: buf.toString('base64'),
       });

--- a/apps/application/server/utils/ai-provider.ts
+++ b/apps/application/server/utils/ai-provider.ts
@@ -383,8 +383,8 @@ type OAIUsage = {
   prompt_tokens_details?: { cached_tokens?: number };
 };
 
-function openAiUserContent(opts: AiCallOptions): string | OAIPart[] {
-  return opts.images?.length
+function openAiUserContent(opts: AiCallOptions, attempt: OpenAiAttempt): string | OAIPart[] {
+  return attempt.withImages && opts.images?.length
     ? [
         ...opts.images.map(
           (img): OAIPart => ({
@@ -397,20 +397,27 @@ function openAiUserContent(opts: AiCallOptions): string | OAIPart[] {
     : opts.user;
 }
 
+/** Which rungs of the OpenAI-compatibility ladder this request body still uses. */
+interface OpenAiAttempt {
+  /** Enforce the JSON schema with `response_format: json_schema` rather than `json_object`. */
+  strictFormat: boolean;
+  /** Send `opts.images` as `image_url` parts. */
+  withImages: boolean;
+}
+
 /**
  * Base chat-completions body. The JSON schema is enforced with
- * `response_format: json_schema` where the server supports it (`strictFormat`);
- * callers retry with the older `json_object` mode on HTTP 400. The schema also
- * stays inlined in the system prompt so servers that ignore response_format
- * still see it.
+ * `response_format: json_schema` where the server supports it; callers step down
+ * to the older `json_object` mode on HTTP 400. The schema also stays inlined in
+ * the system prompt so servers that ignore response_format still see it.
  */
-function buildOpenAiBody(config: ResolvedAiRole, opts: AiCallOptions, strictFormat: boolean): Record<string, unknown> {
+function buildOpenAiBody(config: ResolvedAiRole, opts: AiCallOptions, attempt: OpenAiAttempt): Record<string, unknown> {
   const systemContent = opts.jsonSchema
     ? `${opts.system}\n\nRespond ONLY with a JSON object matching this schema:\n${JSON.stringify(opts.jsonSchema)}`
     : opts.system;
 
   const responseFormat = opts.jsonSchema
-    ? strictFormat
+    ? attempt.strictFormat
       ? { type: 'json_schema', json_schema: { name: 'response', schema: opts.jsonSchema } }
       : { type: 'json_object' }
     : undefined;
@@ -422,9 +429,47 @@ function buildOpenAiBody(config: ResolvedAiRole, opts: AiCallOptions, strictForm
     ...(responseFormat ? { response_format: responseFormat } : {}),
     messages: [
       { role: 'system', content: systemContent },
-      { role: 'user', content: openAiUserContent(opts) },
+      { role: 'user', content: openAiUserContent(opts, attempt) },
     ],
   };
+}
+
+/** A rejection from a text-only model handed `image_url` parts. */
+function rejectsImages(status: number, body: string): boolean {
+  return status === 400 && /image|vision/i.test(body);
+}
+
+/**
+ * POST the chat-completions body, stepping down the compatibility ladder when
+ * the server refuses a rung: `image_url` parts are dropped for a model with no
+ * vision (its text context still carries the failure evidence), and
+ * `response_format: json_schema` falls back to `json_object` for servers that
+ * only know the older mode. Returns the last response, plus its body whenever
+ * that response failed (an ok response is left unread for the caller).
+ */
+async function postOpenAiWithFallbacks(
+  send: (attempt: OpenAiAttempt) => Promise<Response>,
+  opts: AiCallOptions,
+  model: string,
+): Promise<{ res: Response; errorBody: string }> {
+  const attempt: OpenAiAttempt = { strictFormat: true, withImages: true };
+  let res = await send(attempt);
+  let errorBody = res.ok ? '' : await res.text().catch(() => '');
+
+  if (!res.ok && opts.images?.length && rejectsImages(res.status, errorBody)) {
+    console.warn(`[ai-provider] ${model} rejected the attached image(s) — retrying text-only`);
+    attempt.withImages = false;
+    res = await send(attempt);
+    errorBody = res.ok ? '' : await res.text().catch(() => '');
+  }
+
+  if (!res.ok && res.status === 400 && opts.jsonSchema && attempt.strictFormat) {
+    attempt.strictFormat = false;
+    res = await send(attempt);
+    errorBody = res.ok ? '' : await res.text().catch(() => '');
+  }
+
+  return { res, errorBody };
 }
 
 async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Promise<AiCallResult> {
@@ -434,23 +479,20 @@ async function callOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions): Pr
   const headers: Record<string, string> = { 'content-type': 'application/json' };
   if (config.apiKey) headers['authorization'] = `Bearer ${config.apiKey}`;
 
-  const post = (strictFormat: boolean) =>
-    fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(buildOpenAiBody(config, opts, strictFormat)),
-      signal: AbortSignal.timeout(120_000),
-    });
-
-  let res = await post(true);
-  if (res.status === 400 && opts.jsonSchema) {
-    // Server rejects response_format json_schema (older OpenAI-compat) — fall back to json_object.
-    res = await post(false);
-  }
+  const { res, errorBody } = await postOpenAiWithFallbacks(
+    (attempt) =>
+      fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(buildOpenAiBody(config, opts, attempt)),
+        signal: AbortSignal.timeout(120_000),
+      }),
+    opts,
+    config.model,
+  );
 
   if (!res.ok) {
-    const bodyText = await res.text().catch(() => '');
-    throw new Error(`openai provider returned HTTP ${res.status}: ${bodyText.slice(0, 300)}`);
+    throw new Error(`openai provider returned HTTP ${res.status}: ${errorBody.slice(0, 300)}`);
   }
 
   const data = (await res.json()) as {
@@ -555,12 +597,12 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 120_000);
 
-  const post = (strictFormat: boolean) =>
+  const post = (attempt: OpenAiAttempt) =>
     fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({
-        ...buildOpenAiBody(config, opts, strictFormat),
+        ...buildOpenAiBody(config, opts, attempt),
         stream: true,
         stream_options: { include_usage: true },
       }),
@@ -568,15 +610,10 @@ async function* streamOpenAiCompat(config: ResolvedAiRole, opts: AiCallOptions):
     });
 
   try {
-    let res = await post(true);
-    if (res.status === 400 && opts.jsonSchema) {
-      // Server rejects response_format json_schema (older OpenAI-compat) — fall back to json_object.
-      res = await post(false);
-    }
+    const { res, errorBody } = await postOpenAiWithFallbacks(post, opts, config.model);
 
     if (!res.ok) {
-      const bodyText = await res.text().catch(() => '');
-      throw new Error(`openai provider returned HTTP ${res.status}: ${bodyText.slice(0, 300)}`);
+      throw new Error(`openai provider returned HTTP ${res.status}: ${errorBody.slice(0, 300)}`);
     }
 
     const reader = res.body?.getReader();

--- a/apps/application/shared/file-classify.ts
+++ b/apps/application/shared/file-classify.ts
@@ -25,22 +25,39 @@ function extensionOf(path: string): string {
   return path.toLowerCase().split('.').pop() || '';
 }
 
+/**
+ * Whether an attachment row belongs to a media family (`image/`, `video/`).
+ *
+ * The recorded content type decides on its own when the row has one; the
+ * attachment name and the file extension are guesses that only apply to rows
+ * without it. So an attachment named `screenshot-metadata` carrying
+ * `application/json` is a JSON file, and `notes.ogg` carrying `audio/ogg` is
+ * not a video.
+ */
+function isAttachmentOfFamily(
+  row: ClassifiableFileRow,
+  family: 'image' | 'video',
+  namePrefix: string,
+  exts: ReadonlySet<string>,
+): boolean {
+  const contentType = row.label?.toLowerCase();
+  if (contentType) return contentType.startsWith(`${family}/`);
+  if (row.subtype?.toLowerCase().startsWith(namePrefix)) return true;
+  return exts.has(extensionOf(row.path));
+}
+
 /** True when a files row refers to a screenshot image (either storage shape). */
 export function isScreenshotFileRow(row: ClassifiableFileRow): boolean {
   if (row.type === 'screenshot') return true;
   if (row.type !== 'attachment') return false;
-  if (row.subtype?.toLowerCase().startsWith('screenshot')) return true;
-  if (row.label?.toLowerCase().startsWith('image/')) return true;
-  return IMAGE_EXTS.has(extensionOf(row.path));
+  return isAttachmentOfFamily(row, 'image', 'screenshot', IMAGE_EXTS);
 }
 
 /** True when a files row refers to a recorded video. */
 export function isVideoFileRow(row: ClassifiableFileRow): boolean {
   if (row.type === 'video') return true;
   if (row.type !== 'attachment') return false;
-  if (row.subtype?.toLowerCase().startsWith('video')) return true;
-  if (row.label?.toLowerCase().startsWith('video/')) return true;
-  return VIDEO_EXTS.has(extensionOf(row.path));
+  return isAttachmentOfFamily(row, 'video', 'video', VIDEO_EXTS);
 }
 
 /** The evidence kind a files row belongs to. */
@@ -49,6 +66,36 @@ export function classifyEvidenceFile(row: ClassifiableFileRow): EvidenceKind {
   if (isScreenshotFileRow(row)) return 'screenshot';
   if (isVideoFileRow(row)) return 'video';
   return 'attachment';
+}
+
+/** The image media types the provider vision APIs accept. */
+export const SUPPORTED_IMAGE_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'] as const;
+export type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number];
+
+const EXT_IMAGE_MEDIA_TYPES: Record<string, SupportedImageMediaType> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
+/**
+ * The media type a stored screenshot may be sent to a model as. The recorded
+ * content type decides when the row has one — including deciding against it, so
+ * a format no provider accepts (SVG, BMP, TIFF, …) yields null and the file is
+ * left out of the context rather than sent under a media type it does not
+ * match. Rows without a content type fall back to their file extension.
+ */
+export function supportedImageMediaType(row: { label?: string | null; path: string }): SupportedImageMediaType | null {
+  const contentType = row.label?.toLowerCase().split(';')[0]?.trim();
+  if (contentType) {
+    if (contentType === 'image/jpg') return 'image/jpeg';
+    return (SUPPORTED_IMAGE_MEDIA_TYPES as readonly string[]).includes(contentType)
+      ? (contentType as SupportedImageMediaType)
+      : null;
+  }
+  return EXT_IMAGE_MEDIA_TYPES[extensionOf(row.path)] ?? null;
 }
 
 /** Best-effort content type for a stored evidence file. */

--- a/apps/application/shared/test-project-names.ts
+++ b/apps/application/shared/test-project-names.ts
@@ -57,6 +57,7 @@ export const PROJECT = {
   ENV_UPLOAD: 'env-upload-test',
   EXPORT_OFFLINE: 'export-offline-test',
   AI_DIAGNOSIS: 'ai-diagnosis-test',
+  AI_IMAGE_FALLBACK: 'ai-image-fallback-test',
   AI_STEPS: 'ai-steps-coverage-test',
   EXTRACT_CASES: 'extract-cases-test',
   FAILURE_CLUSTERS: 'failure-clusters-test',

--- a/apps/application/shared/test-project-names.ts
+++ b/apps/application/shared/test-project-names.ts
@@ -58,6 +58,7 @@ export const PROJECT = {
   EXPORT_OFFLINE: 'export-offline-test',
   AI_DIAGNOSIS: 'ai-diagnosis-test',
   AI_IMAGE_FALLBACK: 'ai-image-fallback-test',
+  AI_LIVE_DIAGNOSIS: 'ai-live-diagnosis-test',
   AI_STEPS: 'ai-steps-coverage-test',
   EXTRACT_CASES: 'extract-cases-test',
   FAILURE_CLUSTERS: 'failure-clusters-test',

--- a/apps/application/tests/ai-diagnosis.spec.ts
+++ b/apps/application/tests/ai-diagnosis.spec.ts
@@ -728,8 +728,11 @@ test.describe.serial('AI diagnosis — a model that rejects images', () => {
     // The screenshot is in the context, so the first provider call carries it.
     const ctx = (await (await request.get(`/api/failure-clusters/${clusterId}/context?format=json`)).json()) as {
       imageTokenEstimate: number;
+      sections: Array<{ id: string; markdown: string }>;
     };
     expect(ctx.imageTokenEstimate).toBeGreaterThan(0);
+    // The image is titled with the attachment name, not with its content type.
+    expect(ctx.sections.find((s) => s.id === 'screenshots')?.markdown).toContain('![screenshot]');
 
     const res = await request.post(`/api/failure-clusters/${clusterId}/diagnose`);
     expect(res.ok()).toBeTruthy();

--- a/apps/application/tests/ai-diagnosis.spec.ts
+++ b/apps/application/tests/ai-diagnosis.spec.ts
@@ -156,6 +156,63 @@ function startStreamingMockAiServer(port: number): http.Server {
   return server;
 }
 
+/**
+ * Like `startMockAiServer`, but refuses any request carrying an `image_url`
+ * part the way a text-only OpenAI-compatible model does, so the provider's
+ * drop-the-images retry runs without needing a real model. `imageAttempts`
+ * counts the requests that arrived with images.
+ */
+function startTextOnlyMockAiServer(port: number): { server: http.Server; imageAttempts: () => number } {
+  let imageAttempts = 0;
+  const server = http.createServer((req, res) => {
+    if (!(req.method === 'POST' && req.url?.includes('/chat/completions'))) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+      return;
+    }
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      let messages: Array<{ content?: unknown }> = [];
+      try {
+        messages = (JSON.parse(body || '{}') as { messages?: Array<{ content?: unknown }> }).messages ?? [];
+      } catch {
+        /* ignore */
+      }
+      const hasImage = messages.some(
+        (m) =>
+          Array.isArray(m.content) &&
+          m.content.some((part) => (part as { type?: string } | null)?.type === 'image_url'),
+      );
+
+      if (hasImage) {
+        imageAttempts++;
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: { message: 'This model does not support image inputs' } }));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          id: 'chatcmpl-test',
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: JSON.stringify(buildMockAiResponse()) },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 80, total_tokens: 180 },
+        }),
+      );
+    });
+  });
+  server.listen(port, '127.0.0.1');
+  return { server, imageAttempts: () => imageAttempts };
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 async function submitRun(request: APIRequestContext, cases: Array<{ status: string; [key: string]: unknown }>) {
@@ -586,6 +643,100 @@ test.describe.serial('AI diagnosis — streaming success path', () => {
     expect(diagnosis.category).toBe('app-bug');
     expect(diagnosis.confidence).toBe('high');
     expect(diagnosis.details.confidenceScore).toBe(88);
+  });
+});
+
+// ── Text-only models (no vision) ─────────────────────────────────────────────
+
+test.describe.serial('AI diagnosis — a model that rejects images', () => {
+  /** A real (1×1) PNG, so the ingested attachment is classified as a screenshot. */
+  const PNG_1X1 = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64',
+  );
+
+  let mock: { server: http.Server; imageAttempts: () => number };
+  let mockPort: number;
+  let isEnvManaged = false;
+
+  test.beforeAll(async ({ request }) => {
+    const statusRes = await request.get('/api/ai/status');
+    if (statusRes.ok()) {
+      isEnvManaged = ((await statusRes.json()) as { source?: string }).source === 'env';
+    }
+    mockPort = await getFreePort();
+    mock = startTextOnlyMockAiServer(mockPort);
+  });
+
+  test.beforeEach(async () => {
+    if (isEnvManaged) test.skip();
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (!isEnvManaged) await request.put('/api/settings/ai', { data: { roles: null } });
+    mock.server.close();
+  });
+
+  test('drops the screenshots and still completes the diagnosis', async ({ request }) => {
+    const put = await request.put('/api/settings/ai', {
+      data: {
+        roles: { diagnosis: { provider: 'openai', model: 'text-only', baseUrl: `http://127.0.0.1:${mockPort}/v1` } },
+        autoDiagnose: false,
+      },
+    });
+    expect(put.ok()).toBeTruthy();
+
+    // A screenshot only reaches the context through a live case-file upload, so
+    // this failure is ingested through the streaming API rather than /submit.
+    const start = await request.post('/api/test-runs/start', {
+      data: { projectName: PROJECT.AI_IMAGE_FALLBACK, startTime: new Date().toISOString() },
+    });
+    expect(start.ok()).toBeTruthy();
+    const { runId, streamToken } = (await start.json()) as { runId: number; streamToken: string };
+
+    const testCase = { title: 'checkout completes', location: 'tests/no-vision.spec.ts:7:3', retries: 0 };
+    const uniqueError = `TimeoutError: locator.click: Timeout 30000ms exceeded.\nCall log:\n  - waiting for getByTestId('no-vision-${Date.now()}')`;
+    const events = await request.post(`/api/test-runs/${runId}/events`, {
+      data: {
+        streamToken,
+        testCases: [{ type: 'complete', ...testCase, status: 'failed', duration: 5000, error: uniqueError }],
+      },
+    });
+    expect(events.ok()).toBeTruthy();
+
+    const upload = await request.post(`/api/test-runs/${runId}/case-files`, {
+      multipart: {
+        streamToken,
+        testCase: JSON.stringify(testCase),
+        attach_meta: JSON.stringify([{ name: 'screenshot', contentType: 'image/png', originalName: 'failure.png' }]),
+        attach_file: { name: 'failure.png', mimeType: 'image/png', buffer: PNG_1X1 },
+      },
+    });
+    expect(upload.ok()).toBeTruthy();
+
+    const finish = await request.post(`/api/test-runs/${runId}/finish`, {
+      data: { streamToken, status: 'failed', duration: 5000 },
+    });
+    expect(finish.ok()).toBeTruthy();
+
+    const run = (await (await request.get(`/api/test-runs/${runId}`)).json()) as {
+      testCases: Array<{ status: string; failureClusterId?: number }>;
+    };
+    const clusterId = run.testCases.find((c) => c.status === 'failed')?.failureClusterId;
+    expect(clusterId).toBeTruthy();
+
+    // The screenshot is in the context, so the first provider call carries it.
+    const ctx = (await (await request.get(`/api/failure-clusters/${clusterId}/context?format=json`)).json()) as {
+      imageTokenEstimate: number;
+    };
+    expect(ctx.imageTokenEstimate).toBeGreaterThan(0);
+
+    const res = await request.post(`/api/failure-clusters/${clusterId}/diagnose`);
+    expect(res.ok()).toBeTruthy();
+    const diagnosis = await res.json();
+    expect(diagnosis.status).toBe('completed');
+    expect(diagnosis.category).toBe('app-bug');
+    expect(mock.imageAttempts()).toBe(1);
   });
 });
 

--- a/apps/application/tests/live/ai-diagnosis-live.spec.ts
+++ b/apps/application/tests/live/ai-diagnosis-live.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * The LIVE end-to-end test of the AI diagnosis pipeline: a real failure is
+ * ingested, then diagnosed by a REAL model (OpenCode / DeepSeek in CI) through
+ * the same endpoints the dashboard calls — context assembly, the provider call,
+ * schema-validated parsing and persistence, on both the synchronous and the SSE
+ * path.
+ *
+ * `tests/ai-diagnosis.spec.ts` covers the same endpoints against a mock provider
+ * for a zero-token CI gate; this one costs tokens, so it lives under `tests/live/`
+ * (excluded from the main suite) and runs behind `npm run app:test:ai:live` — see
+ * `playwright.config.ts` next to this file and `.github/workflows/ai-live-e2e.yml`.
+ *
+ * The model is text-only, so the server runs with screenshots disabled and the
+ * first test proves an attached screenshot really is kept out of the context: an
+ * image would make the provider reject the whole diagnosis call.
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { DIAGNOSIS_CATEGORIES, DIAGNOSIS_CONFIDENCES, DIAGNOSIS_SEVERITIES } from '#shared/ai-diagnosis';
+import { PROJECT } from '#shared/test-project-names';
+
+test.describe.configure({ mode: 'serial' });
+
+/** A real (1×1) PNG, so the ingested attachment is classified as a screenshot. */
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const EXPECTED_MODEL = process.env.PIWI_AI_MODEL || 'deepseek-v4-flash';
+
+interface Diagnosis {
+  status: string;
+  error: string | null;
+  clusterId: number | null;
+  provider: string;
+  model: string;
+  category: string;
+  confidence: string;
+  summary: string;
+  rootCause: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  details: {
+    severity: string;
+    confidenceScore: number;
+    hypotheses: Array<{ category: string; rootCause: string; likelihood: number; evidence: string[] }>;
+    investigationSteps: string[];
+    preventionTips: string[];
+    pipeline: Array<{ role: string; model: string; inputTokens: number | null; outputTokens: number | null }>;
+  };
+}
+
+/**
+ * Ingest one failing execution through the streaming API and return its cluster.
+ * `attachScreenshot` uploads a PNG for the case, which is what the context has
+ * to leave out for a text-only model.
+ */
+async function ingestFailure(
+  request: APIRequestContext,
+  opts: { title: string; location: string; error: string; attachScreenshot?: boolean },
+): Promise<{ clusterId: number; testRunsCaseId: number }> {
+  const start = await request.post('/api/test-runs/start', {
+    data: { projectName: PROJECT.AI_LIVE_DIAGNOSIS, startTime: new Date().toISOString() },
+  });
+  expect(start.ok()).toBeTruthy();
+  const { runId, streamToken } = (await start.json()) as { runId: number; streamToken: string };
+
+  const testCase = { title: opts.title, location: opts.location, retries: 0 };
+  const events = await request.post(`/api/test-runs/${runId}/events`, {
+    data: {
+      streamToken,
+      testCases: [{ type: 'complete', ...testCase, status: 'failed', duration: 5000, error: opts.error }],
+    },
+  });
+  expect(events.ok()).toBeTruthy();
+
+  if (opts.attachScreenshot) {
+    const upload = await request.post(`/api/test-runs/${runId}/case-files`, {
+      multipart: {
+        streamToken,
+        testCase: JSON.stringify(testCase),
+        attach_meta: JSON.stringify([{ name: 'screenshot', contentType: 'image/png', originalName: 'failure.png' }]),
+        attach_file: { name: 'failure.png', mimeType: 'image/png', buffer: PNG_1X1 },
+      },
+    });
+    expect(upload.ok()).toBeTruthy();
+    expect((await upload.json()).attachments).toBe(1);
+  }
+
+  const finish = await request.post(`/api/test-runs/${runId}/finish`, {
+    data: { streamToken, status: 'failed', duration: 5000 },
+  });
+  expect(finish.ok()).toBeTruthy();
+
+  const run = (await (await request.get(`/api/test-runs/${runId}`)).json()) as {
+    testCases: Array<{ id: number; status: string; failureClusterId?: number }>;
+  };
+  const failed = run.testCases.find((c) => c.status === 'failed');
+  expect(failed?.failureClusterId).toBeTruthy();
+  return { clusterId: failed!.failureClusterId!, testRunsCaseId: failed!.id };
+}
+
+/** Assert a live diagnosis came back complete and inside the schema's vocabulary. */
+function expectWellFormedDiagnosis(diagnosis: Diagnosis, clusterId: number): void {
+  expect(diagnosis.error).toBeNull();
+  expect(diagnosis.status).toBe('completed');
+  expect(diagnosis.clusterId).toBe(clusterId);
+  expect(diagnosis.provider).toBe('openai');
+  expect(diagnosis.model.toLowerCase()).toContain(EXPECTED_MODEL.toLowerCase());
+
+  expect(DIAGNOSIS_CATEGORIES).toContain(diagnosis.category);
+  expect(DIAGNOSIS_CONFIDENCES).toContain(diagnosis.confidence);
+  expect(DIAGNOSIS_SEVERITIES).toContain(diagnosis.details.severity);
+  expect(diagnosis.summary.length).toBeGreaterThan(0);
+  expect(diagnosis.rootCause.length).toBeGreaterThan(0);
+  expect(diagnosis.details.confidenceScore).toBeGreaterThanOrEqual(0);
+  expect(diagnosis.details.confidenceScore).toBeLessThanOrEqual(100);
+
+  expect(diagnosis.details.hypotheses.length).toBeGreaterThanOrEqual(1);
+  for (const hypothesis of diagnosis.details.hypotheses) {
+    expect(DIAGNOSIS_CATEGORIES).toContain(hypothesis.category);
+    expect(hypothesis.likelihood).toBeGreaterThanOrEqual(0);
+    expect(hypothesis.likelihood).toBeLessThanOrEqual(100);
+  }
+  // The top-level verdict is derived from the highest-ranked hypothesis.
+  expect(diagnosis.category).toBe(diagnosis.details.hypotheses[0]!.category);
+  expect(diagnosis.rootCause).toBe(diagnosis.details.hypotheses[0]!.rootCause);
+
+  // A single stage: only a distinct research role adds a second one.
+  expect(diagnosis.details.pipeline.map((s) => s.role)).toEqual(['diagnosis']);
+  expect(diagnosis.inputTokens).toBeGreaterThan(0);
+  expect(diagnosis.outputTokens).toBeGreaterThan(0);
+}
+
+test('the server is configured for a live model from the environment', async ({ request }) => {
+  const res = await request.get('/api/ai/status');
+  expect(res.ok()).toBeTruthy();
+
+  const status = (await res.json()) as { configured: boolean; provider: string; model: string; source: string };
+  expect(status.configured).toBe(true);
+  expect(status.source).toBe('env');
+  expect(status.provider).toBe('openai');
+  expect(status.model).toBe(EXPECTED_MODEL);
+});
+
+test('a real model diagnoses a failure whose screenshot is kept out of the context', async ({ request }) => {
+  const { clusterId, testRunsCaseId } = await ingestFailure(request, {
+    title: 'checkout completes',
+    location: 'tests/checkout.spec.ts:12:3',
+    error: [
+      'TimeoutError: locator.click: Timeout 30000ms exceeded.',
+      'Call log:',
+      "  - waiting for getByRole('button', { name: 'Checkout' })",
+      '  -   locator resolved to <button disabled name="checkout">Checkout</button>',
+      '  - element is not enabled',
+      '',
+      '   at tests/checkout.spec.ts:12:3',
+    ].join('\n'),
+    attachScreenshot: true,
+  });
+
+  // The screenshot really was ingested…
+  const caseData = (await (await request.get(`/api/test-run-cases/${testRunsCaseId}`)).json()) as {
+    attachments: Array<{ name: string; contentType: string }>;
+  };
+  expect(caseData.attachments.map((a) => a.name)).toContain('screenshot');
+
+  // …and the context the model is sent still carries no image at all.
+  const ctxRes = await request.get(`/api/failure-clusters/${clusterId}/context?format=json`);
+  expect(ctxRes.ok()).toBeTruthy();
+  const ctx = (await ctxRes.json()) as {
+    sections: Array<{ id: string }>;
+    imageTokenEstimate: number;
+    textTokenEstimate: number;
+  };
+  expect(ctx.imageTokenEstimate).toBe(0);
+  expect(ctx.sections.map((s) => s.id)).not.toContain('screenshots');
+  expect(ctx.textTokenEstimate).toBeGreaterThan(0);
+
+  const res = await request.post(`/api/failure-clusters/${clusterId}/diagnose`);
+  expect(res.ok()).toBeTruthy();
+  expectWellFormedDiagnosis((await res.json()) as Diagnosis, clusterId);
+
+  // The completed row is what a page load reads back.
+  const stored = (await (await request.get(`/api/failure-clusters/${clusterId}/diagnosis`)).json()) as {
+    diagnosis: Diagnosis | null;
+  };
+  expect(stored.diagnosis).not.toBeNull();
+  expectWellFormedDiagnosis(stored.diagnosis!, clusterId);
+});
+
+test('the streaming endpoint relays real model output and persists the result', async ({ request, baseURL }) => {
+  const { clusterId } = await ingestFailure(request, {
+    title: 'order confirmation appears',
+    location: 'tests/order.spec.ts:20:5',
+    error: [
+      'Error: expect(locator).toBeVisible() failed',
+      '',
+      "Locator: getByTestId('order-confirmation')",
+      'Expected: visible',
+      'Received: <element(s) not found>',
+      'Timeout: 5000ms',
+      '',
+      'Call log:',
+      "  - waiting for getByTestId('order-confirmation')",
+    ].join('\n'),
+  });
+
+  // Raw fetch, not the `request` fixture: that one buffers the whole body, which
+  // would hang until the stream closes on its own.
+  const response = await fetch(`${baseURL}/api/failure-clusters/${clusterId}/diagnose/stream`, { method: 'POST' });
+  expect(response.ok).toBeTruthy();
+  expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+    if (text.includes('event: result')) break;
+  }
+  reader.releaseLock();
+
+  // Output arrived incrementally rather than in one final blob.
+  expect(text.split('event: thinking').length - 1).toBeGreaterThan(1);
+
+  const resultIdx = text.indexOf('event: result');
+  expect(resultIdx).toBeGreaterThan(-1);
+  const dataLine = text
+    .slice(resultIdx)
+    .split('\n')
+    .find((l) => l.startsWith('data:'));
+  expect(dataLine).toBeDefined();
+
+  expectWellFormedDiagnosis(JSON.parse(dataLine!.slice('data:'.length).trim()) as Diagnosis, clusterId);
+});

--- a/apps/application/tests/live/playwright.config.ts
+++ b/apps/application/tests/live/playwright.config.ts
@@ -1,0 +1,93 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Config for the LIVE AI E2E (`ai-diagnosis-live.spec.ts`): the real diagnosis
+ * pipeline against a real model, where `tests/ai-diagnosis.spec.ts` drives a
+ * mock OpenAI-compatible server. It spends tokens, so it sits outside the main
+ * suite — `playwright.config.ts` ignores `tests/live/` — and runs on demand:
+ *
+ *   OPENCODE_API_KEY=<key> npm run app:test:ai:live
+ *
+ * `.github/workflows/ai-live-e2e.yml` runs the same command with the repository
+ * `OPENCODE_API` secret.
+ */
+
+const apiKey = process.env.OPENCODE_API_KEY || process.env.PIWI_AI_API_KEY || '';
+if (!apiKey) {
+  throw new Error(
+    'The live AI E2E needs a provider key — set OPENCODE_API_KEY (or PIWI_AI_API_KEY) before running it.',
+  );
+}
+
+const baseUrl = process.env.PIWI_AI_BASE_URL || 'https://opencode.ai/zen/v1';
+const model = process.env.PIWI_AI_MODEL || 'deepseek-v4-flash';
+
+const PORT = 3102;
+// Its own subdirectory: the workflow runs this alongside the reporter's live
+// AI-step E2E, whose server keeps its state under `.live-temp/steps`.
+const tempDir = join(process.cwd(), '.live-temp', 'diagnosis');
+
+// The server self-migrates on boot but only creates the database file, not the
+// directory holding it.
+mkdirSync(join(tempDir, 'storage'), { recursive: true });
+
+// CI runs the production output the workflow built once; locally the dev server
+// compiles on demand. `PIWI_AI_*` is read when the Nuxt config is evaluated —
+// build time for a production build — so the built server also gets the
+// `NUXT_AI_*` forms Nitro maps onto the same runtimeConfig keys at startup.
+const serverCommand = process.env.CI ? 'node .output/server/index.mjs' : 'npm run app:dev';
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // A gateway hiccup should not redden a run that costs tokens to repeat, but a
+  // second attempt is as far as it goes.
+  retries: process.env.CI ? 1 : 0,
+  // Live model latency: a diagnosis is one long provider call.
+  timeout: 180_000,
+  reporter: [['list']],
+
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+  },
+
+  webServer: [
+    {
+      command: serverCommand,
+      url: `http://localhost:${PORT}/api/ai/status`,
+      env: {
+        PIWI_AI_PROVIDER: 'openai',
+        PIWI_AI_BASE_URL: baseUrl,
+        PIWI_AI_MODEL: model,
+        PIWI_AI_API_KEY: apiKey,
+        NUXT_AI_PROVIDER: 'openai',
+        NUXT_AI_BASE_URL: baseUrl,
+        NUXT_AI_MODEL: model,
+        NUXT_AI_API_KEY: apiKey,
+        // The live model is text-only, and the provider rejects the whole call
+        // when a context carries an image. The diagnosis context stays
+        // image-free; `ai-diagnosis-live.spec.ts` asserts it.
+        PIWI_AI_MAX_IMAGES: '0',
+        // Reasoning tokens count toward the completion budget, so the default
+        // 1024-token step cap truncates a decision mid-JSON.
+        PIWI_AI_STEP_MAX_OUTPUT_TOKENS: '8192',
+        PIWI_SECRET_KEY: process.env.PIWI_SECRET_KEY || 'live-e2e-encryption-key-not-for-production',
+        // Throwaway SQLite + local storage, pinned so an inherited CI storage
+        // matrix cannot repoint this server's backend.
+        PIWI_DATABASE_PATH: join(tempDir, 'live.db'),
+        PIWI_DATABASE_URL: '',
+        PIWI_STORAGE_TYPE: 'local',
+        PIWI_STORAGE_PATH: join(tempDir, 'storage'),
+        PIWI_BUILD_DIR: join(tempDir, 'nuxt-build'),
+        NITRO_PORT: String(PORT),
+      },
+      reuseExistingServer: false,
+      timeout: 120 * 1000,
+    },
+  ],
+});

--- a/apps/application/tests/unit/case-screenshots.test.ts
+++ b/apps/application/tests/unit/case-screenshots.test.ts
@@ -1,32 +1,17 @@
 import { describe, test, expect } from 'vitest';
 import { isScreenshotFileRow } from '~~/server/utils/case-screenshots';
+import { isScreenshotFileRow as sharedPredicate } from '#shared/file-classify';
 
-describe('isScreenshotFileRow', () => {
-  test('accepts legacy type=screenshot rows', () => {
-    expect(isScreenshotFileRow({ type: 'screenshot', path: 'x/shot.png' })).toBe(true);
-  });
-
-  test('accepts attachment rows with a screenshot subtype (incl. numbered variants)', () => {
-    expect(isScreenshotFileRow({ type: 'attachment', subtype: 'screenshot', path: 'x/a.bin' })).toBe(true);
-    expect(isScreenshotFileRow({ type: 'attachment', subtype: 'screenshot-1', path: 'x/a.bin' })).toBe(true);
-  });
-
-  test('accepts attachment rows with an image content-type label', () => {
-    expect(isScreenshotFileRow({ type: 'attachment', subtype: 'my-shot', label: 'image/png', path: 'x/a' })).toBe(true);
-  });
-
-  test('accepts attachment rows with an image file extension', () => {
-    expect(isScreenshotFileRow({ type: 'attachment', subtype: 'evidence', path: 'x/final-state.JPG' })).toBe(true);
-  });
-
-  test('rejects non-image attachments and other file types', () => {
-    expect(isScreenshotFileRow({ type: 'attachment', subtype: 'video', label: 'video/webm', path: 'x/v.webm' })).toBe(
-      false,
-    );
-    expect(isScreenshotFileRow({ type: 'attachment', subtype: 'error-context', path: 'x/error-context.md' })).toBe(
-      false,
-    );
-    expect(isScreenshotFileRow({ type: 'trace', path: 'x/trace.zip' })).toBe(false);
-    expect(isScreenshotFileRow({ type: 'report', subtype: 'html', path: 'x/index.html' })).toBe(false);
+/**
+ * `selectCaseScreenshots` filters rows with the shared predicate, and server
+ * code reaches it through this re-export. The predicate's own behavior is
+ * covered in `file-classify.test.ts`.
+ */
+describe('case-screenshots', () => {
+  test('re-exports the shared screenshot predicate', () => {
+    expect(isScreenshotFileRow).toBe(sharedPredicate);
+    expect(
+      isScreenshotFileRow({ type: 'attachment', subtype: 'screenshot', label: 'image/png', path: 'x/a.png' }),
+    ).toBe(true);
   });
 });

--- a/apps/application/tests/unit/file-classify.test.ts
+++ b/apps/application/tests/unit/file-classify.test.ts
@@ -49,6 +49,7 @@ describe('isScreenshotFileRow', () => {
     expect(isScreenshotFileRow(attachment('evidence', null, 'x/final-state.webp'))).toBe(true);
     expect(isScreenshotFileRow(attachment('evidence', null, 'x/notes.md'))).toBe(false);
     expect(isScreenshotFileRow(attachment('evidence', null, 'x/no-extension'))).toBe(false);
+    expect(isScreenshotFileRow(attachment('evidence', null, ''))).toBe(false);
   });
 
   test('rejects videos, other evidence kinds and unrelated file types', () => {
@@ -151,5 +152,6 @@ describe('contentTypeForPath', () => {
     expect(contentTypeForPath('x/blob.bin')).toBe('application/octet-stream');
     expect(contentTypeForPath('x/no-extension')).toBe('application/octet-stream');
     expect(contentTypeForPath('x/blob.bin', null)).toBe('application/octet-stream');
+    expect(contentTypeForPath('')).toBe('application/octet-stream');
   });
 });

--- a/apps/application/tests/unit/file-classify.test.ts
+++ b/apps/application/tests/unit/file-classify.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect } from 'vitest';
+import {
+  classifyEvidenceFile,
+  contentTypeForPath,
+  isScreenshotFileRow,
+  isVideoFileRow,
+  supportedImageMediaType,
+} from '#shared/file-classify';
+
+/**
+ * Ingestion (`case-files.post.ts`, `upload.post.ts`, `import-runs.ts`) stores a
+ * Playwright attachment as `type='attachment'`, `subtype=<attachment name>`,
+ * `label=<content type>`. These helpers build rows in that exact shape so the
+ * cases below stay tied to what the endpoints actually write.
+ */
+const attachment = (name: string, contentType: string | null, path: string) => ({
+  type: 'attachment',
+  subtype: name,
+  label: contentType,
+  path,
+});
+
+describe('isScreenshotFileRow', () => {
+  test('accepts legacy type=screenshot rows whatever their path', () => {
+    expect(isScreenshotFileRow({ type: 'screenshot', path: 'x/shot.png' })).toBe(true);
+    expect(isScreenshotFileRow({ type: 'screenshot', path: 'x/opaque-blob' })).toBe(true);
+  });
+
+  test('accepts an attachment whose content type is an image', () => {
+    expect(isScreenshotFileRow(attachment('screenshot', 'image/png', 'x/screenshot.png'))).toBe(true);
+    expect(isScreenshotFileRow(attachment('checkout-actual', 'image/png', 'x/checkout-actual.png'))).toBe(true);
+    // The path carries no extension — the content type still settles it.
+    expect(isScreenshotFileRow(attachment('shot', 'image/jpeg', 'x/blob-abc123'))).toBe(true);
+  });
+
+  test('trusts the content type over the attachment name', () => {
+    expect(isScreenshotFileRow(attachment('screenshot-metadata', 'application/json', 'x/meta.json'))).toBe(false);
+    expect(isScreenshotFileRow(attachment('screenshots-taken', 'text/plain', 'x/list.txt'))).toBe(false);
+  });
+
+  test('falls back to the attachment name when no content type was recorded', () => {
+    expect(isScreenshotFileRow(attachment('screenshot', null, 'x/a.bin'))).toBe(true);
+    expect(isScreenshotFileRow(attachment('screenshot-1', null, 'x/a.bin'))).toBe(true);
+    expect(isScreenshotFileRow(attachment('Screenshot', null, 'x/a.bin'))).toBe(true);
+  });
+
+  test('falls back to the file extension, case-insensitively', () => {
+    expect(isScreenshotFileRow(attachment('evidence', null, 'x/final-state.JPG'))).toBe(true);
+    expect(isScreenshotFileRow(attachment('evidence', null, 'x/final-state.webp'))).toBe(true);
+    expect(isScreenshotFileRow(attachment('evidence', null, 'x/notes.md'))).toBe(false);
+    expect(isScreenshotFileRow(attachment('evidence', null, 'x/no-extension'))).toBe(false);
+  });
+
+  test('rejects videos, other evidence kinds and unrelated file types', () => {
+    expect(isScreenshotFileRow(attachment('video', 'video/webm', 'x/v.webm'))).toBe(false);
+    expect(isScreenshotFileRow(attachment('error-context', 'text/markdown', 'x/error-context.md'))).toBe(false);
+    expect(isScreenshotFileRow({ type: 'trace', path: 'x/trace.zip' })).toBe(false);
+    expect(isScreenshotFileRow({ type: 'video', path: 'x/v.webm' })).toBe(false);
+    expect(isScreenshotFileRow({ type: 'report', subtype: 'html', path: 'x/index.html' })).toBe(false);
+  });
+});
+
+describe('isVideoFileRow', () => {
+  test('accepts legacy type=video rows and video content types', () => {
+    expect(isVideoFileRow({ type: 'video', path: 'x/v.webm' })).toBe(true);
+    expect(isVideoFileRow(attachment('video', 'video/webm', 'x/video.webm'))).toBe(true);
+    expect(isVideoFileRow(attachment('recording', 'video/mp4', 'x/opaque-blob'))).toBe(true);
+  });
+
+  test('trusts the content type over the attachment name', () => {
+    expect(isVideoFileRow(attachment('video-notes', 'text/plain', 'x/notes.txt'))).toBe(false);
+    // A .ogg is as often audio as video, and the content type says which.
+    expect(isVideoFileRow(attachment('beep', 'audio/ogg', 'x/beep.ogg'))).toBe(false);
+  });
+
+  test('falls back to the attachment name, then the extension', () => {
+    expect(isVideoFileRow(attachment('video', null, 'x/a.bin'))).toBe(true);
+    expect(isVideoFileRow(attachment('evidence', null, 'x/run.MP4'))).toBe(true);
+    expect(isVideoFileRow(attachment('evidence', null, 'x/shot.png'))).toBe(false);
+  });
+
+  test('rejects screenshots and other file types', () => {
+    expect(isVideoFileRow(attachment('screenshot', 'image/png', 'x/shot.png'))).toBe(false);
+    expect(isVideoFileRow({ type: 'screenshot', path: 'x/shot.png' })).toBe(false);
+    expect(isVideoFileRow({ type: 'trace', path: 'x/trace.zip' })).toBe(false);
+  });
+});
+
+describe('classifyEvidenceFile', () => {
+  test('sorts each evidence kind into its own bucket', () => {
+    expect(classifyEvidenceFile({ type: 'trace', path: 'x/trace.zip' })).toBe('trace');
+    expect(classifyEvidenceFile(attachment('screenshot', 'image/png', 'x/shot.png'))).toBe('screenshot');
+    expect(classifyEvidenceFile(attachment('video', 'video/webm', 'x/v.webm'))).toBe('video');
+    expect(classifyEvidenceFile(attachment('error-context', 'text/markdown', 'x/ctx.md'))).toBe('attachment');
+  });
+
+  test('the trace type wins over anything the name or path suggests', () => {
+    expect(classifyEvidenceFile({ type: 'trace', subtype: 'screenshot', path: 'x/shot.png' })).toBe('trace');
+  });
+
+  test('anything unrecognized is a plain attachment', () => {
+    expect(classifyEvidenceFile(attachment('stdout', 'text/plain', 'x/stdout.txt'))).toBe('attachment');
+    expect(classifyEvidenceFile(attachment('piwi-network', 'application/json', 'x/net.json'))).toBe('attachment');
+    expect(classifyEvidenceFile({ type: 'report', subtype: 'html', path: 'x/index.html' })).toBe('attachment');
+  });
+});
+
+describe('supportedImageMediaType', () => {
+  test('uses the recorded content type', () => {
+    expect(supportedImageMediaType({ label: 'image/png', path: 'x/shot.png' })).toBe('image/png');
+    expect(supportedImageMediaType({ label: 'image/webp', path: 'x/opaque-blob' })).toBe('image/webp');
+    expect(supportedImageMediaType({ label: 'IMAGE/GIF', path: 'x/a.gif' })).toBe('image/gif');
+    // The non-standard alias browsers and tools still emit.
+    expect(supportedImageMediaType({ label: 'image/jpg', path: 'x/a.jpg' })).toBe('image/jpeg');
+    // Parameters are not part of the type.
+    expect(supportedImageMediaType({ label: 'image/png; charset=binary', path: 'x/a.png' })).toBe('image/png');
+  });
+
+  test('rejects an image format no provider accepts, extension notwithstanding', () => {
+    expect(supportedImageMediaType({ label: 'image/svg+xml', path: 'x/diagram.svg' })).toBeNull();
+    expect(supportedImageMediaType({ label: 'image/bmp', path: 'x/a.bmp' })).toBeNull();
+    // A mislabeled extension must not resurrect an unsupported content type.
+    expect(supportedImageMediaType({ label: 'image/svg+xml', path: 'x/diagram.png' })).toBeNull();
+  });
+
+  test('falls back to the file extension when no content type was recorded', () => {
+    expect(supportedImageMediaType({ label: null, path: 'x/shot.PNG' })).toBe('image/png');
+    expect(supportedImageMediaType({ path: 'x/shot.jpeg' })).toBe('image/jpeg');
+    expect(supportedImageMediaType({ label: '', path: 'x/shot.jpg' })).toBe('image/jpeg');
+    expect(supportedImageMediaType({ label: null, path: 'x/shot.svg' })).toBeNull();
+    expect(supportedImageMediaType({ label: null, path: 'x/no-extension' })).toBeNull();
+  });
+});
+
+describe('contentTypeForPath', () => {
+  test('maps known extensions, case-insensitively', () => {
+    expect(contentTypeForPath('x/shot.png')).toBe('image/png');
+    expect(contentTypeForPath('x/shot.JPG')).toBe('image/jpeg');
+    expect(contentTypeForPath('x/v.webm')).toBe('video/webm');
+    expect(contentTypeForPath('x/trace.zip')).toBe('application/zip');
+    expect(contentTypeForPath('x/report.html')).toBe('text/html');
+  });
+
+  test('uses the fallback only for an unknown extension', () => {
+    expect(contentTypeForPath('x/blob.bin', 'application/x-custom')).toBe('application/x-custom');
+    // A known extension outranks a fallback that disagrees with it.
+    expect(contentTypeForPath('x/shot.png', 'application/octet-stream')).toBe('image/png');
+  });
+
+  test('defaults to octet-stream with no extension and no fallback', () => {
+    expect(contentTypeForPath('x/blob.bin')).toBe('application/octet-stream');
+    expect(contentTypeForPath('x/no-extension')).toBe('application/octet-stream');
+    expect(contentTypeForPath('x/blob.bin', null)).toBe('application/octet-stream');
+  });
+});

--- a/apps/docs/ai-diagnosis.md
+++ b/apps/docs/ai-diagnosis.md
@@ -262,6 +262,8 @@ Every piece of evidence sent to the model costs tokens. Piwi caps each input so 
 
 The full list of `PIWI_AI_MAX_*` limit variables, their defaults and their clamping ranges lives in the [Configuration reference → AI context limits](./configuration#ai-context-limits) — generated from the same registry the server reads, so it can never drift from the code.
 
+Screenshots are the one input a provider can refuse outright: many self-hosted and gateway models are text-only and reject a request that carries images. Piwi retries that call without them, so the diagnosis still runs on the text evidence. Setting `PIWI_AI_MAX_IMAGES=0` skips the rejected first attempt.
+
 ## Try it in the demo
 
 The [live demo](https://piwitests.github.io/demo/) runs entirely in your browser with no AI provider — yet the diagnosis experience is fully wired. Several failing clusters ship with a completed diagnosis (category, confidence, evidence with citations, a validated suggested patch, per-stage pipeline stats, and auto-selected suspect commits); others are left undiagnosed so you can trigger a **simulated streaming diagnosis** yourself and watch the reasoning tokens arrive. The diagnoses are generated from each cluster's real seeded evidence (occurrences, failure rate, affected tests, browsers) and a canned SCM history, so the **Context sent to AI** modal, the data-coverage map, the commit browser, baseline pinning, and the diagnosis version history all behave as they do against a real server. Suggested-fix patches are validated against the seeded source files, so the "Applies cleanly" badge means the same thing it does in production.

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
     },
     "apps/application": {
       "name": "@piwitests/dashboard",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -131,7 +131,7 @@
     },
     "apps/extension": {
       "name": "@piwitests/extension",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "dependencies": {
         "@piwitests/core": "*",
         "@piwitests/picker-dom": "*"
@@ -160,7 +160,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation-nitro",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -26417,11 +26417,11 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.24.0"
+      "version": "0.25.0"
     },
     "packages/picker-dom": {
       "name": "@piwitests/picker-dom",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "dependencies": {
         "@piwitests/core": "*"
       },
@@ -26431,7 +26431,7 @@
     },
     "packages/reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -26453,7 +26453,7 @@
     },
     "packages/server": {
       "name": "@piwitests/server",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.17.4",

--- a/packages/reporter/AGENTS.md
+++ b/packages/reporter/AGENTS.md
@@ -41,6 +41,8 @@ npm run reporter:typecheck
 npm run reporter:lint       # :fix to auto-fix
 npm run reporter:format     # :check to verify only
 npm run reporter:test       # :watch, :coverage, :integration
+                            # :integration:ai runs the AI-step authoring loop against a stubbed resolver;
+                            # :integration:ai:live drives a real model through a real dashboard (spends tokens)
 npm run reporter:bench      # capture-overhead benchmark; :micro for the Node-side hot path
 ```
 


### PR DESCRIPTION
## What & why

This PR adds support for text-only AI models (those without vision capabilities) and introduces comprehensive live end-to-end tests for the failure diagnosis pipeline.

**Key changes:**

1. **Text-only model support**: The AI provider now gracefully handles models that reject image inputs by automatically retrying without images. When a model returns a 400 error indicating it doesn't support vision, the diagnosis context is resent as text-only, allowing the diagnosis to complete successfully.

2. **Image media type validation**: Extracted and centralized image format support logic into `file-classify.ts`. The system now validates that screenshots use only media types providers accept (JPEG, PNG, GIF, WebP), filtering out unsupported formats like SVG or BMP rather than sending them with incorrect media types.

3. **Live diagnosis E2E tests** (`tests/live/ai-diagnosis-live.spec.ts`): New test suite that runs against a real LLM (OpenCode/DeepSeek) to verify the complete diagnosis pipeline works end-to-end. Tests cover:
   - Screenshot handling with text-only models (verifying images are dropped from context)
   - Synchronous diagnosis endpoint
   - Streaming diagnosis endpoint with incremental output
   - Schema validation and persistence of results

4. **Mock text-only provider**: Added `startTextOnlyMockAiServer` to the unit test suite to test the image-rejection fallback path without consuming tokens.

5. **Test infrastructure**: New Playwright config for live tests (`tests/live/playwright.config.ts`) with separate environment and database, plus npm script `app:test:ai:live` to run them on demand.

## How was it tested?

- **Unit tests**: `tests/unit/file-classify.test.ts` covers image media type validation and file classification logic
- **Mock E2E tests**: `tests/ai-diagnosis.spec.ts` includes new test suite for text-only model fallback behavior
- **Live E2E tests**: `tests/live/ai-diagnosis-live.spec.ts` validates the full pipeline against a real model (runs on demand with `npm run app:test:ai:live`)
- **CI integration**: `.github/workflows/ai-live-e2e.yml` updated to run both reporter and dashboard live tests

## Checklist

- [x] PR title follows Conventional Commits (`feat(ai): ...`)
- [x] Tests added for new behavior (unit tests, mock E2E, live E2E)
- [x] Docs updated (`apps/docs/ai-diagnosis.md`, `AGENTS.md`)

https://claude.ai/code/session_01Aj73G2vAfSxdY9sJvYr1FA