### PR TITLE
fix(release): keep package-lock workspace versions in the release bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ toolchains (Tauri, VitePress) rather than through the root install, and `example
 `@piwitests/*` from the published npm registry — release-please bumps its pinned versions — so making it a workspace
 would symlink the local copies and defeat the example.
 
+**Adding a workspace takes two entries in [`release-please-config.json`](release-please-config.json)**, not one: its
+`package.json` `$.version`, *and* its `package-lock.json` `$.packages['<dir>'].version`. release-please natively bumps
+only the root package (and the lockfile's root entries); every other workspace is a plain JSON substitution it has no
+npm awareness of, so a missing lockfile entry leaves that workspace a release behind and makes `npm install` rewrite
+the lockfile on every checkout.
+
 `plans/` holds two tracked-by-hand files: `plans/roadmap.md` (working priorities) and `plans/exploration-findings.md`
 (a log of bugs, tech debt and inconsistencies found while exploring). Both are local-only. Public direction lives in the
 committed [`ROADMAP.md`](ROADMAP.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
     },
     "apps/application": {
       "name": "@piwitests/dashboard",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -131,7 +131,7 @@
     },
     "apps/extension": {
       "name": "@piwitests/extension",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@piwitests/core": "*",
         "@piwitests/picker-dom": "*"
@@ -160,7 +160,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation-nitro",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -26417,11 +26417,11 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.23.0"
+      "version": "0.24.0"
     },
     "packages/picker-dom": {
       "name": "@piwitests/picker-dom",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@piwitests/core": "*"
       },
@@ -26431,7 +26431,7 @@
     },
     "packages/reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -26450,7 +26450,7 @@
     },
     "packages/server": {
       "name": "@piwitests/server",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.17.4",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,7 +33,14 @@
         {
           "type": "generic",
           "path": "integrations/aspnetcore/PiwiTests.Instrumentation.AspNetCore/PiwiTests.Instrumentation.AspNetCore.csproj"
-        }
+        },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/core'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/picker-dom'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/server'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['packages/reporter'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['apps/application'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['apps/extension'].version" },
+        { "type": "json", "path": "package-lock.json", "jsonpath": "$.packages['integrations/nitro'].version" }
       ]
     }
   }


### PR DESCRIPTION
release-please natively bumps the root package and the lockfile's root entries, but every other workspace is reached through `extra-files` — plain JSON substitutions it has no npm awareness of. So each workspace's `package.json` moved to the new version while its `package-lock.json` entry stayed on the old one, leaving the lockfile a release behind and making `npm install` rewrite it on every fresh checkout.

Adds the seven `$.packages['<dir>'].version` paths to `extra-files` and syncs the entries that had already drifted to 0.23.0. Verified by applying the config's json updaters with release-please's own jsonpath library and then running `npm install --package-lock-only`: it has nothing left to change, so what a release writes is what npm would write.

Noted in AGENTS.md next to the workspaces list, since a new workspace needs an entry in both places and only one of them is obvious.


Claude-Session: https://claude.ai/code/session_01GbDFjFcFjWSxZYRPJA6abE

<!--
Thanks for contributing! Two things to know:

1. PRs are squash-merged, so the PR TITLE becomes the commit on main and drives
   the release changelog. Give it a Conventional Commit title, e.g.
   `feat(reporter): support custom run labels` — see CONTRIBUTING.md.
2. For non-trivial changes, consider opening an issue/discussion first.
-->

## What & why

<!-- What does this change do, and what problem does it solve?
     Link related issues: Fixes #123 -->

## How was it tested?

<!-- Unit tests / E2E tests / manual steps. `npm test` runs the full suite. -->

## Checklist

- [ ] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (`apps/docs/`, README, or reporter README)
