### PR TITLE
feat(app): public share links for executions and failure clusters

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,10 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 ## Recently shipped
 
+- **Public share links (opt-in)** — a read-only URL for one execution or one failure cluster that anyone can open
+  without an account: the offline-export report rendered live at view time, bounded by the same size budgets,
+  revocable, and off unless `PIWI_SHARE_LINKS_ENABLED` is set. Design record in
+  [proposals/public-share-links.md](proposals/public-share-links.md).
 - **First-admin setup from the browser** — with authentication enabled on a fresh instance, the login page walks you
   through creating the administrator account and signs you in; `POST /api/auth/setup` stays for scripted provisioning.
 - **Auth rate limiting** — login, initial setup and password-reset endpoints are throttled per client address (failed
@@ -65,9 +69,6 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 - **Exporting whole runs** — [offline export](https://piwitests.github.io/offline-export) covers one execution and one failure cluster today; a whole run, and a
   test's history across runs, would follow the same shape.
-- **Public share links** — handing an investigation to someone without a dashboard account means sending them a file; a
-  read-only link would need share tokens, which Piwi has no infrastructure for today. A concrete design is proposed in
-  [proposals/public-share-links.md](proposals/public-share-links.md).
 - **Self-sufficient trace archives** — an export can carry the trace files, but reading them still needs a Playwright
   trace viewer. Bundling the viewer's assets would close that gap, at roughly 10 MB per export.
 - More backend-log instrumentation packages beyond ASP.NET Core and Nitro.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,8 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 - **Exporting whole runs** — [offline export](https://piwitests.github.io/offline-export) covers one execution and one failure cluster today; a whole run, and a
   test's history across runs, would follow the same shape.
 - **Public share links** — handing an investigation to someone without a dashboard account means sending them a file; a
-  read-only link would need share tokens, which Piwi has no infrastructure for today.
+  read-only link would need share tokens, which Piwi has no infrastructure for today. A concrete design is proposed in
+  [proposals/public-share-links.md](proposals/public-share-links.md).
 - **Self-sufficient trace archives** — an export can carry the trace files, but reading them still needs a Playwright
   trace viewer. Bundling the viewer's assets would close that gap, at roughly 10 MB per export.
 - More backend-log instrumentation packages beyond ASP.NET Core and Nitro.

--- a/apps/application/app/components/shared/ShareLinksModal.vue
+++ b/apps/application/app/components/shared/ShareLinksModal.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { Role } from '#shared/types';
+
+interface ShareLinkSummary {
+  id: number;
+  tokenPrefix: string;
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  lastViewedAt: string | null;
+  viewCount: number;
+}
+
+const props = defineProps<{
+  /** API path the mint/list endpoints live at, e.g. `/api/failure-clusters/12/share-links`. */
+  endpoint: string;
+}>();
+
+const toast = useToast();
+const { copy } = useCopy();
+const { hasRole } = useAuth();
+const config = useRuntimeConfig();
+
+const open = ref(false);
+const settings = ref<{ enabled: boolean; maxTtlDays: number } | null>(null);
+const links = ref<ShareLinkSummary[]>([]);
+const loading = ref(false);
+const minting = ref(false);
+const mintedUrl = ref<string | null>(null);
+
+// UI affordance only — the server enforces roles from each route's meta.
+const canManage = computed(() => !config.public.authEnabled || hasRole([Role.ADMINISTRATOR, Role.REPORTER]));
+
+const ttlDays = ref<number | undefined>(undefined);
+const ttlOptions = computed(() => {
+  const max = settings.value?.maxTtlDays ?? 30;
+  const presets = [1, 7, 30, 90, 365].filter((days) => max === 0 || days <= max);
+  const options = presets.map((days) => ({ label: days === 1 ? '1 day' : `${days} days`, value: days }));
+  if (max === 0) options.push({ label: 'No expiry', value: 0 });
+  else if (!presets.includes(max)) options.push({ label: `${max} days`, value: max });
+  return options;
+});
+
+watch(open, async (isOpen) => {
+  if (!isOpen) {
+    mintedUrl.value = null;
+    return;
+  }
+  loading.value = true;
+  try {
+    const [settingsData, listData] = await Promise.all([
+      $fetch<{ enabled: boolean; maxTtlDays: number }>('/api/share-links/settings'),
+      $fetch<{ shareLinks: ShareLinkSummary[] }>(props.endpoint),
+    ]);
+    settings.value = settingsData;
+    links.value = listData.shareLinks;
+    ttlDays.value ??= settingsData.maxTtlDays === 0 ? 0 : Math.min(30, settingsData.maxTtlDays);
+  } catch (error) {
+    toast.add({ title: 'Could not load share links', description: errorMessage(error), color: 'error' });
+  } finally {
+    loading.value = false;
+  }
+});
+
+async function mint() {
+  minting.value = true;
+  try {
+    const result = await $fetch<{ url: string }>(props.endpoint, {
+      method: 'POST',
+      body: { ttlDays: ttlDays.value === 0 ? null : ttlDays.value },
+    });
+    mintedUrl.value = result.url;
+    const listData = await $fetch<{ shareLinks: ShareLinkSummary[] }>(props.endpoint);
+    links.value = listData.shareLinks;
+  } catch (error) {
+    toast.add({ title: 'Could not create the share link', description: errorMessage(error), color: 'error' });
+  } finally {
+    minting.value = false;
+  }
+}
+
+async function revoke(link: ShareLinkSummary) {
+  try {
+    await $fetch(`/api/share-links/${link.id}`, { method: 'DELETE' });
+    toast.add({
+      title: 'Share link revoked',
+      description: `psl_${link.tokenPrefix}… no longer resolves.`,
+      color: 'success',
+    });
+    const listData = await $fetch<{ shareLinks: ShareLinkSummary[] }>(props.endpoint);
+    links.value = listData.shareLinks;
+  } catch (error) {
+    toast.add({ title: 'Could not revoke the link', description: errorMessage(error), color: 'error' });
+  }
+}
+
+function copyMinted() {
+  copy(mintedUrl.value, { toast: 'Share link copied to clipboard' });
+}
+
+function linkState(link: ShareLinkSummary): { label: string; color: 'success' | 'neutral' | 'warning' } {
+  if (link.revokedAt) return { label: 'Revoked', color: 'neutral' };
+  if (link.expiresAt && new Date(link.expiresAt).getTime() <= Date.now()) return { label: 'Expired', color: 'neutral' };
+  if (link.expiresAt) return { label: `Expires ${formatRelativeTime(link.expiresAt)}`, color: 'success' };
+  return { label: 'No expiry', color: 'warning' };
+}
+</script>
+
+<template>
+  <UButton
+    icon="i-lucide-link"
+    size="xs"
+    color="neutral"
+    variant="outline"
+    title="Hand this investigation to someone without an account"
+    @click="open = true"
+  >
+    Share
+  </UButton>
+
+  <UModal v-model:open="open" title="Share links" description="Read-only links anyone can open — no account needed.">
+    <template #body>
+      <LoadingState v-if="loading" text="Loading share links…" />
+
+      <div v-else class="space-y-4">
+        <UAlert
+          v-if="settings && !settings.enabled"
+          color="info"
+          variant="subtle"
+          icon="i-lucide-info"
+          title="Share links are disabled on this instance"
+          description="Set PIWI_SHARE_LINKS_ENABLED=true to allow minting them. Existing links stay stored but resolve to 404 while disabled."
+        />
+
+        <template v-else>
+          <UAlert
+            v-if="mintedUrl"
+            color="success"
+            variant="subtle"
+            icon="i-lucide-check"
+            title="Link created — copy it now"
+            description="For safety, the full link is shown only once. Anyone holding it can view this investigation until it expires or is revoked."
+          />
+          <div v-if="mintedUrl" class="flex gap-2">
+            <UInput :model-value="mintedUrl" readonly class="flex-1 font-mono" size="sm" />
+            <UButton icon="i-lucide-copy" size="sm" color="neutral" variant="outline" @click="copyMinted">Copy</UButton>
+          </div>
+
+          <div v-else-if="canManage" class="flex items-end gap-2">
+            <UFormField label="Expires after" class="flex-1">
+              <USelect v-model="ttlDays" :items="ttlOptions" value-key="value" size="sm" class="w-full" />
+            </UFormField>
+            <UButton icon="i-lucide-plus" size="sm" :loading="minting" @click="mint">Create link</UButton>
+          </div>
+        </template>
+
+        <div v-if="links.length > 0" class="space-y-1.5">
+          <p class="text-xs font-medium text-gray-500">Existing links</p>
+          <div
+            v-for="link in links"
+            :key="link.id"
+            class="flex items-center gap-2 rounded-md border border-default px-2.5 py-1.5 text-sm"
+          >
+            <code class="text-xs">psl_{{ link.tokenPrefix }}…</code>
+            <UBadge :color="linkState(link).color" variant="subtle" size="sm">{{ linkState(link).label }}</UBadge>
+            <span class="text-xs text-muted ml-auto" :title="link.lastViewedAt ?? undefined">
+              {{ link.viewCount }} {{ link.viewCount === 1 ? 'view' : 'views' }}
+            </span>
+            <UButton
+              v-if="canManage && !link.revokedAt"
+              icon="i-lucide-ban"
+              size="xs"
+              color="error"
+              variant="ghost"
+              title="Revoke — the link stops resolving immediately"
+              @click="revoke(link)"
+            />
+          </div>
+        </div>
+        <EmptyState v-else-if="settings?.enabled" text="No share links yet for this page." />
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/apps/application/app/pages/failure-clusters/[id].vue
+++ b/apps/application/app/pages/failure-clusters/[id].vue
@@ -194,6 +194,7 @@ const breadcrumbItems = computed(() => [
           <BreadcrumbNav :items="breadcrumbItems" />
         </template>
         <template #right>
+          <ShareLinksModal v-if="cluster" :endpoint="`/api/failure-clusters/${cluster.id}/share-links`" />
           <ExportMenu
             v-if="cluster"
             :endpoint="`/api/failure-clusters/${cluster.id}/export`"

--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -501,6 +501,7 @@ provide(clusterSectionLocatorKey, {
             <UIcon name="i-lucide-trending-up" class="size-3.5" />
             <span class="hidden sm:inline">Evolution</span>
           </NuxtLink>
+          <ShareLinksModal v-if="testCase" :endpoint="`/api/test-run-cases/${testCase.id}/share-links`" />
           <ExportMenu
             v-if="testCase"
             :endpoint="`/api/test-run-cases/${testCase.id}/export`"

--- a/apps/application/playwright.config.ts
+++ b/apps/application/playwright.config.ts
@@ -17,6 +17,10 @@ const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE?.trim() ||
 // channel flows the suite exercises can save.
 process.env.PIWI_SECRET_KEY ||= 'test-encryption-secret-key-not-for-production';
 
+// Share links are off by default; the suite exercises minting and the public
+// share route, so every test server opts in (inherited via process.env).
+process.env.PIWI_SHARE_LINKS_ENABLED = 'true';
+
 // `PIWI_AUTH_*` is resolved into `runtimeConfig` when the Nuxt config is
 // evaluated, which for a production build is build time. Nitro maps the
 // `NUXT_`-prefixed forms onto the same keys at startup, so auth-enabled servers

--- a/apps/application/scripts/check-demo-routes.mjs
+++ b/apps/application/scripts/check-demo-routes.mjs
@@ -35,6 +35,16 @@ const INTENTIONALLY_EXCLUDED = new Set([
   'POST /api/desktop/import-local', // desktop build only; reads local files, 404 everywhere else
   'POST /api/projects/:id/test-functions/extract', // AI code-to-pattern extraction — unlike diagnosis (a fixed, curated set of seeded clusters a scripted response can convincingly cover), this takes arbitrary pasted code with no server or real LLM to analyze it against in the demo; the "Paste from code (AI)" section is hidden client-side in demo mode instead of faking an understanding of whatever the visitor pastes
   'POST /api/ai/step-resolution', // AI-step authoring — resolves an arbitrary page snapshot against a natural-language prompt; no server or real LLM in the demo, and the reporter only calls it in resolve/heal mode (never a normal run), so there is nothing to script
+  // Share links: capability tokens for anonymous viewers. The demo has no
+  // accounts and its data is already public, so there is nothing to share —
+  // and no server to resolve a token against.
+  'POST /api/test-run-cases/:id/share-links',
+  'GET /api/test-run-cases/:id/share-links',
+  'POST /api/failure-clusters/:id/share-links',
+  'GET /api/failure-clusters/:id/share-links',
+  'DELETE /api/share-links/:id',
+  'GET /api/share-links/settings',
+  'GET /api/projects/:id/share-links',
 ]);
 
 // ── Derive all server routes from the file system ────────────────────────

--- a/apps/application/server/api/failure-clusters/[id]/share-links.get.ts
+++ b/apps/application/server/api/failure-clusters/[id]/share-links.get.ts
@@ -1,0 +1,18 @@
+import { requireResolvedProjectAccess, requireRouteId, resolveClusterProjectId } from '../../../utils/project-access';
+import { listEntityShareLinks } from '../../../utils/share-links';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Failure Clusters'],
+    summary: 'List share links for a failure cluster',
+    description: 'Returns the share links minted for this cluster — prefixes and lifecycle only, never the tokens.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'failure cluster ID');
+  const { db } = await requireResolvedProjectAccess(event, id, resolveClusterProjectId, 'Failure cluster');
+  return { shareLinks: await listEntityShareLinks(db, 'cluster', id) };
+});

--- a/apps/application/server/api/failure-clusters/[id]/share-links.post.ts
+++ b/apps/application/server/api/failure-clusters/[id]/share-links.post.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { requireResolvedProjectAccess, requireRouteId, resolveClusterProjectId } from '../../../utils/project-access';
+import { mintShareLink, resolveShareLinkMaxTtlDays, shareLinksEnabled } from '../../../utils/share-links';
+import { resolvePublicBaseUrl } from '../../../utils/oauth-helpers';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Failure Clusters'],
+    summary: 'Create a share link for a failure cluster',
+    description:
+      'Mints a read-only public link for this cluster. The full token is returned once and stored only as a hash. Requires PIWI_SHARE_LINKS_ENABLED=true.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter'],
+  },
+});
+
+const bodySchema = z.object({ ttlDays: z.number().int().min(1).max(3650).nullish() });
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'failure cluster ID');
+  const { db, projectId, user } = await requireResolvedProjectAccess(
+    event,
+    id,
+    resolveClusterProjectId,
+    'Failure cluster',
+  );
+
+  if (!shareLinksEnabled()) {
+    throw createError({
+      statusCode: 403,
+      message: 'Share links are disabled. Set PIWI_SHARE_LINKS_ENABLED=true to allow them.',
+    });
+  }
+
+  const validation = bodySchema.safeParse((await readBody(event).catch(() => null)) ?? {});
+  if (!validation.success) {
+    throw createError({ statusCode: 400, message: 'Invalid request body', data: validation.error.issues });
+  }
+
+  const minted = await mintShareLink(db, {
+    projectId,
+    entityKind: 'cluster',
+    entityId: id,
+    createdBy: user.id || null,
+    ttlDays: validation.data.ttlDays,
+  });
+
+  const siteUrl = (useRuntimeConfig(event).public as { siteUrl?: string })?.siteUrl;
+  const requestUrl = getRequestURL(event);
+  const base = resolvePublicBaseUrl(siteUrl, `${requestUrl.protocol}//${requestUrl.host}`);
+
+  return {
+    token: minted.token,
+    url: `${base}/share/${minted.token}`,
+    maxTtlDays: resolveShareLinkMaxTtlDays(),
+    link: {
+      id: minted.link.id,
+      tokenPrefix: minted.link.tokenPrefix,
+      expiresAt: minted.link.expiresAt,
+      createdAt: minted.link.createdAt,
+    },
+  };
+});

