### PR TITLE
fix(app): render the execution History tab from the SSR payload

### DIFF
--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -20,22 +20,15 @@ const router = useRouter();
 const testCaseId = route.params.id;
 
 const { data: testCase, refresh } = await useFetch(`/api/test-run-cases/${testCaseId}`);
-const historyData = ref<TestCaseHistoryPoint[]>([]);
-
-watch(
-  () => testCase.value?.testCaseId,
-  async (tcId) => {
-    if (tcId) {
-      try {
-        historyData.value = await $fetch<TestCaseHistoryPoint[]>(`/api/test-cases/${tcId}/history`);
-      } catch {
-        historyData.value = [];
-      }
-    } else {
-      historyData.value = [];
-    }
+// The rows ride in the SSR payload, so the server and the client agree on the
+// History tab's count and its table at hydration.
+const { data: historyData } = await useAsyncData(
+  `test-run-case-history-${testCaseId}`,
+  () => {
+    const tcId = testCase.value?.testCaseId;
+    return tcId ? $fetch<TestCaseHistoryPoint[]>(`/api/test-cases/${tcId}/history`) : Promise.resolve([]);
   },
-  { immediate: true },
+  { default: (): TestCaseHistoryPoint[] => [], watch: [() => testCase.value?.testCaseId] },
 );
 
 const { data: traceData, refresh: refreshTraces } = await useFetch<TraceInfo[]>(
@@ -1036,7 +1029,7 @@ provide(clusterSectionLocatorKey, {
 
         <!-- ── History ──────────────────────────────────────────────────── -->
         <template #tab-history>
-          <div class="space-y-4 pt-4">
+          <div class="space-y-4 pt-4" data-shot="execution-history">
             <div v-if="historyData && historyData.length > 0" class="space-y-4">
               <ChartCard title="Duration trend" icon="i-lucide-trending-up" :legend="legendOf(CASE_STATUS_SERIES)">
                 <template #actions>

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -320,6 +320,15 @@ const SCENES = [
 
   // ── Feature states (report artifacts) ─────────────────────────────────────
   {
+    name: 'execution-history',
+    description: 'Execution page opened straight onto its History tab (duration trend + executions)',
+    route: '/test-run-cases/229?tab=history',
+    viewport: { width: 1280, height: 1000 },
+    charts: true,
+    of: '[data-shot="execution-history"]',
+    pad: 12,
+  },
+  {
     name: 'run-trend',
     description: 'Test runs tab: per-run stacked result bars with day ticks and markers',
     route: '/projects/1',

--- a/apps/application/tests/test-run-case-page.spec.ts
+++ b/apps/application/tests/test-run-case-page.spec.ts
@@ -108,4 +108,28 @@ test.describe('Test-run-case page', () => {
     await waitForHydration(page);
     await expect(page.getByRole('tab', { name: 'Performance' })).toBeVisible();
   });
+
+  test('History tab opens populated from the SSR payload, without refetching or a hydration mismatch', async ({
+    page,
+  }) => {
+    // A client-side call to the history endpoint means the rows are missing from
+    // the payload, which is what tears the server and client renders apart.
+    const historyCalls: string[] = [];
+    page.on('request', (req) => {
+      if (/\/api\/test-cases\/\d+\/history/.test(req.url())) historyCalls.push(req.url());
+    });
+    // Vue only reports mismatches in a dev build; in a production run this stays empty.
+    const hydrationErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.text().includes('Hydration completed but contains mismatches')) hydrationErrors.push(msg.text());
+    });
+
+    await page.goto(`/test-run-cases/${failedCaseId}?tab=history`);
+    await waitForHydration(page);
+
+    await expect(page.getByRole('heading', { name: 'Duration trend' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /History \(\d+\)/ })).toBeVisible();
+    expect(historyCalls).toEqual([]);
+    expect(hydrationErrors).toEqual([]);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,56 +30,6 @@
         "node": ">=24.0.0"
       }
     },
-    "application": {
-      "name": "@piwitests/dashboard",
-      "version": "0.20.0",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.111.0",
-        "@aws-sdk/client-s3": "^3.1088.0",
-        "@emnapi/core": "1.11.2",
-        "@emnapi/runtime": "1.11.2",
-        "@iconify-json/lucide": "^1.2.117",
-        "@libsql/client": "^0.17.4",
-        "@nuxt/hints": "^1.0.0-alpha.5",
-        "@nuxt/test-utils": "^4.0.2",
-        "@nuxt/ui": "^4.10.0",
-        "@unovis/ts": "^1.6.7",
-        "@unovis/vue": "^1.6.7",
-        "@vite-pwa/nuxt": "^1.1.1",
-        "@vueuse/nuxt": "^14.1.0",
-        "date-fns": "^4.1.0",
-        "drizzle-orm": "^0.45.0",
-        "fflate": "^0.8.2",
-        "highlight.js": "^11.11.1",
-        "marked": "^17.0.6",
-        "nodemailer": "^9.0.3",
-        "nuxt": "^4.2.1",
-        "pixelmatch": "^7.2.0",
-        "postgres": "^3.4.9",
-        "sharp": "^0.35.3",
-        "sql.js": "^1.14.1",
-        "vue-virtual-scroller": "^3.0.4",
-        "zod": "^4.1.13"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.61.1",
-        "@types/nodemailer": "^8.0.1",
-        "@types/sql.js": "^1.4.11",
-        "cross-env": "^10.1.0",
-        "drizzle-kit": "^0.31.8",
-        "form-data": "^4.0.0",
-        "monocart-reporter": "^2.12.2",
-        "vue-tsc": "^3.3.7"
-      },
-      "engines": {
-        "node": ">=24.0.0"
-      },
-      "optionalDependencies": {
-        "@libsql/linux-x64-musl": "^0.5.29"
-      }
-    },
     "apps/application": {
       "name": "@piwitests/dashboard",
       "version": "0.25.0",
@@ -130,21 +80,6 @@
     "apps/extension": {
       "name": "@piwitests/extension",
       "version": "0.25.0",
-      "dependencies": {
-        "@piwitests/core": "*",
-        "@piwitests/picker-dom": "*"
-      },
-      "devDependencies": {
-        "@playwright/test": "^1.61.1",
-        "@types/chrome": "^0.1.43",
-        "archiver": "^7.0.1",
-        "vite": "^8.0.16"
-      }
-    },
-    "extension": {
-      "name": "@piwitests/extension",
-      "version": "0.20.0",
-      "extraneous": true,
       "dependencies": {
         "@piwitests/core": "*",
         "@piwitests/picker-dom": "*"
@@ -24934,26 +24869,6 @@
       },
       "engines": {
         "node": ">=24.0.0"
-      }
-    },
-    "reporter": {
-      "name": "@piwitests/reporter",
-      "version": "0.20.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "form-data": "^4.0.0"
-      },
-      "bin": {
-        "piwi": "dist/cli/index.js"
-      },
-      "devDependencies": {
-        "@piwitests/core": "*",
-        "@piwitests/picker-dom": "*",
-        "tsup": "^8.5.0"
-      },
-      "peerDependencies": {
-        "@playwright/test": "^1.61.1"
       }
     }
   }


### PR DESCRIPTION
## What & why

Opening `/test-run-cases/<id>?tab=history` directly showed an **empty History panel**, while the tab label counted the rows the server had already rendered.

The rows came from a bare `watch` + `$fetch`. That sits outside Nuxt's data flow: nothing awaits it into the render and its result is never serialized, so the server and the client resolved it independently. The server usually won that race and emitted the populated panel; the client always started at `[]` and hydrated an empty one:

```
[error] Hydration completed but contains mismatches.
[Vue warn] Hydration text mismatch
  - rendered on server: "History (20)"
  - expected on client: "History"
```

Vue then patched the label back to `History` and left the panel blank until the duplicate client fetch landed. Because it is a race, it does not reproduce on every load — a fast in-process API often lets the client win too, which is why it survived this long.

`useAsyncData` puts the rows in the payload: the panel is populated at first paint, the browser makes no second request for them, and both sides agree at hydration.

Scope was checked rather than assumed:

- The sibling `test-cases/[id].vue` already fetches its history with `await useFetch`, so this matches existing practice rather than introducing a pattern.
- The project page's Performance tab hits the same class of problem and already guards it with `if (import.meta.server) return` — `test-run-cases` was the remaining outlier.
- `/test-cases/1`, whose markers use the same `ref` + `watch` shape, reports **0** hydration warnings, so it was left alone.

Also included: `application`, `extension` and `reporter` sat in the lockfile as extraneous `0.20.0` entries left over from the layout that predates `apps/` and `packages/`. Nothing resolves through those paths, and `npm install` neither prunes them nor puts them back once removed — the diff is 85 deletions and nothing else.

## How was it tested?

- **New E2E** (`test-run-case-page.spec.ts`) opens the tab directly and asserts the panel is populated **and that the browser makes no client-side call to the history endpoint**. That assertion is the one that holds in a production build — Vue strips hydration-mismatch warnings from prod, and CI runs a production server, so a console-based assertion would have been silently vacuous there.
- **Confirmed the test fails without the fix** (panel renders empty) and passes with it.
- Measured before/after on a dev server: hydration warnings **8 → 0**, and the `/api/test-cases/1/history` request disappears from the browser's network log.
- Full suite green: 1443 unit tests, 41 E2E across `test-run-case-page`, `test-case-history` and `dashboard-ui`, plus typecheck, oxlint, oxfmt and `app:screens:check`.
- Lockfile change verified by re-running `npm install` (entries stay gone, nothing else changes) and `npm ls --workspaces`.
- New `execution-history` scene captures the fixed panel.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (no doc surface changes — a panel that was blank now renders as already documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GyV7T5eCHBCZSoPDonSJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_013GyV7T5eCHBCZSoPDonSJ4)_