### PR TITLE
feat(notifications): support global channels and browser subscriptions

### DIFF
--- a/apps/application/app/components/project/SubscribeBell.vue
+++ b/apps/application/app/components/project/SubscribeBell.vue
@@ -7,7 +7,7 @@ const props = defineProps<{ projectId: number; projectLabel?: string }>();
 const config = useRuntimeConfig();
 const isDemoMode = config.public.demoMode;
 const authEnabled = computed(() => config.public.authEnabled);
-const { authState } = useAuth();
+const { authState, canSeeAdmin } = useAuth();
 const isAuthenticated = computed(() => authState.value.authenticated);
 
 const toast = useToast();
@@ -42,9 +42,10 @@ function toggleCookieEvent(evt: NotificationEvent) {
   cookie?.toggleEvent(props.projectId, evt);
 }
 
-// ── Auth-based subscriptions ─────────────────────────────────────────────────
+// ── Channel subscriptions ────────────────────────────────────────────────────
 interface Subscription {
   id: number;
+  userId?: number | null;
   events: string[];
   mode: string;
   mutedUntil: string | null;
@@ -52,7 +53,9 @@ interface Subscription {
   channel: { id: number; name: string; type: string };
 }
 
-const shouldFetch = isDemoMode || (authEnabled.value && isAuthenticated.value);
+// Channels/subscriptions are reachable in demo mode, without auth (instance-wide
+// rows via the virtual admin), and for signed-in users when auth is on.
+const shouldFetch = isDemoMode || !authEnabled.value || isAuthenticated.value;
 const fetchOpts = isDemoMode ? ({ server: false } as const) : {};
 
 const { data: subsData, refresh: refreshSubs } = await useFetch<{ subscriptions: Subscription[] }>(
@@ -68,6 +71,7 @@ interface Channel {
   id: number;
   name: string;
   type: string;
+  userId?: number | null;
   config?: Record<string, unknown>;
 }
 
@@ -82,7 +86,19 @@ const channels = computed(() => channelsData.value?.channels ?? []);
 const showForm = ref(false);
 const selectedChannelId = ref<number | undefined>(undefined);
 const selectedEvents = ref<string[]>(['run.failed']);
+const subscribeGlobal = ref(false);
 const subscribing = ref(false);
+
+const selectedChannel = computed(() => channels.value.find((c) => c.id === selectedChannelId.value));
+// Global subscriptions require a global channel (the API enforces the same).
+const canSubscribeGlobal = computed(
+  () => authEnabled.value && canSeeAdmin.value && selectedChannel.value?.userId === null,
+);
+
+/** Whether the viewer can edit/mute/remove this subscription (mirrors the API rules). */
+function canManageSub(sub: Subscription) {
+  return sub.userId === null ? canSeeAdmin.value : true;
+}
 
 // ── Edit subscription ─────────────────────────────────────────────────────────
 const editingSub = ref<Subscription | null>(null);
@@ -152,10 +168,12 @@ async function subscribe() {
         projectId: props.projectId,
         events: selectedEvents.value,
         mode: 'realtime',
+        ...(canSubscribeGlobal.value && subscribeGlobal.value ? { global: true } : {}),
       },
     });
     await refreshSubs();
     showForm.value = false;