--- a/apps/application/server/api/projects/[id]/share-links.get.ts
+++ b/apps/application/server/api/projects/[id]/share-links.get.ts
@@ -1,0 +1,21 @@
+import { requireProjectAccess, requireRouteId } from '../../../utils/project-access';
+import { listProjectShareLinks } from '../../../utils/share-links';
+import { getDatabase } from '../../../database';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Share Links'],
+    summary: 'List every share link in a project',
+    description:
+      'All share links minted for entities of this project — prefixes and lifecycle only, never the tokens. The audit view of what is publicly reachable right now.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const projectId = requireRouteId(event, 'id', 'project ID');
+  await requireProjectAccess(event, projectId);
+  const db = await getDatabase();
+  return { shareLinks: await listProjectShareLinks(db, projectId) };
+});

--- a/apps/application/server/api/share-links/[id].delete.ts
+++ b/apps/application/server/api/share-links/[id].delete.ts
@@ -1,0 +1,25 @@
+import { requireProjectAccess, requireRouteId } from '../../utils/project-access';
+import { getShareLink, revokeShareLink } from '../../utils/share-links';
+import { getDatabase } from '../../database';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Share Links'],
+    summary: 'Revoke a share link',
+    description: 'Revokes a share link immediately. The row is kept for the audit trail.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'share link ID');
+  const db = await getDatabase();
+  const link = await getShareLink(db, id);
+  if (!link) {
+    throw createError({ statusCode: 404, message: 'Share link not found' });
+  }
+  await requireProjectAccess(event, link.projectId);
+  await revokeShareLink(db, id);
+  return { success: true };
+});

--- a/apps/application/server/api/share-links/settings.get.ts
+++ b/apps/application/server/api/share-links/settings.get.ts
@@ -1,0 +1,17 @@
+import { requireAuth } from '../../utils/auth';
+import { resolveShareLinkMaxTtlDays, shareLinksEnabled } from '../../utils/share-links';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Share Links'],
+    summary: 'Share-link settings',
+    description:
+      'Whether share links are enabled on this instance, and the longest allowed link lifetime in days (0 = links may be minted without an expiry).',
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  await requireAuth(event);
+  return { enabled: shareLinksEnabled(), maxTtlDays: resolveShareLinkMaxTtlDays() };
+});

--- a/apps/application/server/api/test-run-cases/[id]/share-links.get.ts
+++ b/apps/application/server/api/test-run-cases/[id]/share-links.get.ts
@@ -1,0 +1,22 @@
+import {
+  requireResolvedProjectAccess,
+  requireRouteId,
+  resolveTestRunCaseProjectId,
+} from '../../../utils/project-access';
+import { listEntityShareLinks } from '../../../utils/share-links';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Run Cases'],
+    summary: 'List share links for one execution',
+    description: 'Returns the share links minted for this execution — prefixes and lifecycle only, never the tokens.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'test run case ID');
+  const { db } = await requireResolvedProjectAccess(event, id, resolveTestRunCaseProjectId, 'Test run case');
+  return { shareLinks: await listEntityShareLinks(db, 'execution', id) };
+});

--- a/apps/application/server/api/test-run-cases/[id]/share-links.post.ts
+++ b/apps/application/server/api/test-run-cases/[id]/share-links.post.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import {
+  requireResolvedProjectAccess,
+  requireRouteId,
+  resolveTestRunCaseProjectId,
+} from '../../../utils/project-access';
+import { mintShareLink, resolveShareLinkMaxTtlDays, shareLinksEnabled } from '../../../utils/share-links';
+import { resolvePublicBaseUrl } from '../../../utils/oauth-helpers';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Run Cases'],
+    summary: 'Create a share link for one execution',
+    description:
+      'Mints a read-only public link for this execution. The full token is returned once and stored only as a hash. Requires PIWI_SHARE_LINKS_ENABLED=true.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter'],
+  },
+});
+
+const bodySchema = z.object({ ttlDays: z.number().int().min(1).max(3650).nullish() });
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'test run case ID');
+  const { db, projectId, user } = await requireResolvedProjectAccess(
+    event,
+    id,
+    resolveTestRunCaseProjectId,
+    'Test run case',
+  );
+
+  if (!shareLinksEnabled()) {
+    throw createError({
+      statusCode: 403,
+      message: 'Share links are disabled. Set PIWI_SHARE_LINKS_ENABLED=true to allow them.',
+    });
+  }
+
+  const validation = bodySchema.safeParse((await readBody(event).catch(() => null)) ?? {});
+  if (!validation.success) {
+    throw createError({ statusCode: 400, message: 'Invalid request body', data: validation.error.issues });
+  }
+
+  const minted = await mintShareLink(db, {
+    projectId,
+    entityKind: 'execution',
+    entityId: id,
+    createdBy: user.id || null,
+    ttlDays: validation.data.ttlDays,
+  });
+
+  const siteUrl = (useRuntimeConfig(event).public as { siteUrl?: string })?.siteUrl;
+  const requestUrl = getRequestURL(event);
+  const base = resolvePublicBaseUrl(siteUrl, `${requestUrl.protocol}//${requestUrl.host}`);
+
+  return {
+    token: minted.token,
+    url: `${base}/share/${minted.token}`,
+    maxTtlDays: resolveShareLinkMaxTtlDays(),
+    link: {
+      id: minted.link.id,
+      tokenPrefix: minted.link.tokenPrefix,
+      expiresAt: minted.link.expiresAt,
+      createdAt: minted.link.createdAt,
+    },
+  };
+});

--- a/apps/application/server/database/migrations-pg/0049_plain_preak.sql
+++ b/apps/application/server/database/migrations-pg/0049_plain_preak.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "share_links" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"project_id" integer NOT NULL,
+	"entity_kind" text NOT NULL,
+	"entity_id" integer NOT NULL,
+	"token_hash" text NOT NULL,
+	"token_prefix" text NOT NULL,
+	"created_by" integer,
+	"created_at" timestamp NOT NULL,
+	"expires_at" timestamp,
+	"revoked_at" timestamp,
+	"last_viewed_at" timestamp,
+	"view_count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "share_links_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "share_links" ADD CONSTRAINT "share_links_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "share_links" ADD CONSTRAINT "share_links_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_share_links_project_id" ON "share_links" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "idx_share_links_entity" ON "share_links" USING btree ("entity_kind","entity_id");--> statement-breakpoint
+CREATE INDEX "idx_share_links_created_by" ON "share_links" USING btree ("created_by");

