### PR TITLE
fix(app): stop double-counting flaky tests in test runs bar graph

### DIFF
--- a/apps/application/app/components/project/TestRunsChart.vue
+++ b/apps/application/app/components/project/TestRunsChart.vue
@@ -31,16 +31,24 @@ const chartData = computed(() => {
     .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())
     .slice(-30);
 
-  return sortedRuns.map((run) => ({
-    id: run.id,
-    date: new Date(run.startTime),
-    passed: run.passedTests || 0,
-    failed: run.failedTests || 0,
-    skipped: run.skippedTests || 0,
-    flaky: run.flakyTests || 0,
-    total: run.totalTests || 0,
-    status: run.status,
-  }));
+  return sortedRuns.map((run) => {
+    const flaky = run.flakyTests || 0;
+    const passed = run.passedTests || 0;
+    return {
+      id: run.id,
+      date: new Date(run.startTime),
+      // Flaky tests are counted as a subset of passed by the reporter (they
+      // passed on retry), so carve them out of the passed segment. Stacking
+      // flaky on top of the full passed count would double-count them and
+      // inflate the bar past the run's real total.
+      passed: Math.max(0, passed - flaky),
+      failed: run.failedTests || 0,
+      skipped: run.skippedTests || 0,
+      flaky,
+      total: run.totalTests || 0,
+      status: run.status,
+    };
+  });
 });
 
 type DataPoint = (typeof chartData)['value'][number];


### PR DESCRIPTION
Flaky tests are recorded by the reporter as a subset of passed (they
passed on retry), yet TestRunsChart stacked the flaky segment on top of
the full passed count. This counted flaky runs twice and inflated each
bar past the run's real total.

Carve flaky out of the passed segment so the stack reflects the true
total, mirroring the existing convention in TestStatusBar.vue.