+    subscribeGlobal.value = false;
     toast.add({ title: 'Subscribed', color: 'success' });
     if (isDemoMode) {
       demoNotifications?.scheduleFor(props.projectId, props.projectLabel || 'this project', selectedEvents.value);
@@ -205,7 +223,9 @@ function channelIcon(type: string) {
 }
 
 const showComponent = computed(() => isDemoMode || (authEnabled.value && isAuthenticated.value) || cookie != null);
-const bellSubscribed = computed(() => (isDemoMode || authEnabled.value ? isSubscribed.value : cookieSubscribed.value));
+const bellSubscribed = computed(() =>
+  isDemoMode || authEnabled.value ? isSubscribed.value : cookieSubscribed.value || isSubscribed.value,
+);
 </script>
 
 <template>
@@ -256,11 +276,11 @@ const bellSubscribed = computed(() => (isDemoMode || authEnabled.value ? isSubsc
         </template>
       </div>
 
-      <!-- Auth-based UI -->
-      <div v-else class="p-3 space-y-3">
+      <!-- Channel subscriptions -->
+      <div v-if="shouldFetch" class="p-3 space-y-3" :class="cookie ? 'border-t border-default' : ''">
         <div class="flex items-center justify-between">
           <span class="font-medium text-sm inline-flex items-center gap-1">
-            Notifications <HelpHint topic="notifications.subscribe" />
+            {{ cookie ? 'Channel subscriptions' : 'Notifications' }} <HelpHint topic="notifications.subscribe" />
           </span>
           <UButton
             v-if="!showForm"
@@ -337,31 +357,36 @@ const bellSubscribed = computed(() => (isDemoMode || authEnabled.value ? isSubsc
               :class="isMuted(sub) ? 'opacity-60' : ''"
             >
               <UIcon :name="channelIcon(sub.channel.type)" class="size-3.5 text-muted shrink-0" />
-              <span class="flex-1 font-medium truncate">{{ sub.channel.name }}</span>
-              <UButton
-                icon="i-lucide-pencil"
-                color="neutral"
-                variant="ghost"
-                size="xs"
-                title="Edit subscription"
-                @click="startEdit(sub)"
-              />
-              <UButton
-                :icon="isMuted(sub) ? 'i-lucide-bell' : 'i-lucide-bell-off'"
-                color="neutral"
-                variant="ghost"
-                size="xs"
-                :title="isMuted(sub) ? 'Unmute' : 'Mute 7 days'"
-                @click="toggleMute(sub)"
-              />
-              <UButton
-                icon="i-lucide-x"
-                color="error"
-                variant="ghost"
-                size="xs"
-                title="Unsubscribe"
-                @click="unsubscribe(sub.id)"
-              />
+              <span class="flex-1 font-medium truncate">
+                {{ sub.channel.name }}
+                <span v-if="sub.userId === null && authEnabled" class="text-primary">(global)</span>
+              </span>
+              <template v-if="canManageSub(sub)">
+                <UButton
+                  icon="i-lucide-pencil"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  title="Edit subscription"
+                  @click="startEdit(sub)"
+                />
+                <UButton
+                  :icon="isMuted(sub) ? 'i-lucide-bell' : 'i-lucide-bell-off'"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  :title="isMuted(sub) ? 'Unmute' : 'Mute 7 days'"
+                  @click="toggleMute(sub)"
+                />
+                <UButton
+                  icon="i-lucide-x"
+                  color="error"
+                  variant="ghost"
+                  size="xs"
+                  title="Unsubscribe"
+                  @click="unsubscribe(sub.id)"
+                />
+              </template>
             </div>
           </template>
         </div>
@@ -393,6 +418,14 @@ const bellSubscribed = computed(() => (isDemoMode || authEnabled.value ? isSubsc
               </label>
             </div>
           </UFormField>
+          <label
+            v-if="canSubscribeGlobal"
+            class="flex items-center gap-1.5 text-xs cursor-pointer"
+            title="Deliver to this channel for everyone, not tied to your account"
+          >
+            <input type="checkbox" v-model="subscribeGlobal" class="accent-primary size-3" />
+            Instance-wide (global)
+          </label>
           <div class="flex gap-1.5 justify-end">
             <UButton size="xs" color="neutral" variant="ghost" @click="showForm = false">Cancel</UButton>
             <UButton

--- a/apps/application/app/composables/useNotificationStream.ts
+++ b/apps/application/app/composables/useNotificationStream.ts
@@ -96,15 +96,7 @@ function handleEvent(data: NotificationEventData) {
   }
 
   if (_cookie && data.projectId != null) {
-    const subbed = _cookie.isEventSubscribed(data.projectId, data.type);
-    console.log('[notify-stream] GATE: cookie filter', {
-      projectId: data.projectId,
-      type: data.type,
-      subscribed: subbed,
-      cookieProjects: Object.keys(_cookie.stored.value.projects),
-      matchingEvents: _cookie.stored.value.projects[data.projectId]?.events ?? [],
-    });
-    if (!subbed) return;
+    if (!_cookie.isEventSubscribed(data.projectId, data.type)) return;
   }
 
   const body = renderBody(data);
@@ -119,7 +111,6 @@ function handleEvent(data: NotificationEventData) {
     tag,
     icon: '/logo.svg',
   });
-  console.log('[notify-stream] notification fired', { type: data.type, projectId: data.projectId });
 
   const link = getLink(data);
   if (link) {
@@ -187,7 +178,6 @@ function connectLive() {
 
 export function useNotificationStream() {
   if (!import.meta.client || started) return;
-  started = true;
   started = true;
 
   const { active } = useDiagnosisNotification();

--- a/apps/application/app/pages/settings/notifications.vue
+++ b/apps/application/app/pages/settings/notifications.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { NOTIFICATION_EVENTS } from '#shared/notification-events';
-import type { NotificationEvent } from '#shared/notification-events';
 import type { PiwiEnvVarName } from '#shared/piwi-env-vars';
 
 const toast = useToast();
 const config = useRuntimeConfig();
 const authEnabled = computed(() => config.public.authEnabled);
+const { canSeeAdmin } = useAuth();
 
 // SMTP env vars (read-only display) — from the shared registry via the help topic.
 const smtpEnvVars: PiwiEnvVarName[] = [
@@ -21,7 +20,7 @@ const smtpEnvVars: PiwiEnvVarName[] = [
 // ── SMTP status ────────────────────────────────────────────────────────────────
 interface SmtpStatus {
   host: string | null;
-  port: number;
+  port: number | null;
   user: string | null;
   from: string | null;
   fromName: string | null;
@@ -65,9 +64,7 @@ interface Channel {
   config: Record<string, unknown>;
 }
 
-const { data: channelsData, refresh: refreshChannels } = authEnabled.value
-  ? await useFetch<{ channels: Channel[] }>('/api/channels')
-  : { data: ref(null), refresh: () => {} };
+const { data: channelsData, refresh: refreshChannels } = await useFetch<{ channels: Channel[] }>('/api/channels');
 
 const channels = computed(() => channelsData.value?.channels ?? []);
 
@@ -75,7 +72,7 @@ const channels = computed(() => channelsData.value?.channels ?? []);
 const showNewChannel = ref(false);
 const newChannel = reactive({
   name: '',
-  type: 'email' as 'email' | 'slack' | 'webhook',
+  type: 'email' as 'email' | 'slack' | 'webhook' | 'browser',
   address: '',
   webhookUrl: '',
   url: '',
@@ -85,11 +82,14 @@ const newChannel = reactive({
 const savingChannel = ref(false);
 const testingChannel = ref<number | null>(null);
 
-const channelTypeOptions = [
+// Browser channels pair with per-user subscriptions; without auth the project
+// bell's per-browser preferences cover that role instead.
+const channelTypeOptions = computed(() => [
   { label: 'Email', value: 'email' },
   { label: 'Slack webhook', value: 'slack' },
   { label: 'Webhook', value: 'webhook' },
-];
+  ...(authEnabled.value ? [{ label: 'Browser', value: 'browser' }] : []),
+]);
 
 async function saveChannel() {
   savingChannel.value = true;
@@ -138,13 +138,20 @@ async function testChannel(id: number) {
   testingChannel.value = id;
   try {
     const res = await $fetch<{ success: boolean; error?: string }>(`/api/channels/${id}/test`, { method: 'POST' });
-    if (res.success) toast.add({ title: 'Test notification sent', color: 'success' });
-    else toast.add({ title: 'Test failed', description: res.error, color: 'error' });
+    if (res.success) {
+      toast.add({ title: 'Test notification sent', color: 'success' });
+      await refreshChannels();
+    } else toast.add({ title: 'Test failed', description: res.error, color: 'error' });
   } catch (e) {
     toast.add({ title: 'Test failed', description: String((e as Error)?.message ?? e), color: 'error' });
   } finally {
     testingChannel.value = null;
   }
+}
+
+/** Whether the viewer can delete/test this channel (mirrors the API rules). */
+function canManageChannel(ch: Channel) {
+  return ch.userId !== null || canSeeAdmin.value;
 }
 
 // ── Subscriptions ─────────────────────────────────────────────────────────────
@@ -161,11 +168,16 @@ interface Subscription {
   channel: { id: number; name: string; type: string };
 }
 
-const { data: subsData, refresh: refreshSubs } = authEnabled.value
-  ? await useFetch<{ subscriptions: Subscription[] }>('/api/subscriptions')
-  : { data: ref(null), refresh: () => {} };
+const { data: subsData, refresh: refreshSubs } = await useFetch<{ subscriptions: Subscription[] }>(
+  '/api/subscriptions',
+);
 
 const subs = computed(() => subsData.value?.subscriptions ?? []);
+
+/** Whether the viewer can edit/delete this subscription (mirrors the API rules). */
+function canManageSub(sub: Subscription) {
+  return sub.userId !== null || canSeeAdmin.value;
+}
 
 async function deleteSub(id: number) {
   try {
@@ -207,6 +219,7 @@ function channelTypeIcon(type: string) {
   if (type === 'personal_email') return 'i-lucide-user-round';
   if (type === 'email') return 'i-lucide-mail';
   if (type === 'slack') return 'i-lucide-slack';
+  if (type === 'browser') return 'i-lucide-monitor';
   return 'i-lucide-webhook';
 }
 
@@ -217,11 +230,11 @@ function eventLabel(e: string) {
 
 <template>
   <div class="space-y-6">
-    <!-- SMTP status (read-only, admin only) -->
+    <!-- SMTP status (read-only; connection details are admin-only) -->
     <SectionCard icon="i-lucide-mail" title="SMTP email delivery" help="settings.smtp">
       <template #subtitle> Configure SMTP via environment variables. The connection cannot be changed here. </template>
       <template #actions>
-        <EnvManagedBadge v-if="smtp?.configured" :env-vars="smtpEnvVars" size="md" />
+        <EnvManagedBadge v-if="smtp?.configured && canSeeAdmin" :env-vars="smtpEnvVars" size="md" />
       </template>
 
       <div class="space-y-3">
@@ -234,32 +247,39 @@ function eventLabel(e: string) {
           Not configured
         </div>
 
-        <div v-if="smtp?.configured" class="grid grid-cols-2 gap-2 text-sm">
+        <div v-if="smtp?.host" class="grid grid-cols-2 gap-2 text-sm">
           <div class="text-muted">Host</div>
           <div class="font-mono">{{ smtp?.host }}:{{ smtp?.port }}</div>
           <div class="text-muted">From</div>
           <div>{{ smtp?.fromName ? `${smtp.fromName} <${smtp.from}>` : smtp?.from }}</div>
           <div class="text-muted">User</div>
-          <div class="font-mono">{{ smtp?.user }}</div>
+          <div class="font-mono">{{ smtp?.user || '— (no authentication)' }}</div>
           <div class="text-muted">TLS</div>
           <div>{{ smtp?.secure ? 'Yes (port 465)' : 'STARTTLS / plain' }}</div>
         </div>
 
-        <div v-if="!smtp?.configured" class="text-sm text-muted space-y-1">
-          <p>Set these environment variables to enable email notifications:</p>
+        <div v-if="!smtp?.configured && canSeeAdmin" class="text-sm text-muted space-y-1">
+          <p>
+            Set these environment variables to enable email notifications — the user and password are only needed when
+            the server requires authentication:
+          </p>
           <CodeBlock
             code="PIWI_SMTP_HOST=smtp.example.com
 PIWI_SMTP_PORT=465
-PIWI_SMTP_USER=user@example.com
-PIWI_SMTP_PASS=secret
 PIWI_SMTP_FROM=noreply@example.com
-PIWI_SMTP_FROM_NAME=Piwi Dashboard"
+PIWI_SMTP_FROM_NAME=Piwi Dashboard
+PIWI_SMTP_USER=user@example.com
+PIWI_SMTP_PASS=secret"
             lang="bash"
           />
         </div>
+        <p v-else-if="!smtp?.configured" class="text-sm text-muted">
+          Email delivery is not set up, so email channels will not send. An administrator can configure it via
+          environment variables.
+        </p>
       </div>
 
-      <template v-if="smtp?.configured" #footer>
+      <template v-if="smtp?.configured && canSeeAdmin" #footer>
         <div class="flex items-center gap-2 w-full">
           <HelpHint topic="notifications.test-email" />
           <UInput v-model="testEmailTo" type="email" placeholder="Send test to email address…" class="flex-1" />
@@ -277,175 +297,177 @@ PIWI_SMTP_FROM_NAME=Piwi Dashboard"
       </template>
     </SectionCard>
 
-    <!-- Channels (gated on auth) -->
-    <template v-if="authEnabled">
-      <SectionCard
-        icon="i-lucide-radio"
-        title="Notification channels"
-        :count="channels.length"
-        help="notifications.channels"
-      >
-        <template #actions>
-          <UButton size="sm" icon="i-lucide-plus" @click="showNewChannel = !showNewChannel"> Add channel </UButton>
+    <!-- Channels -->
+    <SectionCard
+      icon="i-lucide-radio"
+      title="Notification channels"
+      :count="channels.length"
+      help="notifications.channels"
+    >
+      <template #actions>
+        <UButton size="sm" icon="i-lucide-plus" @click="showNewChannel = !showNewChannel"> Add channel </UButton>
+      </template>
+
+      <!-- New channel form -->
+      <div v-if="showNewChannel" class="mb-4 p-4 rounded-lg border border-primary/30 bg-primary/5 space-y-3">
+        <h4 class="font-medium text-sm">New channel</h4>
+        <div class="grid grid-cols-2 gap-3">
+          <UFormField label="Name">
+            <UInput v-model="newChannel.name" placeholder="e.g. My email" class="w-full" />
+          </UFormField>
+          <UFormField label="Type">
+            <USelect v-model="newChannel.type" :items="channelTypeOptions" class="w-full" />
+          </UFormField>
+        </div>
+
+        <UFormField v-if="newChannel.type === 'email'" label="Email address">
+          <UInput v-model="newChannel.address" type="email" placeholder="you@example.com" class="w-full" />
+        </UFormField>
+        <UFormField v-else-if="newChannel.type === 'slack'" label="Slack webhook URL">
+          <UInput v-model="newChannel.webhookUrl" placeholder="https://hooks.slack.com/…" class="w-full" />
+        </UFormField>
+        <template v-else-if="newChannel.type === 'webhook'">
+          <UFormField label="Endpoint URL">
+            <UInput v-model="newChannel.url" placeholder="https://your-server.com/webhook" class="w-full" />
+          </UFormField>
+          <UFormField label="Secret (optional)" description="Used to sign requests with X-Piwi-Signature header">
+            <UInput v-model="newChannel.secret" type="password" placeholder="Shared secret" class="w-full" />
+          </UFormField>
         </template>
+        <p v-else-if="newChannel.type === 'browser'" class="text-xs text-muted">
+          Sends OS notifications to your open dashboard tabs. No configuration needed — subscribe it to events, then
+          allow notifications when the browser asks.
+        </p>
 
-        <!-- New channel form -->
-        <div v-if="showNewChannel" class="mb-4 p-4 rounded-lg border border-primary/30 bg-primary/5 space-y-3">
-          <h4 class="font-medium text-sm">New channel</h4>
-          <div class="grid grid-cols-2 gap-3">
-            <UFormField label="Name">
-              <UInput v-model="newChannel.name" placeholder="e.g. My email" class="w-full" />
-            </UFormField>
-            <UFormField label="Type">
-              <USelect v-model="newChannel.type" :items="channelTypeOptions" class="w-full" />
-            </UFormField>
-          </div>
+        <UCheckbox
+          v-if="authEnabled && canSeeAdmin"
+          v-model="newChannel.global"
+          label="Global channel"
+          description="Visible to every user; anyone can subscribe to it."
+        />
+        <p v-if="!authEnabled" class="text-xs text-muted">Authentication is disabled, so channels are instance-wide.</p>
 
-          <UFormField v-if="newChannel.type === 'email'" label="Email address">
-            <UInput v-model="newChannel.address" type="email" placeholder="you@example.com" class="w-full" />
-          </UFormField>
-          <UFormField v-else-if="newChannel.type === 'slack'" label="Slack webhook URL">
-            <UInput v-model="newChannel.webhookUrl" placeholder="https://hooks.slack.com/…" class="w-full" />
-          </UFormField>
-          <template v-else-if="newChannel.type === 'webhook'">
-            <UFormField label="Endpoint URL">
-              <UInput v-model="newChannel.url" placeholder="https://your-server.com/webhook" class="w-full" />
-            </UFormField>
-            <UFormField label="Secret (optional)" description="Used to sign requests with X-Piwi-Signature header">
-              <UInput v-model="newChannel.secret" type="password" placeholder="Shared secret" class="w-full" />
-            </UFormField>
-          </template>
-
-          <div class="flex justify-end gap-2">
-            <UButton color="neutral" variant="ghost" size="sm" @click="showNewChannel = false">Cancel</UButton>
-            <UButton
-              color="primary"
-              size="sm"
-              :loading="savingChannel"
-              :disabled="!newChannel.name"
-              @click="saveChannel"
-            >
-              Save channel
-            </UButton>
-          </div>
+        <div class="flex justify-end gap-2">
+          <UButton color="neutral" variant="ghost" size="sm" @click="showNewChannel = false">Cancel</UButton>
+          <UButton color="primary" size="sm" :loading="savingChannel" :disabled="!newChannel.name" @click="saveChannel">
+            Save channel
+          </UButton>
         </div>
+      </div>
 
-        <div v-if="channels.length === 0 && !showNewChannel" class="text-sm text-muted py-4 text-center">
-          No channels yet. Add one to start receiving notifications.
-        </div>
+      <div v-if="channels.length === 0 && !showNewChannel" class="text-sm text-muted py-4 text-center">
+        No channels yet. Add one to start receiving notifications.
+      </div>
 
-        <div class="space-y-2">
-          <div
-            v-for="ch in channels"
-            :key="ch.id"
-            class="flex items-center gap-3 rounded-lg border border-default px-4 py-3"
-          >
-            <UIcon :name="channelTypeIcon(ch.type)" class="size-5 text-muted shrink-0" />
-            <div class="flex-1 min-w-0">
-              <div class="font-medium text-sm flex items-center gap-1.5">
-                {{ ch.name }}
-                <UBadge v-if="ch.type === 'personal_email'" size="xs" variant="soft" color="neutral">auto</UBadge>
-              </div>
-              <div class="text-xs text-muted">
-                <template v-if="ch.type === 'personal_email' || ch.type === 'email'">{{
-                  ch.config.address as string
-                }}</template>
-                <template v-else-if="ch.type === 'slack'">Slack webhook</template>
-                <template v-else>{{ ch.config.url as string }}</template>
-                <span v-if="ch.userId === null" class="ml-1 text-primary text-xs">(global)</span>
-              </div>
-            </div>
-            <div class="flex items-center gap-1">
-              <UButton
-                icon="i-lucide-send"
-                color="neutral"
-                variant="ghost"
-                size="sm"
-                title="Send test notification"
-                :loading="testingChannel === ch.id"
-                @click="testChannel(ch.id)"
-              />
-              <UTooltip v-if="ch.type === 'personal_email'" text="Remove your email in Account settings to disconnect">
-                <UButton icon="i-lucide-trash-2" color="neutral" variant="ghost" size="sm" disabled />
+      <div class="space-y-2">
+        <div
+          v-for="ch in channels"
+          :key="ch.id"
+          class="flex items-center gap-3 rounded-lg border border-default px-4 py-3"
+        >
+          <UIcon :name="channelTypeIcon(ch.type)" class="size-5 text-muted shrink-0" />
+          <div class="flex-1 min-w-0">
+            <div class="font-medium text-sm flex items-center gap-1.5">
+              {{ ch.name }}
+              <UBadge v-if="ch.type === 'personal_email'" size="xs" variant="soft" color="neutral">auto</UBadge>
+              <UTooltip
+                v-if="ch.type !== 'personal_email' && ch.type !== 'browser' && !ch.verified"
+                text="No successful test yet — send one to verify delivery"
+              >
+                <UBadge size="xs" variant="soft" color="warning">unverified</UBadge>
               </UTooltip>
-              <UButton
-                v-else
-                icon="i-lucide-trash-2"
-                color="error"
-                variant="ghost"
-                size="sm"
-                title="Delete channel"
-                @click="deleteChannel(ch.id)"
-              />
+            </div>
+            <div class="text-xs text-muted">
+              <template v-if="ch.type === 'personal_email' || ch.type === 'email'">{{
+                ch.config.address as string
+              }}</template>
+              <template v-else-if="ch.type === 'slack'">Slack webhook</template>
+              <template v-else-if="ch.type === 'browser'">Dashboard tabs (OS notifications)</template>
+              <template v-else>{{ ch.config.url as string }}</template>
+              <span v-if="ch.userId === null && authEnabled" class="ml-1 text-primary text-xs">(global)</span>
             </div>
           </div>
-        </div>
-      </SectionCard>
-
-      <!-- Subscriptions -->
-      <SectionCard
-        icon="i-lucide-bell"
-        title="My subscriptions"
-        :count="subs.length"
-        help="notifications.subscriptions"
-      >
-        <div v-if="subs.length === 0" class="text-sm text-muted py-4 text-center">
-          No subscriptions yet. Use the <strong>Subscribe</strong> bell on a project page to get started.
-        </div>
-
-        <div class="space-y-2">
-          <div
-            v-for="sub in subs"
-            :key="sub.id"
-            class="flex items-center gap-3 rounded-lg border border-default px-4 py-3"
-            :class="isMuted(sub) ? 'opacity-60' : ''"
-          >
-            <UIcon :name="channelTypeIcon(sub.channel.type)" class="size-5 text-muted shrink-0" />
-            <div class="flex-1 min-w-0 space-y-0.5">
-              <div class="font-medium text-sm">{{ sub.channel.name }}</div>
-              <div class="text-xs text-muted flex flex-wrap gap-x-3">
-                <span v-if="sub.projectId">Project #{{ sub.projectId }}</span>
-                <span v-else>All projects</span>
-                <span>{{ sub.mode }}</span>
-                <span v-if="isMuted(sub)" class="text-warning-500"
-                  >Muted until {{ new Date(sub.mutedUntil!).toLocaleDateString() }}</span
-                >
-              </div>
-              <div class="flex flex-wrap gap-1 mt-1">
-                <UBadge v-for="e in sub.events ?? []" :key="e" size="xs" variant="soft" color="neutral">
-                  {{ eventLabel(e) }}
-                </UBadge>
-              </div>
-            </div>
-            <div class="flex items-center gap-1">
-              <UButton
-                :icon="isMuted(sub) ? 'i-lucide-bell' : 'i-lucide-bell-off'"
-                color="neutral"
-                variant="ghost"
-                size="sm"
-                :title="isMuted(sub) ? 'Unmute' : 'Mute for 7 days'"
-                @click="toggleMute(sub)"
-              />
-              <UButton
-                icon="i-lucide-trash-2"
-                color="error"
-                variant="ghost"
-                size="sm"
-                title="Remove subscription"
-                @click="deleteSub(sub.id)"
-              />
-            </div>
+          <div class="flex items-center gap-1">
+            <UButton
+              v-if="canManageChannel(ch)"
+              icon="i-lucide-send"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              title="Send test notification"
+              :loading="testingChannel === ch.id"
+              @click="testChannel(ch.id)"
+            />
+            <UTooltip v-if="ch.type === 'personal_email'" text="Remove your email in Account settings to disconnect">
+              <UButton icon="i-lucide-trash-2" color="neutral" variant="ghost" size="sm" disabled />
+            </UTooltip>
+            <UButton
+              v-else-if="canManageChannel(ch)"
+              icon="i-lucide-trash-2"
+              color="error"
+              variant="ghost"
+              size="sm"
+              title="Delete channel"
+              @click="deleteChannel(ch.id)"
+            />
           </div>
         </div>
-      </SectionCard>
-    </template>
+      </div>
+    </SectionCard>
 
-    <UAlert
-      v-else
-      color="info"
-      icon="i-lucide-info"
-      title="Authentication required"
-      description="Channels and subscriptions require authentication (PIWI_AUTH_ENABLED=true)."
-    />
+    <!-- Subscriptions -->
+    <SectionCard icon="i-lucide-bell" title="Subscriptions" :count="subs.length" help="notifications.subscriptions">
+      <div v-if="subs.length === 0" class="text-sm text-muted py-4 text-center">
+        No subscriptions yet. Use the <strong>Subscribe</strong> bell on a project page to get started.
+      </div>
+
+      <div class="space-y-2">
+        <div
+          v-for="sub in subs"
+          :key="sub.id"
+          class="flex items-center gap-3 rounded-lg border border-default px-4 py-3"
+          :class="isMuted(sub) ? 'opacity-60' : ''"
+        >
+          <UIcon :name="channelTypeIcon(sub.channel.type)" class="size-5 text-muted shrink-0" />
+          <div class="flex-1 min-w-0 space-y-0.5">
+            <div class="font-medium text-sm flex items-center gap-1.5">
+              {{ sub.channel.name }}
+              <span v-if="sub.userId === null && authEnabled" class="text-primary text-xs">(global)</span>
+            </div>
+            <div class="text-xs text-muted flex flex-wrap gap-x-3">
+              <span v-if="sub.projectId">Project #{{ sub.projectId }}</span>
+              <span v-else>All projects</span>
+              <span>{{ sub.mode }}</span>
+              <span v-if="isMuted(sub)" class="text-warning-500"
+                >Muted until {{ new Date(sub.mutedUntil!).toLocaleDateString() }}</span
+              >
+            </div>
+            <div class="flex flex-wrap gap-1 mt-1">
+              <UBadge v-for="e in sub.events ?? []" :key="e" size="xs" variant="soft" color="neutral">
+                {{ eventLabel(e) }}
+              </UBadge>
+            </div>
+          </div>
+          <div v-if="canManageSub(sub)" class="flex items-center gap-1">
+            <UButton
+              :icon="isMuted(sub) ? 'i-lucide-bell' : 'i-lucide-bell-off'"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              :title="isMuted(sub) ? 'Unmute' : 'Mute for 7 days'"
+              @click="toggleMute(sub)"
+            />
+            <UButton
+              icon="i-lucide-trash-2"
+              color="error"
+              variant="ghost"
+              size="sm"
+              title="Remove subscription"
+              @click="deleteSub(sub.id)"
+            />
+          </div>
+        </div>
+      </div>
+    </SectionCard>
   </div>
 </template>

--- a/apps/application/app/utils/help-content.ts
+++ b/apps/application/app/utils/help-content.ts
@@ -467,12 +467,12 @@ export const HELP_TOPICS = {
   },
   'notifications.channels': {
     title: 'Channels',
-    text: 'Destinations an alert can go to — email, Slack or webhook. Create a channel, then subscribe events to it.',
+    text: 'Destinations an alert can go to — browser, email, Slack or webhook. Create a channel, then subscribe events to it. Administrators can make a channel global (usable by everyone); without authentication every channel is global.',
     doc: 'notifications#channels',
   },
   'notifications.subscriptions': {
     title: 'Subscriptions',
-    text: 'Which events (run failed, new cluster, etc.) notify which channel, optionally scoped to one project and filtered.',
+    text: 'Which events (run failed, new cluster, etc.) notify which channel, optionally scoped to one project and filtered. Global subscriptions deliver instance-wide and are managed by administrators.',
     doc: 'notifications#subscriptions',
   },
   'settings.ai-provider': {

--- a/apps/application/app/utils/settings-metadata.ts
+++ b/apps/application/app/utils/settings-metadata.ts
@@ -115,7 +115,7 @@ export const SETTINGS_PAGES: SettingsPageMeta[] = [
       { id: 'notifications.smtp', label: 'SMTP email delivery', help: 'settings.smtp', envOnly: true },
       { id: 'notifications.test-email', label: 'Send test email', help: 'notifications.test-email' },
       { id: 'notifications.channels', label: 'Notification channels', help: 'notifications.channels' },
-      { id: 'notifications.subscriptions', label: 'My subscriptions', help: 'notifications.subscriptions' },
+      { id: 'notifications.subscriptions', label: 'Subscriptions', help: 'notifications.subscriptions' },
     ],
   },
   {

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -330,6 +330,40 @@ const SCENES = [
       await shoot();
     },
   },
+  {
+    name: 'notifications-settings',
+    description: 'Notifications settings (auth off): SMTP status, channels, subscriptions; plus the project bell',
+    route: '/settings/notifications',
+    viewport: { width: 1280, height: 1250 },
+    outputs: ['notifications-settings.png', 'notifications-settings-bell.png'],
+    async prepare({ base, request }) {
+      // One channel + subscription so neither section captures empty. Reruns
+      // reuse the rows from the previous run instead of duplicating them.
+      const list = await (await request.get(`${base}/api/channels`)).json();
+      if (!list.channels.some((c) => c.name === 'Team Slack')) {
+        const ch = await (
+          await request.post(`${base}/api/channels`, {
+            data: {
+              name: 'Team Slack',
+              type: 'slack',
+              config: { webhookUrl: 'https://hooks.slack.com/services/T/B/x' },
+            },
+          })
+        ).json();
+        await request.post(`${base}/api/subscriptions`, {
+          data: { channelId: ch.channel.id, projectId: 1, events: ['run.failed', 'cluster.new'] },
+        });
+      }
+    },
+    async run({ page, shoot, goto, settle }) {
+      await shoot();
+      await goto('/projects/1');
+      await page.getByTitle('Notification subscriptions for this project').click();
+      await page.getByText('Browser notifications').waitFor();
+      await settle();
+      await shoot('bell');
+    },
+  },
 ];
 
 /** Output basename for a scene, before any `shoot()` label. */

--- a/apps/application/server/api/channels/[id].delete.ts
+++ b/apps/application/server/api/channels/[id].delete.ts
@@ -1,7 +1,7 @@
 import { eq, and } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { notificationChannels } from '../../database/schema';
-import { requireAuth, isAuthEnabled } from '../../utils/auth';
+import { requireAuth } from '../../utils/auth';
 import { Role } from '#shared/types';
 
 defineRouteMeta({
@@ -15,7 +15,6 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event)) throw createError({ statusCode: 400, message: 'Authentication not enabled' });
   const user = await requireAuth(event);
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) throw createError({ statusCode: 400, message: 'Invalid channel ID' });

--- a/apps/application/server/api/channels/[id]/test.post.ts
+++ b/apps/application/server/api/channels/[id]/test.post.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { getDatabase } from '../../../database';
 import { notificationChannels, users } from '../../../database/schema';
-import { requireAuth, isAuthEnabled } from '../../../utils/auth';
+import { requireAuth } from '../../../utils/auth';
 import { decryptSecret, getEncryptionKey } from '../../../utils/crypto';
 import { sendEmail, renderTestEmail, isEmailConfigured } from '../../../utils/email';
 import { safeFetch } from '../../../utils/safe-fetch';
@@ -11,14 +11,14 @@ defineRouteMeta({
   openAPI: {
     tags: ['Notifications'],
     summary: 'Send test notification',
-    description: 'Sends a test notification through the specified channel.',
+    description:
+      'Sends a test notification through the specified channel and marks it verified on success. Global channels can only be tested by administrators.',
     'x-required-roles': [],
     parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
   },
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event)) throw createError({ statusCode: 400, message: 'Authentication not enabled' });
   const user = await requireAuth(event);
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) throw createError({ statusCode: 400, message: 'Invalid channel ID' });
@@ -28,7 +28,9 @@ export default eventHandler(async (event) => {
   if (!channel) throw createError({ statusCode: 404, message: 'Channel not found' });
 
   const isAdmin = user.role === Role.ADMINISTRATOR;
-  if (channel.userId !== user.id && channel.userId !== null && !isAdmin) {
+  // Global channels reach every subscriber, so only admins may fire tests at them.
+  const allowed = channel.userId === null ? isAdmin : channel.userId === user.id || isAdmin;
+  if (!allowed) {
     throw createError({ statusCode: 403, message: 'Not authorized' });
   }
 
@@ -70,8 +72,15 @@ export default eventHandler(async (event) => {
       }
       const res = await safeFetch(url, { method: 'POST', headers, body });
       if (!res.ok) throw new Error(`Webhook returned ${res.status}`);
-    } else if (channel.type === 'browser') {
-      return { success: true };
+    }
+
+    // A delivered test proves the destination works. personal_email stays
+    // driven by account email verification instead.
+    if (channel.type !== 'personal_email' && !channel.verified) {
+      await db
+        .update(notificationChannels)
+        .set({ verified: true, updatedAt: new Date() })
+        .where(eq(notificationChannels.id, id));
     }
     return { success: true };
   } catch (err) {

--- a/apps/application/server/api/channels/index.get.ts
+++ b/apps/application/server/api/channels/index.get.ts
@@ -1,26 +1,19 @@
 import { eq, or, isNull } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { notificationChannels, users } from '../../database/schema';
-import { requireAuth, isAuthEnabled } from '../../utils/auth';
-import { Role } from '#shared/types';
+import { requireAuth } from '../../utils/auth';
 
 defineRouteMeta({
   openAPI: {
     tags: ['Notifications'],
     summary: 'List notification channels',
     description:
-      'Returns channels owned by the current user and global (admin-managed) channels. Auto-creates a personal email channel if the user has an account email set.',
+      'Returns channels owned by the current user and global (admin-managed) channels. Auto-creates a personal email channel if the user has an account email set. With authentication disabled every channel is global.',
     'x-required-roles': [],
   },
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event)) {
-    throw createError({
-      statusCode: 400,
-      message: 'Enable authentication to use notifications (PIWI_AUTH_ENABLED=true)',
-    });
-  }
   const user = await requireAuth(event);
   const db = await getDatabase();
 
@@ -30,11 +23,10 @@ export default eventHandler(async (event) => {
     .from(users)
     .where(eq(users.id, user.id));
 
-  const isAdmin = user.role === Role.ADMINISTRATOR;
   const rows = await db
     .select()
     .from(notificationChannels)
-    .where(isAdmin ? undefined : or(isNull(notificationChannels.userId), eq(notificationChannels.userId, user.id)));
+    .where(or(isNull(notificationChannels.userId), eq(notificationChannels.userId, user.id)));
 
   // Auto-create a personal_email channel for users who have an account email but no channel yet
   if (dbUser?.email) {

--- a/apps/application/server/api/channels/index.post.ts
+++ b/apps/application/server/api/channels/index.post.ts
@@ -9,7 +9,8 @@ defineRouteMeta({
   openAPI: {
     tags: ['Notifications'],
     summary: 'Create a notification channel',
-    description: 'Creates a new notification channel. Webhook secrets are encrypted at rest.',
+    description:
+      'Creates a new notification channel. Webhook secrets are encrypted at rest. Administrators can create global channels; with authentication disabled every channel is global.',
     'x-required-roles': [],
   },
 });
@@ -22,9 +23,6 @@ const schema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event)) {
-    throw createError({ statusCode: 400, message: 'Enable authentication to use notifications' });
-  }
   const user = await requireAuth(event);
   const body = await readBody(event);
   const parsed = schema.safeParse(body);
@@ -32,11 +30,14 @@ export default eventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Invalid request body', data: parsed.error.issues });
   }
 
-  const { name, type, config, global: isGlobal } = parsed.data;
+  const { name, type, config, global: requestedGlobal } = parsed.data;
 
-  if (isGlobal && user.role !== Role.ADMINISTRATOR) {
+  if (requestedGlobal && user.role !== Role.ADMINISTRATOR) {
     throw createError({ statusCode: 403, message: 'Only administrators can create global channels' });
   }
+
+  // Without auth there is no user row to own a channel — everything is global.
+  const isGlobal = requestedGlobal || !isAuthEnabled(event);
 
   // Encrypt webhook secret if present
   let storedConfig: Record<string, unknown> = { ...config };

--- a/apps/application/server/api/notifications/stream.get.ts
+++ b/apps/application/server/api/notifications/stream.get.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, isNull, lte } from 'drizzle-orm';
+import { eq, and, or, isNull } from 'drizzle-orm';
 import { requireAuth, isAuthEnabled } from '../../utils/auth';
 import { getProjectScope, scopeAllows } from '../../utils/project-access';
 import { runEventBus } from '../../utils/run-events';
@@ -6,11 +6,21 @@ import { createSSEEndpoint } from '../../utils/sse';
 import { getDatabase } from '../../database';
 import { notificationChannels, subscriptions } from '../../database/schema';
 
+/** How long a connection's loaded browser subscriptions stay fresh. */
+const SUBSCRIPTIONS_TTL_MS = 60_000;
+
+interface BrowserSubscription {
+  events: string[];
+  projectId: number | null;
+  mutedUntil: Date | null;
+}
+
 export default eventHandler(async (event) => {
   const user = await requireAuth(event);
 
   // With auth disabled the instance is single-user, so there is no cross-project
-  // boundary to enforce — stream every notification as before.
+  // boundary to enforce — stream every notification; the client's cookie
+  // preferences gate which events raise browser notifications.
   if (!isAuthEnabled()) {
     return createSSEEndpoint(event, (controller, encoder) =>
       runEventBus.subscribeNotifications((notificationEvent) => {
@@ -24,23 +34,34 @@ export default eventHandler(async (event) => {
   }
 
   const db = await getDatabase();
-  const now = new Date();
 
-  const rows = await db
-    .select({ id: subscriptions.id })
-    .from(subscriptions)
-    .innerJoin(notificationChannels, eq(subscriptions.channelId, notificationChannels.id))
-    .where(
-      and(
-        eq(notificationChannels.type, 'browser'),
-        eq(subscriptions.userId, user.id),
-        eq(subscriptions.active, true),
-        or(isNull(subscriptions.mutedUntil), lte(subscriptions.mutedUntil, now)),
-      ),
-    )
-    .limit(1);
+  // The user's active browser-channel subscriptions (own + global) decide which
+  // events this connection streams.
+  const loadSubscriptions = async (): Promise<BrowserSubscription[]> => {
+    const rows = await db
+      .select({
+        events: subscriptions.events,
+        projectId: subscriptions.projectId,
+        mutedUntil: subscriptions.mutedUntil,
+      })
+      .from(subscriptions)
+      .innerJoin(notificationChannels, eq(subscriptions.channelId, notificationChannels.id))
+      .where(
+        and(
+          eq(notificationChannels.type, 'browser'),
+          eq(subscriptions.active, true),
+          or(isNull(subscriptions.userId), eq(subscriptions.userId, user.id)),
+        ),
+      );
+    return rows.map((r) => ({
+      events: (r.events as string[] | null) ?? [],
+      projectId: r.projectId,
+      mutedUntil: r.mutedUntil,
+    }));
+  };
 
-  if (rows.length === 0) {
+  let subs = await loadSubscriptions();
+  if (subs.length === 0) {
     setResponseHeaders(event, { 'Content-Type': 'text/event-stream' });
     return new Response('', { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
   }
@@ -49,10 +70,42 @@ export default eventHandler(async (event) => {
   // never stream an event for a project they cannot access.
   const scope = await getProjectScope(db, user);
 
+  let loadedAt = Date.now();
+  let refreshing = false;
+
+  const matchesSubscription = (type: string, projectId: number): boolean => {
+    const now = new Date();
+    return subs.some(
+      (s) =>
+        s.events.includes(type) &&
+        (s.projectId == null || s.projectId === projectId) &&
+        (!s.mutedUntil || s.mutedUntil <= now),
+    );
+  };
+
   return createSSEEndpoint(event, (controller, encoder) => {
     return runEventBus.subscribeNotifications((notificationEvent) => {
       const projectId = notificationEvent.projectId as number | undefined;
       if (typeof projectId === 'number' && !scopeAllows(scope, projectId)) return;
+
+      // Refresh the subscription snapshot in the background when stale, so
+      // event/mute changes apply to long-lived connections without a reconnect.
+      if (Date.now() - loadedAt > SUBSCRIPTIONS_TTL_MS && !refreshing) {
+        refreshing = true;
+        loadSubscriptions()
+          .then((next) => {
+            subs = next;
+            loadedAt = Date.now();
+          })
+          .catch(() => {})
+          .finally(() => {
+            refreshing = false;
+          });
+      }
+
+      const type = notificationEvent.type as string | undefined;
+      if (typeof projectId === 'number' && type && !matchesSubscription(type, projectId)) return;
+
       try {
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(notificationEvent)}\n\n`));
       } catch {

--- a/apps/application/server/api/settings/smtp.get.ts
+++ b/apps/application/server/api/settings/smtp.get.ts
@@ -1,19 +1,37 @@
 import { requireAuth } from '../../utils/auth';
 import { getSmtpConfig } from '../../utils/email';
+import { Role } from '#shared/types';
 
 defineRouteMeta({
   openAPI: {
     tags: ['Settings'],
     summary: 'Get SMTP configuration',
     description:
-      'Returns SMTP configuration display info (host, port, from address, configured status). Password is never returned. Requires administrator role.',
-    'x-required-roles': ['administrator'],
+      'Returns whether SMTP is configured. Administrators also get display info (host, port, from address); other roles only see the configured flag. Password is never returned.',
+    'x-required-roles': ['administrator', 'reporter', 'user'],
   },
 });
 
 export default eventHandler(async (event) => {
-  await requireAuth(event);
+  const user = await requireAuth(event);
   const cfg = getSmtpConfig();
+
+  // Non-admins get the configured flag only — enough to know whether email
+  // channels deliver, without exposing the server's mail infrastructure.
+  if (user.role !== Role.ADMINISTRATOR) {
+    return {
+      host: null,
+      port: null,
+      user: null,
+      from: null,
+      fromName: null,
+      hasPassword: false,
+      secure: false,
+      configured: cfg.configured,
+      envManaged: true,
+    };
+  }
+
   return {
     host: cfg.host || null,
     port: cfg.port,

--- a/apps/application/server/api/subscriptions/[id].delete.ts
+++ b/apps/application/server/api/subscriptions/[id].delete.ts
@@ -1,7 +1,7 @@
 import { eq, and } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { subscriptions } from '../../database/schema';
-import { requireAuth, isAuthEnabled } from '../../utils/auth';
+import { requireAuth } from '../../utils/auth';
 import { Role } from '#shared/types';
 
 defineRouteMeta({
@@ -15,7 +15,6 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event)) throw createError({ statusCode: 400, message: 'Authentication not enabled' });
   const user = await requireAuth(event);
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) throw createError({ statusCode: 400, message: 'Invalid subscription ID' });

--- a/apps/application/server/api/subscriptions/[id].patch.ts
+++ b/apps/application/server/api/subscriptions/[id].patch.ts
@@ -1,7 +1,7 @@
 import { eq, and, or, isNull } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { subscriptions, notificationChannels } from '../../database/schema';
-import { requireAuth, isAuthEnabled } from '../../utils/auth';
+import { requireAuth } from '../../utils/auth';
 import { NOTIFICATION_EVENTS } from '#shared/notification-events';
 import { Role } from '#shared/types';
 import { z } from 'zod';
@@ -31,7 +31,6 @@ const schema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event)) throw createError({ statusCode: 400, message: 'Authentication not enabled' });
   const user = await requireAuth(event);
   const id = parseInt(getRouterParam(event, 'id') || '0');
   if (!id) throw createError({ statusCode: 400, message: 'Invalid subscription ID' });
@@ -54,7 +53,7 @@ export default eventHandler(async (event) => {
   if (d.channelId !== undefined) {
     // Ensure the target channel is owned by this user or is global
     const [ch] = await db
-      .select({ id: notificationChannels.id })
+      .select({ id: notificationChannels.id, userId: notificationChannels.userId })
       .from(notificationChannels)
       .where(
         and(
@@ -63,6 +62,11 @@ export default eventHandler(async (event) => {
         ),
       );
     if (!ch) throw createError({ statusCode: 403, message: 'Channel not found or not accessible' });
+    // A global subscription delivers with no per-user access check, so it must
+    // stay on a global channel.
+    if (sub.userId === null && ch.userId !== null) {
+      throw createError({ statusCode: 400, message: 'Global subscriptions require a global channel' });
+    }
     update.channelId = d.channelId;
   }
 

--- a/apps/application/server/api/subscriptions/index.get.ts
+++ b/apps/application/server/api/subscriptions/index.get.ts
@@ -1,29 +1,24 @@
 import { eq, and, or, isNull } from 'drizzle-orm';
 import { getDatabase } from '../../database';
 import { subscriptions, notificationChannels } from '../../database/schema';
-import { requireAuth, isAuthEnabled } from '../../utils/auth';
-import { Role } from '#shared/types';
+import { requireAuth } from '../../utils/auth';
 
 defineRouteMeta({
   openAPI: {
     tags: ['Notifications'],
     summary: 'List subscriptions',
-    description: "Returns the current user's subscriptions (admins can see all).",
+    description: "Returns the current user's subscriptions plus global (admin-managed) ones.",
     'x-required-roles': [],
     parameters: [{ name: 'projectId', in: 'query', schema: { type: 'integer' } }],
   },
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event))
-    throw createError({ statusCode: 400, message: 'Enable authentication to use notifications' });
   const user = await requireAuth(event);
   const db = await getDatabase();
 
   const projectIdParam = getQuery(event).projectId;
   const projectId = projectIdParam ? parseInt(String(projectIdParam)) : null;
-
-  const isAdmin = user.role === Role.ADMINISTRATOR;
 
   const rows = await db
     .select({ sub: subscriptions, channel: notificationChannels })
@@ -31,7 +26,7 @@ export default eventHandler(async (event) => {
     .innerJoin(notificationChannels, eq(subscriptions.channelId, notificationChannels.id))
     .where(
       and(
-        isAdmin ? undefined : or(isNull(subscriptions.userId), eq(subscriptions.userId, user.id)),
+        or(isNull(subscriptions.userId), eq(subscriptions.userId, user.id)),
         projectId ? eq(subscriptions.projectId, projectId) : undefined,
       ),
     );

--- a/apps/application/server/api/subscriptions/index.post.ts
+++ b/apps/application/server/api/subscriptions/index.post.ts
@@ -11,7 +11,8 @@ defineRouteMeta({
   openAPI: {
     tags: ['Notifications'],
     summary: 'Create a subscription',
-    description: 'Creates a new subscription for the current user.',
+    description:
+      'Creates a new subscription for the current user. Administrators can create global (instance-wide) subscriptions; with authentication disabled every subscription is global.',
     'x-required-roles': [],
   },
 });
@@ -34,11 +35,10 @@ const schema = z.object({
     .string()
     .regex(/^\d{1,2}:\d{2}$/)
     .optional(),
+  global: z.boolean().optional(), // admin only: instance-wide (userId=null) subscription
 });
 
 export default eventHandler(async (event) => {
-  if (!isAuthEnabled(event))
-    throw createError({ statusCode: 400, message: 'Enable authentication to use notifications' });
   const user = await requireAuth(event);
   const body = await readBody(event);
   const parsed = schema.safeParse(body);
@@ -46,7 +46,7 @@ export default eventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Invalid request body', data: parsed.error.issues });
   }
 
-  const { channelId, projectId, events, filters, mode, digestAt } = parsed.data;
+  const { channelId, projectId, events, filters, mode, digestAt, global: requestedGlobal } = parsed.data;
 
   const db = await getDatabase();
   const [channel] = await db.select().from(notificationChannels).where(eq(notificationChannels.id, channelId));
@@ -55,6 +55,20 @@ export default eventHandler(async (event) => {
   const isAdmin = user.role === Role.ADMINISTRATOR;
   if (channel.userId !== null && channel.userId !== user.id && !isAdmin) {
     throw createError({ statusCode: 403, message: "Cannot subscribe to another user's channel" });
+  }
+
+  if (requestedGlobal && !isAdmin) {
+    throw createError({ statusCode: 403, message: 'Only administrators can create global subscriptions' });
+  }
+
+  // Without auth there is no user row to own a subscription — everything is global.
+  const isGlobal = requestedGlobal || !isAuthEnabled(event);
+
+  // A global subscription delivers with no per-user access check, so it must
+  // target a channel that is itself global — a personal channel would leak
+  // other projects' failures to its owner.
+  if (isGlobal && channel.userId !== null) {
+    throw createError({ statusCode: 400, message: 'Global subscriptions require a global channel' });
   }
 
   // Only let the caller subscribe to projects they can access. A null projectId
@@ -76,7 +90,7 @@ export default eventHandler(async (event) => {
   const [sub] = await db
     .insert(subscriptions)
     .values({
-      userId: user.id,
+      userId: isGlobal ? null : user.id,
       channelId,
       projectId: projectId ?? null,
       events: events as unknown as string[],

--- a/apps/application/server/database/schema.pg.ts
+++ b/apps/application/server/database/schema.pg.ts
@@ -11,8 +11,35 @@ import {
   index,
   uniqueIndex,
   primaryKey,
+  customType,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
+
+/**
+ * Boolean stored in an integer column (0/1). Mirrors the SQLite dialect's
+ * `integer(..., { mode: 'boolean' })` columns, so application code reads and
+ * writes plain booleans on both dialects while the column type stays integer
+ * (no data migration for existing databases).
+ *
+ * `.default()` on these columns must be the driver value (`0`/`1`, cast to
+ * boolean) — drizzle-kit serializes defaults into DDL without running
+ * `toDriver`, and a literal `true`/`false` default is invalid SQL for an
+ * integer column.
+ */
+const intBoolean = customType<{ data: boolean; driverData: number }>({
+  dataType() {
+    return 'integer';
+  },
+  toDriver(value) {
+    return value ? 1 : 0;
+  },
+  fromDriver(value) {
+    return Number(value) !== 0;
+  },
+});
+
+const INT_BOOLEAN_FALSE = 0 as unknown as boolean;
+const INT_BOOLEAN_TRUE = 1 as unknown as boolean;
 
 // Projects table
 export const projects = pgTable(
@@ -712,7 +739,7 @@ export const users = pgTable(
     role: text('role').notNull(), // Role enum: 'administrator', 'reporter', 'user'
     name: text('name'), // Display name
     email: text('email'), // Email address (nullable; OAuth callback can populate it)
-    emailVerified: integer('email_verified').notNull().default(0), // boolean (0/1)
+    emailVerified: intBoolean('email_verified').notNull().default(INT_BOOLEAN_FALSE),
     avatarUrl: text('avatar_url'), // Avatar from OAuth provider
     oauthProvider: text('oauth_provider'), // 'google', 'github', etc.
     oauthProviderId: text('oauth_provider_id'), // User ID from the OAuth provider
@@ -762,7 +789,7 @@ export const notificationChannels = pgTable(
     type: text('type').notNull(), // 'email' | 'slack' | 'webhook'
     config: jsonb('config'), // { address } | { webhookUrl } | { url, secret (encrypted) }
     userId: integer('user_id').references(() => users.id, { onDelete: 'cascade' }), // null = global (admin-managed)
-    verified: integer('verified').notNull().default(0),
+    verified: intBoolean('verified').notNull().default(INT_BOOLEAN_FALSE),
     createdAt: timestamp('created_at', { mode: 'date' })
       .notNull()
       .$defaultFn(() => new Date()),
@@ -790,7 +817,7 @@ export const subscriptions = pgTable(
     mode: text('mode').notNull().default('realtime'), // 'realtime' | 'digest'
     digestAt: text('digest_at'), // 'HH:mm' UTC for daily digest
     mutedUntil: timestamp('muted_until', { mode: 'date' }),
-    active: integer('active').notNull().default(1),
+    active: intBoolean('active').notNull().default(INT_BOOLEAN_TRUE),
     createdAt: timestamp('created_at', { mode: 'date' })
       .notNull()
       .$defaultFn(() => new Date()),

--- a/apps/application/server/utils/ai-diagnosis.ts
+++ b/apps/application/server/utils/ai-diagnosis.ts
@@ -394,6 +394,7 @@ async function persistCompletedDiagnosis(
   emitNotification(db, 'diagnosis.completed', {
     clusterId: cluster.id,
     projectId: cluster.projectId,
+    completedAt: completed.updatedAt?.getTime() ?? Date.now(),
     summary: diagnosis.summary,
     rootCause: diagnosis.rootCause,
     category: diagnosis.category,

--- a/apps/application/server/utils/email.ts
+++ b/apps/application/server/utils/email.ts
@@ -1,6 +1,12 @@
 import nodemailer from 'nodemailer';
 import type { Transporter } from 'nodemailer';
-import type { TopFailure } from '#shared/notification-events';
+import { renderEventSubject, notificationTargetPath } from '#shared/notification-events';
+import type {
+  NotificationEvent,
+  NotificationPayload,
+  RunFinishedPayload,
+  TopFailure,
+} from '#shared/notification-events';
 
 export interface SmtpConfig {
   host: string;
@@ -35,7 +41,9 @@ export function getSmtpConfig(): SmtpConfig {
   const secureDefault = port === 465;
   const secure =
     process.env.PIWI_SMTP_SECURE === 'true' || (process.env.PIWI_SMTP_SECURE === undefined && secureDefault);
-  const configured = Boolean(host && user && pass && from);
+  // Credentials are optional — a relay that accepts unauthenticated mail only
+  // needs host + from.
+  const configured = Boolean(host && from);
 
   return { host, port, user, from, fromName, hasPassword: Boolean(pass), secure, configured, envManaged: true };
 }
@@ -47,11 +55,14 @@ export function isEmailConfigured(): boolean {
 function getTransport(): Transporter {
   if (_transport) return _transport;
   const cfg = getSmtpConfig();
+  const pass = process.env.PIWI_SMTP_PASS || '';
   _transport = nodemailer.createTransport({
     host: cfg.host,
     port: cfg.port,
     secure: cfg.secure,
-    auth: { user: cfg.user, pass: process.env.PIWI_SMTP_PASS || '' },
+    // Only authenticate when credentials are set; an auth block with empty
+    // values would make nodemailer attempt AUTH against auth-less relays.
+    ...(cfg.user && pass ? { auth: { user: cfg.user, pass } } : {}),
   });
   return _transport;
 }
@@ -248,4 +259,49 @@ export function renderNewClusterEmail(opts: {
   const { html } = emailLayout(`New failure cluster — ${opts.projectName}`, body);
   const text = `New failure cluster in ${opts.projectName}${opts.affectedCases ? ` (${opts.affectedCases} affected)` : ''}\n\n${opts.signature}${opts.sampleErrorExcerpt ? `\n\n${opts.sampleErrorExcerpt}` : ''}\n\nView: ${url}`;
   return { html, text };
+}
+
+/** One event queued for a digest send. */
+export interface DigestItem {
+  event: NotificationEvent;
+  payload: NotificationPayload;
+}
+
+/**
+ * One email summarizing every notification a digest-mode subscription batched
+ * since the previous send: subject line + link per item, with run stats where
+ * the payload carries them.
+ */
+export function renderDigestEmail(items: DigestItem[]): { subject: string; html: string; text: string } {
+  const subject = `Piwi digest — ${items.length} notification${items.length === 1 ? '' : 's'}`;
+
+  const rows = items
+    .map(({ event, payload }) => {
+      const line = renderEventSubject(event, payload);
+      const path = notificationTargetPath(event, payload);
+      const url = path ? `${siteUrl()}${path}` : null;
+      const run = payload as RunFinishedPayload;
+      const stats =
+        event.startsWith('run.') && run.totalTests != null
+          ? `<div style="color:#71717a;font-size:12px;">${run.totalTests} tests${run.failedTests ? ` · <span style="color:#ef4444;">${run.failedTests} failed</span>` : ''}</div>`
+          : '';
+      const title = url
+        ? `<a href="${url}" style="color:#18181b;font-weight:600;text-decoration:none;">${escapeHtml(line)}</a>`
+        : `<span style="font-weight:600;">${escapeHtml(line)}</span>`;
+      return `<li style="margin-bottom:12px;list-style:none;">${title}${stats}</li>`;
+    })
+    .join('');
+
+  const body = `
+    <h2 style="margin:0 0 16px;font-size:20px;color:#18181b;">Your notification digest</h2>
+    <ul style="margin:0;padding:0;">${rows}</ul>`;
+  const { html } = emailLayout(subject, body);
+
+  const text = items
+    .map(({ event, payload }) => {
+      const path = notificationTargetPath(event, payload);
+      return `- ${renderEventSubject(event, payload)}${path ? `\n  ${siteUrl()}${path}` : ''}`;
+    })
+    .join('\n');
+  return { subject, html, text: `${subject}\n\n${text}` };
 }

--- a/apps/application/server/utils/notifications/dispatch.ts
+++ b/apps/application/server/utils/notifications/dispatch.ts
@@ -1,6 +1,13 @@
 import { and, eq, lte, lt } from 'drizzle-orm';
-import { notificationDeliveries, notificationChannels, users } from '../../database/schema';
-import { sendEmail, renderRunNotificationEmail, renderNewClusterEmail, isEmailConfigured } from '../email';
+import { notificationDeliveries, notificationChannels, subscriptions, users } from '../../database/schema';
+import {
+  sendEmail,
+  renderRunNotificationEmail,
+  renderNewClusterEmail,
+  renderDigestEmail,
+  isEmailConfigured,
+  type DigestItem,
+} from '../email';
 import { decryptSecret, getEncryptionKey } from '../crypto';
 import { safeFetch } from '../safe-fetch';
 import type {
@@ -9,16 +16,48 @@ import type {
   RunFinishedPayload,
   ClusterNewPayload,
 } from '#shared/notification-events';
-import { renderEventSubject } from '#shared/notification-events';
+import { renderEventSubject, notificationTargetPath } from '#shared/notification-events';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
 
 const MAX_ATTEMPTS = 5;
 const BACKOFF_MINUTES = [1, 5, 15, 60, 240]; // progressive backoff
+/** Slack digest messages list at most this many items; the rest are counted. */
+const SLACK_DIGEST_MAX_ITEMS = 20;
+
+const siteBase = () => process.env.PIWI_SITE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function sendToEmail(config: Record<string, unknown>, event: NotificationEvent, payload: NotificationPayload) {
-  const to = config.address as string;
+type Db = LibSQLDatabase<any>;
+
+interface ChannelRow {
+  id: number;
+  type: string;
+  userId: number | null;
+  config: unknown;
+}
+
+interface DeliveryRow {
+  id: number;
+  event: string;
+  payload: unknown;
+  attempts: number | null;
+  scheduledFor: Date | null;
+}
+
+/** Resolve the destination address for an email or personal_email channel. */
+async function resolveEmailAddress(db: Db, channel: ChannelRow): Promise<string> {
+  if (channel.type === 'personal_email') {
+    if (!channel.userId) throw new Error('Personal email channel has no owner');
+    const [owner] = await db.select({ email: users.email }).from(users).where(eq(users.id, channel.userId));
+    if (!owner?.email) throw new Error('Account has no email address');
+    return owner.email;
+  }
+  const to = (channel.config as Record<string, unknown> | null)?.address as string;
   if (!to) throw new Error('No email address configured');
+  return to;
+}
+
+async function sendToEmail(to: string, event: NotificationEvent, payload: NotificationPayload) {
   if (!isEmailConfigured()) throw new Error('SMTP not configured');
 
   let html: string;
@@ -53,7 +92,15 @@ async function sendToEmail(config: Record<string, unknown>, event: NotificationE
   await sendEmail({ to, subject: renderEventSubject(event, payload), html, text });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function postToSlack(webhookUrl: string, body: Record<string, unknown>) {
+  const res = await safeFetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Slack webhook returned ${res.status}`);
+}
+
 async function sendToSlack(config: Record<string, unknown>, event: NotificationEvent, payload: NotificationPayload) {
   const webhookUrl = config.webhookUrl as string;
   if (!webhookUrl) throw new Error('No Slack webhook URL configured');
@@ -64,7 +111,7 @@ async function sendToSlack(config: Record<string, unknown>, event: NotificationE
   else if (event === 'cluster.new') emoji = ':bug:';
   else if (event === 'flakiness.spike') emoji = ':game_die:';
 
-  const base = process.env.PIWI_SITE_URL?.replace(/\/$/, '') || 'http://localhost:3000';
+  const base = siteBase();
   // Slack section text is capped at 3000 chars; keep excerpts short.
   const slackExcerpt = (s: string) => (s.length > 600 ? s.slice(0, 600) + '…' : s);
 
@@ -86,17 +133,33 @@ async function sendToSlack(config: Record<string, unknown>, event: NotificationE
     blocks.push({ type: 'section', text: { type: 'mrkdwn', text: parts.join('\n') } });
   }
 
-  const body = { text: `${emoji} *${text}*`, blocks };
-
-  const res = await safeFetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) throw new Error(`Slack webhook returned ${res.status}`);
+  await postToSlack(webhookUrl, { text: `${emoji} *${text}*`, blocks });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function sendSlackDigest(config: Record<string, unknown>, items: DigestItem[]) {
+  const webhookUrl = config.webhookUrl as string;
+  if (!webhookUrl) throw new Error('No Slack webhook URL configured');
+
+  const base = siteBase();
+  const header = `:bell: Piwi digest — ${items.length} notification${items.length === 1 ? '' : 's'}`;
+  const blocks: Record<string, unknown>[] = [{ type: 'section', text: { type: 'mrkdwn', text: `*${header}*` } }];
+
+  for (const { event, payload } of items.slice(0, SLACK_DIGEST_MAX_ITEMS)) {
+    const line = renderEventSubject(event, payload);
+    const path = notificationTargetPath(event, payload);
+    const text = path ? `• <${base}${path}|${line}>` : `• ${line}`;
+    blocks.push({ type: 'section', text: { type: 'mrkdwn', text } });
+  }
+  if (items.length > SLACK_DIGEST_MAX_ITEMS) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `…and ${items.length - SLACK_DIGEST_MAX_ITEMS} more` },
+    });
+  }
+
+  await postToSlack(webhookUrl, { text: header, blocks });
+}
+
 async function sendToWebhook(config: Record<string, unknown>, event: NotificationEvent, payload: NotificationPayload) {
   const url = config.url as string;
   if (!url) throw new Error('No webhook URL configured');
@@ -118,20 +181,86 @@ async function sendToWebhook(config: Record<string, unknown>, event: Notificatio
   if (!res.ok) throw new Error(`Webhook returned ${res.status}`);
 }
 
+/** Deliver a single outbox row through its channel. */
+async function sendSingle(db: Db, d: DeliveryRow, c: ChannelRow) {
+  const config = (c.config ?? {}) as Record<string, unknown>;
+  const event = d.event as NotificationEvent;
+  const payload = (d.payload ?? {}) as NotificationPayload;
+
+  if (c.type === 'personal_email' || c.type === 'email') {
+    await sendToEmail(await resolveEmailAddress(db, c), event, payload);
+  } else if (c.type === 'slack') await sendToSlack(config, event, payload);
+  else if (c.type === 'webhook') await sendToWebhook(config, event, payload);
+  else if (c.type === 'browser') {
+    /* Delivered via SSE — the notification/stream endpoint handles this channel type */
+  } else throw new Error(`Unknown channel type: ${c.type}`);
+}
+
+/** Deliver a batch of digest-mode rows through one channel as one message. */
+async function sendDigest(db: Db, c: ChannelRow, rows: DeliveryRow[]) {
+  const items: DigestItem[] = rows.map((d) => ({
+    event: d.event as NotificationEvent,
+    payload: (d.payload ?? {}) as NotificationPayload,
+  }));
+
+  if (c.type === 'personal_email' || c.type === 'email') {
+    if (!isEmailConfigured()) throw new Error('SMTP not configured');
+    const to = await resolveEmailAddress(db, c);
+    const { subject, html, text } = renderDigestEmail(items);
+    await sendEmail({ to, subject, html, text });
+  } else if (c.type === 'slack') {
+    await sendSlackDigest((c.config ?? {}) as Record<string, unknown>, items);
+  } else {
+    throw new Error(`Digest not supported for channel type: ${c.type}`);
+  }
+}
+
+async function markSent(db: Db, rows: DeliveryRow[], now: Date) {
+  for (const d of rows) {
+    await db
+      .update(notificationDeliveries)
+      .set({ status: 'sent', sentAt: now, attempts: (d.attempts ?? 0) + 1, error: null })
+      .where(eq(notificationDeliveries.id, d.id));
+  }
+}
+
+async function markFailed(db: Db, rows: DeliveryRow[], message: string, now: Date) {
+  for (const d of rows) {
+    const attempts = (d.attempts ?? 0) + 1;
+    const nextBackoffMs = (BACKOFF_MINUTES[Math.min(attempts, BACKOFF_MINUTES.length - 1)] ?? 240) * 60 * 1000;
+    const isFinal = attempts >= MAX_ATTEMPTS;
+
+    await db
+      .update(notificationDeliveries)
+      .set({
+        status: isFinal ? 'failed' : 'pending',
+        attempts,
+        error: message,
+        scheduledFor: isFinal ? d.scheduledFor : new Date(now.getTime() + nextBackoffMs),
+      })
+      .where(eq(notificationDeliveries.id, d.id));
+
+    console.error(`[notifications] Delivery ${d.id} failed (attempt ${attempts}/${MAX_ATTEMPTS}): ${message}`);
+  }
+}
+
 /**
  * Process pending deliveries that are due now (scheduledFor <= now, status = 'pending', attempts < MAX).
- * Returns the number of deliveries processed.
+ *
+ * Email and Slack deliveries queued by a digest-mode subscription batch into
+ * one message per channel; every other delivery (realtime, webhook, browser)
+ * sends individually. Returns per-row sent/failed counts.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function sweepOutbox(db: LibSQLDatabase<any>): Promise<{ sent: number; failed: number }> {
+export async function sweepOutbox(db: Db): Promise<{ sent: number; failed: number }> {
   const now = new Date();
   let sent = 0;
   let failed = 0;
 
   const due = await db
-    .select({ d: notificationDeliveries, c: notificationChannels })
+    .select({ d: notificationDeliveries, c: notificationChannels, mode: subscriptions.mode })
     .from(notificationDeliveries)
     .innerJoin(notificationChannels, eq(notificationDeliveries.channelId, notificationChannels.id))
+    .leftJoin(subscriptions, eq(notificationDeliveries.subscriptionId, subscriptions.id))
     .where(
       and(
         eq(notificationDeliveries.status, 'pending'),
@@ -140,48 +269,48 @@ export async function sweepOutbox(db: LibSQLDatabase<any>): Promise<{ sent: numb
       ),
     );
 
-  for (const { d, c } of due) {
-    const config = (c.config ?? {}) as Record<string, unknown>;
-    const event = d.event as NotificationEvent;
-    const payload = (d.payload ?? {}) as NotificationPayload;
+  const digestable = (row: (typeof due)[number]) =>
+    row.mode === 'digest' && (row.c.type === 'email' || row.c.type === 'personal_email' || row.c.type === 'slack');
 
+  const singles: (typeof due)[number][] = [];
+  const digestGroups = new Map<number, (typeof due)[number][]>();
+  for (const row of due) {
+    if (!digestable(row)) {
+      singles.push(row);
+      continue;
+    }
+    const group = digestGroups.get(row.c.id);
+    if (group) group.push(row);
+    else digestGroups.set(row.c.id, [row]);
+  }
+  // A batch of one reads better as the full single-event message.
+  for (const [channelId, group] of digestGroups) {
+    if (group.length === 1) {
+      singles.push(group[0]!);
+      digestGroups.delete(channelId);
+    }
+  }
+
+  for (const { d, c } of singles) {
     try {
-      if (c.type === 'personal_email') {
-        if (!c.userId) throw new Error('Personal email channel has no owner');
-        const [owner] = await db.select({ email: users.email }).from(users).where(eq(users.id, c.userId));
-        if (!owner?.email) throw new Error('Account has no email address');
-        await sendToEmail({ address: owner.email }, event, payload);
-      } else if (c.type === 'email') await sendToEmail(config, event, payload);
-      else if (c.type === 'slack') await sendToSlack(config, event, payload);
-      else if (c.type === 'webhook') await sendToWebhook(config, event, payload);
-      else if (c.type === 'browser') {
-        /* Delivered via SSE — the notification/stream endpoint handles this channel type */
-      } else throw new Error(`Unknown channel type: ${c.type}`);
-
-      await db
-        .update(notificationDeliveries)
-        .set({ status: 'sent', sentAt: now, attempts: (d.attempts ?? 0) + 1, error: null })
-        .where(eq(notificationDeliveries.id, d.id));
+      await sendSingle(db, d, c);
+      await markSent(db, [d], now);
       sent++;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const attempts = (d.attempts ?? 0) + 1;
-      const nextBackoffMs = (BACKOFF_MINUTES[Math.min(attempts, BACKOFF_MINUTES.length - 1)] ?? 240) * 60 * 1000;
-      const nextScheduled = new Date(now.getTime() + nextBackoffMs);
-      const isFinal = attempts >= MAX_ATTEMPTS;
-
-      await db
-        .update(notificationDeliveries)
-        .set({
-          status: isFinal ? 'failed' : 'pending',
-          attempts,
-          error: message,
-          scheduledFor: isFinal ? d.scheduledFor : nextScheduled,
-        })
-        .where(eq(notificationDeliveries.id, d.id));
-
-      console.error(`[notifications] Delivery ${d.id} failed (attempt ${attempts}/${MAX_ATTEMPTS}): ${message}`);
+      await markFailed(db, [d], err instanceof Error ? err.message : String(err), now);
       failed++;
+    }
+  }
+
+  for (const group of digestGroups.values()) {
+    const rows = group.map((g) => g.d);
+    try {
+      await sendDigest(db, group[0]!.c, rows);
+      await markSent(db, rows, now);
+      sent += rows.length;
+    } catch (err) {
+      await markFailed(db, rows, err instanceof Error ? err.message : String(err), now);
+      failed += rows.length;
     }
   }
 

--- a/apps/application/server/utils/notifications/emit.ts
+++ b/apps/application/server/utils/notifications/emit.ts
@@ -1,4 +1,3 @@
-import { isAuthEnabled } from '../auth';
 import { matchAndEnqueue } from './match';
 import { sweepOutbox } from './dispatch';
 import { runEventBus } from '../run-events';
@@ -11,8 +10,9 @@ import type { LibSQLDatabase } from 'drizzle-orm/libsql';
  * kick the sweeper for realtime deliveries (email/Slack/webhook).
  *
  * The SSE bus publishes regardless of auth — when auth is off, client-side
- * cookie preferences gate which events trigger browser notifications.
- * The outbox path (email/Slack/webhook) requires auth.
+ * cookie preferences gate which events trigger browser notifications. The
+ * outbox path works in both modes: with auth off every channel and
+ * subscription is global (userId null), so no per-user access check applies.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function emitNotification(
@@ -21,8 +21,6 @@ export async function emitNotification(
   payload: NotificationPayload,
 ): Promise<void> {
   runEventBus.publishNotification({ type: event, ...payload });
-
-  if (!isAuthEnabled()) return; // outbox path requires auth for user identity
 
   try {
     const enqueued = await matchAndEnqueue(db, event, payload);

--- a/apps/application/server/utils/notifications/match.ts
+++ b/apps/application/server/utils/notifications/match.ts
@@ -1,19 +1,14 @@
 import { and, eq, or, isNull } from 'drizzle-orm';
 import { subscriptions, notificationChannels, notificationDeliveries, users } from '../../database/schema';
 import { getProjectScope, scopeAllows, type DrizzleDB } from '../project-access';
-import type { NotificationEvent, NotificationPayload, RunFinishedPayload } from '#shared/notification-events';
+import {
+  buildNotificationDedupeKey,
+  passesSubscriptionFilters,
+  type NotificationEvent,
+  type NotificationPayload,
+  type SubscriptionFilters,
+} from '#shared/notification-events';
 import type { LibSQLDatabase } from 'drizzle-orm/libsql';
-
-interface SubscriptionFilters {
-  branches?: string[];
-  tags?: string[];
-  statuses?: string[];
-  defaultBranchOnly?: boolean;
-  /** Only deliver when one of these owns a failing test in the run. */
-  owners?: string[];
-  flakinessThreshold?: number;
-  perfRegressionPct?: number;
-}
 
 function parseDigestHHMM(digestAt: string | null | undefined): { hour: number; minute: number } | null {
   if (!digestAt) return null;
@@ -31,38 +26,6 @@ function nextDigestTime(digestAt: string): Date {
   );
   if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
   return next;
-}
-
-function passesFilters(
-  filters: SubscriptionFilters | null | undefined,
-  event: NotificationEvent,
-  payload: NotificationPayload,
-): boolean {
-  if (!filters) return true;
-
-  const runPayload = payload as RunFinishedPayload;
-
-  if (filters.defaultBranchOnly && event.startsWith('run.')) {
-    if (!runPayload.isDefaultBranch) return false;
-  }
-  if (filters.branches?.length && event.startsWith('run.') && runPayload.branch) {
-    if (!filters.branches.includes(runPayload.branch)) return false;
-  }
-  if (filters.statuses?.length && event.startsWith('run.') && runPayload.status) {
-    if (!filters.statuses.includes(runPayload.status)) return false;
-  }
-  if (filters.owners?.length && event.startsWith('run.')) {
-    // No owner on the payload means nothing failed, or ownership could not be
-    // resolved. Either way an owner-scoped subscription has nothing to say.
-    const runOwners = runPayload.owners ?? [];
-    if (!runOwners.some((owner) => filters.owners!.includes(owner))) return false;
-  }
-  if (filters.flakinessThreshold != null && event === 'flakiness.spike') {
-    const rate = runPayload.flakinessRate ?? 0;
-    if (rate < filters.flakinessThreshold) return false;
-  }
-
-  return true;
 }
 
 /**
@@ -102,7 +65,9 @@ export async function matchAndEnqueue(
   };
 
   for (const { sub, channel } of rows) {
-    if (sub.userId == null || !(await subscriberCanAccess(sub.userId))) continue;
+    // Global subscriptions (userId null) are admin-managed and span every
+    // project; per-user subscriptions re-check the subscriber's access.
+    if (sub.userId != null && !(await subscriberCanAccess(sub.userId))) continue;
 
     // Check event is subscribed
     const events = (sub.events as string[] | null) ?? [];
@@ -113,10 +78,9 @@ export async function matchAndEnqueue(
 
     // Check filters
     const filters = sub.filters as SubscriptionFilters | null;
-    if (!passesFilters(filters, event, payload)) continue;
+    if (!passesSubscriptionFilters(filters, event, payload)) continue;
 
-    const runId = (payload as { runId?: number }).runId;
-    const dedupeKey = `${event}:${runId ?? 'x'}:${channel.id}`;
+    const dedupeKey = buildNotificationDedupeKey(event, payload, channel.id);
     const scheduledFor = sub.mode === 'digest' && sub.digestAt ? nextDigestTime(sub.digestAt) : now;
 
     try {

--- a/apps/application/server/utils/notifications/run-notifications.ts
+++ b/apps/application/server/utils/notifications/run-notifications.ts
@@ -1,16 +1,31 @@
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, lt, desc, inArray } from 'drizzle-orm';
 
 /** Failures scanned for ownership; well past what any comment or digest lists. */
 const OWNER_LOOKUP_LIMIT = 200;
+/** Prior runs fetched per project when looking for same-branch baseline runs. */
+const BASELINE_FETCH_LIMIT = 25;
 import { projects, testRuns, failureClusters, testRunsCases, testCases } from '../../database/schema';
 import { emitNotification } from './emit';
-import { buildTopFailures, truncateExcerpt, TOP_FAILURES_LIMIT } from '#shared/notification-events';
+import {
+  buildTopFailures,
+  truncateExcerpt,
+  computePerfBaseline,
+  TOP_FAILURES_LIMIT,
+  PERF_BASELINE_RUNS,
+  PERF_REGRESSION_MIN_PCT,
+} from '#shared/notification-events';
 import { resolveOwners } from '../scm/ownership';
 import type { DbClient } from '../../database';
 
+function runBranch(metadata: Record<string, unknown> | null): string | undefined {
+  const meta = metadata ?? {};
+  return (meta.branch as string | undefined) || (meta.gitBranch as string | undefined) || undefined;
+}
+
 /**
  * Emit run.finished / run.failed / run.failed.default_branch notifications for a completed run,
- * plus cluster.new for any failure clusters first seen in this run.
+ * plus flakiness.spike / perf.regression when the run qualifies, and cluster.new
+ * for any failure clusters first seen in this run.
  * Call this after the run status is finalized.
  */
 export async function emitRunNotifications(db: DbClient, runId: number): Promise<void> {
@@ -22,7 +37,7 @@ export async function emitRunNotifications(db: DbClient, runId: number): Promise
     if (!project) return;
 
     const meta = (runRow.metadata as Record<string, unknown> | null) ?? {};
-    const branch = (meta.branch as string | undefined) || (meta.gitBranch as string | undefined) || undefined;
+    const branch = runBranch(runRow.metadata as Record<string, unknown> | null);
     const defaultBranch = (meta.defaultBranch as string | undefined) || 'main';
     const isDefaultBranch = branch ? branch === defaultBranch : false;
 
@@ -63,6 +78,8 @@ export async function emitRunNotifications(db: DbClient, runId: number): Promise
       failedTests: runRow.failedTests,
       passedTests: runRow.passedTests,
       flakyTests: runRow.flakyTests,
+      flakinessRate: runRow.totalTests > 0 ? runRow.flakyTests / runRow.totalTests : 0,
+      durationMs: runRow.duration ?? undefined,
       branch,
       isDefaultBranch,
       topFailures,
@@ -75,6 +92,45 @@ export async function emitRunNotifications(db: DbClient, runId: number): Promise
       await emitNotification(db, 'run.failed', runPayload);
       if (isDefaultBranch) {
         await emitNotification(db, 'run.failed.default_branch', runPayload);
+      }
+    }
+
+    // Flaky tests in the run: subscriptions filter on flakinessRate via their
+    // flakinessThreshold, so the event fires for any flaky run and the
+    // per-subscription threshold decides delivery.
+    if (runRow.flakyTests > 0) {
+      await emitNotification(db, 'flakiness.spike', runPayload);
+    }
+
+    // Perf regression: the run is markedly slower than the median of prior
+    // completed runs on the same branch.
+    if (runRow.duration && runRow.duration > 0) {
+      const priorRuns = await db
+        .select({ duration: testRuns.duration, metadata: testRuns.metadata })
+        .from(testRuns)
+        .where(
+          and(
+            eq(testRuns.projectId, runRow.projectId),
+            lt(testRuns.id, runId),
+            inArray(testRuns.status, ['passed', 'failed']),
+          ),
+        )
+        .orderBy(desc(testRuns.id))
+        .limit(BASELINE_FETCH_LIMIT);
+
+      const priorDurations = priorRuns
+        .filter((r) => runBranch(r.metadata as Record<string, unknown> | null) === branch)
+        .map((r) => r.duration ?? 0)
+        .filter((d) => d > 0)
+        .slice(0, PERF_BASELINE_RUNS);
+
+      const baseline = computePerfBaseline(priorDurations, runRow.duration);
+      if (baseline && baseline.regressionPct >= PERF_REGRESSION_MIN_PCT) {
+        await emitNotification(db, 'perf.regression', {
+          ...runPayload,
+          baselineDurationMs: baseline.baselineDurationMs,
+          regressionPct: Math.round(baseline.regressionPct),
+        });
       }
     }
 

--- a/apps/application/shared/notification-events.ts
+++ b/apps/application/shared/notification-events.ts
@@ -15,6 +15,12 @@ export type NotificationEvent = (typeof NOTIFICATION_EVENTS)[number];
 export const TOP_FAILURES_LIMIT = 3;
 /** Max characters kept from an error message embedded in a notification. */
 export const ERROR_EXCERPT_MAX = 300;
+/** How many prior completed runs the perf-regression baseline is computed from. */
+export const PERF_BASELINE_RUNS = 5;
+/** Minimum prior runs required before a perf-regression baseline is trusted. */
+export const PERF_BASELINE_MIN_RUNS = 2;
+/** How much slower than baseline (percent) a run must be to emit perf.regression. */
+export const PERF_REGRESSION_MIN_PCT = 20;
 
 /** A single failing test embedded in a run notification for debugging context. */
 export interface TopFailure {
@@ -37,6 +43,12 @@ export interface RunFinishedPayload {
   branch?: string;
   isDefaultBranch?: boolean;
   flakinessRate?: number; // 0-1
+  /** Duration of the run in milliseconds. */
+  durationMs?: number;
+  /** Median duration (ms) of the prior runs a perf regression was measured against. */
+  baselineDurationMs?: number;
+  /** How much slower this run is than the baseline, in percent. */
+  regressionPct?: number;
   topFailures?: TopFailure[];
   /**
    * Distinct owners of the run's failing tests — from `piwi:owner` where a test
@@ -97,6 +109,8 @@ export function buildTopFailures(rows: TopFailureInput[], limit: number = TOP_FA
 export interface DiagnosisCompletedPayload {
   clusterId: number;
   projectId: number;
+  /** Epoch ms of this completion — distinguishes re-diagnoses of the same cluster. */
+  completedAt?: number;
   summary?: string | null;
   rootCause?: string | null;
   category?: string | null;
@@ -104,6 +118,110 @@ export interface DiagnosisCompletedPayload {
 }
 
 export type NotificationPayload = RunFinishedPayload | ClusterNewPayload | DiagnosisCompletedPayload;
+
+/** Per-subscription delivery filters, stored as JSON on the subscription row. */
+export interface SubscriptionFilters {
+  branches?: string[];
+  tags?: string[];
+  statuses?: string[];
+  defaultBranchOnly?: boolean;
+  /** Only deliver when one of these owns a failing test in the run. */
+  owners?: string[];
+  /** Minimum flakiness rate (0-1) for flakiness.spike deliveries. */
+  flakinessThreshold?: number;
+  /** Minimum slowdown percent for perf.regression deliveries. */
+  perfRegressionPct?: number;
+}
+
+/** Whether an event/payload passes a subscription's delivery filters. */
+export function passesSubscriptionFilters(
+  filters: SubscriptionFilters | null | undefined,
+  event: NotificationEvent,
+  payload: NotificationPayload,
+): boolean {
+  if (!filters) return true;
+
+  const runPayload = payload as RunFinishedPayload;
+
+  if (filters.defaultBranchOnly && event.startsWith('run.')) {
+    if (!runPayload.isDefaultBranch) return false;
+  }
+  if (filters.branches?.length && event.startsWith('run.') && runPayload.branch) {
+    if (!filters.branches.includes(runPayload.branch)) return false;
+  }
+  if (filters.statuses?.length && event.startsWith('run.') && runPayload.status) {
+    if (!filters.statuses.includes(runPayload.status)) return false;
+  }
+  if (filters.owners?.length && event.startsWith('run.')) {
+    // No owner on the payload means nothing failed, or ownership could not be
+    // resolved. Either way an owner-scoped subscription has nothing to say.
+    const runOwners = runPayload.owners ?? [];
+    if (!runOwners.some((owner) => filters.owners!.includes(owner))) return false;
+  }
+  if (filters.flakinessThreshold != null && event === 'flakiness.spike') {
+    const rate = runPayload.flakinessRate ?? 0;
+    if (rate < filters.flakinessThreshold) return false;
+  }
+  if (filters.perfRegressionPct != null && event === 'perf.regression') {
+    const pct = runPayload.regressionPct ?? 0;
+    if (pct < filters.perfRegressionPct) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Idempotency key for one logical notification to one channel. Keyed on the
+ * entity the event is about — the run for run-scoped events, the cluster for
+ * cluster.new (one run can surface several new clusters), and the cluster plus
+ * completion time for diagnosis.completed (the same cluster can be re-diagnosed).
+ */
+export function buildNotificationDedupeKey(
+  event: NotificationEvent,
+  payload: NotificationPayload,
+  channelId: number,
+): string {
+  if (event === 'cluster.new') {
+    const p = payload as ClusterNewPayload;
+    return `${event}:c${p.clusterId}:${channelId}`;
+  }
+  if (event === 'diagnosis.completed') {
+    const p = payload as DiagnosisCompletedPayload;
+    return `${event}:c${p.clusterId}:${p.completedAt ?? 'x'}:${channelId}`;
+  }
+  const runId = (payload as RunFinishedPayload).runId;
+  return `${event}:r${runId ?? 'x'}:${channelId}`;
+}
+
+/**
+ * Perf-regression baseline: the median duration of prior completed runs, and how
+ * much slower the current run is. Returns null when there are fewer than
+ * {@link PERF_BASELINE_MIN_RUNS} usable prior durations or the current duration
+ * is not positive.
+ */
+export function computePerfBaseline(
+  priorDurationsMs: number[],
+  currentDurationMs: number,
+): { baselineDurationMs: number; regressionPct: number } | null {
+  const usable = priorDurationsMs.filter((d) => d > 0);
+  if (currentDurationMs <= 0 || usable.length < PERF_BASELINE_MIN_RUNS) return null;
+  const sorted = [...usable].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const baselineDurationMs = sorted.length % 2 === 1 ? sorted[mid]! : Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+  if (baselineDurationMs <= 0) return null;
+  const regressionPct = ((currentDurationMs - baselineDurationMs) / baselineDurationMs) * 100;
+  return { baselineDurationMs, regressionPct };
+}
+
+/** Dashboard path the notification links to, or null when it has no target. */
+export function notificationTargetPath(event: NotificationEvent, payload: NotificationPayload): string | null {
+  if (event === 'cluster.new' || event === 'diagnosis.completed') {
+    const clusterId = (payload as ClusterNewPayload).clusterId;
+    return clusterId ? `/failure-clusters/${clusterId}` : null;
+  }
+  const runId = (payload as RunFinishedPayload).runId;
+  return runId ? `/test-runs/${runId}` : null;
+}
 
 /** Subject / title line for each event type. */
 export function renderEventSubject(event: NotificationEvent, payload: NotificationPayload): string {
@@ -124,7 +242,8 @@ export function renderEventSubject(event: NotificationEvent, payload: Notificati
     }
     case 'perf.regression': {
       const p = payload as RunFinishedPayload;
-      return `Performance regression — ${p.projectName}`;
+      const pct = p.regressionPct != null ? ` (+${Math.round(p.regressionPct)}% slower)` : '';
+      return `Performance regression — ${p.projectName}${pct}`;
     }
     case 'diagnosis.completed': {
       return 'Diagnosis complete';

--- a/apps/application/shared/piwi-env-vars.ts
+++ b/apps/application/shared/piwi-env-vars.ts
@@ -197,7 +197,7 @@ export const PIWI_ENV_CATEGORIES: Record<PiwiEnvVarCategory, PiwiEnvVarCategoryM
     order: 12,
     intro:
       'Required for email notifications and account flows (verification, password reset, invites). Set via environment only.',
-    note: 'Email sending activates once `PIWI_SMTP_HOST`, `PIWI_SMTP_USER`, `PIWI_SMTP_PASS` and `PIWI_SMTP_FROM` are all set. See [Notifications](./notifications) for channels and subscriptions.',
+    note: 'Email sending activates once `PIWI_SMTP_HOST` and `PIWI_SMTP_FROM` are set; add `PIWI_SMTP_USER`/`PIWI_SMTP_PASS` when the server requires authentication. See [Notifications](./notifications) for channels and subscriptions.',
   },
   clustering: {
     title: 'Failure clustering',
@@ -929,17 +929,15 @@ export const PIWI_ENV_VARS = {
     relevantWhen: { PIWI_SMTP_HOST: '*' },
   },
   PIWI_SMTP_USER: {
-    description: 'SMTP username.',
+    description: 'SMTP username. Optional — only when the server requires authentication.',
     category: 'smtp',
     relevantWhen: { PIWI_SMTP_HOST: '*' },
-    requiredWhen: { PIWI_SMTP_HOST: '*' },
   },
   PIWI_SMTP_PASS: {
-    description: 'SMTP password. Never returned by the API.',
+    description: 'SMTP password. Optional — only when the server requires authentication. Never returned by the API.',
     category: 'smtp',
     secret: true,
     relevantWhen: { PIWI_SMTP_HOST: '*' },
-    requiredWhen: { PIWI_SMTP_HOST: '*' },
   },
   PIWI_SMTP_FROM: {
     description: 'From address for outbound email (e.g. noreply@example.com).',

--- a/apps/application/tests/browser-notifications.spec.ts
+++ b/apps/application/tests/browser-notifications.spec.ts
@@ -274,6 +274,39 @@ test.describe.serial('Browser Notifications (Cookie Mode)', () => {
     expect(clusterEvent.affectedCases).toBe(2);
   });
 
+  // ── Channels & subscriptions without auth ──────────────────────────────────
+
+  test('channels and subscriptions work without auth and are global', async ({ request }) => {
+    const chRes = await request.post('/api/channels', {
+      data: { name: 'No-auth webhook', type: 'webhook', config: { url: 'https://example.com/hook' } },
+    });
+    expect(chRes.ok()).toBeTruthy();
+    const channelId = ((await chRes.json()) as { channel: { id: number } }).channel.id;
+
+    const listRes = await request.get('/api/channels');
+    const listData = (await listRes.json()) as { channels: Array<{ id: number; userId: number | null }> };
+    const created = listData.channels.find((c) => c.id === channelId);
+    expect(created).toBeDefined();
+    expect(created!.userId).toBeNull();
+
+    const subRes = await request.post('/api/subscriptions', {
+      data: { channelId, projectId, events: ['run.failed'] },
+    });
+    expect(subRes.ok()).toBeTruthy();
+    const subId = ((await subRes.json()) as { subscriptionId: number }).subscriptionId;
+
+    const subList = await request.get(`/api/subscriptions?projectId=${projectId}`);
+    const subData = (await subList.json()) as { subscriptions: Array<{ id: number; userId: number | null }> };
+    const sub = subData.subscriptions.find((s) => s.id === subId);
+    expect(sub).toBeDefined();
+    expect(sub!.userId).toBeNull();
+
+    const delSub = await request.delete(`/api/subscriptions/${subId}`);
+    expect(delSub.ok()).toBeTruthy();
+    const delCh = await request.delete(`/api/channels/${channelId}`);
+    expect(delCh.ok()).toBeTruthy();
+  });
+
   // ── Client-side cookie filter logic ────────────────────────────────────────
 
   test('handleEvent filters by cookie project+event', async ({ page }) => {

--- a/apps/application/tests/notifications.spec.ts
+++ b/apps/application/tests/notifications.spec.ts
@@ -213,6 +213,15 @@ test.describe.serial('Channels API', () => {
     expect(res.status).toBe(400);
   });
 
+  test('POST /api/channels creates a browser channel', async () => {
+    skip();
+    const res = await api('POST', '/api/channels', { name: 'My tabs', type: 'browser', config: {} }, adminCookie);
+    expect(res.ok).toBe(true);
+    const data = (await res.json()) as { success: boolean; channel: { id: number; type: string } };
+    expect(data.channel.type).toBe('browser');
+    await api('DELETE', `/api/channels/${data.channel.id}`, undefined, adminCookie);
+  });
+
   test('DELETE /api/channels/[id] removes the webhook channel', async () => {
     skip();
     const res = await api('DELETE', `/api/channels/${webhookChannelId}`, undefined, adminCookie);
@@ -329,6 +338,136 @@ test.describe.serial('Subscriptions API', () => {
   });
 });
 
+// ── Global channels & subscriptions ────────────────────────────────────────────
+
+test.describe.serial('Global channels & subscriptions', () => {
+  let globalChannelId = 0;
+  let globalSubId = 0;
+
+  test('non-admin cannot create a global channel', async () => {
+    skip();
+    const res = await api(
+      'POST',
+      '/api/channels',
+      { name: 'Rogue global', type: 'slack', config: { webhookUrl: 'https://hooks.slack.com/x' }, global: true },
+      userCookie,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test('admin creates a global channel visible to every user', async () => {
+    skip();
+    const res = await api(
+      'POST',
+      '/api/channels',
+      {
+        name: 'Team Slack',
+        type: 'slack',
+        config: { webhookUrl: 'https://hooks.slack.com/services/T/B/x' },
+        global: true,
+      },
+      adminCookie,
+    );
+    expect(res.ok).toBe(true);
+    const data = (await res.json()) as { channel: { id: number } };
+    globalChannelId = data.channel.id;
+
+    const listRes = await api('GET', '/api/channels', undefined, userCookie);
+    const listData = (await listRes.json()) as {
+      channels: Array<{ id: number; userId: number | null; config: Record<string, unknown> }>;
+    };
+    const ch = listData.channels.find((c) => c.id === globalChannelId);
+    expect(ch).toBeDefined();
+    expect(ch?.userId).toBeNull();
+    expect(ch?.config.webhookUrl).toBeUndefined();
+  });
+
+  test("channel listing excludes other users' personal channels", async () => {
+    skip();
+    const res = await api(
+      'POST',
+      '/api/channels',
+      { name: 'User personal email', type: 'email', config: { address: 'user@example.com' } },
+      userCookie,
+    );
+    const data = (await res.json()) as { channel: { id: number } };
+    const userChannelId = data.channel.id;
+
+    const listRes = await api('GET', '/api/channels', undefined, adminCookie);
+    const listData = (await listRes.json()) as { channels: Array<{ id: number }> };
+    expect(listData.channels.find((c) => c.id === userChannelId)).toBeUndefined();
+
+    const delRes = await api('DELETE', `/api/channels/${userChannelId}`, undefined, adminCookie);
+    expect(delRes.ok).toBe(true);
+  });
+
+  test('non-admin cannot fire tests at a global channel', async () => {
+    skip();
+    const res = await api('POST', `/api/channels/${globalChannelId}/test`, undefined, userCookie);
+    expect(res.status).toBe(403);
+  });
+
+  test('global subscriptions require admin and a global channel', async () => {
+    skip();
+    const nonAdmin = await api(
+      'POST',
+      '/api/subscriptions',
+      { channelId: globalChannelId, projectId, events: ['run.failed'], global: true },
+      userCookie,
+    );
+    expect(nonAdmin.status).toBe(403);
+
+    const personalRes = await api(
+      'POST',
+      '/api/channels',
+      { name: 'Admin personal', type: 'email', config: { address: 'admin@example.com' } },
+      adminCookie,
+    );
+    const personalId = ((await personalRes.json()) as { channel: { id: number } }).channel.id;
+    const onPersonal = await api(
+      'POST',
+      '/api/subscriptions',
+      { channelId: personalId, projectId, events: ['run.failed'], global: true },
+      adminCookie,
+    );
+    expect(onPersonal.status).toBe(400);
+    await api('DELETE', `/api/channels/${personalId}`, undefined, adminCookie);
+
+    const onGlobal = await api(
+      'POST',
+      '/api/subscriptions',
+      { channelId: globalChannelId, projectId, events: ['run.failed'], global: true },
+      adminCookie,
+    );
+    expect(onGlobal.ok).toBe(true);
+    const subData = (await onGlobal.json()) as { subscriptionId: number };
+    globalSubId = subData.subscriptionId;
+    expect(globalSubId).toBeGreaterThan(0);
+  });
+
+  test('global subscription is listed for every user but only admins can modify it', async () => {
+    skip();
+    const listRes = await api('GET', '/api/subscriptions', undefined, userCookie);
+    const listData = (await listRes.json()) as { subscriptions: Array<{ id: number; userId: number | null }> };
+    const sub = listData.subscriptions.find((s) => s.id === globalSubId);
+    expect(sub).toBeDefined();
+    expect(sub?.userId).toBeNull();
+
+    const patchRes = await api('PATCH', `/api/subscriptions/${globalSubId}`, { active: false }, userCookie);
+    expect(patchRes.status).toBe(404);
+    const delRes = await api('DELETE', `/api/subscriptions/${globalSubId}`, undefined, userCookie);
+    expect(delRes.status).toBe(404);
+  });
+
+  test('admin removes the global subscription and channel', async () => {
+    skip();
+    const delSub = await api('DELETE', `/api/subscriptions/${globalSubId}`, undefined, adminCookie);
+    expect(delSub.ok).toBe(true);
+    const delCh = await api('DELETE', `/api/channels/${globalChannelId}`, undefined, adminCookie);
+    expect(delCh.ok).toBe(true);
+  });
+});
+
 // ── Subscribe Bell UI ──────────────────────────────────────────────────────────
 
 test.describe.serial('Subscribe Bell UI', () => {
@@ -435,11 +574,11 @@ test.describe.serial('Subscribe Bell UI', () => {
     await expect(page.getByText('PIWI_SMTP_HOST')).toBeVisible();
   });
 
-  test('notifications settings page shows channels section when auth enabled', async ({ page }) => {
+  test('notifications settings page shows channels and subscriptions sections', async ({ page }) => {
     skip();
     await loginBrowser(page);
     await page.goto(`${BASE}/settings/notifications`);
-    await expect(page.getByText('Notification channels')).toBeVisible();
-    await expect(page.getByText('My subscriptions')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Notification channels' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Subscriptions' })).toBeVisible();
   });
 });

--- a/apps/application/tests/unit/notification-events.test.ts
+++ b/apps/application/tests/unit/notification-events.test.ts
@@ -49,6 +49,12 @@ describe('renderEventSubject', () => {
     expect(renderEventSubject('flakiness.spike', runPayload)).toBe('Flakiness spike — my-project');
     expect(renderEventSubject('perf.regression', runPayload)).toBe('Performance regression — my-project');
   });
+
+  test('perf.regression includes the slowdown when the payload carries it', () => {
+    expect(renderEventSubject('perf.regression', { ...runPayload, regressionPct: 34 })).toBe(
+      'Performance regression — my-project (+34% slower)',
+    );
+  });
 });
 
 describe('truncateExcerpt', () => {

--- a/apps/application/tests/unit/notification-match.test.ts
+++ b/apps/application/tests/unit/notification-match.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect } from 'vitest';
+import {
+  buildNotificationDedupeKey,
+  passesSubscriptionFilters,
+  computePerfBaseline,
+  notificationTargetPath,
+  PERF_BASELINE_MIN_RUNS,
+  type RunFinishedPayload,
+  type ClusterNewPayload,
+  type DiagnosisCompletedPayload,
+} from '#shared/notification-events';
+
+const runPayload: RunFinishedPayload = {
+  runId: 7,
+  projectId: 2,
+  projectName: 'my-project',
+  status: 'failed',
+  totalTests: 10,
+  failedTests: 2,
+  passedTests: 8,
+  flakyTests: 1,
+  flakinessRate: 0.1,
+};
+
+const clusterPayload = (clusterId: number): ClusterNewPayload => ({
+  clusterId,
+  projectId: 2,
+  projectName: 'my-project',
+  signature: 'TimeoutError',
+  runId: 7,
+});
+
+describe('buildNotificationDedupeKey', () => {
+  test('run events dedupe on the run', () => {
+    const a = buildNotificationDedupeKey('run.failed', runPayload, 1);
+    const b = buildNotificationDedupeKey('run.failed', runPayload, 1);
+    expect(a).toBe(b);
+    expect(a).toContain('r7');
+  });
+
+  test('two new clusters from the same run get distinct keys per channel', () => {
+    const a = buildNotificationDedupeKey('cluster.new', clusterPayload(11), 1);
+    const b = buildNotificationDedupeKey('cluster.new', clusterPayload(12), 1);
+    expect(a).not.toBe(b);
+  });
+
+  test('the same cluster stays deduped across channels but not across clusters', () => {
+    const sameCluster = buildNotificationDedupeKey('cluster.new', clusterPayload(11), 1);
+    expect(buildNotificationDedupeKey('cluster.new', clusterPayload(11), 1)).toBe(sameCluster);
+    expect(buildNotificationDedupeKey('cluster.new', clusterPayload(11), 2)).not.toBe(sameCluster);
+  });
+
+  test('re-diagnoses of one cluster get distinct keys via completedAt', () => {
+    const diag = (completedAt: number): DiagnosisCompletedPayload => ({ clusterId: 5, projectId: 2, completedAt });
+    const first = buildNotificationDedupeKey('diagnosis.completed', diag(1000), 1);
+    const second = buildNotificationDedupeKey('diagnosis.completed', diag(2000), 1);
+    expect(first).not.toBe(second);
+    expect(buildNotificationDedupeKey('diagnosis.completed', diag(1000), 1)).toBe(first);
+  });
+
+  test('run events on different channels get distinct keys', () => {
+    expect(buildNotificationDedupeKey('run.finished', runPayload, 1)).not.toBe(
+      buildNotificationDedupeKey('run.finished', runPayload, 2),
+    );
+  });
+});
+
+describe('passesSubscriptionFilters', () => {
+  test('no filters passes everything', () => {
+    expect(passesSubscriptionFilters(null, 'run.failed', runPayload)).toBe(true);
+    expect(passesSubscriptionFilters(undefined, 'run.failed', runPayload)).toBe(true);
+  });
+
+  test('branch filter applies to run events only', () => {
+    const payload = { ...runPayload, branch: 'feature-x' };
+    expect(passesSubscriptionFilters({ branches: ['main'] }, 'run.failed', payload)).toBe(false);
+    expect(passesSubscriptionFilters({ branches: ['feature-x'] }, 'run.failed', payload)).toBe(true);
+  });
+
+  test('defaultBranchOnly drops non-default-branch runs', () => {
+    expect(passesSubscriptionFilters({ defaultBranchOnly: true }, 'run.failed', runPayload)).toBe(false);
+    expect(
+      passesSubscriptionFilters({ defaultBranchOnly: true }, 'run.failed', { ...runPayload, isDefaultBranch: true }),
+    ).toBe(true);
+  });
+
+  test('owner filter requires an owned failing test', () => {
+    expect(passesSubscriptionFilters({ owners: ['team-a'] }, 'run.failed', runPayload)).toBe(false);
+    expect(
+      passesSubscriptionFilters({ owners: ['team-a'] }, 'run.failed', { ...runPayload, owners: ['team-a', 'team-b'] }),
+    ).toBe(true);
+  });
+
+  test('flakinessThreshold gates flakiness.spike on the rate', () => {
+    expect(passesSubscriptionFilters({ flakinessThreshold: 0.2 }, 'flakiness.spike', runPayload)).toBe(false);
+    expect(passesSubscriptionFilters({ flakinessThreshold: 0.05 }, 'flakiness.spike', runPayload)).toBe(true);
+  });
+
+  test('perfRegressionPct gates perf.regression on the slowdown', () => {
+    const regressed = { ...runPayload, regressionPct: 30 };
+    expect(passesSubscriptionFilters({ perfRegressionPct: 50 }, 'perf.regression', regressed)).toBe(false);
+    expect(passesSubscriptionFilters({ perfRegressionPct: 25 }, 'perf.regression', regressed)).toBe(true);
+  });
+});
+
+describe('computePerfBaseline', () => {
+  test('returns null below the minimum prior-run count', () => {
+    const tooFew = Array.from({ length: PERF_BASELINE_MIN_RUNS - 1 }, () => 1000);
+    expect(computePerfBaseline(tooFew, 2000)).toBeNull();
+  });
+
+  test('returns null for a non-positive current duration', () => {
+    expect(computePerfBaseline([1000, 1000, 1000], 0)).toBeNull();
+  });
+
+  test('ignores non-positive prior durations', () => {
+    expect(computePerfBaseline([0, -5, 1000], 2000)).toBeNull();
+  });
+
+  test('uses the median of prior durations', () => {
+    const result = computePerfBaseline([1000, 4000, 1200], 1800);
+    expect(result).not.toBeNull();
+    expect(result!.baselineDurationMs).toBe(1200);
+    expect(result!.regressionPct).toBeCloseTo(50);
+  });
+
+  test('averages the two middle values for an even count', () => {
+    const result = computePerfBaseline([1000, 2000], 3000);
+    expect(result!.baselineDurationMs).toBe(1500);
+    expect(result!.regressionPct).toBeCloseTo(100);
+  });
+
+  test('reports a negative percentage for a faster run', () => {
+    const result = computePerfBaseline([1000, 1000, 1000], 800);
+    expect(result!.regressionPct).toBeCloseTo(-20);
+  });
+});
+
+describe('notificationTargetPath', () => {
+  test('run events link to the run', () => {
+    expect(notificationTargetPath('run.failed', runPayload)).toBe('/test-runs/7');
+  });
+
+  test('cluster and diagnosis events link to the cluster', () => {
+    expect(notificationTargetPath('cluster.new', clusterPayload(11))).toBe('/failure-clusters/11');
+    expect(notificationTargetPath('diagnosis.completed', { clusterId: 5, projectId: 2 })).toBe('/failure-clusters/5');
+  });
+});

--- a/apps/application/tests/unit/schema-dialect-drift.test.ts
+++ b/apps/application/tests/unit/schema-dialect-drift.test.ts
@@ -37,6 +37,9 @@ const CANONICAL_TYPES: Record<string, string> = {
   PgJsonb: 'json',
   PgReal: 'float',
   PgDoublePrecision: 'float',
+  // The only PG custom type is intBoolean (schema.pg.ts): a boolean stored in
+  // an integer column, matching SQLite's integer boolean mode.
+  PgCustomColumn: 'boolean',
 };
 
 /**
@@ -47,10 +50,6 @@ const CANONICAL_TYPES: Record<string, string> = {
 const KNOWN_DIALECT_DIFFS: Record<string, [string, string]> = {
   // Millisecond epoch values exceed int32 on PostgreSQL.
   'test_runs_cases.started_at': ['int', 'bigint'],
-  // Historical: PG stores these as plain 0/1 integers rather than native booleans.
-  'users.email_verified': ['boolean', 'int'],
-  'notification_channels.verified': ['boolean', 'int'],
-  'subscriptions.active': ['boolean', 'int'],
 };
 
 interface ColumnShape {

--- a/apps/docs/notifications.md
+++ b/apps/docs/notifications.md
@@ -7,7 +7,7 @@ lang: en-US
 
 Piwi can push run events to **browser**, **email**, **Slack**, or **HTTP webhooks** so your team hears about failures, new failure clusters, flakiness spikes, and performance regressions without watching the dashboard. AI diagnosis completions can also notify you when they finish.
 
-Browser notifications work even with auth disabled — the other channel types require `PIWI_AUTH_ENABLED=true` ([see authentication](./authentication)).
+Notifications do not require authentication. With auth disabled the instance is single-tenant, so every channel and subscription is **global** (instance-wide). With `PIWI_AUTH_ENABLED=true` ([see authentication](./authentication)) each user manages their own channels and subscriptions, and administrators can additionally create global ones shared by everyone.
 
 ## How it works
 
@@ -25,21 +25,20 @@ Manage both from **Settings → Notifications**, and subscribe to a single proje
 | `run.failed` | A run completes with failures |
 | `run.failed.default_branch` | A run fails on the repository's default branch |
 | `cluster.new` | A new failure cluster appears |
-| `flakiness.spike` | Flakiness rises above the configured threshold |
-| `perf.regression` | A performance regression is detected |
+| `flakiness.spike` | A completed run contains flaky tests — use the flakiness-threshold filter to only hear about rates above N% |
+| `perf.regression` | A run is at least 20% slower than the median of the previous five completed runs on the same branch — raise the bar per subscription with the regression-% filter |
 | `diagnosis.completed` | An AI diagnosis finishes (requires an AI provider) |
 
 ## Channels
 
 ### Browser
 
-Sends native OS notifications to any open Piwi tab, even when the tab is in the background. No configuration needed — create a channel of type `browser` and subscribe to events. Notifications fire via the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API); grant permission when prompted.
+Sends native OS notifications to any open Piwi tab, even when the tab is in the background. Notifications fire via the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API); grant permission when prompted.
+
+- **With authentication**: create a channel of type `browser` in **Settings → Notifications** and subscribe it to events; the stream then delivers exactly the events and projects your subscriptions cover.
+- **Without authentication**: skip channels entirely — the **bell** on each project page stores per-browser preferences (a cookie) for which events raise notifications.
 
 Diagnosis completion notifications can be toggled on/off from the diagnosis panel without deleting the subscription.
-
-::: tip
-Browser notifications work without authentication. For email/Slack/webhook channels, [authentication must be enabled](./authentication).
-:::
 
 ### Email
 
@@ -81,7 +80,9 @@ The body is `{ "event": "run.failed", "payload": { … }, "timestamp": "…" }`.
 
 `cluster.new` payloads similarly carry `sampleErrorExcerpt` and `affectedCases`. These fields are **additive** — existing consumers keep working, but if you re-serialize the payload to re-check the HMAC, sign the exact bytes you received.
 
-Admins can mark a channel **global** so it is available to all users.
+### Global channels & subscriptions
+
+Admins can mark a channel **global** so it is available to all users, and mark a subscription **instance-wide** (from the project bell) so it delivers regardless of who is signed in — the way to route every failure to one team Slack channel. Global subscriptions must target a global channel. With authentication disabled, every channel and subscription is global.
 
 ## Subscriptions
 
@@ -91,20 +92,20 @@ A subscription controls *what* is delivered and *how*:
 - **Scope** — all projects, or a single project.
 - **Filters** — by branch, status, **owner** (deliver only when the run broke a test that team owns — see
   [Tags & ownership](./concepts#tags-ownership)), or a numeric threshold (e.g. only notify on flakiness above N%).
-- **Mode** — `realtime` (dispatched as events happen) or `digest` (batched, sent at a configured time). Browser channels only support `realtime`.
+- **Mode** — `realtime` (dispatched as events happen) or `digest` (held until the configured time, then sent as **one combined message** per email/Slack channel). Webhook and browser deliveries are always individual.
 - **Mute** — silence a subscription until a chosen time without deleting it.
 
 ## SMTP configuration
 
-Email channels and the account flows (verification, password reset, invites) need SMTP. These are set via environment variables only and shown read-only in **Settings → Notifications**:
+Email channels and the account flows (verification, password reset, invites) need SMTP. Slack, webhook and browser channels work without it. SMTP is set via environment variables only and shown read-only in **Settings → Notifications**; `PIWI_SMTP_HOST` and `PIWI_SMTP_FROM` are enough for a relay that accepts unauthenticated mail:
 
 ```bash
 PIWI_SMTP_HOST=smtp.example.com
 PIWI_SMTP_PORT=587            # default 587
-PIWI_SMTP_USER=apikey
-PIWI_SMTP_PASS=••••••••        # never returned by the API
 PIWI_SMTP_FROM=noreply@example.com
 PIWI_SMTP_FROM_NAME=Piwi Dashboard   # optional display name
+PIWI_SMTP_USER=apikey         # only when the server requires authentication
+PIWI_SMTP_PASS=••••••••        # only when the server requires authentication; never returned by the API
 PIWI_SMTP_SECURE=false        # true for port 465 (implicit TLS)
 PIWI_SITE_URL=https://piwi.example.com   # base URL used in email links
 ```
@@ -114,6 +115,6 @@ Send a test email from **Settings → Notifications** to confirm delivery.
 ## See also
 
 - [CI & sharding](./ci) — the alternative: pull the run URL into your pipeline instead
-- [Authentication](./authentication) — required for non-browser notifications
+- [Authentication](./authentication) — per-user channels and subscriptions
 - [Configuration reference](./configuration) — all environment variables
 - [AI diagnosis & failure clustering](./ai-diagnosis) — what triggers `cluster.new` and `diagnosis.completed`


### PR DESCRIPTION
## What & why

This change extends the notification system to support:

1. **Global channels & subscriptions** — Administrators can now create instance-wide notification channels and subscriptions (with `userId=null`) that apply to all users. Non-admin users can only manage their own personal channels/subscriptions.

2. **Browser notification channel type** — A new `browser` channel type enables in-app notifications via Server-Sent Events (SSE). Browser subscriptions are per-user when auth is enabled, or global when auth is disabled.

3. **Subscription delivery filters** — Subscriptions now support fine-grained filtering by branch, status, owner, flakiness threshold, and performance regression threshold. These filters are evaluated before delivery to reduce noise.

4. **Digest mode for channels** — Channels can now operate in digest mode (e.g., daily digest emails or Slack summaries) instead of real-time delivery, with configurable send times.

5. **Performance regression detection** — Run notifications now include performance regression analysis, comparing run duration against a baseline of prior runs on the same branch.

6. **Auth-optional notifications** — The notification system now works without authentication enabled. When auth is disabled, all channels and subscriptions are global (instance-wide), and the project bell uses cookie-based preferences instead of per-user subscriptions.

The changes maintain backward compatibility while making notifications more flexible and reducing alert fatigue through filtering and digest modes.

## How was it tested?

- Added comprehensive unit tests in `tests/unit/notification-match.test.ts` covering deduplication, filter matching, and baseline computation
- Extended E2E tests in `tests/notifications.spec.ts` to cover global channels, browser channels, and subscription management
- Added browser notification tests in `tests/browser-notifications.spec.ts` for cookie-mode and auth-enabled scenarios
- Existing notification dispatch and email rendering tests continue to pass
- Updated feature screenshot generation to include the new notifications settings UI

## Checklist

- [x] PR title follows Conventional Commits (`feat(notifications): ...`)
- [x] Tests added for new behavior (unit tests for filters/deduplication, E2E tests for global channels/browser subscriptions)
- [x] Docs updated (`apps/docs/notifications.md` clarifies auth-optional behavior and global subscriptions)

https://claude.ai/code/session_019azdqedf3JeT36Z8Y62UjV