### PR TITLE
fix(app): lower the dashboard Node floor to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,13 @@ jobs:
         # exactly; a sixth pushes four jobs into a queue that costs more than
         # the extra parallelism buys.
         shard: [1, 2, 3, 4, 5]
+        # The sqlite/local leg runs on Node 22 — the dashboard's engines floor —
+        # against the Node 24-built output, the same combination an npm user on
+        # LTS gets. The other legs run current Node (24, the default below).
+        include:
+          - storage: local
+            database: sqlite
+            node: 22
 
     env:
       # Keep in step with the shard list above.
@@ -236,7 +243,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: ${{ matrix.node || 24 }}
           cache: npm
           cache-dependency-path: ./package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Five ways in, depending on what you already have:
 | **[Live demo](https://piwitests.github.io/demo/)** | You just want to look around first | Nothing — seeded data, runs entirely in your browser |
 | **[Desktop app](https://piwitests.github.io/desktop)** | You run Playwright locally and don't want to run a server | Download an installer — no Docker, no Node |
 | **Docker** *(below)* | You have Docker, or you're setting up a shared instance | One command |
-| **`npx @piwitests/server`** | You have Node.js 24+ and would rather skip Docker | One command |
+| **`npx @piwitests/server`** | You have Node.js 22+ and would rather skip Docker | One command |
 | **[One-click deploy](https://piwitests.github.io/deployment#one-click-deploy)** | You want a shared instance and no server to run it on | A button, plus whatever your host charges |
 
 Two caveats worth knowing before you pick. The **desktop installers are not yet code-signed**, so the
@@ -100,7 +100,7 @@ docker run -p 3000:3000 -v ${PWD}/.data:/app/.data phenx/piwitests-server:latest
 ```
 
 Visit `http://localhost:3000`. A [`docker-compose.yml`](./docker-compose.yml) is included, and with
-**Node.js 24+** you can skip Docker entirely — `npx @piwitests/server` creates its `.data/` in the
+**Node.js 22+** you can skip Docker entirely — `npx @piwitests/server` creates its `.data/` in the
 current directory.
 
 > **Linux hosts:** the container runs as non-root UID 1001, so without the `chown` above, Docker
@@ -155,7 +155,7 @@ metadata and `--shard` merging are detected automatically. See
 
 It's one Node process: **~300 MB RAM idle** (1 GB comfortable), **1 vCPU**, `linux/amd64` or
 `linux/arm64`. Disk is the variable — traces and reports dominate, so budget roughly 50–200 MB per run
-and set a retention window. Your test project only needs a Node version Playwright supports; Node 24 is
+and set a retention window. Your test project only needs a Node version Playwright supports; Node 22 is
 the *dashboard's* requirement.
 
 ## Before you expose it

--- a/apps/application/package.json
+++ b/apps/application/package.json
@@ -83,6 +83,6 @@
     "@libsql/linux-x64-musl": "^0.5.29"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   }
 }

--- a/apps/docs/comparison.md
+++ b/apps/docs/comparison.md
@@ -57,9 +57,9 @@ Only if you turn it on, and only to the provider *you* configure. The diagnosis 
 
 Start with SQLite — it's zero-config and easily handles a team's test volume. Switch to PostgreSQL (`PIWI_DATABASE_URL`) when you want concurrent write headroom, an existing backup story, or your ops standard is Postgres. Both backends are exercised by the project's CI on every commit.
 
-### Why does the dashboard require Node 24?
+### Which Node version does the dashboard need?
 
-The dashboard server targets current Node (the Docker image ships it, so this only matters when running from source). The **reporter** that runs inside your test project is much less demanding — Node 20+, the version it is built for and declares in its `engines` — so your test suite's runtime almost certainly doesn't need to change.
+**Node 22 or newer**, and only for the `npx` / from-source paths — the Docker image and the desktop app bundle their own runtime. CI runs the E2E suite on Node 22 against the published build, so the floor is tested, not aspirational. The **reporter** that runs inside your test project is much less demanding — Node 20+, the version it is built for and declares in its `engines` — so your test suite's runtime almost certainly doesn't need to change.
 
 ### Can I use it with Cypress / Jest / other frameworks?
 

--- a/apps/docs/deployment.md
+++ b/apps/docs/deployment.md
@@ -357,7 +357,7 @@ spec:
 
 For a quick local run without Docker, the server is published to npm as
 [`@piwitests/server`](https://www.npmjs.com/package/@piwitests/server). It bundles the
-prebuilt server and needs only **Node.js 24+**:
+prebuilt server and needs only **Node.js 22+**:
 
 ```bash
 npx @piwitests/server

--- a/apps/docs/getting-started.md
+++ b/apps/docs/getting-started.md
@@ -29,7 +29,7 @@ The dashboard is one Node process, and there are five ways to get one running:
 | [Live demo](https://piwitests.github.io/demo/) | Looking around before installing anything | Seeded data, runs in your browser, no backend |
 | [Desktop app](./desktop) | A single developer running Playwright locally | No Docker or Node needed; Windows x64 and Apple-silicon macOS only, and the installers are not yet signed |
 | Docker *(below)* | A shared instance for a team | The recommended path for anything long-lived |
-| [`npx @piwitests/server`](./deployment#npm-npx-quick-local-run) | A quick local run with Node 24+ already installed | Same server, no container |
+| [`npx @piwitests/server`](./deployment#npm-npx-quick-local-run) | A quick local run with Node 22+ already installed | Same server, no container |
 | [One-click deploy](./deployment#one-click-deploy) | A shared instance with no server of your own | Railway, Render, Fly.io, Koyeb, Coolify or Dokploy — a button, plus whatever the host charges |
 
 If you only want your own history, flaky scores and locator healing on a laptop, the
@@ -45,11 +45,11 @@ Only the dashboard side has requirements — and only for some paths:
 |---|---|
 | Desktop app | Nothing; the runtime is bundled |
 | Docker | Docker; ~300 MB RAM, 1 vCPU, `linux/amd64` or `linux/arm64` |
-| `npx` / from source | **Node.js 24+** and npm |
+| `npx` / from source | **Node.js 22+** and npm |
 | PostgreSQL backend *(optional)* | PostgreSQL 14+ — otherwise SQLite is built in and needs no setup |
 
 Your **test project** is unaffected by all of this: it just needs a Node version Playwright supports.
-Node 24 is the dashboard's requirement, not your suite's.
+Node 22 is the dashboard's requirement, not your suite's.
 
 ## Quick start with Docker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "vue-tsc": "^3.3.7"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@libsql/linux-x64-musl": "^0.5.29"
@@ -24879,7 +24879,7 @@
         "piwi-server": "bin/piwi-server.mjs"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=22.0.0"
       }
     }
   }

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -298,7 +298,7 @@ addition:
 
 ## Requirements
 
-- Node.js 18 or higher (the reporter runs inside your test project — the dashboard *server* itself targets Node 24+, or use its Docker image)
+- Node.js 18 or higher (the reporter runs inside your test project — the dashboard *server* itself targets Node 22+, or use its Docker image)
 - Playwright Test 1.40 or higher
 - Running Piwi Dashboard server
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## What & why

Lowers the dashboard's `engines.node` floor from `>=24.0.0` to `>=22.0.0` (`apps/application` and `packages/server`), so `npx @piwitests/server` and from-source runs work for users on the widely deployed Node 22 maintenance LTS. The reporter's floor (`>=20`) is unchanged.

The 24 floor was a "targets current Node" policy rather than a technical need:

- No Node-24-only APIs in the source (`RegExp.escape`, `Float16Array`, `node:sqlite`, `Promise.try`, `fs.glob`, `using` declarations — all absent).
- No dependency declares `engines` excluding Node 22.
- The docs FAQ claimed no API constraint, only policy.

To keep the floor honest, the CI E2E matrix now runs its sqlite/local leg on Node 22 against the Node 24-built output — the exact combination an npm user on LTS gets. Job count stays at 20, so nothing queues. Runtimes the project ships (Docker image, desktop sidecar, publish workflows) stay on Node 24.

User-facing docs updated: README (3 mentions), getting-started (3), deployment (1), reporter README (1), and the comparison FAQ entry reworded to state the tested floor.

## How was it tested?

- Full Playwright E2E suite on Node 22.22.2 against the production build (`CI=true`, sqlite/local leg): **569 passed, 0 failed, 30 skipped** (the pg/s3-conditional specs) in 3.6m.
- Production server boot on Node 22 via `npx @piwitests/server`: starts, runs SQLite migrations, serves.
- Unit suite on Node 22: 1443/1443 pass. Builds (app, demo, docs, reporter) all succeed on Node 22.
- `ci.yml` parses; commitlint clean on all three commits.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (CI now covers the Node 22 floor)
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TV6N9C1avA4wapbgLXFSxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TV6N9C1avA4wapbgLXFSxZ)_