--- a/apps/application/server/database/migrations-pg/meta/0049_snapshot.json
+++ b/apps/application/server/database/migrations-pg/meta/0049_snapshot.json
@@ -1,0 +1,4667 @@
+{
+  "id": "f72006c9-eb2c-451b-af67-467ac1b2b1d6",
+  "prevId": "8f809089-13d1-4774-994d-e2a6372cfd68",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_tokens": {
+      "name": "account_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_account_tokens_hash": {
+          "name": "idx_account_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_user": {
+          "name": "idx_account_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_tokens_user_id_users_id_fk": {
+          "name": "account_tokens_user_id_users_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_payloads": {
+      "name": "case_payloads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_case_payloads_project_hash": {
+          "name": "idx_case_payloads_project_hash",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_payloads_project_id_projects_id_fk": {
+          "name": "case_payloads_project_id_projects_id_fk",
+          "tableFrom": "case_payloads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_merge_suggestions": {
+      "name": "cluster_merge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_a_id": {
+          "name": "cluster_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_b_id": {
+          "name": "cluster_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "llm_confidence": {
+          "name": "llm_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_reason": {
+          "name": "llm_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_cluster_merge_suggestions_pair": {
+          "name": "idx_cluster_merge_suggestions_pair",
+          "columns": [
+            {
+              "expression": "cluster_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cluster_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cluster_merge_suggestions_project_status": {
+          "name": "idx_cluster_merge_suggestions_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cluster_merge_suggestions_cluster_b": {
+          "name": "idx_cluster_merge_suggestions_cluster_b",
+          "columns": [
+            {
+              "expression": "cluster_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cluster_merge_suggestions_project_id_projects_id_fk": {
+          "name": "cluster_merge_suggestions_project_id_projects_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_links": {
+      "name": "entity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generic'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_text": {
+          "name": "status_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unfurled_at": {
+          "name": "unfurled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_entity_links_run": {
+          "name": "idx_entity_links_run",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entity_links_case_run": {
+          "name": "idx_entity_links_case_run",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entity_links_case": {
+          "name": "idx_entity_links_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entity_links_created_by": {
+          "name": "idx_entity_links_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_links_test_run_id_test_runs_id_fk": {
+          "name": "entity_links_test_run_id_test_runs_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "entity_links_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_case_id_test_cases_id_fk": {
+          "name": "entity_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_created_by_users_id_fk": {
+          "name": "entity_links_created_by_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_cluster_aliases": {
+      "name": "failure_cluster_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_failure_cluster_aliases_project_fingerprint": {
+          "name": "idx_failure_cluster_aliases_project_fingerprint",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_cluster_aliases_cluster": {
+          "name": "idx_failure_cluster_aliases_cluster",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_cluster_aliases_project_id_projects_id_fk": {
+          "name": "failure_cluster_aliases_project_id_projects_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_cluster_aliases_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_cluster_aliases_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_clusters": {
+      "name": "failure_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sample_error": {
+          "name": "sample_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_run_id": {
+          "name": "first_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "triage_note": {
+          "name": "triage_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_base_commit": {
+          "name": "manual_base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_landed_run_id": {
+          "name": "fix_landed_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_landed_at": {
+          "name": "fix_landed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_commit": {
+          "name": "fix_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_resolution_ms": {
+          "name": "time_to_resolution_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fix_verification": {
+          "name": "fix_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_failure_clusters_project_fingerprint": {
+          "name": "idx_failure_clusters_project_fingerprint",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_clusters_project_last_seen": {
+          "name": "idx_failure_clusters_project_last_seen",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_clusters_project_status": {
+          "name": "idx_failure_clusters_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_clusters_project_id_projects_id_fk": {
+          "name": "failure_clusters_project_id_projects_id_fk",
+          "tableFrom": "failure_clusters",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_diagnoses": {
+      "name": "failure_diagnoses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_failure_diagnoses_cluster_scope": {
+          "name": "idx_failure_diagnoses_cluster_scope",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_failure_diagnoses_execution": {
+          "name": "idx_failure_diagnoses_execution",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnoses_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnoses_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failure_diagnosis_versions": {
+      "name": "failure_diagnosis_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_fdv_diagnosis_id": {
+          "name": "idx_fdv_diagnosis_id",
+          "columns": [
+            {
+              "expression": "diagnosis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fdv_cluster_id": {
+          "name": "idx_fdv_cluster_id",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fdv_test_runs_case": {
+          "name": "idx_fdv_test_runs_case",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk": {
+          "name": "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_diagnoses",
+          "columnsFrom": ["diagnosis_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_id": {
+          "name": "blob_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_files_test_run_id": {
+          "name": "idx_files_test_run_id",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_test_runs_case_id": {
+          "name": "idx_files_test_runs_case_id",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_files_blob_id": {
+          "name": "idx_files_blob_id",
+          "columns": [
+            {
+              "expression": "blob_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_test_run_id_test_runs_id_fk": {
+          "name": "files_test_run_id_test_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "files_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_blob_id_trace_blobs_id_fk": {
+          "name": "files_blob_id_trace_blobs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "trace_blobs",
+          "columnsFrom": ["blob_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locator_snapshots": {
+      "name": "locator_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_method": {
+          "name": "used_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_args": {
+          "name": "used_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_args_fp": {
+          "name": "used_args_fp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_tag": {
+          "name": "element_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element_attrs": {
+          "name": "element_attrs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_text": {
+          "name": "element_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_locator_snapshots_location": {
+          "name": "idx_locator_snapshots_location",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locator_snapshots_fp": {
+          "name": "idx_locator_snapshots_fp",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_args_fp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locator_snapshots_last_seen_run": {
+          "name": "idx_locator_snapshots_last_seen_run",
+          "columns": [
+            {
+              "expression": "last_seen_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locator_snapshots_args_fp": {
+          "name": "idx_locator_snapshots_args_fp",
+          "columns": [
+            {
+              "expression": "used_args_fp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locator_snapshots_test_case_id_test_cases_id_fk": {
+          "name": "locator_snapshots_test_case_id_test_cases_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locator_snapshots_last_seen_run_id_test_runs_id_fk": {
+          "name": "locator_snapshots_last_seen_run_id_test_runs_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_runs",
+          "columnsFrom": ["last_seen_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.markers": {
+      "name": "markers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'event'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_markers_project_id": {
+          "name": "idx_markers_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_markers_project_occurred": {
+          "name": "idx_markers_project_occurred",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_markers_run_id": {
+          "name": "idx_markers_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "markers_project_id_projects_id_fk": {
+          "name": "markers_project_id_projects_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "markers_run_id_test_runs_id_fk": {
+          "name": "markers_run_id_test_runs_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "test_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_requests": {
+      "name": "network_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_logs": {
+          "name": "server_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_traces": {
+          "name": "server_traces",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_nr_run": {
+          "name": "idx_nr_run",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nr_case": {
+          "name": "idx_nr_case",
+          "columns": [
+            {
+              "expression": "test_runs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_nr_normalized_url": {
+          "name": "idx_nr_normalized_url",
+          "columns": [
+            {
+              "expression": "normalized_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "network_requests_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "network_requests_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "network_requests_test_run_id_test_runs_id_fk": {
+          "name": "network_requests_test_run_id_test_runs_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_notification_channels_user": {
+          "name": "idx_notification_channels_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_users_id_fk": {
+          "name": "notification_channels_user_id_users_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_deliveries": {
+      "name": "notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_status": {
+          "name": "idx_notification_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_dedupe": {
+          "name": "idx_notification_deliveries_dedupe",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_subscription": {
+          "name": "idx_notification_deliveries_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_deliveries_channel": {
+          "name": "idx_notification_deliveries_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_subscription_id_subscriptions_id_fk": {
+          "name": "notification_deliveries_subscription_id_subscriptions_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_channel_id_notification_channels_id_fk": {
+          "name": "notification_deliveries_channel_id_notification_channels_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_assignments": {
+      "name": "project_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_project_assignments_user": {
+          "name": "idx_project_assignments_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_assignments_project": {
+          "name": "idx_project_assignments_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_assignments_user_project": {
+          "name": "idx_project_assignments_user_project",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_assignments_created_by": {
+          "name": "idx_project_assignments_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_assignments_user_id_users_id_fk": {
+          "name": "project_assignments_user_id_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_project_id_projects_id_fk": {
+          "name": "project_assignments_project_id_projects_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_created_by_users_id_fk": {
+          "name": "project_assignments_created_by_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_tags": {
+      "name": "project_tags",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_project_tags_project_id": {
+          "name": "idx_project_tags_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_tags_tag_id": {
+          "name": "idx_project_tags_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_tags_project_id_projects_id_fk": {
+          "name": "project_tags_project_id_projects_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tags_tag_id_tags_id_fk": {
+          "name": "project_tags_tag_id_tags_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_tags_project_id_tag_id_pk": {
+          "name": "project_tags_project_id_tag_id_pk",
+          "columns": ["project_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_instructions": {
+          "name": "diagnosis_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scm_token": {
+          "name": "scm_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quarantined_tests": {
+      "name": "quarantined_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "quarantined_at_run_id": {
+          "name": "quarantined_at_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_reason": {
+          "name": "released_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_quarantined_tests_project": {
+          "name": "idx_quarantined_tests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quarantined_tests_created_by": {
+          "name": "idx_quarantined_tests_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quarantined_tests_active": {
+          "name": "idx_quarantined_tests_active",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "released_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quarantined_tests_project_id_projects_id_fk": {
+          "name": "quarantined_tests_project_id_projects_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_test_case_id_test_cases_id_fk": {
+          "name": "quarantined_tests_test_case_id_test_cases_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_created_by_users_id_fk": {
+          "name": "quarantined_tests_created_by_users_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_kind": {
+          "name": "entity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_share_links_project_id": {
+          "name": "idx_share_links_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_share_links_entity": {
+          "name": "idx_share_links_entity",
+          "columns": [
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_share_links_created_by": {
+          "name": "idx_share_links_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_hash_unique": {
+          "name": "share_links_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'realtime'"
+        },
+        "digest_at": {
+          "name": "digest_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_project": {
+          "name": "idx_subscriptions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_user": {
+          "name": "idx_subscriptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscriptions_channel": {
+          "name": "idx_subscriptions_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_channel_id_notification_channels_id_fk": {
+          "name": "subscriptions_channel_id_notification_channels_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_project_id_projects_id_fk": {
+          "name": "subscriptions_project_id_projects_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'neutral'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tags_updated_at": {
+          "name": "idx_tags_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_text_unique": {
+          "name": "tags_text_unique",
+          "nullsNotDistinct": false,
+          "columns": ["text"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flaky_root_cause": {
+          "name": "flaky_root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_cases_project_id": {
+          "name": "idx_test_cases_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_cases_file_path_title": {
+          "name": "idx_test_cases_file_path_title",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suite_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_cases_suite": {
+          "name": "idx_test_cases_suite",
+          "columns": [
+            {
+              "expression": "suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_cases_owner": {
+          "name": "idx_test_cases_owner",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_suite_id_test_suites_id_fk": {
+          "name": "test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": ["suite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_functions": {
+      "name": "test_functions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver": {
+          "name": "receiver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_name": {
+          "name": "import_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "returns_page": {
+          "name": "returns_page",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "url_pattern": {
+          "name": "url_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "param_sources": {
+          "name": "param_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_functions_project_id": {
+          "name": "idx_test_functions_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_functions_project_module_name": {
+          "name": "idx_test_functions_project_module_name",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_functions_project_id_projects_id_fk": {
+          "name": "test_functions_project_id_projects_id_fk",
+          "tableFrom": "test_functions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tests": {
+          "name": "total_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "passed_tests": {
+          "name": "passed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_tests": {
+          "name": "failed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_tests": {
+          "name": "skipped_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "did_not_run_tests": {
+          "name": "did_not_run_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "flaky_tests": {
+          "name": "flaky_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_test_duration": {
+          "name": "avg_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "p90_test_duration": {
+          "name": "p90_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_total": {
+          "name": "shard_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shards_finished": {
+          "name": "shards_finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_full_run": {
+          "name": "is_full_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "filter_details": {
+          "name": "filter_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_steps": {
+          "name": "setup_steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_token": {
+          "name": "stream_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playwright_version": {
+          "name": "playwright_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_version": {
+          "name": "reporter_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_hash": {
+          "name": "import_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_test_runs_project_id": {
+          "name": "idx_test_runs_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_project_start": {
+          "name": "idx_test_runs_project_start",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_start_time": {
+          "name": "idx_test_runs_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_status": {
+          "name": "idx_test_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_import_hash": {
+          "name": "idx_test_runs_import_hash",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs_cases": {
+      "name": "test_runs_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_cluster_id": {
+          "name": "failure_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_events": {
+          "name": "step_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slowest_step": {
+          "name": "slowest_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slowest_step_duration": {
+          "name": "slowest_step_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wasted_time_ms": {
+          "name": "wasted_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web_vitals": {
+          "name": "web_vitals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_state": {
+          "name": "page_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_usage": {
+          "name": "ai_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_logs": {
+          "name": "console_logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aria_snapshot": {
+          "name": "aria_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source": {
+          "name": "test_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source_frames": {
+          "name": "test_source_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aria_snapshot_payload_id": {
+          "name": "aria_snapshot_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source_payload_id": {
+          "name": "test_source_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_source_frames_payload_id": {
+          "name": "test_source_frames_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_annotations": {
+          "name": "test_annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_meta": {
+          "name": "test_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_index": {
+          "name": "worker_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_index": {
+          "name": "shard_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_regression": {
+          "name": "is_new_regression",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_new_flaky": {
+          "name": "is_new_flaky",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did_not_run_reason": {
+          "name": "did_not_run_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_runs_cases_test_run_id": {
+          "name": "idx_test_runs_cases_test_run_id",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_cases_case_created": {
+          "name": "idx_test_runs_cases_case_created",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_cases_failure_cluster_id": {
+          "name": "idx_test_runs_cases_failure_cluster_id",
+          "columns": [
+            {
+              "expression": "failure_cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_test_runs_cases_run_browser": {
+          "name": "idx_test_runs_cases_run_browser",
+          "columns": [
+            {
+              "expression": "test_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retries",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "browser_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trc_aria_payload": {
+          "name": "idx_trc_aria_payload",
+          "columns": [
+            {
+              "expression": "aria_snapshot_payload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "aria_snapshot_payload_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trc_source_payload": {
+          "name": "idx_trc_source_payload",
+          "columns": [
+            {
+              "expression": "test_source_payload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "test_source_payload_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trc_frames_payload": {
+          "name": "idx_trc_frames_payload",
+          "columns": [
+            {
+              "expression": "test_source_frames_payload_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "test_source_frames_payload_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_runs_cases_test_run_id_test_runs_id_fk": {
+          "name": "test_runs_cases_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_case_id_test_cases_id_fk": {
+          "name": "test_runs_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_failure_cluster_id_failure_clusters_id_fk": {
+          "name": "test_runs_cases_failure_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["failure_cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["aria_snapshot_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_frames_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_test_suites_unique": {
+          "name": "idx_test_suites_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suite_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trace_blobs": {
+      "name": "trace_blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trace_blobs_project_hash": {
+          "name": "idx_trace_blobs_project_hash",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trace_blobs_project_id_projects_id_fk": {
+          "name": "trace_blobs_project_id_projects_id_fk",
+          "tableFrom": "trace_blobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trace_resources": {
+      "name": "trace_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_trace_resources_project_name": {
+          "name": "idx_trace_resources_project_name",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trace_resources_project_id_projects_id_fk": {
+          "name": "trace_resources_project_id_projects_id_fk",
+          "tableFrom": "trace_resources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_id": {
+          "name": "oauth_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_epoch": {
+          "name": "session_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_users_oauth": {
+          "name": "idx_users_oauth",
+          "columns": [
+            {
+              "expression": "oauth_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/application/server/database/migrations-pg/meta/_journal.json
+++ b/apps/application/server/database/migrations-pg/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1785916466268,
       "tag": "0048_right_gargoyle",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1786091705372,
+      "tag": "0049_plain_preak",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/application/server/database/migrations/0048_stormy_whizzer.sql
+++ b/apps/application/server/database/migrations/0048_stormy_whizzer.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `share_links` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` integer NOT NULL,
+	`entity_kind` text NOT NULL,
+	`entity_id` integer NOT NULL,
+	`token_hash` text NOT NULL,
+	`token_prefix` text NOT NULL,
+	`created_by` integer,
+	`created_at` integer NOT NULL,
+	`expires_at` integer,
+	`revoked_at` integer,
+	`last_viewed_at` integer,
+	`view_count` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `share_links_token_hash_unique` ON `share_links` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `idx_share_links_project_id` ON `share_links` (`project_id`);--> statement-breakpoint
+CREATE INDEX `idx_share_links_entity` ON `share_links` (`entity_kind`,`entity_id`);--> statement-breakpoint
+CREATE INDEX `idx_share_links_created_by` ON `share_links` (`created_by`);

--- a/apps/application/server/database/migrations/meta/0048_snapshot.json
+++ b/apps/application/server/database/migrations/meta/0048_snapshot.json
@@ -1,0 +1,3935 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8472f5e3-fd1e-4c7d-b2c7-b7c7dd75c7a5",
+  "prevId": "cd736b27-87da-4d65-ad42-527667376824",
+  "tables": {
+    "account_tokens": {
+      "name": "account_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_tokens_hash": {
+          "name": "idx_account_tokens_hash",
+          "columns": ["token_hash"],
+          "isUnique": true
+        },
+        "idx_account_tokens_user": {
+          "name": "idx_account_tokens_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_tokens_user_id_users_id_fk": {
+          "name": "account_tokens_user_id_users_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        },
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "case_payloads": {
+      "name": "case_payloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_case_payloads_project_hash": {
+          "name": "idx_case_payloads_project_hash",
+          "columns": ["project_id", "hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "case_payloads_project_id_projects_id_fk": {
+          "name": "case_payloads_project_id_projects_id_fk",
+          "tableFrom": "case_payloads",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cluster_merge_suggestions": {
+      "name": "cluster_merge_suggestions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_a_id": {
+          "name": "cluster_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_b_id": {
+          "name": "cluster_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "llm_confidence": {
+          "name": "llm_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_reason": {
+          "name": "llm_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cluster_merge_suggestions_pair": {
+          "name": "idx_cluster_merge_suggestions_pair",
+          "columns": ["cluster_a_id", "cluster_b_id"],
+          "isUnique": true
+        },
+        "idx_cluster_merge_suggestions_project_status": {
+          "name": "idx_cluster_merge_suggestions_project_status",
+          "columns": ["project_id", "status"],
+          "isUnique": false
+        },
+        "idx_cluster_merge_suggestions_cluster_b": {
+          "name": "idx_cluster_merge_suggestions_cluster_b",
+          "columns": ["cluster_b_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cluster_merge_suggestions_project_id_projects_id_fk": {
+          "name": "cluster_merge_suggestions_project_id_projects_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_a_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_a_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk": {
+          "name": "cluster_merge_suggestions_cluster_b_id_failure_clusters_id_fk",
+          "tableFrom": "cluster_merge_suggestions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_b_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_links": {
+      "name": "entity_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'generic'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_text": {
+          "name": "status_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_color": {
+          "name": "status_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unfurled_at": {
+          "name": "unfurled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_entity_links_run": {
+          "name": "idx_entity_links_run",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_entity_links_case_run": {
+          "name": "idx_entity_links_case_run",
+          "columns": ["test_runs_case_id"],
+          "isUnique": false
+        },
+        "idx_entity_links_case": {
+          "name": "idx_entity_links_case",
+          "columns": ["test_case_id"],
+          "isUnique": false
+        },
+        "idx_entity_links_created_by": {
+          "name": "idx_entity_links_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_links_test_run_id_test_runs_id_fk": {
+          "name": "entity_links_test_run_id_test_runs_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "entity_links_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_test_case_id_test_cases_id_fk": {
+          "name": "entity_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_links_created_by_users_id_fk": {
+          "name": "entity_links_created_by_users_id_fk",
+          "tableFrom": "entity_links",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_cluster_aliases": {
+      "name": "failure_cluster_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failure_cluster_aliases_project_fingerprint": {
+          "name": "idx_failure_cluster_aliases_project_fingerprint",
+          "columns": ["project_id", "fingerprint"],
+          "isUnique": true
+        },
+        "idx_failure_cluster_aliases_cluster": {
+          "name": "idx_failure_cluster_aliases_cluster",
+          "columns": ["cluster_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_cluster_aliases_project_id_projects_id_fk": {
+          "name": "failure_cluster_aliases_project_id_projects_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_cluster_aliases_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_cluster_aliases_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_cluster_aliases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_clusters": {
+      "name": "failure_clusters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sample_error": {
+          "name": "sample_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_run_id": {
+          "name": "first_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "triage_note": {
+          "name": "triage_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manual_base_commit": {
+          "name": "manual_base_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_landed_run_id": {
+          "name": "fix_landed_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_landed_at": {
+          "name": "fix_landed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_commit": {
+          "name": "fix_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_resolution_ms": {
+          "name": "time_to_resolution_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fix_verification": {
+          "name": "fix_verification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failure_clusters_project_fingerprint": {
+          "name": "idx_failure_clusters_project_fingerprint",
+          "columns": ["project_id", "fingerprint"],
+          "isUnique": true
+        },
+        "idx_failure_clusters_project_last_seen": {
+          "name": "idx_failure_clusters_project_last_seen",
+          "columns": ["project_id", "last_seen_run_id"],
+          "isUnique": false
+        },
+        "idx_failure_clusters_project_status": {
+          "name": "idx_failure_clusters_project_status",
+          "columns": ["project_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_clusters_project_id_projects_id_fk": {
+          "name": "failure_clusters_project_id_projects_id_fk",
+          "tableFrom": "failure_clusters",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_diagnoses": {
+      "name": "failure_diagnoses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_failure_diagnoses_cluster_scope": {
+          "name": "idx_failure_diagnoses_cluster_scope",
+          "columns": ["cluster_id", "scope"],
+          "isUnique": true
+        },
+        "idx_failure_diagnoses_execution": {
+          "name": "idx_failure_diagnoses_execution",
+          "columns": ["test_runs_case_id", "scope"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnoses_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnoses_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnoses_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnoses",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "failure_diagnosis_versions": {
+      "name": "failure_diagnosis_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "diagnosis_id": {
+          "name": "diagnosis_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cluster'"
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_sha": {
+          "name": "context_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_fdv_diagnosis_id": {
+          "name": "idx_fdv_diagnosis_id",
+          "columns": ["diagnosis_id"],
+          "isUnique": false
+        },
+        "idx_fdv_cluster_id": {
+          "name": "idx_fdv_cluster_id",
+          "columns": ["cluster_id"],
+          "isUnique": false
+        },
+        "idx_fdv_test_runs_case": {
+          "name": "idx_fdv_test_runs_case",
+          "columns": ["test_runs_case_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk": {
+          "name": "failure_diagnosis_versions_diagnosis_id_failure_diagnoses_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_diagnoses",
+          "columnsFrom": ["diagnosis_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk": {
+          "name": "failure_diagnosis_versions_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "failure_diagnosis_versions_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "failure_diagnosis_versions",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob_id": {
+          "name": "blob_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_files_test_run_id": {
+          "name": "idx_files_test_run_id",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_files_test_runs_case_id": {
+          "name": "idx_files_test_runs_case_id",
+          "columns": ["test_runs_case_id"],
+          "isUnique": false
+        },
+        "idx_files_blob_id": {
+          "name": "idx_files_blob_id",
+          "columns": ["blob_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "files_test_run_id_test_runs_id_fk": {
+          "name": "files_test_run_id_test_runs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "files_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "files",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_blob_id_trace_blobs_id_fk": {
+          "name": "files_blob_id_trace_blobs_id_fk",
+          "tableFrom": "files",
+          "tableTo": "trace_blobs",
+          "columnsFrom": ["blob_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locator_snapshots": {
+      "name": "locator_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_method": {
+          "name": "used_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_args": {
+          "name": "used_args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_args_fp": {
+          "name": "used_args_fp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element_tag": {
+          "name": "element_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "element_attrs": {
+          "name": "element_attrs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element_text": {
+          "name": "element_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_locator_snapshots_location": {
+          "name": "idx_locator_snapshots_location",
+          "columns": ["test_case_id", "location"],
+          "isUnique": true
+        },
+        "idx_locator_snapshots_fp": {
+          "name": "idx_locator_snapshots_fp",
+          "columns": ["test_case_id", "used_method", "used_args_fp"],
+          "isUnique": false
+        },
+        "idx_locator_snapshots_args_fp": {
+          "name": "idx_locator_snapshots_args_fp",
+          "columns": ["used_args_fp"],
+          "isUnique": false
+        },
+        "idx_locator_snapshots_last_seen_run": {
+          "name": "idx_locator_snapshots_last_seen_run",
+          "columns": ["last_seen_run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "locator_snapshots_test_case_id_test_cases_id_fk": {
+          "name": "locator_snapshots_test_case_id_test_cases_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locator_snapshots_last_seen_run_id_test_runs_id_fk": {
+          "name": "locator_snapshots_last_seen_run_id_test_runs_id_fk",
+          "tableFrom": "locator_snapshots",
+          "tableTo": "test_runs",
+          "columnsFrom": ["last_seen_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "markers": {
+      "name": "markers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'event'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_markers_project_id": {
+          "name": "idx_markers_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_markers_project_occurred": {
+          "name": "idx_markers_project_occurred",
+          "columns": ["project_id", "occurred_at"],
+          "isUnique": false
+        },
+        "idx_markers_run_id": {
+          "name": "idx_markers_run_id",
+          "columns": ["run_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "markers_project_id_projects_id_fk": {
+          "name": "markers_project_id_projects_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "markers_run_id_test_runs_id_fk": {
+          "name": "markers_run_id_test_runs_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "test_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "network_requests": {
+      "name": "network_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_runs_case_id": {
+          "name": "test_runs_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalized_url": {
+          "name": "normalized_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_logs": {
+          "name": "server_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_traces": {
+          "name": "server_traces",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_nr_run": {
+          "name": "idx_nr_run",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_nr_case": {
+          "name": "idx_nr_case",
+          "columns": ["test_runs_case_id", "status"],
+          "isUnique": false
+        },
+        "idx_nr_normalized_url": {
+          "name": "idx_nr_normalized_url",
+          "columns": ["normalized_url"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "network_requests_test_runs_case_id_test_runs_cases_id_fk": {
+          "name": "network_requests_test_runs_case_id_test_runs_cases_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs_cases",
+          "columnsFrom": ["test_runs_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "network_requests_test_run_id_test_runs_id_fk": {
+          "name": "network_requests_test_run_id_test_runs_id_fk",
+          "tableFrom": "network_requests",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_channels": {
+      "name": "notification_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notification_channels_user": {
+          "name": "idx_notification_channels_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_users_id_fk": {
+          "name": "notification_channels_user_id_users_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_deliveries": {
+      "name": "notification_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notification_deliveries_status": {
+          "name": "idx_notification_deliveries_status",
+          "columns": ["status", "scheduled_for"],
+          "isUnique": false
+        },
+        "idx_notification_deliveries_dedupe": {
+          "name": "idx_notification_deliveries_dedupe",
+          "columns": ["dedupe_key"],
+          "isUnique": true
+        },
+        "idx_notification_deliveries_subscription": {
+          "name": "idx_notification_deliveries_subscription",
+          "columns": ["subscription_id"],
+          "isUnique": false
+        },
+        "idx_notification_deliveries_channel": {
+          "name": "idx_notification_deliveries_channel",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_deliveries_subscription_id_subscriptions_id_fk": {
+          "name": "notification_deliveries_subscription_id_subscriptions_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_deliveries_channel_id_notification_channels_id_fk": {
+          "name": "notification_deliveries_channel_id_notification_channels_id_fk",
+          "tableFrom": "notification_deliveries",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_assignments": {
+      "name": "project_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_assignments_user": {
+          "name": "idx_project_assignments_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_project_assignments_project": {
+          "name": "idx_project_assignments_project",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_project_assignments_user_project": {
+          "name": "idx_project_assignments_user_project",
+          "columns": ["user_id", "project_id"],
+          "isUnique": true
+        },
+        "idx_project_assignments_created_by": {
+          "name": "idx_project_assignments_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_assignments_user_id_users_id_fk": {
+          "name": "project_assignments_user_id_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_project_id_projects_id_fk": {
+          "name": "project_assignments_project_id_projects_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_assignments_created_by_users_id_fk": {
+          "name": "project_assignments_created_by_users_id_fk",
+          "tableFrom": "project_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_tags": {
+      "name": "project_tags",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_tags_project_id": {
+          "name": "idx_project_tags_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_project_tags_tag_id": {
+          "name": "idx_project_tags_tag_id",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_tags_project_id_projects_id_fk": {
+          "name": "project_tags_project_id_projects_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tags_tag_id_tags_id_fk": {
+          "name": "project_tags_tag_id_tags_id_fk",
+          "tableFrom": "project_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_tags_project_id_tag_id_pk": {
+          "columns": ["project_id", "tag_id"],
+          "name": "project_tags_project_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diagnosis_instructions": {
+          "name": "diagnosis_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scm_token": {
+          "name": "scm_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "idx_projects_updated_at": {
+          "name": "idx_projects_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quarantined_tests": {
+      "name": "quarantined_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "quarantined_at_run_id": {
+          "name": "quarantined_at_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "released_reason": {
+          "name": "released_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quarantined_tests_project": {
+          "name": "idx_quarantined_tests_project",
+          "columns": ["project_id", "released_at"],
+          "isUnique": false
+        },
+        "idx_quarantined_tests_created_by": {
+          "name": "idx_quarantined_tests_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        },
+        "idx_quarantined_tests_active": {
+          "name": "idx_quarantined_tests_active",
+          "columns": ["test_case_id"],
+          "isUnique": true,
+          "where": "released_at IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "quarantined_tests_project_id_projects_id_fk": {
+          "name": "quarantined_tests_project_id_projects_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_test_case_id_test_cases_id_fk": {
+          "name": "quarantined_tests_test_case_id_test_cases_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quarantined_tests_created_by_users_id_fk": {
+          "name": "quarantined_tests_created_by_users_id_fk",
+          "tableFrom": "quarantined_tests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_links": {
+      "name": "share_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_kind": {
+          "name": "entity_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "share_links_token_hash_unique": {
+          "name": "share_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        },
+        "idx_share_links_project_id": {
+          "name": "idx_share_links_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_share_links_entity": {
+          "name": "idx_share_links_entity",
+          "columns": ["entity_kind", "entity_id"],
+          "isUnique": false
+        },
+        "idx_share_links_created_by": {
+          "name": "idx_share_links_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "share_links_created_by_users_id_fk": {
+          "name": "share_links_created_by_users_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'realtime'"
+        },
+        "digest_at": {
+          "name": "digest_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_subscriptions_project": {
+          "name": "idx_subscriptions_project",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_subscriptions_user": {
+          "name": "idx_subscriptions_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_subscriptions_channel": {
+          "name": "idx_subscriptions_channel",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_channel_id_notification_channels_id_fk": {
+          "name": "subscriptions_channel_id_notification_channels_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_project_id_projects_id_fk": {
+          "name": "subscriptions_project_id_projects_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'neutral'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_text_unique": {
+          "name": "tags_text_unique",
+          "columns": ["text"],
+          "isUnique": true
+        },
+        "idx_tags_updated_at": {
+          "name": "idx_tags_updated_at",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_cases": {
+      "name": "test_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flaky_root_cause": {
+          "name": "flaky_root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_cases_project_id": {
+          "name": "idx_test_cases_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_test_cases_file_path_title": {
+          "name": "idx_test_cases_file_path_title",
+          "columns": ["project_id", "file_path", "suite_path", "title"],
+          "isUnique": false
+        },
+        "idx_test_cases_suite": {
+          "name": "idx_test_cases_suite",
+          "columns": ["suite_id"],
+          "isUnique": false
+        },
+        "idx_test_cases_owner": {
+          "name": "idx_test_cases_owner",
+          "columns": ["project_id", "owner"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_suite_id_test_suites_id_fk": {
+          "name": "test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": ["suite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_functions": {
+      "name": "test_functions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "module": {
+          "name": "module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "receiver": {
+          "name": "receiver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "import_name": {
+          "name": "import_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "returns_page": {
+          "name": "returns_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_pattern": {
+          "name": "url_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "param_sources": {
+          "name": "param_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_functions_project_id": {
+          "name": "idx_test_functions_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_test_functions_project_module_name": {
+          "name": "idx_test_functions_project_module_name",
+          "columns": ["project_id", "module", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "test_functions_project_id_projects_id_fk": {
+          "name": "test_functions_project_id_projects_id_fk",
+          "tableFrom": "test_functions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_runs": {
+      "name": "test_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tests": {
+          "name": "total_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "passed_tests": {
+          "name": "passed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_tests": {
+          "name": "failed_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_tests": {
+          "name": "skipped_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "did_not_run_tests": {
+          "name": "did_not_run_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "flaky_tests": {
+          "name": "flaky_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_test_duration": {
+          "name": "avg_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "p90_test_duration": {
+          "name": "p90_test_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shard_total": {
+          "name": "shard_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shards_finished": {
+          "name": "shards_finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_full_run": {
+          "name": "is_full_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "filter_details": {
+          "name": "filter_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "setup_steps": {
+          "name": "setup_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_token": {
+          "name": "stream_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playwright_version": {
+          "name": "playwright_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporter_version": {
+          "name": "reporter_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "import_hash": {
+          "name": "import_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_runs_project_id": {
+          "name": "idx_test_runs_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "idx_test_runs_project_start": {
+          "name": "idx_test_runs_project_start",
+          "columns": ["project_id", "start_time"],
+          "isUnique": false
+        },
+        "idx_test_runs_start_time": {
+          "name": "idx_test_runs_start_time",
+          "columns": ["start_time"],
+          "isUnique": false
+        },
+        "idx_test_runs_status": {
+          "name": "idx_test_runs_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_test_runs_import_hash": {
+          "name": "idx_test_runs_import_hash",
+          "columns": ["project_id", "import_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_runs_cases": {
+      "name": "test_runs_cases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_cluster_id": {
+          "name": "failure_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_events": {
+          "name": "step_events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slowest_step": {
+          "name": "slowest_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slowest_step_duration": {
+          "name": "slowest_step_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wasted_time_ms": {
+          "name": "wasted_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "web_vitals": {
+          "name": "web_vitals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_state": {
+          "name": "page_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_usage": {
+          "name": "ai_usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "console_logs": {
+          "name": "console_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aria_snapshot": {
+          "name": "aria_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source": {
+          "name": "test_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source_frames": {
+          "name": "test_source_frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aria_snapshot_payload_id": {
+          "name": "aria_snapshot_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source_payload_id": {
+          "name": "test_source_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_source_frames_payload_id": {
+          "name": "test_source_frames_payload_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_annotations": {
+          "name": "test_annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "test_meta": {
+          "name": "test_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worker_index": {
+          "name": "worker_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shard_index": {
+          "name": "shard_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new_regression": {
+          "name": "is_new_regression",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new_flaky": {
+          "name": "is_new_flaky",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "did_not_run_reason": {
+          "name": "did_not_run_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_runs_cases_test_run_id": {
+          "name": "idx_test_runs_cases_test_run_id",
+          "columns": ["test_run_id"],
+          "isUnique": false
+        },
+        "idx_test_runs_cases_case_created": {
+          "name": "idx_test_runs_cases_case_created",
+          "columns": ["test_case_id", "created_at"],
+          "isUnique": false
+        },
+        "idx_test_runs_cases_failure_cluster_id": {
+          "name": "idx_test_runs_cases_failure_cluster_id",
+          "columns": ["failure_cluster_id"],
+          "isUnique": false
+        },
+        "idx_test_runs_cases_run_browser": {
+          "name": "idx_test_runs_cases_run_browser",
+          "columns": ["test_run_id", "test_case_id", "retries", "browser_name"],
+          "isUnique": true
+        },
+        "idx_trc_aria_payload": {
+          "name": "idx_trc_aria_payload",
+          "columns": ["aria_snapshot_payload_id"],
+          "isUnique": false,
+          "where": "aria_snapshot_payload_id IS NOT NULL"
+        },
+        "idx_trc_source_payload": {
+          "name": "idx_trc_source_payload",
+          "columns": ["test_source_payload_id"],
+          "isUnique": false,
+          "where": "test_source_payload_id IS NOT NULL"
+        },
+        "idx_trc_frames_payload": {
+          "name": "idx_trc_frames_payload",
+          "columns": ["test_source_frames_payload_id"],
+          "isUnique": false,
+          "where": "test_source_frames_payload_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "test_runs_cases_test_run_id_test_runs_id_fk": {
+          "name": "test_runs_cases_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_runs",
+          "columnsFrom": ["test_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_case_id_test_cases_id_fk": {
+          "name": "test_runs_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": ["test_case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_failure_cluster_id_failure_clusters_id_fk": {
+          "name": "test_runs_cases_failure_cluster_id_failure_clusters_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "failure_clusters",
+          "columnsFrom": ["failure_cluster_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_aria_snapshot_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["aria_snapshot_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk": {
+          "name": "test_runs_cases_test_source_frames_payload_id_case_payloads_id_fk",
+          "tableFrom": "test_runs_cases",
+          "tableTo": "case_payloads",
+          "columnsFrom": ["test_source_frames_payload_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_suites": {
+      "name": "test_suites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suite_path": {
+          "name": "suite_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_test_suites_unique": {
+          "name": "idx_test_suites_unique",
+          "columns": ["project_id", "file_path", "suite_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trace_blobs": {
+      "name": "trace_blobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trace_blobs_project_hash": {
+          "name": "idx_trace_blobs_project_hash",
+          "columns": ["project_id", "hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "trace_blobs_project_id_projects_id_fk": {
+          "name": "trace_blobs_project_id_projects_id_fk",
+          "tableFrom": "trace_blobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trace_resources": {
+      "name": "trace_resources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trace_resources_project_name": {
+          "name": "idx_trace_resources_project_name",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "trace_resources_project_id_projects_id_fk": {
+          "name": "trace_resources_project_id_projects_id_fk",
+          "tableFrom": "trace_resources",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_id": {
+          "name": "oauth_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_epoch": {
+          "name": "session_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        },
+        "idx_users_oauth": {
+          "name": "idx_users_oauth",
+          "columns": ["oauth_provider", "oauth_provider_id"],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/application/server/database/migrations/meta/_journal.json
+++ b/apps/application/server/database/migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1785916459975,
       "tag": "0047_lethal_white_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "6",
+      "when": 1786091704395,
+      "tag": "0048_stormy_whizzer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/application/server/database/schema.pg.ts
+++ b/apps/application/server/database/schema.pg.ts
@@ -925,6 +925,39 @@ export const testFunctions = pgTable(
   }),
 );
 
+// Share links — read-only capability tokens for handing one execution or one
+// failure cluster to someone without a dashboard account. The token itself is
+// never stored: only its SHA-256 hash (unguessable 256-bit secrets need no
+// salt, and the plain hash is what makes an indexed equality lookup possible).
+// `entity_id` is polymorphic over test_runs_cases / failure_clusters, so it
+// carries no FK; retention's orphan sweep removes rows whose entity is gone.
+export const shareLinks = pgTable(
+  'share_links',
+  {
+    id: serial('id').primaryKey(),
+    projectId: integer('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    entityKind: text('entity_kind').notNull(), // 'execution' | 'cluster' (ExportKind)
+    entityId: integer('entity_id').notNull(), // test_runs_cases.id or failure_clusters.id
+    tokenHash: text('token_hash').notNull().unique(), // SHA-256 hash of the full psl_ token
+    tokenPrefix: text('token_prefix').notNull(), // First 8 chars after "psl_" — shown in UI
+    createdBy: integer('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { mode: 'date' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    expiresAt: timestamp('expires_at', { mode: 'date' }), // null = no expiry
+    revokedAt: timestamp('revoked_at', { mode: 'date' }), // set on revoke; row kept for the audit trail
+    lastViewedAt: timestamp('last_viewed_at', { mode: 'date' }),
+    viewCount: integer('view_count').notNull().default(0),
+  },
+  (table) => ({
+    projectIdIdx: index('idx_share_links_project_id').on(table.projectId),
+    entityIdx: index('idx_share_links_entity').on(table.entityKind, table.entityId),
+    createdByIdx: index('idx_share_links_created_by').on(table.createdBy),
+  }),
+);
+
 export const apiKeys = pgTable(
   'api_keys',
   {
@@ -996,4 +1029,6 @@ export type NewNetworkRequest = typeof networkRequests.$inferInsert;
 export type LocatorSnapshotRow = typeof locatorSnapshots.$inferSelect;
 export type NewLocatorSnapshotRow = typeof locatorSnapshots.$inferInsert;
 export type TestFunction = typeof testFunctions.$inferSelect;
+export type ShareLink = typeof shareLinks.$inferSelect;
+export type NewShareLink = typeof shareLinks.$inferInsert;
 export type NewTestFunction = typeof testFunctions.$inferInsert;

--- a/apps/application/server/database/schema.sqlite.ts
+++ b/apps/application/server/database/schema.sqlite.ts
@@ -903,6 +903,39 @@ export const testFunctions = sqliteTable(
   }),
 );
 
+// Share links — read-only capability tokens for handing one execution or one
+// failure cluster to someone without a dashboard account. The token itself is
+// never stored: only its SHA-256 hash (unguessable 256-bit secrets need no
+// salt, and the plain hash is what makes an indexed equality lookup possible).
+// `entity_id` is polymorphic over test_runs_cases / failure_clusters, so it
+// carries no FK; retention's orphan sweep removes rows whose entity is gone.
+export const shareLinks = sqliteTable(
+  'share_links',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    projectId: integer('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    entityKind: text('entity_kind').notNull(), // 'execution' | 'cluster' (ExportKind)
+    entityId: integer('entity_id').notNull(), // test_runs_cases.id or failure_clusters.id
+    tokenHash: text('token_hash').notNull().unique(), // SHA-256 hash of the full psl_ token
+    tokenPrefix: text('token_prefix').notNull(), // First 8 chars after "psl_" — shown in UI
+    createdBy: integer('created_by').references(() => users.id, { onDelete: 'set null' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    expiresAt: integer('expires_at', { mode: 'timestamp' }), // null = no expiry
+    revokedAt: integer('revoked_at', { mode: 'timestamp' }), // set on revoke; row kept for the audit trail
+    lastViewedAt: integer('last_viewed_at', { mode: 'timestamp' }),
+    viewCount: integer('view_count').notNull().default(0),
+  },
+  (table) => ({
+    projectIdIdx: index('idx_share_links_project_id').on(table.projectId),
+    entityIdx: index('idx_share_links_entity').on(table.entityKind, table.entityId),
+    createdByIdx: index('idx_share_links_created_by').on(table.createdBy),
+  }),
+);
+
 export const apiKeys = sqliteTable(
   'api_keys',
   {
@@ -980,4 +1013,6 @@ export type NewNetworkRequest = typeof networkRequests.$inferInsert;
 export type LocatorSnapshotRow = typeof locatorSnapshots.$inferSelect;
 export type NewLocatorSnapshotRow = typeof locatorSnapshots.$inferInsert;
 export type TestFunction = typeof testFunctions.$inferSelect;
+export type ShareLink = typeof shareLinks.$inferSelect;
+export type NewShareLink = typeof shareLinks.$inferInsert;
 export type NewTestFunction = typeof testFunctions.$inferInsert;

--- a/apps/application/server/database/schema.ts
+++ b/apps/application/server/database/schema.ts
@@ -41,6 +41,7 @@ export const {
   locatorSnapshots,
   casePayloads,
   testFunctions,
+  shareLinks,
 } = schema;
 
 // TypeScript type exports – always based on SQLite schema (the canonical reference)
@@ -101,4 +102,6 @@ export type {
   NewCasePayload,
   TestFunction,
   NewTestFunction,
+  ShareLink,
+  NewShareLink,
 } from './schema.sqlite';

--- a/apps/application/server/routes/share/[token].get.ts
+++ b/apps/application/server/routes/share/[token].get.ts
@@ -1,0 +1,87 @@
+import { getDatabase } from '../../database';
+import { collectClusterBundle, collectExecutionBundle } from '#shared/export/collect';
+import { buildExport } from '#shared/export/build';
+import { checkRateLimit, rateLimitClientIp, rateLimitedError } from '../../utils/rate-limit';
+import { resolveExportBudget, resolveExportMaxCases, serverAssetReader } from '../../utils/export-assets';
+import { exportPiwiVersion, exportSourceUrl } from '../../utils/export-request';
+import { recordShareLinkView, resolveShareToken, shareLinksEnabled } from '../../utils/share-links';
+
+/** Requests per client address per window — log-noise defense; the 256-bit token is the security boundary. */
+const LOOKUP_LIMIT = 120;
+const LOOKUP_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * The public face of a share link: renders the linked execution or failure
+ * cluster as the offline export's self-contained HTML, resolved live at view
+ * time. Evidence is inlined under the export size budget, so this one route is
+ * the whole anonymous surface — no session, no cookies, no follow-up requests.
+ */
+export default eventHandler(async (event) => {
+  // Every branch is uncacheable and uninteresting to crawlers, valid or not.
+  setResponseHeader(event, 'Cache-Control', 'no-store');
+  setResponseHeader(event, 'X-Robots-Tag', 'noindex, nofollow');
+
+  if (!shareLinksEnabled()) {
+    throw createError({ statusCode: 404, message: 'Not found' });
+  }
+
+  const rateKey = `share:${rateLimitClientIp(event)}`;
+  if (!checkRateLimit(rateKey, LOOKUP_LIMIT, LOOKUP_WINDOW_MS)) {
+    throw rateLimitedError(event, [rateKey]);
+  }
+
+  const token = String(getRouterParam(event, 'token') ?? '');
+  const db = await getDatabase();
+  const resolved = await resolveShareToken(db, token);
+
+  if (resolved.state === 'missing') {
+    throw createError({ statusCode: 404, message: 'Not found' });
+  }
+  if (resolved.state === 'gone') {
+    // The hash matched, so the holder once had the real link — telling them it
+    // is dead has no enumeration value and beats a bare 404.
+    setResponseStatus(event, 404);
+    setResponseHeader(event, 'Content-Type', 'text/html; charset=utf-8');
+    setResponseHeader(event, 'Content-Security-Policy', 'sandbox');
+    return '<!doctype html><html><head><title>Link no longer available</title></head><body style="font-family: system-ui, sans-serif; margin: 4rem auto; max-width: 32rem; text-align: center;"><h1>This link is no longer available</h1><p>The share link was revoked or has expired. Ask the person who sent it for a new one.</p></body></html>';
+  }
+
+  const { link } = resolved;
+  const bundle =
+    link.entityKind === 'cluster'
+      ? await collectClusterBundle(db, link.entityId, {
+          maxCases: resolveExportMaxCases(),
+          sourceUrl: exportSourceUrl(event, `/failure-clusters/${link.entityId}`),
+          piwiVersion: exportPiwiVersion(event),
+        })
+      : await collectExecutionBundle(db, link.entityId, {
+          maxCases: 1,
+          sourceUrl: exportSourceUrl(event, `/test-run-cases/${link.entityId}`),
+          piwiVersion: exportPiwiVersion(event),
+        });
+
+  // The entity was pruned (retention) or deleted — indistinguishable from an
+  // unknown token by design.
+  if (!bundle) {
+    throw createError({ statusCode: 404, message: 'Not found' });
+  }
+
+  const built = await buildExport(bundle, 'html', link.entityId, {
+    reader: serverAssetReader,
+    budget: resolveExportBudget(),
+    print: false,
+  });
+
+  await recordShareLinkView(db, link.id);
+
+  setResponseHeader(event, 'Content-Type', built.contentType);
+  setResponseHeader(event, 'Content-Length', built.bytes.length);
+  setResponseHeader(event, 'Content-Disposition', 'inline');
+  setResponseHeader(event, 'X-Content-Type-Options', 'nosniff');
+  setResponseHeader(event, 'Referrer-Policy', 'no-referrer');
+  // Unique opaque origin: the document cannot read cookies or make
+  // credentialed calls back into the dashboard, exactly like a print export.
+  setResponseHeader(event, 'Content-Security-Policy', 'sandbox allow-scripts allow-modals');
+
+  return Buffer.from(built.bytes);
+});

--- a/apps/application/server/utils/retention.ts
+++ b/apps/application/server/utils/retention.ts
@@ -6,12 +6,14 @@ import type { DbClient } from '../database';
 import {
   casePayloads,
   entityLinks,
+  failureClusters,
   failureDiagnoses,
   failureDiagnosisVersions,
   files,
   locatorSnapshots,
   networkRequests,
   notificationDeliveries,
+  shareLinks,
   subscriptions,
   testRuns,
   testRunsCases,
@@ -168,6 +170,7 @@ export interface OrphanSweepResult {
   diagnosisVersions: number;
   notificationDeliveries: number;
   casePayloads: number;
+  shareLinks: number;
 }
 
 async function countWhere(db: DbClient, table: SQLiteTable, where: SQL): Promise<number> {
@@ -195,6 +198,10 @@ export async function sweepOrphans(db: DbClient): Promise<OrphanSweepResult> {
   // so a concurrent sweep must not reap rows from an in-flight ingest batch.
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
   const orphanedPayloads = and(lt(casePayloads.createdAt, oneHourAgo), payloadUnreferenced())!;
+  // `share_links.entity_id` is polymorphic over two tables and carries no FK,
+  // so a link whose entity was pruned lingers until this sweep removes it.
+  const orphanedShareLinks = sql`(${shareLinks.entityKind} = 'execution' AND NOT EXISTS (SELECT 1 FROM ${testRunsCases} WHERE ${testRunsCases.id} = ${shareLinks.entityId}))
+    OR (${shareLinks.entityKind} = 'cluster' AND NOT EXISTS (SELECT 1 FROM ${failureClusters} WHERE ${failureClusters.id} = ${shareLinks.entityId}))`;
 
   const result: OrphanSweepResult = {
     networkRequests: await countWhere(db, networkRequests, orphanedNetworkRequests),
@@ -204,6 +211,7 @@ export async function sweepOrphans(db: DbClient): Promise<OrphanSweepResult> {
     diagnosisVersions: await countWhere(db, failureDiagnosisVersions, orphanedVersions),
     notificationDeliveries: await countWhere(db, notificationDeliveries, orphanedDeliveries),
     casePayloads: await countWhere(db, casePayloads, orphanedPayloads),
+    shareLinks: await countWhere(db, shareLinks, orphanedShareLinks),
   };
 
   await db.delete(networkRequests).where(orphanedNetworkRequests);
@@ -215,6 +223,7 @@ export async function sweepOrphans(db: DbClient): Promise<OrphanSweepResult> {
   await db.delete(failureDiagnosisVersions).where(orphanedVersions);
   await db.delete(notificationDeliveries).where(orphanedDeliveries);
   await db.delete(casePayloads).where(orphanedPayloads);
+  await db.delete(shareLinks).where(orphanedShareLinks);
 
   return result;
 }

--- a/apps/application/server/utils/share-links.ts
+++ b/apps/application/server/utils/share-links.ts
@@ -1,0 +1,177 @@
+import { randomBytes, createHash } from 'node:crypto';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import { shareLinks, type ShareLink } from '../database/schema';
+import type { DbClient } from '../database';
+import type { ExportKind } from '#shared/export/types';
+
+export const SHARE_TOKEN_PREFIX = 'psl_';
+
+/** Full share token: `psl_` + 64 hex chars. */
+const SHARE_TOKEN_RE = /^psl_[0-9a-f]{64}$/;
+
+export const DEFAULT_SHARE_LINK_MAX_TTL_DAYS = 30;
+export const MAX_SHARE_LINK_MAX_TTL_DAYS = 3650;
+
+/** Share links are off unless the operator opts in. */
+export function shareLinksEnabled(): boolean {
+  return process.env.PIWI_SHARE_LINKS_ENABLED === 'true';
+}
+
+/**
+ * Longest allowed link lifetime in days. `0` lifts the cap entirely and lets
+ * links be minted without an expiry.
+ */
+export function resolveShareLinkMaxTtlDays(): number {
+  const raw = process.env.PIWI_SHARE_LINK_MAX_TTL_DAYS;
+  if (raw == null || raw.trim() === '') return DEFAULT_SHARE_LINK_MAX_TTL_DAYS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_SHARE_LINK_MAX_TTL_DAYS;
+  return Math.min(Math.floor(parsed), MAX_SHARE_LINK_MAX_TTL_DAYS);
+}
+
+/** SHA-256 hex of the full token (including the `psl_` prefix). */
+function hashShareToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * The expiry a mint request resolves to. With a TTL cap in force, every link
+ * expires — a missing or out-of-range request falls back to the cap. With the
+ * cap lifted (`0`), a missing request means no expiry.
+ */
+export function resolveShareLinkExpiry(requestedTtlDays: number | null | undefined, now = new Date()): Date | null {
+  const maxTtlDays = resolveShareLinkMaxTtlDays();
+  let ttlDays: number | null;
+  if (maxTtlDays > 0) {
+    const requested =
+      typeof requestedTtlDays === 'number' && Number.isFinite(requestedTtlDays) ? requestedTtlDays : null;
+    ttlDays = requested && requested >= 1 ? Math.min(Math.floor(requested), maxTtlDays) : maxTtlDays;
+  } else {
+    ttlDays =
+      typeof requestedTtlDays === 'number' && Number.isFinite(requestedTtlDays) && requestedTtlDays >= 1
+        ? Math.floor(requestedTtlDays)
+        : null;
+  }
+  return ttlDays == null ? null : new Date(now.getTime() + ttlDays * 24 * 60 * 60 * 1000);
+}
+
+export interface MintedShareLink {
+  /** The full token — shown once, never stored. */
+  token: string;
+  link: ShareLink;
+}
+
+export async function mintShareLink(
+  db: DbClient,
+  input: {
+    projectId: number;
+    entityKind: ExportKind;
+    entityId: number;
+    createdBy: number | null;
+    ttlDays?: number | null;
+  },
+): Promise<MintedShareLink> {
+  const secret = randomBytes(32).toString('hex');
+  const token = `${SHARE_TOKEN_PREFIX}${secret}`;
+  const inserted = await db
+    .insert(shareLinks)
+    .values({
+      projectId: input.projectId,
+      entityKind: input.entityKind,
+      entityId: input.entityId,
+      tokenHash: hashShareToken(token),
+      tokenPrefix: secret.slice(0, 8),
+      createdBy: input.createdBy,
+      expiresAt: resolveShareLinkExpiry(input.ttlDays),
+    })
+    .returning();
+  return { token, link: inserted[0]! };
+}
+
+export type ResolvedShareLink =
+  /** The token matched a row that is neither revoked nor expired. */
+  | { state: 'live'; link: ShareLink }
+  /** The token matched a row, so the holder once had a real link — but it is revoked or expired. */
+  | { state: 'gone' }
+  /** No matching row (or not a share token at all). */
+  | { state: 'missing' };
+
+export async function resolveShareToken(db: DbClient, token: string): Promise<ResolvedShareLink> {
+  if (!SHARE_TOKEN_RE.test(token)) return { state: 'missing' };
+  const rows = await db
+    .select()
+    .from(shareLinks)
+    .where(eq(shareLinks.tokenHash, hashShareToken(token)));
+  const link = rows[0];
+  if (!link) return { state: 'missing' };
+  if (link.revokedAt || (link.expiresAt && link.expiresAt.getTime() <= Date.now())) return { state: 'gone' };
+  return { state: 'live', link };
+}
+
+/** Count a successful view. */
+export async function recordShareLinkView(db: DbClient, id: number): Promise<void> {
+  await db
+    .update(shareLinks)
+    .set({ lastViewedAt: new Date(), viewCount: sql`${shareLinks.viewCount} + 1` })
+    .where(eq(shareLinks.id, id));
+}
+
+/** UI-facing row — everything except the hash, which never leaves the server. */
+export interface ShareLinkSummary {
+  id: number;
+  entityKind: string;
+  entityId: number;
+  tokenPrefix: string;
+  createdBy: number | null;
+  createdAt: Date;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  lastViewedAt: Date | null;
+  viewCount: number;
+}
+
+function toSummary(link: ShareLink): ShareLinkSummary {
+  return {
+    id: link.id,
+    entityKind: link.entityKind,
+    entityId: link.entityId,
+    tokenPrefix: link.tokenPrefix,
+    createdBy: link.createdBy,
+    createdAt: link.createdAt,
+    expiresAt: link.expiresAt,
+    revokedAt: link.revokedAt,
+    lastViewedAt: link.lastViewedAt,
+    viewCount: link.viewCount,
+  };
+}
+
+export async function listEntityShareLinks(
+  db: DbClient,
+  entityKind: ExportKind,
+  entityId: number,
+): Promise<ShareLinkSummary[]> {
+  const rows = await db
+    .select()
+    .from(shareLinks)
+    .where(and(eq(shareLinks.entityKind, entityKind), eq(shareLinks.entityId, entityId)))
+    .orderBy(desc(shareLinks.createdAt));
+  return rows.map(toSummary);
+}
+
+export async function listProjectShareLinks(db: DbClient, projectId: number): Promise<ShareLinkSummary[]> {
+  const rows = await db
+    .select()
+    .from(shareLinks)
+    .where(eq(shareLinks.projectId, projectId))
+    .orderBy(desc(shareLinks.createdAt));
+  return rows.map(toSummary);
+}
+
+export async function getShareLink(db: DbClient, id: number): Promise<ShareLink | null> {
+  const rows = await db.select().from(shareLinks).where(eq(shareLinks.id, id));
+  return rows[0] ?? null;
+}
+
+export async function revokeShareLink(db: DbClient, id: number): Promise<void> {
+  await db.update(shareLinks).set({ revokedAt: new Date() }).where(eq(shareLinks.id, id));
+}

--- a/apps/application/shared/piwi-env-vars.ts
+++ b/apps/application/shared/piwi-env-vars.ts
@@ -378,6 +378,25 @@ export const PIWI_ENV_VARS = {
     requiredWhen: { PIWI_AUTH_ENABLED: 'true' },
     notes: 'The server refuses to start when auth is enabled and this is unset.',
   },
+  PIWI_SHARE_LINKS_ENABLED: {
+    description:
+      'Set to "true" to allow minting read-only public share links for executions and failure clusters. Off by default; turning it off again immediately dead-ends every outstanding link without deleting anything.',
+    category: 'auth',
+    type: 'boolean',
+    default: 'false',
+    since: '0.26.0',
+  },
+  PIWI_SHARE_LINK_MAX_TTL_DAYS: {
+    description:
+      'Longest allowed share-link lifetime, in days. The creation dialog offers expiries up to this; 0 lifts the cap and allows links with no expiry.',
+    category: 'auth',
+    type: 'number',
+    default: '30',
+    min: 0,
+    max: 3650,
+    relevantWhen: { PIWI_SHARE_LINKS_ENABLED: 'true' },
+    since: '0.26.0',
+  },
   PIWI_TRUST_PROXY: {
     description:
       'Set to "true" when a reverse proxy sits in front of Piwi, so per-IP rate limits on the auth endpoints key on the client address your proxy appends to X-Forwarded-For instead of on the proxy\'s own address (which would pool every client into one bucket). Leave off when clients connect directly: the header is client-controlled then, and trusting it would let a caller choose its own bucket.',

--- a/apps/application/shared/test-project-names.ts
+++ b/apps/application/shared/test-project-names.ts
@@ -113,6 +113,7 @@ export const PROJECT = {
   RUN_LABEL: 'run-label-test',
   RUN_SUMMARY_TEST: 'run-summary-test',
   SHARDING_TEST: 'sharding-test',
+  SHARE_LINKS: 'share-links-e2e-test',
   STATS_TEST: 'stats-test-project',
   SUMMARY_FOLD: 'summary-fold-test',
   STORAGE_TEST: 'storage-test-project',

--- a/apps/application/tests/reporter-with-auth.spec.ts
+++ b/apps/application/tests/reporter-with-auth.spec.ts
@@ -688,6 +688,65 @@ test.describe.serial('Reporter with authentication enabled', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Share links — the one anonymous read path on an auth-enabled server.
+  // ---------------------------------------------------------------------------
+
+  test('a share link renders anonymously while the API stays authenticated', async ({ request, playwright }) => {
+    const loginRes = await request.post(`${AUTH_SERVER_URL}/api/auth/login`, {
+      data: { username: 'admin', password: 'adminpassword123' },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+
+    const submit = await request.post(`${AUTH_SERVER_URL}/api/test-runs/submit`, {
+      data: {
+        projectName: PROJECT.REPORTER_AUTH,
+        status: 'failed',
+        startTime: new Date().toISOString(),
+        duration: 900,
+        totalTests: 1,
+        passedTests: 0,
+        failedTests: 1,
+        skippedTests: 0,
+        testCases: [
+          {
+            title: 'anonymously shared failure',
+            status: 'failed',
+            duration: 300,
+            location: 'tests/shared.spec.ts:3:1',
+            error: 'Error: expected banner to be visible',
+          },
+        ],
+      },
+    });
+    expect(submit.ok()).toBeTruthy();
+    const { testRunId } = await submit.json();
+    const run = (await (await request.get(`${AUTH_SERVER_URL}/api/test-runs/${testRunId}`)).json()) as {
+      testCases: Array<{ id: number; status: string }>;
+    };
+    const executionId = run.testCases.find((c) => c.status === 'failed')!.id;
+
+    const minted = await (
+      await request.post(`${AUTH_SERVER_URL}/api/test-run-cases/${executionId}/share-links`, { data: {} })
+    ).json();
+    expect(minted.token).toMatch(/^psl_/);
+
+    // A context with no session: the share URL renders, the API refuses.
+    const anon = await playwright.request.newContext();
+    try {
+      const shared = await anon.get(minted.url);
+      expect(shared.status()).toBe(200);
+      expect(await shared.text()).toContain('anonymously shared failure');
+
+      const api = await anon.get(`${AUTH_SERVER_URL}/api/test-run-cases/${executionId}`);
+      expect(api.status()).toBe(401);
+      const mint = await anon.post(`${AUTH_SERVER_URL}/api/test-run-cases/${executionId}/share-links`, { data: {} });
+      expect(mint.status()).toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
   // Project members API — administrator-only authorization
   //
   // These checks need a real authenticated non-admin session (a "user" role

--- a/apps/application/tests/share-links.spec.ts
+++ b/apps/application/tests/share-links.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from './fixtures';
+import { PROJECT } from '#shared/test-project-names';
+
+const CASE_TITLE = 'share link case renders';
+
+test.describe.serial('Share links', () => {
+  let executionId: number;
+  let clusterId: number | undefined;
+  let executionShareUrl: string;
+  let executionLinkId: number;
+
+  test('a failing run provides an execution and a cluster to share', async ({ request }) => {
+    const submit = await request.post('/api/test-runs/submit', {
+      data: {
+        projectName: PROJECT.SHARE_LINKS,
+        status: 'failed',
+        startTime: new Date().toISOString(),
+        duration: 4000,
+        totalTests: 1,
+        passedTests: 0,
+        failedTests: 1,
+        skippedTests: 0,
+        testCases: [
+          {
+            title: CASE_TITLE,
+            status: 'failed',
+            duration: 1200,
+            location: 'tests/share.spec.ts:5:3',
+            error:
+              "TimeoutError: locator.click: Timeout 30000ms exceeded.\nCall log:\n  - waiting for getByTestId('share-target')",
+          },
+        ],
+      },
+    });
+    expect(submit.ok()).toBeTruthy();
+    const { testRunId } = await submit.json();
+
+    const run = (await (await request.get(`/api/test-runs/${testRunId}`)).json()) as {
+      testCases: Array<{ id: number; status: string; failureClusterId?: number }>;
+    };
+    const failed = run.testCases.find((c) => c.status === 'failed');
+    expect(failed).toBeDefined();
+    executionId = failed!.id;
+    clusterId = failed!.failureClusterId;
+  });
+
+  test('the settings probe reports the suite-enabled feature', async ({ request }) => {
+    const res = await request.get('/api/share-links/settings');
+    expect(res.ok()).toBeTruthy();
+    const settings = await res.json();
+    expect(settings.enabled).toBe(true);
+    expect(settings.maxTtlDays).toBe(30);
+  });
+
+  test('minting returns the full token once, capped to the TTL limit', async ({ request }) => {
+    const res = await request.post(`/api/test-run-cases/${executionId}/share-links`, { data: { ttlDays: 365 } });
+    expect(res.ok()).toBeTruthy();
+    const minted = await res.json();
+    expect(minted.token).toMatch(/^psl_[0-9a-f]{64}$/);
+    expect(minted.url).toContain(`/share/${minted.token}`);
+    expect(minted.link.tokenPrefix).toBe(minted.token.slice(4, 12));
+    // 365 days is over the cap — the expiry lands at the 30-day maximum.
+    const days = (new Date(minted.link.expiresAt).getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+    expect(days).toBeLessThanOrEqual(30);
+    expect(days).toBeGreaterThan(29);
+    executionShareUrl = minted.url;
+    executionLinkId = minted.link.id;
+  });
+
+  test('the share URL renders the investigation for an anonymous viewer', async ({ request }) => {
+    const res = await request.get(executionShareUrl);
+    expect(res.status()).toBe(200);
+    const headers = res.headers();
+    expect(headers['content-type']).toContain('text/html');
+    expect(headers['content-security-policy']).toContain('sandbox');
+    expect(headers['x-robots-tag']).toContain('noindex');
+    expect(headers['cache-control']).toContain('no-store');
+    expect(headers['referrer-policy']).toBe('no-referrer');
+    expect(await res.text()).toContain(CASE_TITLE);
+  });
+
+  test('the listing shows the view without ever returning the token', async ({ request }) => {
+    const res = await request.get(`/api/test-run-cases/${executionId}/share-links`);
+    expect(res.ok()).toBeTruthy();
+    const { shareLinks } = await res.json();
+    expect(shareLinks).toHaveLength(1);
+    expect(shareLinks[0].viewCount).toBe(1);
+    expect(shareLinks[0].tokenPrefix).toHaveLength(8);
+    expect(shareLinks[0]).not.toHaveProperty('tokenHash');
+    expect(JSON.stringify(shareLinks)).not.toContain(executionShareUrl.split('/share/psl_')[1]);
+  });
+
+  test('a cluster share link renders too', async ({ request }) => {
+    test.skip(!clusterId, 'failure clustering did not assign a cluster');
+    const minted = await (await request.post(`/api/failure-clusters/${clusterId}/share-links`, { data: {} })).json();
+    const res = await request.get(minted.url);
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toContain(CASE_TITLE);
+  });
+
+  test('a revoked link answers 404 with a human explanation', async ({ request }) => {
+    const revoke = await request.delete(`/api/share-links/${executionLinkId}`);
+    expect(revoke.ok()).toBeTruthy();
+    const res = await request.get(executionShareUrl);
+    expect(res.status()).toBe(404);
+    expect(await res.text()).toContain('no longer available');
+  });
+
+  test('unknown and malformed tokens are a plain 404', async ({ request }) => {
+    const unknown = await request.get(`/share/psl_${'0'.repeat(64)}`);
+    expect(unknown.status()).toBe(404);
+    expect(await unknown.text()).not.toContain('no longer available');
+    const malformed = await request.get('/share/not-a-token');
+    expect(malformed.status()).toBe(404);
+  });
+});

--- a/apps/application/tests/unit/share-links.test.ts
+++ b/apps/application/tests/unit/share-links.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createClient } from '@libsql/client';
+import * as schema from '../../server/database/schema.sqlite';
+
+// The schema barrel (server/database/schema.ts) picks the PostgreSQL schema at
+// import time when PIWI_DATABASE_URL is set, so clear it before share-links.ts
+// (which imports the barrel) is loaded.
+delete process.env.PIWI_DATABASE_URL;
+const {
+  mintShareLink,
+  resolveShareToken,
+  resolveShareLinkExpiry,
+  recordShareLinkView,
+  listEntityShareLinks,
+  listProjectShareLinks,
+  revokeShareLink,
+  getShareLink,
+  shareLinksEnabled,
+} = await import('../../server/utils/share-links');
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+let db: Db;
+let projectId: number;
+
+async function freshDb(): Promise<Db> {
+  const next = drizzle(createClient({ url: ':memory:' }), { schema });
+  await migrate(next, {
+    migrationsFolder: fileURLToPath(new URL('../../server/database/migrations', import.meta.url)),
+  });
+  return next;
+}
+
+beforeEach(async () => {
+  db = await freshDb();
+  const inserted = await db.insert(schema.projects).values({ name: 'share-links-test' }).returning();
+  projectId = inserted[0]!.id;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+function mint(ttlDays?: number | null) {
+  return mintShareLink(db, { projectId, entityKind: 'execution', entityId: 42, createdBy: null, ttlDays });
+}
+
+describe('mintShareLink', () => {
+  test('returns a psl_ token once and stores only its hash and prefix', async () => {
+    const minted = await mint();
+    expect(minted.token).toMatch(/^psl_[0-9a-f]{64}$/);
+    expect(minted.link.tokenPrefix).toBe(minted.token.slice(4, 12));
+    const row = await getShareLink(db, minted.link.id);
+    expect(row!.tokenHash).toHaveLength(64);
+    expect(row!.tokenHash).not.toContain(minted.token.slice(4));
+  });
+
+  test('applies the default 30-day cap when no expiry is requested', async () => {
+    const minted = await mint();
+    const days = (minted.link.expiresAt!.getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+    expect(days).toBeGreaterThan(29.9);
+    expect(days).toBeLessThanOrEqual(30);
+  });
+});
+
+describe('resolveShareLinkExpiry', () => {
+  test('clamps a request above the cap down to the cap', () => {
+    const expiry = resolveShareLinkExpiry(365, new Date(0));
+    expect(expiry!.getTime()).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  test('honors a request under the cap', () => {
+    const expiry = resolveShareLinkExpiry(7, new Date(0));
+    expect(expiry!.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  test('with the cap lifted (0), no request means no expiry', () => {
+    vi.stubEnv('PIWI_SHARE_LINK_MAX_TTL_DAYS', '0');
+    expect(resolveShareLinkExpiry(undefined, new Date(0))).toBeNull();
+    expect(resolveShareLinkExpiry(5, new Date(0))!.getTime()).toBe(5 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe('resolveShareToken', () => {
+  test('resolves a live token', async () => {
+    const minted = await mint();
+    const resolved = await resolveShareToken(db, minted.token);
+    expect(resolved.state).toBe('live');
+    if (resolved.state === 'live') expect(resolved.link.id).toBe(minted.link.id);
+  });
+
+  test('rejects garbage and unknown tokens as missing', async () => {
+    await mint();
+    expect((await resolveShareToken(db, 'not-a-token')).state).toBe('missing');
+    expect((await resolveShareToken(db, `psl_${'0'.repeat(64)}`)).state).toBe('missing');
+  });
+
+  test('a revoked token is gone, not missing', async () => {
+    const minted = await mint();
+    await revokeShareLink(db, minted.link.id);
+    expect((await resolveShareToken(db, minted.token)).state).toBe('gone');
+  });
+
+  test('an expired token is gone', async () => {
+    vi.useFakeTimers();
+    const minted = await mint(1);
+    vi.advanceTimersByTime(2 * 24 * 60 * 60 * 1000);
+    expect((await resolveShareToken(db, minted.token)).state).toBe('gone');
+  });
+});
+
+describe('view counting and listings', () => {
+  test('recordShareLinkView increments the counter and stamps the view', async () => {
+    const minted = await mint();
+    await recordShareLinkView(db, minted.link.id);
+    await recordShareLinkView(db, minted.link.id);
+    const row = await getShareLink(db, minted.link.id);
+    expect(row!.viewCount).toBe(2);
+    expect(row!.lastViewedAt).not.toBeNull();
+  });
+
+  test('listings carry the prefix but never the hash', async () => {
+    await mint();
+    const forEntity = await listEntityShareLinks(db, 'execution', 42);
+    const forProject = await listProjectShareLinks(db, projectId);
+    expect(forEntity).toHaveLength(1);
+    expect(forProject).toHaveLength(1);
+    expect(forEntity[0]!.tokenPrefix).toHaveLength(8);
+    expect(forEntity[0]).not.toHaveProperty('tokenHash');
+    expect(forProject[0]).not.toHaveProperty('tokenHash');
+  });
+});
+
+describe('shareLinksEnabled', () => {
+  test('is off unless the env opts in', () => {
+    expect(shareLinksEnabled()).toBe(false);
+    vi.stubEnv('PIWI_SHARE_LINKS_ENABLED', 'true');
+    expect(shareLinksEnabled()).toBe(true);
+  });
+});

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -117,6 +117,7 @@ export default defineConfig({
           { text: 'Timeline markers', link: '/timeline-markers' },
           { text: 'Notifications & alerts', link: '/notifications' },
           { text: 'Offline export', link: '/offline-export' },
+          { text: 'Share links', link: '/share-links' },
         ],
       },
       {

--- a/apps/docs/offline-export.md
+++ b/apps/docs/offline-export.md
@@ -52,6 +52,7 @@ Piwi instance. Bundling the viewer's assets into the export itself is on the
 
 ## See also
 
+- [Share links](./share-links) — the live counterpart: a revocable read-only URL instead of a file
 - [Failure evidence](./evidence) — what the export is a snapshot of
 - [AI diagnosis & clustering](./ai-diagnosis) — cluster exports carry the diagnosis too
 - [Storage configuration](./storage#data-retention) — retention, and why an export outlives it

--- a/apps/docs/share-links.md
+++ b/apps/docs/share-links.md
@@ -1,0 +1,60 @@
+---
+title: Share links
+lang: en-US
+---
+
+# Share links
+
+A share link is a read-only URL for one execution or one failure cluster that anyone can open — no dashboard
+account, no login. It is the live counterpart of an [offline export](./offline-export): instead of a file frozen at
+export time, the link renders the investigation as it stands when it is opened.
+
+Share links are **off by default**. Set `PIWI_SHARE_LINKS_ENABLED=true` to allow them — see the
+[configuration reference](./configuration#authentication).
+
+## Creating a link
+
+On an execution page or a failure-cluster page, open **Share** (next to **Export**):
+
+1. Pick an expiry. The dialog offers lifetimes up to `PIWI_SHARE_LINK_MAX_TTL_DAYS` (30 days unless configured;
+   setting it to `0` lifts the cap and allows links with no expiry).
+2. **Copy the link immediately — it is shown only once.** The server stores a hash of the token, not the token, so
+   there is no way to display the URL again later. Mint a new link instead.
+
+Creating and revoking links requires the administrator or reporter role; any project member can see which links
+exist. Each entry in the dialog shows the link's prefix, its expiry state, and how many times it was opened.
+
+## What the viewer sees
+
+The link serves the same self-contained HTML report the [offline export](./offline-export) produces, rebuilt from
+the current data on every view — a diagnosis added after the link was minted shows up, a cluster marked fixed reads
+as fixed. The same size budgets apply (`PIWI_EXPORT_MAX_*`), so an anonymous view can never cost the server more
+than an authenticated export does.
+
+Two consequences of "live" worth knowing:
+
+- **Retention thins a shared cluster over time.** When [data retention](./storage#data-retention) prunes old runs, a
+  cluster link keeps resolving but progressively loses member evidence — the same thinning the dashboard shows. A
+  link whose entity is pruned entirely answers 404. When the investigation must outlive retention, hand over an
+  export file instead.
+- **Revocation is immediate.** A revoked link stops resolving on the next request. Turning the feature off entirely
+  (`PIWI_SHARE_LINKS_ENABLED` unset) dead-ends every outstanding link at once without deleting anything, so the
+  variable doubles as a kill switch.
+
+## Security properties
+
+- The token is a 256-bit random secret (`psl_` + 64 hex characters) — unguessable at any request rate. The server
+  stores only its SHA-256 hash.
+- Everything a link serves is data its creator could already see: minting requires project access, so a link is a
+  narrower delegation of an existing member's read access, never an escalation.
+- The rendered page is sandboxed into a unique origin and served with `noindex` and `Referrer-Policy: no-referrer`,
+  so it cannot read dashboard cookies, call the API with credentials, or leak the URL through outbound links. Share
+  responses are never cached.
+- A share URL is a capability: anyone holding it can view the page, and it can end up in browser history or proxy
+  logs like any URL. Prefer short expiries, and revoke links when an investigation closes.
+
+## See also
+
+- [Offline export](./offline-export) — the file to hand over when the recipient has no network path to your instance
+- [Authentication](./authentication) — roles, and who can mint or revoke
+- [Storage configuration](./storage#data-retention) — retention, and how it interacts with long-lived links

--- a/proposals/public-share-links.md
+++ b/proposals/public-share-links.md
@@ -127,9 +127,9 @@ user" in `generateApiKey`). Afterwards the UI shows only `token_prefix`.
 
 - **`/share/<token>`** — the page. A Vue page at `app/pages/share/[token].vue`, server-rendered like the rest of the
   app, with `definePageMeta({ layout: false })` like `/login` (no sidebar, no project menu — nothing that assumes a
-  session). The global auth middleware (`apps/application/app/middleware/auth.global.ts`) today early-returns only for
-  `to.path === '/login'`; that skip becomes a small public-path check covering `/share/` too, so the page never
-  redirects an anonymous viewer to the login screen.
+  session). The global auth middleware (`apps/application/app/middleware/auth.global.ts`) early-returns for the paths
+  in its `PUBLIC_PATHS` list; share pages join it by prefix rather than exact match, so the page never redirects an
+  anonymous viewer to the login screen.
 - **`GET /api/share/<token>`** — resolves the token and returns the bundle JSON
   (`server/api/share/[token].get.ts`).
 - **`GET /api/share/<token>/assets/<...path>`** — serves one evidence asset

--- a/proposals/public-share-links.md
+++ b/proposals/public-share-links.md
@@ -1,0 +1,310 @@
+# Public share links
+
+A design proposal for read-only share links: handing one investigation to someone without a dashboard account, as a
+URL instead of a file. This is the "Public share links" entry under Exploring in [ROADMAP.md](../ROADMAP.md), which
+notes that a read-only link "would need share tokens, which Piwi has no infrastructure for today". This document
+proposes that infrastructure. Nothing here is committed work — it is a concrete position to argue with.
+
+**Summary.** A share link is an unguessable capability token (`psl_` + 64 hex chars, 256-bit) stored only as a SHA-256
+hash in a new `share_links` table, scoped to exactly one entity: one execution or one failure cluster — the same two
+entities offline export covers. Two anonymous GET routes resolve a token to the same `ExportBundle` the export
+pipeline already collects, so the shared view shows exactly what the dashboard shows, live at view time, bounded by
+the existing export size budget. Links are minted, listed and revoked through authenticated project-scoped endpoints.
+The whole feature is off by default behind `PIWI_SHARE_LINKS_ENABLED`.
+
+## Problem
+
+Offline export (shipped — see the "Recently shipped" entry in [ROADMAP.md](../ROADMAP.md) and
+`apps/docs/offline-export.md`) hands an investigation over as a self-contained file: HTML, ZIP, PDF, Markdown or JSON.
+That is the right answer when the recipient must read it with no network, or when the report must outlive the
+retention window. It is the wrong shape for "look at this now": the file is frozen at export time, so a diagnosis
+added an hour later, a cluster marked fixed, or a new occurrence never reaches the recipient; and a 100 MB ZIP is a
+heavy way to show a colleague one failing test.
+
+A read-only link is the live counterpart: the recipient opens a URL and sees the current state of the investigation,
+with the evidence, without an account. Piwi has no share-token infrastructure today — its existing credentials
+(session cookie and API key in `apps/application/server/utils/auth.ts`, stream tokens, the emailed account tokens,
+the desktop access token) all authenticate a known user or a machine flow, none an anonymous viewer.
+
+## Scope (v1)
+
+A share link covers exactly the two entities offline export covers:
+
+- **One execution** — a `test_runs_cases` row, what `/test-run-cases/:id` shows (the vocabulary is
+  `apps/docs/concepts.md`: an execution is one attempt of one test in one run).
+- **One failure cluster** — what `/failure-clusters/:id` shows, including the member executions' evidence up to the
+  export case cap.
+
+The link renders a read-only view of what the corresponding detail page shows, resolved **live at view time** — not a
+frozen snapshot. If the cluster gains occurrences or a diagnosis after the link was minted, the viewer sees them. If
+retention prunes the underlying data, the viewer sees less (see "Retention interplay" below).
+
+### Non-goals (v1)
+
+- **Whole-run links.** Run-level offline export is itself still under Exploring in ROADMAP.md; share links for runs
+  follow the same shape once that ships. Listed under open questions.
+- **Editing or triage via link.** A link viewer can never change cluster status, save a locator pick, or trigger a
+  diagnosis. The anonymous surface is strictly GET.
+- **Password-protected links.** The token is the secret; a second secret on top adds UX cost without changing the
+  threat model (both travel over the same channel).
+- **Per-viewer identity.** No "shared with alice@" — one link, anyone holding it. `view_count` and `last_viewed_at`
+  give coarse usage signal without identifying viewers.
+- **Embedding/iframes.** The share page is a standalone document; nothing in v1 relaxes framing protections for it.
+- **Any hosted relay service.** A project-run redirector or link gallery would mean investigation data leaving
+  the operator's server, which contradicts how the project describes itself everywhere: "Self-hosted, MIT, zero
+  telemetry" (README.md), and ROADMAP.md's non-goal "A hosted SaaS — Piwi is built to be self-hosted; your data stays
+  yours." A share link is served by *your* instance, at *your* origin, and dies when you revoke it or shut the server
+  down.
+
+## Reuse over new machinery
+
+The core argument of this design: the share endpoint serves **the same bundle the offline export already collects**,
+rather than a new "share view" data path.
+
+`apps/application/shared/export/collect.ts` assembles an `ExportBundle` from the handlers that already back the detail
+pages — its header comment states the invariant this feature inherits: "an export shows exactly what the dashboard
+shows". `collectExecutionBundle(db, executionId, opts)` and `collectClusterBundle(db, clusterId, opts)` are exactly
+the two entry points the share resolver needs, one per `entity_kind`. Because the share view renders from that bundle,
+it can never drift from the dashboard: any field added to the detail pages flows into exports and share views through
+one collector.
+
+Reuse also answers the resource question. The export size budget (`apps/application/shared/export/limits.ts`,
+enforced through `resolveExportBudget()` / `resolveExportMaxCases()` in
+`apps/application/server/utils/export-assets.ts`, tunable via `PIWI_EXPORT_MAX_INLINE_BYTES`, `PIWI_EXPORT_MAX_BYTES`
+and `PIWI_EXPORT_MAX_CASES`) already bounds what one export costs the server. The share routes sit behind the same
+bounds, so one anonymous request can never cost more than one authenticated export does today.
+
+Evidence bytes go through the same plumbing: the `ExportAssetReader` interface
+(`apps/application/shared/export/types.ts`) and its server implementation `serverAssetReader`
+(`apps/application/server/utils/export-assets.ts`), which keeps the same path-traversal guard the file endpoint
+applies (rejecting `..` and absolute paths).
+
+## Token model
+
+### Table
+
+A new `share_links` table, added to **both** `apps/application/server/database/schema.sqlite.ts` and
+`schema.pg.ts`, with migrations generated by `npm run db:generate` and `npm run db:generate:pg` — never hand-written,
+per the rule in [apps/application/AGENTS.md](../apps/application/AGENTS.md) (a hand-made migration is silently skipped
+by the migrator).
+
+| Column | Type / constraint | Notes |
+|---|---|---|
+| `id` | PK, autoincrement | |
+| `token_hash` | text, unique index | Unsalted SHA-256 hex of the full token, including the `psl_` prefix |
+| `token_prefix` | text | First 8 hex chars after `psl_`; display-only, like `api_keys.key_prefix` |
+| `project_id` | FK → `projects`, ON DELETE CASCADE, indexed | Deleting a project takes its links with it |
+| `entity_kind` | text: `'execution'` \| `'cluster'` | Same union as `ExportKind` in `shared/export/types.ts` |
+| `entity_id` | integer | `test_runs_cases.id` or `failure_clusters.id`; no FK (polymorphic — see retention) |
+| `created_by` | FK → `users`, ON DELETE SET NULL | Survives its creator, like `project_assignments.created_by` |
+| `created_at` | timestamp | |
+| `expires_at` | timestamp, nullable | Null = no expiry (same convention as `api_keys.expires_at`) |
+| `revoked_at` | timestamp, nullable | Set on revoke; the row is kept for the audit trail |
+| `last_viewed_at` | timestamp, nullable | Updated on successful resolve, throttled like `api_keys.last_used_at` |
+| `view_count` | integer, default 0 | Coarse usage signal |
+
+Storing the hash unsalted is deliberate and matches existing practice for high-entropy secrets:
+`account_tokens.token_hash` is "SHA-256 of the emailed token" (`apps/application/server/utils/account-tokens.ts`,
+`hashToken`), and `api_keys.key_hash` is a SHA-256 of the full key (`generateApiKey` in
+`apps/application/server/utils/auth.ts`). Salting and slow hashing defend low-entropy secrets (passwords) against
+offline brute force; a 256-bit random token cannot be brute-forced regardless, and the plain hash is what makes an
+indexed equality lookup possible.
+
+### Token format
+
+`psl_` + 64 lowercase hex chars from `randomBytes(32)` — 256 bits of entropy, the same generator and size as API keys
+and account tokens. The `pd_` prefix is taken: API keys use it (`API_KEY_PREFIX` in `server/utils/auth.ts`) and the
+desktop access token is deliberately `pd_`-prefixed so the reporter's API-key path can carry it
+(`apps/application/server/middleware/desktop-guard.ts`). A distinct prefix keeps share tokens visually and
+programmatically distinguishable — a `psl_` value pasted into an API-key field can be rejected with a useful message.
+
+The full token is shown **once**, at creation, and never again — the same UX contract as API keys ("shown ONCE to the
+user" in `generateApiKey`). Afterwards the UI shows only `token_prefix`.
+
+## URL shape and routes
+
+### Public (anonymous) surface — two GET routes
+
+- **`/share/<token>`** — the page. A Vue page at `app/pages/share/[token].vue`, server-rendered like the rest of the
+  app, with `definePageMeta({ layout: false })` like `/login` (no sidebar, no project menu — nothing that assumes a
+  session). The global auth middleware (`apps/application/app/middleware/auth.global.ts`) today early-returns only for
+  `to.path === '/login'`; that skip becomes a small public-path check covering `/share/` too, so the page never
+  redirects an anonymous viewer to the login screen.
+- **`GET /api/share/<token>`** — resolves the token and returns the bundle JSON
+  (`server/api/share/[token].get.ts`).
+- **`GET /api/share/<token>/assets/<...path>`** — serves one evidence asset
+  (`server/api/share/[token]/assets/[...path].get.ts`), and only if the requested storage path is listed in the
+  resolved bundle's asset list. Response headers follow `server/api/files/[...path].get.ts`:
+  `X-Content-Type-Options: nosniff` on everything, the `sandbox allow-scripts` CSP on HTML, the no-scripts sandbox
+  CSP on SVG, and the same refusal to honor content-type overrides that name an active type.
+
+### Management surface (authenticated)
+
+- `POST /api/test-run-cases/[id]/share-links` and `POST /api/failure-clusters/[id]/share-links` — mint a link for the
+  entity; body carries the requested expiry. Returns the full token once.
+- `GET` on the same two paths — list the entity's links (prefix, creator, expiry, revoked state, view count).
+- `DELETE /api/share-links/[id]` — revoke (sets `revoked_at`).
+- `GET /api/projects/[id]/share-links` — every link in the project, for the admin view in project settings.
+
+All management routes authorize exactly like the neighboring entity routes: `requireResolvedProjectAccess` with
+`resolveTestRunCaseProjectId` / `resolveClusterProjectId` (`apps/application/server/utils/project-access.ts`), which
+resolves the entity's project, 404s a missing entity, then combines role and project scope. Per the route-meta rule in
+[apps/application/AGENTS.md](../apps/application/AGENTS.md), each handler declares its roles once in
+`defineRouteMeta` `openAPI['x-required-roles']`: mint and revoke declare `['administrator', 'reporter']` (the same
+elevated pair as triage endpoints like `failure-clusters/[id]/status.patch.ts` — creating anonymous surface is a
+write-grade action), listing declares all three roles. The two public routes declare `security: []` in their
+OpenAPI meta — the documented convention for public endpoints, as `auth/login.post.ts` does — and an empty role
+list like the stream-token-authenticated streaming endpoints (`test-runs/[id]/events.post.ts`), so `/docs` renders
+them as token-authenticated rather than role-gated.
+
+## Token validation
+
+Resolution is: SHA-256 the presented token, then an indexed equality lookup on `token_hash`. The database compares
+hashes, not secrets, so there is no timing oracle over token bytes to begin with — the same reasoning
+`timingSafeEqualStr` (`apps/application/server/utils/timing-safe.ts`) documents for direct secret comparisons applies,
+without needing that helper here.
+
+A resolved row is live only if `revoked_at` is null, `expires_at` is null or in the future, the feature gate is on,
+and the referenced entity still exists. Invalid, revoked, expired and entity-pruned tokens all return the same 404
+response, with no distinguishable body or timing — with one deliberate exception: a token that **did** match its hash
+but is revoked or expired may render "this link is no longer available" instead of a bare 404. A matched hash proves
+the holder once had the real link, so the friendlier message has no enumeration value, and it saves the recipient of a
+stale link from concluding the server is broken.
+
+The public lookup gets a per-IP rate limit through the existing in-memory helper
+(`apps/application/server/utils/rate-limit.ts` — the same one the login, setup and forgot-password endpoints use).
+This is defense in depth against scripted probing and log noise, not the security boundary: a 256-bit token is
+unguessable regardless of request rate, and the design should say so plainly rather than pretend the rate limit is
+what protects the data.
+
+## Feature gate
+
+Off by default. Two new variables, both registered in `apps/application/shared/piwi-env-vars.ts` in the same change
+that reads them, each with a `since` stamp for the shipping release — the registry rule from
+[apps/application/AGENTS.md](../apps/application/AGENTS.md), enforced by `tests/unit/piwi-env-vars.test.ts` (an
+unregistered referenced var, a missing `since`, or a drifted default fails the suite):
+
+- **`PIWI_SHARE_LINKS_ENABLED`** — boolean, default `false`. When disabled, mint endpoints return 403 with an explicit
+  message and the public routes return 404. Existing rows are kept but resolve 404, so the variable doubles as an
+  operator kill switch: flipping it off dead-ends every outstanding link immediately without deleting anything.
+- **`PIWI_SHARE_LINK_MAX_TTL_DAYS`** — number, default `30`. The creation UI offers expiries up to this many days;
+  `0` means links may be minted without an expiry (`expires_at` null). Operators who never want an immortal link keep
+  the default.
+
+## UI
+
+- A **Share** action beside the existing Export menu on the execution and cluster detail pages —
+  `app/components/shared/ExportMenu.vue` is mounted from `app/pages/test-run-cases/[id].vue` and
+  `app/pages/failure-clusters/[id].vue`, and the share button lives in the same header group.
+- The share modal mints a link, shows the full URL **once** with a copy button and the one-time warning, and offers
+  the expiry picker bounded by `PIWI_SHARE_LINK_MAX_TTL_DAYS`.
+- A per-entity list of active links (prefix, creator, expiry, views) with one-click revoke, in the same modal.
+- An admin list of all links per project in project settings (`app/pages/projects/[id]/edit.vue`), for the "what is
+  exposed right now" audit.
+
+The components follow the existing shared-component rules (Nuxt UI primitives, `SectionCard`, the inline-help
+convention) — the specifics belong to the implementation PR, not this proposal.
+
+## Security posture
+
+- **The anonymous surface is two GET routes.** Nothing else changes its authentication story; in particular the
+  existing `/api/files/[...path]` route stays session/key-authenticated and is not reachable through a share token.
+- **Everything served is data the link creator could already see.** Minting requires project access on the entity, so
+  a share link is a narrower delegation of an existing member's read access — never an escalation.
+- **Assets are restricted to the resolved bundle.** The asset route first resolves the token to its bundle, then
+  serves a storage path only if it appears in that bundle's asset list. The token grants exactly the evidence of one
+  entity — it is not a general read capability over project storage — and the `serverAssetReader` traversal guard
+  applies on top.
+- **Response headers on both share routes:** `Cache-Control: no-store` (matching what the files route sets for
+  content-mutable paths), `X-Robots-Tag: noindex, nofollow` and `Referrer-Policy: no-referrer` (both new — no current
+  route needs them because no current route is public), and `X-Content-Type-Options: nosniff` on asset responses.
+- **Stored HTML and SVG evidence keeps its sandbox.** The share asset route applies the same CSP treatment as
+  `server/api/files/[...path].get.ts`: `sandbox allow-scripts` for HTML (unique opaque origin, no cookies, no
+  credentialed calls back to `/api`) and the inert-image sandbox for SVG. A hostile uploaded report opened through a
+  share link gets no more purchase than it gets today.
+- **No cookies are set or read on share routes.** The page renders purely from the token. A logged-in viewer opening a
+  share link must see exactly what an anonymous viewer sees — the share view never widens itself with the viewer's
+  session, so a screenshot of it can be trusted to show what the recipient will get, and the response can never leak
+  session-derived state into a cacheable/anonymous context.
+- **In-scope for security reports.** [SECURITY.md](../SECURITY.md) lists authentication/authorization bypass and path
+  traversal in file storage as report classes we especially care about; this feature adds exactly the kind of surface
+  those classes cover and must hold that bar.
+
+**The token lives in the URL path — acknowledge the tradeoff.** Capability URLs end up in browser history, server and
+reverse-proxy access logs, and (absent countermeasures) the Referer header of any outbound navigation. The
+mitigations: `Referrer-Policy: no-referrer` on share responses, the short default TTL (30 days), one-click revocation,
+and `noindex` so a leaked link does not become a search result. This is the standard tradeoff every capability-URL
+design makes (compare Google Docs "anyone with the link"); the alternative — a viewer login — is precisely what the
+feature exists to avoid.
+
+## Retention interplay
+
+Retention (`apps/application/server/utils/retention.ts`, run nightly by `server/tasks/retention/sweep.ts`) prunes runs
+older than the opt-in `PIWI_RETENTION_DAYS`. Share links intersect it in three ways:
+
+- **A link whose entity is pruned resolves 404** — indistinguishable from an invalid token, per the validation rules.
+- **`sweepOrphans` gains one more predicate** deleting `share_links` rows whose entity no longer exists. The rows need
+  the sweep because `entity_id` is polymorphic over two tables and carries no FK; the sweep is already idempotent and
+  set-based, and this follows its existing pattern (`NOT EXISTS` against the parent table per `entity_kind`).
+- **Cluster links survive pruning but progressively lose evidence.** `deleteRunsOlderThan` calls
+  `recomputeClusterOccurrences` (`shared/handlers/failure-cluster-ops.ts`) so clusters persist while their member
+  executions are pruned. A cluster share link therefore keeps resolving, showing the cluster's stats and whatever
+  member evidence still exists — the same progressive thinning the dashboard itself shows. Stated plainly: a
+  long-lived cluster link degrades gracefully; it does not freeze evidence, and an export is the right tool when the
+  evidence must outlive retention (that is already `offline-export.md`'s pitch).
+
+## Demo and desktop
+
+- **Demo.** `npm run app:check:demo` (`apps/application/scripts/check-demo-routes.mjs`) fails when a server API route
+  has no demo handler. The share routes go on its `INTENTIONALLY_EXCLUDED` list with a justification in the
+  established style: the demo has no accounts and its data is already public, so a share link adds nothing there —
+  and there is no server to mint against.
+- **Desktop.** The feature stays available in the desktop build (it is the same server), but honesty about usefulness:
+  the bundled server binds loopback-only and its local-access guard (`server/middleware/desktop-guard.ts`) requires
+  the per-install desktop token on every `/api` request, so a generated share URL is unreachable for anyone but the
+  machine's own user — on desktop, offline export remains the real answer for handing an investigation over.
+
+## Alternatives considered
+
+1. **Signed URLs (HMAC over entity + expiry, no DB row).** Stateless and table-free, but there is no way to revoke one
+   link without rotating the signing key (killing all links), nothing to list in an admin view, and no view stats.
+   Rejected: a tiny table buys revocation, listing and stats, and the table is not the hard part of this feature.
+2. **A special "share viewer" identity through the existing auth path.** Threading a pseudo-user through
+   `requireAuth` would sprinkle bypass logic across the auth stack — `requireAuth` already has one special case
+   (virtual admin when auth is disabled) and every consumer would need to reason about a second. Rejected in favor of
+   a parallel route family that is *explicitly* public: the reader of `server/api/share/` sees exactly what anonymous
+   requests can reach, and the auth path stays untouched.
+3. **A frozen snapshot at share time (copy the bundle to storage).** Predictable — the viewer sees what the sharer
+   saw — but it duplicates storage per link, goes stale the moment a diagnosis lands, and sits oddly beside
+   revocation (the copy exists until something garbage-collects it). Rejected: live resolve matches both "keep the
+   history" (the ROADMAP's first purpose — the link shows the history as it is now) and the revocation semantics
+   (revoked means gone, immediately). Pinning a cluster's state is listed as an open question, not a v1 behavior.
+4. **Static-file sharing (export + any file host).** Already possible today with the shipped offline export, and it
+   stays the answer for sharing without exposing a server at all. This feature does not replace it; it covers the
+   live case the file cannot.
+
+## Open questions
+
+- **Should `user`-role members mint links?** v1 says no (mint is `['administrator', 'reporter']`), but a `user` can
+  already export the same data to a file, so the restriction governs creating anonymous surface, not data access. Is
+  that distinction worth the asymmetry?
+- **Should a link optionally pin a cluster's state at share time?** An "as of when I shared it" toggle would
+  reintroduce the snapshot alternative in opt-in form. Deferred until someone asks with a concrete case.
+- **Whole-run links.** ROADMAP's Exploring entry for exporting whole runs says a run export "would follow the same
+  shape" as the existing exports; once a run bundle exists, `entity_kind: 'run'` follows this design unchanged.
+- **Default TTL.** 30 days is proposed; is the right default shorter (7) for a link whose value is "look at this now"?
+
+## Rollout sketch
+
+1. **Server.** The `share_links` table in both schemas plus generated migrations; mint/list/revoke endpoints; the two
+   public routes; the rate limit; both env vars registered with `since` stamps. Unit tests for the token lifecycle
+   (mint → hash → resolve → expire → revoke, and the gate-off behavior); Playwright E2E for the public routes
+   with auth enabled — an anonymous request reaches a valid link, gets 404 on a revoked one, and never reaches
+   anything else — with test project names registered in `shared/test-project-names.ts` per the root
+   [AGENTS.md](../AGENTS.md) rule.
+2. **UI.** Share modal, per-entity link list, project-settings admin list; feature screenshots per the
+   feature-screenshot rule in [apps/application/AGENTS.md](../apps/application/AGENTS.md) (scenes in
+   `scripts/take-feature-screenshots.mjs`).
+3. **Docs.** A page under "Reading the results" (the sidebar group in `apps/docs/.vitepress/config.mts`), linked from
+   `offline-export.md` as the live counterpart; the configuration reference picks the new vars up from the registry
+   automatically.

--- a/proposals/public-share-links.md
+++ b/proposals/public-share-links.md
@@ -1,9 +1,10 @@
 # Public share links
 
-A design proposal for read-only share links: handing one investigation to someone without a dashboard account, as a
-URL instead of a file. This is the "Public share links" entry under Exploring in [ROADMAP.md](../ROADMAP.md), which
-notes that a read-only link "would need share tokens, which Piwi has no infrastructure for today". This document
-proposes that infrastructure. Nothing here is committed work — it is a concrete position to argue with.
+A design record for read-only share links: handing one investigation to someone without a dashboard account, as a
+URL instead of a file. The feature shipped behind the default-off `PIWI_SHARE_LINKS_ENABLED` flag; this document
+remains the reference for its decisions, alternatives and open questions. One deliberate simplification against the
+original proposal is called out inline: the anonymous surface is a single server-rendered route rather than a Vue
+page plus separate bundle/asset APIs.
 
 **Summary.** A share link is an unguessable capability token (`psl_` + 64 hex chars, 256-bit) stored only as a SHA-256
 hash in a new `share_links` table, scoped to exactly one entity: one execution or one failure cluster — the same two
@@ -123,20 +124,17 @@ user" in `generateApiKey`). Afterwards the UI shows only `token_prefix`.
 
 ## URL shape and routes
 
-### Public (anonymous) surface — two GET routes
+### Public (anonymous) surface — one GET route
 
-- **`/share/<token>`** — the page. A Vue page at `app/pages/share/[token].vue`, server-rendered like the rest of the
-  app, with `definePageMeta({ layout: false })` like `/login` (no sidebar, no project menu — nothing that assumes a
-  session). The global auth middleware (`apps/application/app/middleware/auth.global.ts`) early-returns for the paths
-  in its `PUBLIC_PATHS` list; share pages join it by prefix rather than exact match, so the page never redirects an
-  anonymous viewer to the login screen.
-- **`GET /api/share/<token>`** — resolves the token and returns the bundle JSON
-  (`server/api/share/[token].get.ts`).
-- **`GET /api/share/<token>/assets/<...path>`** — serves one evidence asset
-  (`server/api/share/[token]/assets/[...path].get.ts`), and only if the requested storage path is listed in the
-  resolved bundle's asset list. Response headers follow `server/api/files/[...path].get.ts`:
-  `X-Content-Type-Options: nosniff` on everything, the `sandbox allow-scripts` CSP on HTML, the no-scripts sandbox
-  CSP on SVG, and the same refusal to honor content-type overrides that name an active type.
+**As implemented**, the anonymous surface collapsed to a single route: **`GET /share/<token>`**
+(`server/routes/share/[token].get.ts`, outside `/api`) resolves the token and serves the offline export's
+self-contained HTML rendering of the live bundle, inline. Evidence is embedded as `data:` URIs under the export
+budget by the same `buildExport` pipeline the download uses, so no separate bundle or asset endpoints exist — there
+is nothing else an anonymous request can reach, the Vue app is never involved (no auth-middleware change), and the
+document ships with `X-Content-Type-Options: nosniff` plus the print export's `sandbox allow-scripts allow-modals`
+CSP: a unique opaque origin that cannot read cookies or make credentialed calls back into the dashboard. The
+original two-API shape (bundle JSON + per-asset route) remains the natural extension if a richer interactive share
+page is ever wanted.
 
 ### Management surface (authenticated)
 


### PR DESCRIPTION
## What & why

ROADMAP's Exploring section noted that share links "would need share tokens, which Piwi has no infrastructure for today." This PR ships that infrastructure end to end: the design proposal (`proposals/public-share-links.md`, the PR's original content, kept as the design record) **plus its implementation** — read-only capability URLs for one execution or one failure cluster, off by default behind `PIWI_SHARE_LINKS_ENABLED`.

**Token model.** `psl_` + 256 random bits, stored only as an unsalted SHA-256 hash with an 8-char display prefix (the `account_tokens`/`api_keys` practice) in a new `share_links` table — both dialects, generated migrations, FK-indexed. Expiry is capped by `PIWI_SHARE_LINK_MAX_TTL_DAYS` (default 30; `0` lifts the cap and permits non-expiring links); revocation keeps the row for the audit trail; views are counted.

**Anonymous surface = one route.** `GET /share/<token>` renders the offline export's self-contained HTML from the **live** bundle — same collectors, same size budgets, evidence inlined as `data:` URIs — so a share view can never drift from the dashboard and an anonymous request can never cost more than an authenticated export. Served sandboxed into an opaque origin (`sandbox allow-scripts allow-modals`, like print exports: no cookies, no credentialed API calls) with `noindex`, `no-referrer`, `no-store`, and a per-address rate limit on lookups. A revoked/expired link (matched hash — the holder once had it) gets a human "no longer available" 404; unknown tokens and pruned entities are indistinguishable plain 404s. This is one deliberate simplification vs. the original proposal (which sketched a Vue page + bundle/asset APIs) — the proposal text records the change and the reasoning.

**Management.** Mint/list endpoints on both entities, revoke by id, per-project audit list (admin), and a settings probe — all role-declared (`administrator`/`reporter` to mint or revoke) and project-scoped. The **Share** dialog sits beside **Export** on execution and cluster pages: expiry picker bounded by the cap, one-time URL with copy, per-link state badges, views, and one-click revoke.

**Lifecycle.** Retention's orphan sweep now deletes links whose entity was pruned (the polymorphic `entity_id` carries no FK); flipping the env var off dead-ends every outstanding link immediately without deleting anything. Demo excludes the routes with justification (no accounts, data already public).

**Docs.** New `share-links.md` under "Reading the results", cross-linked with offline export as its live counterpart; ROADMAP moves share links from Exploring to Recently shipped; both new env vars registered in the typed registry (`since: 0.26.0`).

## How was it tested?

- **Unit: 1472 passed** — including 12 new tests for the token lifecycle (mint → hash → resolve → expire → revoke, TTL-cap semantics, gate, listings never exposing the hash) against real migrations on in-memory SQLite; the schema dialect-drift and FK-index guards cover the new table.
- **E2E: new `share-links.spec.ts` (8 tests)** — submit → mint (TTL clamped) → anonymous render with all security headers asserted → view counted, hash never serialized → cluster link renders → revoked = explanatory 404 → unknown/malformed = plain 404. Plus a new **auth-enabled contrast test** in `reporter-with-auth.spec.ts`: the share URL renders with zero credentials while the same execution's API answers 401. Both suites run locally in CI mode against the production build: **42/42**.
- `app:typecheck` 0 errors, lint/format clean, demo route-parity check green.
- Manually drove the modal and the anonymous page against a production build (screenshots in the session report).

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)