### PR TITLE
feat(auth): harden auth rate limiting and polish the first-admin setup flow

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,11 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 ## Recently shipped
 
+- **First-admin setup from the browser** — with authentication enabled on a fresh instance, the login page walks you
+  through creating the administrator account and signs you in; `POST /api/auth/setup` stays for scripted provisioning.
+- **Auth rate limiting** — login, initial setup and password-reset endpoints are throttled per client address (failed
+  logins also per account), throttled responses carry `Retry-After`, and `PIWI_TRUST_PROXY` keys the limits on the real
+  client address behind a reverse proxy.
 - **Distinct timed-out and interrupted run statuses** — the reporter keeps Playwright's `timedout` and `interrupted` run outcomes instead of folding them into `failed`, so a run the CI killed and a run that blew its budget read differently in the run list and analytics (all non-`passed` statuses still count as failing where it matters).
 - **Fail on flaky** — `failOnFlakyTests` reporter option (forwarded to Playwright 1.52+'s native option, or `PIWI_FAIL_ON_FLAKY_TESTS`) fails the run locally when any test passed only on a retry; `piwi gate --fail-on-flaky` does the same against the dashboard's recorded flaky count.
 - **Per-attempt outcomes** — the reporter records every attempt's status, duration and start time; a retried execution shows one chip per attempt on its detail page, and the history views carry the same data.
@@ -54,8 +59,6 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 ## Next
 
-- **First-admin setup UI** — create the initial admin from the browser when auth is enabled (today it's one `POST /api/auth/setup` call).
-- **Login rate limiting** — extend the existing throttling (currently on password reset) to login and setup endpoints.
 - **1.0 stabilization** — settle the wire format and API surface, then commit to semver stability.
 
 ## Exploring

--- a/apps/application/app/middleware/auth.global.ts
+++ b/apps/application/app/middleware/auth.global.ts
@@ -1,8 +1,11 @@
 import { Role } from '#shared/types';
 
+// Pages that must work without a session: signing in, and the account-recovery
+// pages reached from emailed links.
+const PUBLIC_PATHS = ['/login', '/forgot-password', '/reset-password'];
+
 export default defineNuxtRouteMiddleware(async (to) => {
-  // Skip auth check for login page
-  if (to.path === '/login') {
+  if (PUBLIC_PATHS.includes(to.path)) {
     return;
   }
 

--- a/apps/application/app/pages/login.vue
+++ b/apps/application/app/pages/login.vue
@@ -44,6 +44,16 @@ async function handleSetup() {
     setupError.value = 'Please choose a username and password';
     return;
   }
+  // Mirror the server's validation rules so their violations read as field
+  // hints instead of a generic "Invalid request body" error.
+  if (setupState.username.length < 3) {
+    setupError.value = 'Username must be at least 3 characters';
+    return;
+  }
+  if (setupState.password.length < 8) {
+    setupError.value = 'Password must be at least 8 characters';
+    return;
+  }
   if (setupState.password !== setupState.confirmPassword) {
     setupError.value = 'Passwords do not match';
     return;
@@ -183,7 +193,7 @@ definePageMeta({
           <UInput
             v-model="setupState.password"
             type="password"
-            placeholder="Choose a password"
+            placeholder="Choose a password (min. 8 characters)"
             autocomplete="new-password"
             :disabled="setupLoading"
             class="w-full"

--- a/apps/application/app/pages/settings/users.vue
+++ b/apps/application/app/pages/settings/users.vue
@@ -44,7 +44,7 @@ const isAddUserModalOpen = ref(false);
 const addUserSchema = z.object({
   username: z.string().min(3, 'Username must be at least 3 characters'),
   password: z
-    .union([z.string().min(6, 'Password must be at least 6 characters'), z.literal('').transform(() => undefined)])
+    .union([z.string().min(8, 'Password must be at least 8 characters'), z.literal('').transform(() => undefined)])
     .optional(),
   role: z.enum(['administrator', 'reporter', 'user']),
   name: z.string().optional(),

--- a/apps/application/nuxt.config.ts
+++ b/apps/application/nuxt.config.ts
@@ -275,8 +275,9 @@ export default defineNuxtConfig({
             sessionCookie: {
               type: 'apiKey',
               in: 'cookie',
-              name: 'nuxt_session',
-              description: 'Session cookie authentication. Set via POST /api/auth/login.',
+              // h3's sealed-session cookie keeps its default name.
+              name: 'h3',
+              description: 'Session cookie authentication (sealed session cookie). Set via POST /api/auth/login.',
             },
           },
         },

--- a/apps/application/server/api/auth/forgot-password.post.ts
+++ b/apps/application/server/api/auth/forgot-password.post.ts
@@ -3,7 +3,7 @@ import { getDatabase } from '../../database';
 import { users } from '../../database/schema';
 import { mintAccountToken } from '../../utils/account-tokens';
 import { isEmailConfigured, sendEmail, renderPasswordResetEmail } from '../../utils/email';
-import { checkRateLimit } from '../../utils/rate-limit';
+import { checkRateLimit, rateLimitClientIp, rateLimitedError } from '../../utils/rate-limit';
 import { z } from 'zod';
 
 defineRouteMeta({
@@ -20,9 +20,9 @@ defineRouteMeta({
 const schema = z.object({ email: z.string().email() });
 
 export default eventHandler(async (event) => {
-  const ip = getRequestIP(event) ?? 'unknown';
-  if (!checkRateLimit(`forgot:${ip}`, 5, 15 * 60 * 1000)) {
-    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
+  const rateKey = `forgot:${rateLimitClientIp(event)}`;
+  if (!checkRateLimit(rateKey, 5, 15 * 60 * 1000)) {
+    throw rateLimitedError(event, [rateKey]);
   }
 
   const body = await readBody(event);

--- a/apps/application/server/api/auth/login.post.ts
+++ b/apps/application/server/api/auth/login.post.ts
@@ -1,6 +1,12 @@
 import { Role } from '#shared/types';
 import { verifyUser, setUserSession, isAuthEnabled } from '../../utils/auth';
-import { isRateLimited, recordRateLimitHit, resetRateLimit } from '../../utils/rate-limit';
+import {
+  isRateLimited,
+  rateLimitClientIp,
+  rateLimitedError,
+  recordRateLimitHit,
+  resetRateLimit,
+} from '../../utils/rate-limit';
 import { z } from 'zod';
 
 const WINDOW_MS = 15 * 60 * 1000;
@@ -41,14 +47,13 @@ export default eventHandler(async (event) => {
 
   const { username, password } = validation.data;
 
-  const ip = getRequestIP(event) ?? 'unknown';
-  const ipKey = `login:ip:${ip}`;
+  const ipKey = `login:ip:${rateLimitClientIp(event)}`;
   const accountKey = `login:user:${username.toLowerCase()}`;
   // Throttle repeated failures — per source and per account — so credentials
   // can't be brute-forced online. Only failed attempts count; a valid login
   // clears the account's counter.
   if (isRateLimited(ipKey, 20) || isRateLimited(accountKey, 5)) {
-    throw createError({ statusCode: 429, message: 'Too many failed attempts. Please wait before trying again.' });
+    throw rateLimitedError(event, [ipKey, accountKey], 'Too many failed attempts. Please wait before trying again.');
   }
 
   const user = await verifyUser(username, password);

--- a/apps/application/server/api/auth/reset-password.post.ts
+++ b/apps/application/server/api/auth/reset-password.post.ts
@@ -4,7 +4,7 @@ import { users } from '../../database/schema';
 import { validateAccountToken, consumeAccountToken } from '../../utils/account-tokens';
 import { hashPassword, revokeUserSessions } from '../../utils/auth';
 import { clearUserSession } from '../../utils/auth';
-import { checkRateLimit } from '../../utils/rate-limit';
+import { checkRateLimit, rateLimitClientIp, rateLimitedError } from '../../utils/rate-limit';
 import { z } from 'zod';
 
 defineRouteMeta({
@@ -23,9 +23,9 @@ const schema = z.object({
 });
 
 export default eventHandler(async (event) => {
-  const ip = getRequestIP(event) ?? 'unknown';
-  if (!checkRateLimit(`reset:${ip}`, 10, 15 * 60 * 1000)) {
-    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
+  const rateKey = `reset:${rateLimitClientIp(event)}`;
+  if (!checkRateLimit(rateKey, 10, 15 * 60 * 1000)) {
+    throw rateLimitedError(event, [rateKey]);
   }
 
   const body = await readBody(event);

--- a/apps/application/server/api/auth/send-verify-email.post.ts
+++ b/apps/application/server/api/auth/send-verify-email.post.ts
@@ -2,7 +2,7 @@ import { getDatabase } from '../../database';
 import { requireAuth } from '../../utils/auth';
 import { mintAccountToken } from '../../utils/account-tokens';
 import { isEmailConfigured, sendEmail, renderVerifyEmail } from '../../utils/email';
-import { checkRateLimit } from '../../utils/rate-limit';
+import { checkRateLimit, rateLimitedError } from '../../utils/rate-limit';
 
 defineRouteMeta({
   openAPI: {
@@ -20,7 +20,7 @@ export default eventHandler(async (event) => {
 
   // Bound how often a user can trigger verification emails.
   if (!checkRateLimit(`verify-email:${user.id}`, 5, 15 * 60 * 1000)) {
-    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
+    throw rateLimitedError(event, [`verify-email:${user.id}`]);
   }
 
   const db = await getDatabase();

--- a/apps/application/server/api/auth/setup.post.ts
+++ b/apps/application/server/api/auth/setup.post.ts
@@ -1,6 +1,6 @@
 import { Role } from '#shared/types';
 import { createUser, isAuthEnabled, needsInitialSetup, claimInitialSetup, releaseInitialSetup } from '../../utils/auth';
-import { checkRateLimit } from '../../utils/rate-limit';
+import { checkRateLimit, rateLimitClientIp, rateLimitedError } from '../../utils/rate-limit';
 import { z } from 'zod';
 
 defineRouteMeta({
@@ -28,9 +28,9 @@ export default eventHandler(async (event) => {
     });
   }
 
-  const ip = getRequestIP(event) ?? 'unknown';
-  if (!checkRateLimit(`setup:${ip}`, 5, 15 * 60 * 1000)) {
-    throw createError({ statusCode: 429, message: 'Too many requests. Please wait before trying again.' });
+  const rateKey = `setup:${rateLimitClientIp(event)}`;
+  if (!checkRateLimit(rateKey, 5, 15 * 60 * 1000)) {
+    throw rateLimitedError(event, [rateKey]);
   }
 
   if (!(await needsInitialSetup())) {

--- a/apps/application/server/api/users/index.post.ts
+++ b/apps/application/server/api/users/index.post.ts
@@ -17,7 +17,7 @@ defineRouteMeta({
 
 const createUserSchema = z.object({
   username: z.string().min(3),
-  password: z.string().min(6).optional(),
+  password: z.string().min(8).optional(),
   role: z.nativeEnum(Role),
   name: z.string().optional(),
   email: z.string().email().optional().or(z.literal('')),

--- a/apps/application/server/utils/rate-limit.ts
+++ b/apps/application/server/utils/rate-limit.ts
@@ -1,3 +1,6 @@
+import type { H3Event } from 'h3';
+import { createError, getRequestHeader, getRequestIP, setResponseHeader } from 'h3';
+
 const store = new Map<string, { count: number; resetAt: number }>();
 
 /**
@@ -39,4 +42,44 @@ export function recordRateLimitHit(key: string, windowMs: number): void {
 /** Clear a key's counter (e.g. after a success), so it no longer counts toward a lockout. */
 export function resetRateLimit(key: string): void {
   store.delete(key);
+}
+
+/** Seconds until `key`'s current window expires — 0 when no window is active. */
+export function rateLimitResetSeconds(key: string): number {
+  const entry = store.get(key);
+  if (!entry) return 0;
+  return Math.max(0, Math.ceil((entry.resetAt - Date.now()) / 1000));
+}
+
+/**
+ * 429 error carrying a `Retry-After` header derived from the longest-lived
+ * window among `keys` (at least 1 second, so clients always get a usable hint).
+ */
+export function rateLimitedError(
+  event: H3Event,
+  keys: string[],
+  message = 'Too many requests. Please wait before trying again.',
+) {
+  const retryAfter = Math.max(1, ...keys.map(rateLimitResetSeconds));
+  setResponseHeader(event, 'Retry-After', retryAfter);
+  return createError({ statusCode: 429, message });
+}
+
+/**
+ * Client address used in rate-limit keys.
+ *
+ * By default this is the socket peer address, which behind a reverse proxy is
+ * the proxy itself — every client then shares one bucket. `PIWI_TRUST_PROXY=true`
+ * switches to the last `X-Forwarded-For` entry (the one appended by the proxy in
+ * front of Piwi, which clients cannot forge). Only set it when such a proxy is
+ * actually in front of the server: trusted, the header is client-controlled on
+ * direct connections, which would let a caller pick its own bucket.
+ */
+export function rateLimitClientIp(event: H3Event): string {
+  if (process.env.PIWI_TRUST_PROXY === 'true') {
+    const forwarded = getRequestHeader(event, 'x-forwarded-for');
+    const lastHop = forwarded?.split(',').at(-1)?.trim();
+    if (lastHop) return lastHop;
+  }
+  return getRequestIP(event) ?? 'unknown';
 }

--- a/apps/application/shared/piwi-env-vars.ts
+++ b/apps/application/shared/piwi-env-vars.ts
@@ -378,6 +378,14 @@ export const PIWI_ENV_VARS = {
     requiredWhen: { PIWI_AUTH_ENABLED: 'true' },
     notes: 'The server refuses to start when auth is enabled and this is unset.',
   },
+  PIWI_TRUST_PROXY: {
+    description:
+      'Set to "true" when a reverse proxy sits in front of Piwi, so per-IP rate limits on the auth endpoints key on the client address your proxy appends to X-Forwarded-For instead of on the proxy\'s own address (which would pool every client into one bucket). Leave off when clients connect directly: the header is client-controlled then, and trusting it would let a caller choose its own bucket.',
+    category: 'auth',
+    type: 'boolean',
+    default: 'false',
+    since: '0.26.0',
+  },
 
   // ── OAuth ────────────────────────────────────────────────────────────────
   PIWI_OAUTH_GOOGLE_CLIENT_ID: {

--- a/apps/application/tests/reporter-with-auth.spec.ts
+++ b/apps/application/tests/reporter-with-auth.spec.ts
@@ -46,13 +46,13 @@ test.describe.serial('Reporter with authentication enabled', () => {
 
   test.beforeAll(() => {
     // Clean up test database and storage before running, in case of retries from a previous run
-    safeRmSync(DB_PATH);
+    for (const path of [DB_PATH, `${DB_PATH}-wal`, `${DB_PATH}-shm`]) safeRmSync(path);
     safeRmSync(STORAGE_PATH, { recursive: true, force: true });
   });
 
   test.afterAll(() => {
     // Clean up test database and storage created by the auth server
-    safeRmSync(DB_PATH);
+    for (const path of [DB_PATH, `${DB_PATH}-wal`, `${DB_PATH}-shm`]) safeRmSync(path);
     safeRmSync(STORAGE_PATH, { recursive: true, force: true });
   });
 
@@ -70,22 +70,23 @@ test.describe.serial('Reporter with authentication enabled', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Initial setup
+  // Initial setup — the login page swaps to a first-admin form while the users
+  // table is empty, and creating the admin signs them straight in.
   // ---------------------------------------------------------------------------
 
-  test('should create admin user via setup endpoint', async ({ request }) => {
-    const res = await request.post(`${AUTH_SERVER_URL}/api/auth/setup`, {
-      data: {
-        username: 'admin',
-        password: 'adminpassword123',
-        name: 'Administrator',
-      },
-    });
-    expect(res.ok()).toBeTruthy();
-    const data = await res.json();
-    expect(data.success).toBe(true);
-    expect(data.user.username).toBe('admin');
-    expect(data.user.role).toBe('administrator');
+  test('first-admin setup form creates the admin from the browser', async ({ page }) => {
+    await page.goto(`${AUTH_SERVER_URL}/login`);
+    await expect(page.getByRole('heading', { name: 'Create the first admin account' })).toBeVisible();
+
+    await page.getByRole('textbox', { name: 'Username*' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Administrator');
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('adminpassword123');
+    await page.getByRole('textbox', { name: 'Confirm password*' }).fill('adminpassword123');
+    await page.getByRole('button', { name: 'Create admin account' }).click();
+
+    // Setup logs the new admin in and lands on the dashboard.
+    await expect(page.getByText('Admin account created', { exact: true })).toBeVisible();
+    await page.waitForURL(`${AUTH_SERVER_URL}/`);
   });
 
   test('setup endpoint should reject a second call once users exist', async ({ request }) => {
@@ -93,6 +94,31 @@ test.describe.serial('Reporter with authentication enabled', () => {
       data: { username: 'admin2', password: 'password123' },
     });
     expect(res.status()).toBe(400);
+  });
+
+  test('login form rejects a wrong password, then signs in with the right one', async ({ page }) => {
+    await page.goto(`${AUTH_SERVER_URL}/login`);
+    // With the admin created, the page shows the login card, not the setup card.
+    await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+
+    await page.getByRole('textbox', { name: 'Username*' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('wrongpassword');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page.getByText('Invalid username or password').first()).toBeVisible();
+
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('adminpassword123');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL(`${AUTH_SERVER_URL}/`);
+  });
+
+  test('password-recovery pages are reachable without a session', async ({ page }) => {
+    await page.goto(`${AUTH_SERVER_URL}/forgot-password`);
+    await expect(page.getByRole('heading', { name: 'Forgot password' })).toBeVisible();
+    await expect(page).toHaveURL(`${AUTH_SERVER_URL}/forgot-password`);
+
+    await page.goto(`${AUTH_SERVER_URL}/reset-password`);
+    await expect(page.getByRole('heading', { name: 'Reset your password' })).toBeVisible();
+    await expect(page).toHaveURL(`${AUTH_SERVER_URL}/reset-password`);
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/application/tests/unit/rate-limit.test.ts
+++ b/apps/application/tests/unit/rate-limit.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { H3Event } from 'h3';
+import {
+  checkRateLimit,
+  isRateLimited,
+  recordRateLimitHit,
+  resetRateLimit,
+  rateLimitResetSeconds,
+  rateLimitedError,
+  rateLimitClientIp,
+} from '../../server/utils/rate-limit';
+
+const WINDOW_MS = 15 * 60 * 1000;
+
+/** Minimal H3Event carrying just what the helpers under test read. */
+function fakeEvent(opts: { remoteAddress?: string; forwardedFor?: string } = {}) {
+  const headers: Record<string, string> = {};
+  if (opts.forwardedFor) headers['x-forwarded-for'] = opts.forwardedFor;
+  const setHeader = vi.fn();
+  const event = {
+    context: {},
+    node: {
+      req: { headers, socket: { remoteAddress: opts.remoteAddress } },
+      res: { setHeader },
+    },
+  } as unknown as H3Event;
+  return { event, setHeader };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe('checkRateLimit', () => {
+  test('allows up to the limit within a window, then blocks', () => {
+    for (let i = 0; i < 3; i++) {
+      expect(checkRateLimit('check:basic', 3, WINDOW_MS)).toBe(true);
+    }
+    expect(checkRateLimit('check:basic', 3, WINDOW_MS)).toBe(false);
+  });
+
+  test('starts a fresh window once the previous one expires', () => {
+    expect(checkRateLimit('check:expiry', 1, WINDOW_MS)).toBe(true);
+    expect(checkRateLimit('check:expiry', 1, WINDOW_MS)).toBe(false);
+    vi.advanceTimersByTime(WINDOW_MS + 1);
+    expect(checkRateLimit('check:expiry', 1, WINDOW_MS)).toBe(true);
+  });
+});
+
+describe('isRateLimited', () => {
+  test('peeks without counting', () => {
+    recordRateLimitHit('peek:key', WINDOW_MS);
+    expect(isRateLimited('peek:key', 2)).toBe(false);
+    expect(isRateLimited('peek:key', 2)).toBe(false);
+    recordRateLimitHit('peek:key', WINDOW_MS);
+    expect(isRateLimited('peek:key', 2)).toBe(true);
+  });
+
+  test('an expired window no longer limits', () => {
+    recordRateLimitHit('peek:expired', WINDOW_MS);
+    expect(isRateLimited('peek:expired', 1)).toBe(true);
+    vi.advanceTimersByTime(WINDOW_MS + 1);
+    expect(isRateLimited('peek:expired', 1)).toBe(false);
+  });
+});
+
+describe('recordRateLimitHit / resetRateLimit', () => {
+  test('reset clears the counter', () => {
+    recordRateLimitHit('reset:key', WINDOW_MS);
+    expect(isRateLimited('reset:key', 1)).toBe(true);
+    resetRateLimit('reset:key');
+    expect(isRateLimited('reset:key', 1)).toBe(false);
+  });
+});
+
+describe('rateLimitResetSeconds', () => {
+  test('is 0 with no active window', () => {
+    expect(rateLimitResetSeconds('seconds:none')).toBe(0);
+  });
+
+  test('reports the remaining window, rounded up, and counts down', () => {
+    recordRateLimitHit('seconds:live', WINDOW_MS);
+    expect(rateLimitResetSeconds('seconds:live')).toBe(WINDOW_MS / 1000);
+    vi.advanceTimersByTime(WINDOW_MS / 3);
+    expect(rateLimitResetSeconds('seconds:live')).toBe(600);
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(rateLimitResetSeconds('seconds:live')).toBe(0);
+  });
+});
+
+describe('rateLimitedError', () => {
+  test('is a 429 with a Retry-After header from the longest-lived window', () => {
+    recordRateLimitHit('err:short', 60 * 1000);
+    recordRateLimitHit('err:long', 300 * 1000);
+    const { event, setHeader } = fakeEvent();
+    const error = rateLimitedError(event, ['err:short', 'err:long']);
+    expect(error.statusCode).toBe(429);
+    expect(error.message).toBe('Too many requests. Please wait before trying again.');
+    expect(setHeader).toHaveBeenCalledWith('Retry-After', 300);
+  });
+
+  test('sends at least 1 second even when no window is active', () => {
+    const { event, setHeader } = fakeEvent();
+    const error = rateLimitedError(event, ['err:missing'], 'Too many failed attempts.');
+    expect(error.statusCode).toBe(429);
+    expect(error.message).toBe('Too many failed attempts.');
+    expect(setHeader).toHaveBeenCalledWith('Retry-After', 1);
+  });
+});
+
+describe('rateLimitClientIp', () => {
+  test('uses the socket address by default, even when X-Forwarded-For is present', () => {
+    const { event } = fakeEvent({ remoteAddress: '203.0.113.9', forwardedFor: '198.51.100.7' });
+    expect(rateLimitClientIp(event)).toBe('203.0.113.9');
+  });
+
+  test('falls back to "unknown" without an address', () => {
+    const { event } = fakeEvent();
+    expect(rateLimitClientIp(event)).toBe('unknown');
+  });
+
+  test('with PIWI_TRUST_PROXY, uses the last X-Forwarded-For entry', () => {
+    vi.stubEnv('PIWI_TRUST_PROXY', 'true');
+    const { event } = fakeEvent({
+      remoteAddress: '127.0.0.1',
+      forwardedFor: '198.51.100.7, 192.0.2.1 , 10.0.0.3',
+    });
+    expect(rateLimitClientIp(event)).toBe('10.0.0.3');
+  });
+
+  test('with PIWI_TRUST_PROXY but no header, falls back to the socket address', () => {
+    vi.stubEnv('PIWI_TRUST_PROXY', 'true');
+    const { event } = fakeEvent({ remoteAddress: '203.0.113.9' });
+    expect(rateLimitClientIp(event)).toBe('203.0.113.9');
+  });
+});

--- a/apps/docs/authentication.md
+++ b/apps/docs/authentication.md
@@ -48,7 +48,9 @@ Administrators always see everything. **Reporter** and **User** accounts are add
 
 ## Initial setup
 
-When authentication is first enabled and no users exist, create the first administrator account:
+When authentication is enabled and no users exist yet, opening the dashboard lands on the login page, which shows a **Create the first admin account** form in place of the sign-in form. Fill it in and you are signed in as the administrator — no API call needed.
+
+For provisioning an instance from a script, the same step is available as an API call:
 
 ::: code-group
 
@@ -70,7 +72,7 @@ Invoke-RestMethod -Method Post -Uri http://localhost:3000/api/auth/setup `
 
 :::
 
-This endpoint is only available when the users table is empty.
+Both routes go through `POST /api/auth/setup`, which is only available while the users table is empty and is rate-limited per client address.
 
 ## Logging in
 
@@ -204,8 +206,7 @@ Both edit the same underlying assignments, so use whichever is more convenient.
 
 When authentication is enabled:
 
-- `POST` / `PUT` / `DELETE` endpoints require an active session with appropriate role permissions.
-- `GET` endpoints remain publicly accessible (read-only), **except** `GET /api/users`, which requires an authenticated session so the user list (usernames and roles) is not exposed to anonymous callers.
+- Every endpoint requires an authenticated caller — a session cookie or an API key — with the role the endpoint declares (listed per endpoint in the [API docs](/docs)). The exceptions are `GET /api/health`, `GET /api/version`, the auth flows themselves (login, initial setup, password reset, email verification, OAuth), and the live-run streaming endpoints, which authenticate with per-run stream tokens instead.
 - The reporter's submission endpoints (`/api/test-runs/submit` and `/api/test-runs/upload`) accept both session cookies and API keys.
 
 ## API keys
@@ -316,6 +317,7 @@ The reporter automatically calls `/api/auth/login` before each upload and uses t
 - Set `PIWI_SECRET_KEY` (generate with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`, or `openssl rand -hex 32`) to encrypt AI API keys and SCM tokens at rest in the database. This is recommended even when authentication is disabled.
 - Set `PIWI_AUTH_SECRET` (same generator) for session cookie encryption — required when `PIWI_AUTH_ENABLED=true`.
 - Passwords are hashed using scrypt with per-password salts.
+- Login, initial setup, and password-reset endpoints are rate-limited per client address — failed logins also per account — and throttled requests get a `429` with a `Retry-After` header. Behind a reverse proxy, set `PIWI_TRUST_PROXY` so those per-address limits see real client addresses; see the [configuration reference](./configuration#authentication).
 - Never use the default secrets in production.
 
 ## Disabling authentication

--- a/apps/docs/deployment.md
+++ b/apps/docs/deployment.md
@@ -210,8 +210,9 @@ and TLS are wired up automatically.
   that caps request size below that will fail ingest.
 - **Check that responses aren't buffered.** Live runs and browser notifications use long-lived
   `text/event-stream` responses.
-- **Finish the auth setup.** These templates set `PIWI_AUTH_ENABLED=true`, so create the first admin via
-  `POST /api/auth/setup` — see [Authentication](/authentication) — before sharing the URL.
+- **Finish the auth setup.** These templates set `PIWI_AUTH_ENABLED=true`, so the first visit shows a
+  **Create the first admin account** form — complete it before sharing the URL (or provision the admin via
+  `POST /api/auth/setup`, see [Authentication](/authentication)).
 - **Pin a version.** The templates track `latest`. Pin a tag before you depend on the instance, and read
   [Upgrading](./upgrading) first: migrations are forward-only.
 
@@ -440,7 +441,7 @@ server {
 }
 ```
 
-When auth is enabled, set `PIWI_SITE_URL` to the public HTTPS URL so email links and OAuth callbacks point at the right origin.
+When auth is enabled, set `PIWI_SITE_URL` to the public HTTPS URL so email links and OAuth callbacks point at the right origin, and set `PIWI_TRUST_PROXY=true` so the per-address rate limits on the auth endpoints key on the client address your proxy appends to `X-Forwarded-For` instead of on the proxy's own address — see the [configuration reference](./configuration#authentication).
 
 ## Backups
 


### PR DESCRIPTION
## What & why

The two auth items in ROADMAP's "Next" — first-admin setup UI and login rate limiting — turned out to be **already shipped** (the login page has carried the setup form, and login/setup throttling landed with the fail-closed-secrets work). What was genuinely missing is the hardening and polish around them; this PR closes those gaps and syncs the roadmap:

**Rate limiting**
- Throttled 429s on login, setup, password reset and verification email now carry a **`Retry-After` header** derived from the active window.
- New **`PIWI_TRUST_PROXY`** env var (registered in the typed registry, default off): behind a reverse proxy the per-address limits key on the last `X-Forwarded-For` entry — the one appended by your proxy — instead of the proxy's own address, which pooled every client into a single bucket. The docs' own nginx example (`$proxy_add_x_forwarded_for`) appends, so last-entry is the spoof-safe choice for one trusted hop.
- First unit tests for `rate-limit.ts` (windows, peeks, failure counting, `Retry-After` derivation, client-address resolution).

**First-run & recovery flow**
- `/forgot-password` and `/reset-password` were missing from the auth middleware's public paths, so **emailed reset links bounced to `/login`** when signed out (contradicting ARCHITECTURE.md, which calls the three pages public). Fixed.
- The setup form now states the 8-character password minimum in the placeholder and pre-checks it (and the username minimum) client-side — previously a short password surfaced as a raw "Invalid request body".
- Admin-created users now share the same 8-character minimum as setup/reset/change-password (was 6 — the one inconsistent site).
- The OpenAPI `sessionCookie` scheme claimed the cookie is `nuxt_session`; the server actually sets h3's default `h3` cookie. The reference now documents reality (whether to *rename* the cookie pre-1.0 is left as a stabilization decision).
- ROADMAP: both items move to "Recently shipped" with what actually shipped.
- Docs: `authentication.md` describes the browser-first setup (curl stays as the scripted path) and corrects the stale claim that GET endpoints are publicly accessible when auth is on; `deployment.md` points template users at the setup form and documents `PIWI_TRUST_PROXY` in the reverse-proxy section.

## How was it tested?

- `npm run app:typecheck`, `app:lint`, `app:format:check` clean.
- Unit: full suite passes (1456 tests, including 13 new for `rate-limit.ts`; `piwi-env-vars` drift test covers the new var).
- E2E: `reporter-with-auth.spec.ts` now **drives the setup and login forms in a real browser** — the first-admin form creates the admin and signs in, wrong-password shows the error, and the recovery pages stay reachable signed out (that last test fails without the middleware fix). Full auth suite run locally in CI mode against the production build: **33/33 passed**.
- Manually booted an auth-enabled empty-DB production build and screenshotted the setup form.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK6JDbdXGszeFx22QqJw11)_