### PR TITLE
fix(app): settle pre-1.0 wire and API-surface inconsistencies from a full audit

### DIFF
--- a/apps/application/app/components/test-case/TestCaseHistoryChart.vue
+++ b/apps/application/app/components/test-case/TestCaseHistoryChart.vue
@@ -35,7 +35,7 @@ const [PASSED, FAILED, SKIPPED] = CASE_STATUS_SERIES;
 
 const statusColor = (status: string): string => {
   if (status === 'passed') return PASSED.color;
-  if (status === 'failed' || status === 'timedOut') return FAILED.color;
+  if (status === 'failed' || status === 'timedOut' || status === 'timedout') return FAILED.color;
   return SKIPPED.color;
 };
 
@@ -156,7 +156,9 @@ const { data: tooltipData, pos: tooltipPos, show, move, hide } = useChartTooltip
             :class="
               tooltipData.status === 'passed'
                 ? 'text-green-600'
-                : tooltipData.status === 'failed' || tooltipData.status === 'timedOut'
+                : tooltipData.status === 'failed' ||
+                    tooltipData.status === 'timedOut' ||
+                    tooltipData.status === 'timedout'
                   ? 'text-red-600'
                   : ''
             "

--- a/apps/application/app/components/test-case/TestCaseVerdictCard.vue
+++ b/apps/application/app/components/test-case/TestCaseVerdictCard.vue
@@ -46,7 +46,7 @@ const chips = computed<Chip[]>(() => {
       icon: 'i-lucide-shuffle',
       title: 'Newly started passing only on retry — intermittent failure',
     });
-  if (tc.status === 'timedOut')
+  if (tc.status === 'timedOut' || tc.status === 'timedout')
     out.push({
       label: 'Timed out',
       color: 'warning',

--- a/apps/application/nuxt.config.ts
+++ b/apps/application/nuxt.config.ts
@@ -261,8 +261,8 @@ export default defineNuxtConfig({
         description:
           'REST API for storing and querying Playwright test results, traces, failure diagnoses, and project statistics.',
         version: pkg.version as string,
-        // Security scheme definitions for endpoint-level `security` annotations.
-        // See docs/development.md for conventions.
+        // Security scheme definitions for endpoint-level `security` annotations,
+        // rendered by the in-app reference (app/pages/docs.vue).
         components: {
           securitySchemes: {
             bearerAuth: {

--- a/apps/application/server/api/ai/step-resolution.post.ts
+++ b/apps/application/server/api/ai/step-resolution.post.ts
@@ -49,7 +49,7 @@ export default eventHandler(async (event) => {
   const role = config?.roles.research ?? config?.roles.diagnosis;
   if (!role) {
     throw createError({
-      statusCode: 400,
+      statusCode: 503,
       message: 'AI is not configured for this instance — set it up in Settings → AI to author AI steps.',
     });
   }

--- a/apps/application/server/api/notifications/stream.get.ts
+++ b/apps/application/server/api/notifications/stream.get.ts
@@ -6,6 +6,16 @@ import { createSSEEndpoint } from '../../utils/sse';
 import { getDatabase } from '../../database';
 import { notificationChannels, subscriptions } from '../../database/schema';
 
+defineRouteMeta({
+  openAPI: {
+    tags: ['Notifications'],
+    summary: 'Notification event stream',
+    description:
+      "Server-sent events stream (text/event-stream) of the signed-in user's browser notifications, filtered to their subscriptions and project scope.",
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
 /** How long a connection's loaded browser subscriptions stay fresh. */
 const SUBSCRIPTIONS_TTL_MS = 60_000;
 

--- a/apps/application/server/api/projects/[id]/test-functions.get.ts
+++ b/apps/application/server/api/projects/[id]/test-functions.get.ts
@@ -4,7 +4,7 @@ import { listProjectTestFunctions } from '#shared/handlers/test-functions';
 
 defineRouteMeta({
   openAPI: {
-    tags: ['Test functions'],
+    tags: ['Test Functions'],
     summary: 'List a project’s test function catalog',
     description:
       'Returns the page-object methods and helpers recorded or registered for a project, used to match against a recorded browser-extension session and substitute raw locator steps with calls to the project’s own code.',

--- a/apps/application/server/api/projects/[id]/test-functions.post.ts
+++ b/apps/application/server/api/projects/[id]/test-functions.post.ts
@@ -6,7 +6,7 @@ import { createTestFunctionSchema } from '#shared/test-function-schemas';
 
 defineRouteMeta({
   openAPI: {
-    tags: ['Test functions'],
+    tags: ['Test Functions'],
     summary: 'Add a test function to a project’s catalog',
     description:
       'Registers a page-object method or helper — its name, module, parameters, and the DOM pattern it drives — so recorded browser-extension sessions can match against it. Requires reporter or administrator role.',

--- a/apps/application/server/api/projects/[id]/test-functions/extract.post.ts
+++ b/apps/application/server/api/projects/[id]/test-functions/extract.post.ts
@@ -7,7 +7,7 @@ import { Role } from '#shared/types';
 
 defineRouteMeta({
   openAPI: {
-    tags: ['Test functions'],
+    tags: ['Test Functions'],
     summary: 'Propose a catalog entry from pasted function source (AI)',
     description:
       'Analyzes pasted Playwright page-object-method/helper source with the configured AI provider and returns a proposed test-function catalog entry — a draft only, not saved. Requires reporter or administrator role, and a configured AI provider (see Settings → AI).',
@@ -35,7 +35,7 @@ export default eventHandler(async (event) => {
   const role = config?.roles.research ?? config?.roles.diagnosis;
   if (!role) {
     throw createError({
-      statusCode: 400,
+      statusCode: 503,
       message: 'AI is not configured for this instance — set it up in Settings → AI, or fill in the pattern by hand.',
     });
   }

--- a/apps/application/server/api/projects/[id]/test-functions/validate-proposal.post.ts
+++ b/apps/application/server/api/projects/[id]/test-functions/validate-proposal.post.ts
@@ -5,7 +5,7 @@ import { Role } from '#shared/types';
 
 defineRouteMeta({
   openAPI: {
-    tags: ['Test functions'],
+    tags: ['Test Functions'],
     summary: 'Validate a pasted AI response into a proposed catalog entry (no AI call)',
     description:
       'For instances with no AI provider configured: paste the JSON reply from your own AI chat (seeded with the dashboard\'s "Copy prompt for your own AI" button) and get back the same validated, reviewable proposal shape as the AI-calling extract endpoint — no AI call, no credits spent here. Requires reporter or administrator role.',

--- a/apps/application/server/api/test-cases/[id]/stability-trend.get.ts
+++ b/apps/application/server/api/test-cases/[id]/stability-trend.get.ts
@@ -7,6 +7,7 @@ defineRouteMeta({
     summary: 'Stability trend for a test case',
     description:
       'Returns time-series of flaky rate, pass rate, avg duration grouped into N buckets for a single test case',
+    'x-required-roles': ['administrator', 'reporter', 'user'],
     parameters: [
       { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
       { name: 'buckets', in: 'query', schema: { type: 'integer', default: 20 } },

--- a/apps/application/server/api/test-functions/[id].delete.ts
+++ b/apps/application/server/api/test-functions/[id].delete.ts
@@ -4,7 +4,7 @@ import { Role } from '#shared/types';
 
 defineRouteMeta({
   openAPI: {
-    tags: ['Test functions'],
+    tags: ['Test Functions'],
     summary: 'Delete a test function',
     description: 'Removes a catalog entry. Requires reporter or administrator role.',
     parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],

--- a/apps/application/server/api/test-functions/[id].put.ts
+++ b/apps/application/server/api/test-functions/[id].put.ts
@@ -5,7 +5,7 @@ import { updateTestFunctionSchema } from '#shared/test-function-schemas';
 
 defineRouteMeta({
   openAPI: {
-    tags: ['Test functions'],
+    tags: ['Test Functions'],
     summary: 'Update a test function',
     description: 'Updates a project’s catalog entry. Requires reporter or administrator role.',
     parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],

--- a/apps/application/server/api/test-runs/[id]/cases/[caseId]/trace-network-body.get.ts
+++ b/apps/application/server/api/test-runs/[id]/cases/[caseId]/trace-network-body.get.ts
@@ -39,7 +39,7 @@ export default eventHandler(async (event) => {
 
   const sha1 = String(getQuery(event).sha1 ?? '').toLowerCase();
   if (!SHA1_NAME_RE.test(sha1)) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid sha1 parameter' });
+    throw createError({ statusCode: 400, message: 'Invalid sha1 parameter' });
   }
 
   const traceRows = await db

--- a/apps/application/server/api/test-runs/[id]/insights.get.ts
+++ b/apps/application/server/api/test-runs/[id]/insights.get.ts
@@ -7,6 +7,7 @@ defineRouteMeta({
     summary: 'Run insights',
     description:
       'Returns comparison insights for a test run: new regressions, recurrences, recovered tests, performance changes, worker imbalance, and new clusters',
+    'x-required-roles': ['administrator', 'reporter', 'user'],
     parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
   },
 });

--- a/apps/application/server/api/test-runs/upload.post.ts
+++ b/apps/application/server/api/test-runs/upload.post.ts
@@ -483,6 +483,9 @@ export default eventHandler(async (event) => {
 
       return {
         filePath,
+        suitePath: (testCase.suitePath as string[] | null | undefined) ?? null,
+        suiteConfig: (testCase.suiteConfig as RunCaseInput['suiteConfig']) ?? null,
+        testAnnotations: (testCase.testAnnotations as RunCaseInput['testAnnotations']) ?? null,
         title: testCase.title as string,
         status: testCase.status as string,
         duration: testCase.duration as number | null | undefined,

--- a/apps/application/server/database/schema.pg.ts
+++ b/apps/application/server/database/schema.pg.ts
@@ -438,7 +438,7 @@ export const testRunsCases = pgTable(
     testCaseId: integer('test_case_id')
       .notNull()
       .references(() => testCases.id, { onDelete: 'cascade' }),
-    status: text('status').notNull(), // 'passed', 'failed', 'timedout', 'skipped'
+    status: text('status').notNull(), // 'passed', 'failed', 'timedout', 'skipped', 'didnotrun' — canonical lowercase; rows from earlier releases may carry 'timedOut'
     duration: integer('duration'), // in milliseconds
     timeout: integer('timeout'), // Effective per-test timeout in ms (TestCase.timeout); 0 = unbounded, null = unknown/legacy
     error: text('error'),

--- a/apps/application/server/database/schema.sqlite.ts
+++ b/apps/application/server/database/schema.sqlite.ts
@@ -404,7 +404,7 @@ export const testRunsCases = sqliteTable(
     testCaseId: integer('test_case_id')
       .notNull()
       .references(() => testCases.id, { onDelete: 'cascade' }),
-    status: text('status').notNull(), // 'passed', 'failed', 'timedout', 'skipped'
+    status: text('status').notNull(), // 'passed', 'failed', 'timedout', 'skipped', 'didnotrun' — canonical lowercase; rows from earlier releases may carry 'timedOut'
     duration: integer('duration'), // in milliseconds
     timeout: integer('timeout'), // Effective per-test timeout in ms (TestCase.timeout); 0 = unbounded, null = unknown/legacy
     error: text('error'),

--- a/apps/application/server/routes/mcp.post.ts
+++ b/apps/application/server/routes/mcp.post.ts
@@ -6,7 +6,7 @@ import type { McpContext } from '../utils/mcp/tools';
 import { getPrompt, isKnownPrompt } from '../utils/mcp/prompts';
 import { getProjectScope } from '../utils/project-access';
 import { resolvePublicBaseUrl } from '../utils/oauth-helpers';
-import { ok, rpcErr, RPC, MCP_SERVER_INFO, negotiateProtocolVersion } from '../utils/mcp/protocol';
+import { ok, rpcErr, RPC, mcpServerInfo, negotiateProtocolVersion } from '../utils/mcp/protocol';
 import type { JsonRpcRequest } from '../utils/mcp/protocol';
 import { MCP_PROMPT_DEFS } from '#shared/mcp-prompts';
 
@@ -96,7 +96,7 @@ async function dispatch(ctx: McpContext, req: JsonRpcRequest, event: H3Event) {
       return ok(id, {
         protocolVersion: negotiateProtocolVersion(requested),
         capabilities: { tools: {}, prompts: {} },
-        serverInfo: MCP_SERVER_INFO,
+        serverInfo: mcpServerInfo(useRuntimeConfig(event).public.appVersion as string),
         instructions:
           'Piwi Dashboard MCP server — query Playwright test results, failure clusters, AI diagnoses, and SCM diffs. ' +
           'Start with list_projects to discover project IDs. ' +

--- a/apps/application/server/utils/mcp/protocol.ts
+++ b/apps/application/server/utils/mcp/protocol.ts
@@ -3,7 +3,11 @@
 // this. Kept broad so older clients (2024-11-05) keep working.
 export const MCP_PROTOCOL_VERSION = '2025-06-18';
 export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'] as const;
-export const MCP_SERVER_INFO = { name: 'piwi-dashboard', version: '1.2.0' };
+
+/** `serverInfo` for the `initialize` response — the version is the running app's version. */
+export function mcpServerInfo(appVersion: string) {
+  return { name: 'piwi-dashboard', version: appVersion };
+}
 
 /** Pick the protocol version to advertise: the client's if supported, else ours. */
 export function negotiateProtocolVersion(requested: unknown): string {

--- a/apps/application/server/utils/mcp/tools.ts
+++ b/apps/application/server/utils/mcp/tools.ts
@@ -8,6 +8,7 @@ import {
   getProjectSpecHealth,
 } from '#shared/handlers/projects';
 import { parseTagFilter } from '#shared/utils/tag-filter';
+import { FAILED_STATUS_KEYS } from '#shared/utils/test-counts';
 import { buildFixPlan } from '../fix-plan';
 import { enrichFixPlanOwnership } from '../scm/ownership';
 import { getNetworkRequests, getFailureGroups } from '#shared/handlers/test-runs';
@@ -393,7 +394,7 @@ const HANDLERS: Record<McpToolName, McpToolHandler> = {
     if (statusFilter === 'flaky') {
       caseConditions.push(and(eq(testRunsCases.status, 'passed'), gt(testRunsCases.retries, 0))!);
     } else if (statusFilter !== 'all') {
-      caseConditions.push(or(eq(testRunsCases.status, 'failed'), eq(testRunsCases.status, 'timedOut'))!);
+      caseConditions.push(inArray(testRunsCases.status, [...FAILED_STATUS_KEYS]));
     }
     if (cursor) caseConditions.push(lt(testRunsCases.id, cursor));
 
@@ -470,10 +471,7 @@ const HANDLERS: Record<McpToolName, McpToolHandler> = {
     const cursor = numericCursor(params.cursor);
     const runId = params.runId ? numericParam(params.runId, 'runId') : undefined;
 
-    const conditions = [
-      eq(testRuns.projectId, projectId),
-      or(eq(testRunsCases.status, 'failed'), eq(testRunsCases.status, 'timedOut'))!,
-    ];
+    const conditions = [eq(testRuns.projectId, projectId), inArray(testRunsCases.status, [...FAILED_STATUS_KEYS])];
     if (runId) conditions.push(eq(testRunsCases.testRunId, runId));
     if (cursor) conditions.push(lt(testRunsCases.id, cursor));
 

--- a/apps/application/server/utils/notifications/run-notifications.ts
+++ b/apps/application/server/utils/notifications/run-notifications.ts
@@ -15,6 +15,7 @@ import {
   PERF_REGRESSION_MIN_PCT,
 } from '#shared/notification-events';
 import { resolveOwners } from '../scm/ownership';
+import { FAILED_STATUS_KEYS } from '#shared/utils/test-counts';
 import type { DbClient } from '../../database';
 
 function runBranch(metadata: Record<string, unknown> | null): string | undefined {
@@ -55,7 +56,7 @@ export async function emitRunNotifications(db: DbClient, runId: number): Promise
       })
       .from(testRunsCases)
       .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
-      .where(and(eq(testRunsCases.testRunId, runId), inArray(testRunsCases.status, ['failed', 'timedout'])))
+      .where(and(eq(testRunsCases.testRunId, runId), inArray(testRunsCases.status, [...FAILED_STATUS_KEYS])))
       .limit(OWNER_LOOKUP_LIMIT);
 
     // The notification still names only the first few failures, but ownership

--- a/apps/application/server/utils/persist-run-cases.ts
+++ b/apps/application/server/utils/persist-run-cases.ts
@@ -13,6 +13,7 @@ import {
   sanitizeAiUsage,
 } from './sanitize';
 import { resolveIngestLimits } from './ingest-limits';
+import { normalizeTestCaseStatus } from '#shared/utils/test-counts';
 import { upsertCasePayloads } from './case-payloads';
 import { computeErrorFingerprint, type ErrorFingerprint } from '#shared/error-fingerprint';
 import {
@@ -28,6 +29,17 @@ import { getOrCreateFailureClusters, type PendingCluster } from '#shared/handler
 import { upsertLocatorSnapshots } from './locator-healing';
 import type { LocatorSnapshot } from '#shared/locator-healing.types';
 import type { DbClient as DB } from '../database';
+
+/** Apply the canonical per-case status spelling to each attempt entry. */
+function normalizeAttemptStatuses(attempts: unknown): unknown {
+  if (!Array.isArray(attempts)) return attempts;
+  return attempts.map((attempt) => {
+    if (!attempt || typeof attempt !== 'object') return attempt;
+    const status = (attempt as { status?: unknown }).status;
+    if (typeof status !== 'string') return attempt;
+    return { ...attempt, status: normalizeTestCaseStatus(status) };
+  });
+}
 
 /**
  * Normalised test-case data ready to be persisted for a run. `filePath` + `suitePath` + `title`
@@ -387,12 +399,12 @@ export async function persistRunCases(
     runCasesRows.push({
       testRunId,
       testCaseId: caseId,
-      status: c.status,
+      status: normalizeTestCaseStatus(c.status),
       duration: c.duration ?? null,
       timeout: c.timeout ?? null,
       error: capErrorText(c.error, limits.errorChars),
       retries: c.retries ?? 0,
-      attempts: capArray(c.attempts, 30),
+      attempts: capArray(normalizeAttemptStatuses(c.attempts), 30),
       line: c.line,
       column: c.column,
       steps: capArray(c.steps, limits.steps),

--- a/apps/application/server/utils/regression-context.ts
+++ b/apps/application/server/utils/regression-context.ts
@@ -3,6 +3,7 @@ import { testRuns, testRunsCases } from '../database/schema';
 import type { RunMetadata } from './run-json-types';
 import type { DbClient } from '../database';
 import { buildCompareUrl, computeMetadataDiff, type MetaDiffEntry } from '#shared/utils/run-metadata';
+import { FAILED_STATUS_KEYS } from '#shared/utils/test-counts';
 
 export interface RunForRegression {
   id: number;
@@ -53,7 +54,7 @@ export function normalizeGitUrl(remoteUrl: string | null | undefined): string | 
   }
 }
 
-const FAIL_STATUSES = new Set(['failed', 'timedOut']);
+const FAIL_STATUSES = new Set<string>(FAILED_STATUS_KEYS);
 
 export async function computeRegressionContext(db: DbClient, run: RunForRegression): Promise<RegressionContextResult> {
   const greenResults = await db

--- a/apps/application/shared/handlers/projects.ts
+++ b/apps/application/shared/handlers/projects.ts
@@ -347,8 +347,10 @@ export async function updateProject(
     .innerJoin(tags, eq(projectTags.tagId, tags.id))
     .where(eq(projectTags.projectId, id));
 
+  const { scmToken: _scmToken, ...updatedProjectPublic } = updatedProject[0];
+
   return {
-    ...updatedProject[0],
+    ...updatedProjectPublic,
     tags: projectTagRows.map((r: any) => r.tag),
   };
 }

--- a/apps/application/shared/handlers/projects.ts
+++ b/apps/application/shared/handlers/projects.ts
@@ -12,6 +12,7 @@ import {
 } from '../../server/database/schema';
 import { asc, desc, eq, exists, sql, and, inArray, gte, lte, isNotNull, count } from 'drizzle-orm';
 import { jsonArrayContainsAll, parseTagFilter } from '../utils/tag-filter';
+import { FAILED_STATUS_KEYS } from '../utils/test-counts';
 import { TEST_PRIORITIES } from '@piwitests/core/test-meta';
 
 import type { DrizzleDB } from './db';
@@ -1278,7 +1279,7 @@ export async function getProjectFlakyTests(
         const sorted = group.rows.slice().sort((a: any, b: any) => (a.retries ?? 0) - (b.retries ?? 0));
         const maxRetryRow = sorted[sorted.length - 1];
         group.finalStatus = maxRetryRow?.status ?? 'unknown';
-        const hasFailed = group.rows.some((r: any) => r.status === 'failed' || r.status === 'timedOut');
+        const hasFailed = group.rows.some((r: any) => FAILED_STATUS_KEYS.includes(r.status));
         const hasPassed = group.rows.some((r: any) => r.status === 'passed');
         group.retryPass = hasFailed && hasPassed;
       }

--- a/apps/application/shared/handlers/test-cases.ts
+++ b/apps/application/shared/handlers/test-cases.ts
@@ -200,7 +200,10 @@ export async function getTestRunCase(
   let project = null;
   if (testRun) {
     const [projectResult] = await db.select().from(projects).where(eq(projects.id, testRun.projectId));
-    project = projectResult ?? null;
+    if (projectResult) {
+      const { scmToken: _scmToken, ...projectPublic } = projectResult;
+      project = projectPublic;
+    }
   }
 
   let failureCluster = null;
@@ -326,6 +329,8 @@ export async function getTestRunCase(
     }
   }
 
+  const { streamToken: _streamToken, ...testRunPublic } = testRun ?? {};
+
   return {
     id: trc.id,
     testCaseId: trc.testCaseId,
@@ -369,7 +374,7 @@ export async function getTestRunCase(
     blockedByCase,
     blockedTests,
     failureCluster,
-    testRun: testRun ? { ...testRun, project, reports: reportList } : testRun,
+    testRun: testRun ? { ...testRunPublic, project, reports: reportList } : testRun,
     attachments: attachmentList,
     links: linksForCaseRun,
     stableLinks: linksForTestCase,

--- a/apps/application/shared/handlers/test-cases.ts
+++ b/apps/application/shared/handlers/test-cases.ts
@@ -32,7 +32,7 @@ export async function getTestCase(db: DrizzleDB, id: number) {
         passedRuns: sql<number>`SUM(CASE WHEN ${testRunsCases.status} = 'passed' THEN 1 ELSE 0 END)`,
         failedRuns: sql<number>`SUM(CASE WHEN ${testRunsCases.status} = 'failed' THEN 1 ELSE 0 END)`,
         skippedRuns: sql<number>`SUM(CASE WHEN ${testRunsCases.status} = 'skipped' THEN 1 ELSE 0 END)`,
-        timedOutRuns: sql<number>`SUM(CASE WHEN ${testRunsCases.status} = 'timedOut' THEN 1 ELSE 0 END)`,
+        timedOutRuns: sql<number>`SUM(CASE WHEN ${testRunsCases.status} IN ('timedOut', 'timedout') THEN 1 ELSE 0 END)`,
         flakyRuns: sql<number>`SUM(CASE WHEN ${testRunsCases.status} = 'passed' AND ${testRunsCases.retries} > 0 THEN 1 ELSE 0 END)`,
         recentFlakyRuns: sql<number>`(
           SELECT COUNT(*) FROM (

--- a/apps/application/shared/handlers/test-runs.ts
+++ b/apps/application/shared/handlers/test-runs.ts
@@ -13,6 +13,7 @@ import {
   markers,
 } from '../../server/database/schema';
 import { fetchAndFormatSuites, splitSuitePath } from '../utils/suites';
+import { FAILED_STATUS_KEYS } from '../utils/test-counts';
 import { normalizeRoute } from '../utils/route';
 import { percentile } from '../utils/stats';
 import { computeWastedMs, DEFAULT_WASTED_WAIT_PATTERNS } from '../utils/wasted-waits';
@@ -626,7 +627,7 @@ export async function getFailureGroups(db: DrizzleDB, runId: number) {
 
 // ─── computeRegressionContextForRun — regression vs last green run ────────────
 
-const FAIL_STATUSES = new Set(['failed', 'timedOut']);
+const FAIL_STATUSES = new Set<string>(FAILED_STATUS_KEYS);
 
 export async function computeRegressionContextForRun(db: DrizzleDB, runId: number) {
   const runResults = await db

--- a/apps/application/shared/handlers/test-runs.ts
+++ b/apps/application/shared/handlers/test-runs.ts
@@ -195,6 +195,12 @@ export async function getTestRun(
 
   const { streamToken: _streamToken, ...testRunPublic } = testRun;
 
+  let projectPublic;
+  if (project) {
+    const { scmToken: _scmToken, ...projectRest } = project;
+    projectPublic = { ...projectRest, latestRunId, latestRunStatus };
+  }
+
   // Nearest timeline marker before this run's start, scoped to the run's
   // environment (or global markers with no environment) — surfaced as context.
   const precedingMarkerCandidates = await db
@@ -210,7 +216,7 @@ export async function getTestRun(
     ...testRunPublic,
     precedingMarker,
     isFullRun: testRun.isFullRun === 1,
-    project: project ? { ...project, latestRunId, latestRunStatus } : project,
+    project: projectPublic,
     reports: reportResults.map((r: any) => ({
       id: r.id,
       type: r.subtype || r.type,

--- a/apps/application/shared/mcp-tools.ts
+++ b/apps/application/shared/mcp-tools.ts
@@ -56,8 +56,8 @@ export const MCP_TOOL_DEFS = [
         projectId: { type: 'number', description: 'Project ID' },
         status: {
           type: 'string',
-          enum: ['passed', 'failed', 'running', 'initialising', 'aborted'],
-          description: 'Filter by status',
+          enum: ['passed', 'failed', 'timedout', 'interrupted', 'running', 'cancelled', 'initialising', 'finalizing'],
+          description: 'Filter by run status (exact match against the stored value)',
         },
         branch: { type: 'string', description: 'Filter by branch name (exact match against SCM metadata)' },
         pageSize: { type: 'number', description: 'Results per page (default 10, max 50)' },

--- a/apps/application/shared/types.ts
+++ b/apps/application/shared/types.ts
@@ -39,6 +39,10 @@ export type TestRunStatus =
 // skipped as a side effect of an earlier failure in a `describe.serial` group.
 // Distinct from `skipped`, which is reserved for intentional `test.skip()` /
 // `test.fixme()`.
+// `timedout` is the canonical stored spelling: ingest normalizes Playwright's
+// camelCase `timedOut` wire value (`normalizeTestCaseStatus`), while rows
+// written by earlier releases may still carry the camelCase form — readers
+// match both via `FAILED_STATUS_KEYS` (shared/utils/test-counts.ts).
 export type TestCaseStatus = 'passed' | 'failed' | 'skipped' | 'timedout' | 'didnotrun';
 
 export type ClusterStatus = 'open' | 'resolved' | 'ignored';

--- a/apps/application/shared/types.ts
+++ b/apps/application/shared/types.ts
@@ -174,7 +174,6 @@ export interface StreamEventPayload {
   aiUsage?: unknown;
   consoleLogs?: unknown;
   ariaSnapshot?: unknown;
-  projectName?: string | null;
   browser?: BrowserConfig | null;
   suitePath?: string[] | null;
   suiteConfig?: SuiteConfigEntry[] | null;
@@ -207,6 +206,8 @@ export interface TestRunFinishPayload {
   didNotRunTests?: number;
   flakyTests: number;
   durations: number[];
+  /** Trace/report uploads are still in flight — the run enters `finalizing` instead of completing. */
+  hasPendingUploads?: boolean;
   /** Suite-level hook/fixture steps (beforeAll/afterAll) for the run timeline. */
   setupSteps?: Array<{
     title: string;

--- a/apps/application/shared/utils/test-counts.ts
+++ b/apps/application/shared/utils/test-counts.ts
@@ -20,6 +20,17 @@
 export const FAILED_STATUS_KEYS = ['failed', 'timedOut', 'timedout'] as const;
 
 /**
+ * Canonical spelling for a per-case status. The wire may carry Playwright's
+ * camelCase `timedOut`; every stored value uses the lowercase `TestCaseStatus`
+ * form. Rows written by earlier releases can still hold the camelCase form, so
+ * readers keep matching both (`FAILED_STATUS_KEYS`) while writers go through
+ * this.
+ */
+export function normalizeTestCaseStatus(status: string): string {
+  return status === 'timedOut' ? 'timedout' : status;
+}
+
+/**
  * Sum the failed-ish entries from a per-status tally (e.g. the
  * `insertedStatusCounts` record built while persisting streaming events).
  * Returns 0 when the record is empty or has no failed/timed-out entries.

--- a/apps/application/tests/unit/docs-drift.test.ts
+++ b/apps/application/tests/unit/docs-drift.test.ts
@@ -40,6 +40,13 @@ describe('documented counts', () => {
       expect(read(relative), `${relative} says "${stated[0]}", there are ${MCP_TOOL_DEFS.length}`).toMatch(claim);
     }
   });
+
+  test('every registered MCP tool is documented in apps/docs/mcp.md', () => {
+    const contents = read('apps/docs/mcp.md');
+    for (const { name } of MCP_TOOL_DEFS) {
+      expect(contents, `apps/docs/mcp.md has no entry for \`${name}\``).toContain(`\`${name}\``);
+    }
+  });
 });
 
 describe('docs pages the app deep-links into', () => {

--- a/apps/application/tests/unit/test-counts.test.ts
+++ b/apps/application/tests/unit/test-counts.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { countFailedFromTally, sumFailedAndTimedOut } from '#shared/utils/test-counts';
+import { countFailedFromTally, normalizeTestCaseStatus, sumFailedAndTimedOut } from '#shared/utils/test-counts';
 
 describe('countFailedFromTally', () => {
   test('sums failed, timedOut (camelCase), and timedout (lowercase)', () => {
@@ -50,5 +50,17 @@ describe('sumFailedAndTimedOut', () => {
   test('ignores zero/negative values', () => {
     expect(sumFailedAndTimedOut(0, 0)).toBe(0);
     expect(sumFailedAndTimedOut(-1, 5)).toBe(5);
+  });
+});
+
+describe('normalizeTestCaseStatus', () => {
+  test("maps Playwright's camelCase timedOut to the canonical lowercase form", () => {
+    expect(normalizeTestCaseStatus('timedOut')).toBe('timedout');
+  });
+
+  test('passes every other status through unchanged', () => {
+    for (const status of ['passed', 'failed', 'skipped', 'timedout', 'didnotrun', 'interrupted']) {
+      expect(normalizeTestCaseStatus(status)).toBe(status);
+    }
   });
 });

--- a/apps/application/tests/unit/wire-shared-drift.test.ts
+++ b/apps/application/tests/unit/wire-shared-drift.test.ts
@@ -17,9 +17,6 @@ import type { WireTestCase } from '../../../../packages/reporter/src/types/wire'
  * `npm run app:typecheck` on a shape mismatch, and the key-set comparison
  * fails `vitest run` when a key exists on one side but not the reporter's
  * union (or vice versa).
- *
- * `projectName` is the one intentional exception: it is stream-envelope
- * metadata added by the stream manager, not part of the per-case payload.
  */
 
 // Every field populated (including optionals) so `satisfies` catches a
@@ -40,6 +37,7 @@ const testCasePayloadFixture = {
   wastedTimeMs: null,
   networkRequests: null,
   webVitals: null,
+  pageState: { url: 'https://app.example.com/checkout', localStorage: [{ key: 'cart', length: 42 }] },
   aiUsage: null,
   consoleLogs: null,
   ariaSnapshot: null,
@@ -50,8 +48,11 @@ const testCasePayloadFixture = {
   suitePath: null,
   suiteConfig: null,
   testAnnotations: null,
+  tags: ['smoke'],
+  testMeta: { owner: 'checkout-team' },
   locatorSnapshots: null,
   testSource: null,
+  testSourceFrames: [{ file: 'a.spec.ts', line: 1, snippet: '> 1 | test' }],
   didNotRunReason: null,
   blockedBy: null,
 } satisfies TestCasePayload;
@@ -78,16 +79,19 @@ const streamEventPayloadFixture = {
   wastedTimeMs: null,
   networkRequests: null,
   webVitals: null,
+  pageState: { url: 'https://app.example.com/checkout', localStorage: [{ key: 'cart', length: 42 }] },
   aiUsage: null,
   consoleLogs: null,
   ariaSnapshot: null,
-  projectName: null,
   browser: null,
   suitePath: null,
   suiteConfig: null,
   testAnnotations: null,
+  tags: ['smoke'],
+  testMeta: { owner: 'checkout-team' },
   locatorSnapshots: null,
   testSource: null,
+  testSourceFrames: [{ file: 'a.spec.ts', line: 1, snippet: '> 1 | test' }],
   didNotRunReason: null,
   blockedBy: null,
 } satisfies StreamEventPayload;
@@ -112,14 +116,18 @@ const wireTestCaseFixture = {
   wastedTimeMs: null,
   networkRequests: null,
   webVitals: null,
+  pageState: { url: 'https://app.example.com/checkout', localStorage: [{ key: 'cart', length: 42 }] },
   aiUsage: null,
   consoleLogs: null,
   ariaSnapshot: null,
   testSource: null,
+  testSourceFrames: [{ file: 'a.spec.ts', line: 1, snippet: '> 1 | test' }],
   browser: null,
   suitePath: null,
   suiteConfig: null,
   testAnnotations: null,
+  tags: ['smoke'],
+  testMeta: { owner: 'checkout-team' },
   stepCategory: null,
   parentTitle: null,
   locatorSnapshots: null,
@@ -127,19 +135,14 @@ const wireTestCaseFixture = {
   blockedBy: null,
 } satisfies WireTestCase;
 
-// Stream-envelope metadata, not part of the per-case payload.
-const STREAM_ENVELOPE_ONLY_FIELDS = new Set(['projectName']);
-
 describe('wire ↔ shared per-case contract drift guard', () => {
   test('WireTestCase carries every TestCasePayload field', () => {
     const missing = Object.keys(testCasePayloadFixture).filter((k) => !(k in wireTestCaseFixture));
     expect(missing, 'fields present in TestCasePayload but missing from WireTestCase').toEqual([]);
   });
 
-  test('WireTestCase carries every StreamEventPayload field (except stream-envelope metadata)', () => {
-    const missing = Object.keys(streamEventPayloadFixture)
-      .filter((k) => !STREAM_ENVELOPE_ONLY_FIELDS.has(k))
-      .filter((k) => !(k in wireTestCaseFixture));
+  test('WireTestCase carries every StreamEventPayload field', () => {
+    const missing = Object.keys(streamEventPayloadFixture).filter((k) => !(k in wireTestCaseFixture));
     expect(missing, 'fields present in StreamEventPayload but missing from WireTestCase').toEqual([]);
   });
 

--- a/apps/docs/mcp.md
+++ b/apps/docs/mcp.md
@@ -60,6 +60,7 @@ The server exposes 40 tools — mostly read-only, plus a few write/triage tools 
 | `list_clusters` | Failure clusters grouped by error fingerprint |
 | `list_open_clusters` | Open clusters across *all* projects, ranked by occurrences — a triage queue |
 | `get_cluster` | Cluster detail with affected tests and diagnosis summary |
+| `get_fix_plan` | **One-call fix plan** for a cluster: diagnosis with its validated patch, ranked locator replacements with the file and line to edit, failing tests, owning team, and the command that verifies the fix |
 | `get_cluster_diagnosis` | Full AI diagnosis: root cause, evidence, suggested fix |
 | `get_cluster_context` | Full AI evidence context (errors, steps, console logs, SCM diff) — the same data the built-in diagnosis AI receives |
 

--- a/packages/core/src/status-classify.ts
+++ b/packages/core/src/status-classify.ts
@@ -103,7 +103,7 @@ function sharedPrefixDepth(a: readonly string[], b: readonly string[]): number {
  * sibling test) keeps `blockedBy` null. Mutates the passed cases in place.
  */
 export function linkBlockedTests(cases: BlockableCase[]): void {
-  const blockers = cases.filter((c) => c.status === 'failed' || c.status === 'timedOut');
+  const blockers = cases.filter((c) => c.status === 'failed' || c.status === 'timedOut' || c.status === 'timedout');
   if (blockers.length === 0) return;
 
   for (const c of cases) {


### PR DESCRIPTION
## What & why

ROADMAP's "Next" holds one item: **1.0 stabilization — settle the wire format and API surface**. This PR is the first concrete slice of that: a full audit of the HTTP surface (160 routes), the reporter↔server wire contract, and the 40-tool MCP registry, followed by the fixes that are cheap now and breaking after 1.0. Two commits:

### Commit 1 — surface fixes

- **Security-relevant strips**: the execution-detail response embedded the raw run row including the **live `streamToken`** — the credential that authorizes streaming writes for an in-flight run — readable by any project viewer during a live run. Run detail, execution detail and the project-update response also embedded the encrypted `scmToken` blob. All stripped, matching what the project list/detail endpoints already did.
- **MCP**: `list_runs` offered `status: 'aborted'`, which matches nothing (cancellation stores `cancelled`) while the real `timedout` / `interrupted` / `cancelled` / `finalizing` values were missing — the enum now mirrors `TestRunStatus`. The MCP handshake advertised a fictitious `version: '1.2.0'`; it now reports the running app version. `get_fix_plan` was missing from the docs' tool tables (the count said 40, the tables listed 39), and the docs-drift test now asserts **every** registered tool name appears in `mcp.md` so a missing row fails CI.
- **Wire contract**: `TestRunFinishPayload` now declares `hasPendingUploads` (sent by the reporter, read by `finish`, absent from the written contract); the dead `StreamEventPayload.projectName` field (never sent, never read, held a bespoke drift-test exemption) is gone; the wire drift test's fixtures cover `pageState`, `tags`, `testMeta`, `testSourceFrames` — previously invisible to the guard, so a one-sided rename would have passed CI.
- **Data-loss fix**: multipart `/upload` never mapped `suitePath`, `suiteConfig`, `testAnnotations` — the reporter sends them and JSON `/submit` persists them, so runs ingested through the upload rung silently lost suite hierarchy and annotations.
- **OpenAPI hygiene**: `notifications/stream` was the only `/api` route with no `defineRouteMeta`; `insights` and `stability-trend` now declare their roles like their siblings; `trace-network-body` used `statusMessage` (changing the error body shape); the `Test functions` tag now matches Title Case; AI-not-configured now answers `503` on the two routes that answered `400` (seven siblings already said 503); a `nuxt.config.ts` comment pointed at a nonexistent `docs/development.md`.

### Commit 2 — one canonical per-case timeout status

Playwright emits camelCase `timedOut` per case; the declared `TestCaseStatus` union says `timedout`; stored rows carry the camelCase form and matchers disagreed three ways. Concretely broken: **notification top-failures and owner routing matched only lowercase and silently dropped timed-out failures**, while MCP failed-case listings, regression context, run failure groups, the test-case aggregate, retry grouping, the core blocked-test linker, and two UI spots matched only camelCase — which would miss rows once anything normalized. Now: ingest normalizes case and attempt statuses to the canonical lowercase at the single write path (`persist-run-cases`, shared with the demo), every reader accepts both spellings via the shared `FAILED_STATUS_KEYS`, and the schema/type docs state the vocabulary. No migration needed — old rows stay readable forever.

### Audit findings deliberately *not* fixed here (1.0 decision list)

Documented for follow-up rather than slipped into this diff:
- `initialising` (British) vs `finalizing` (American) in `TestRunStatus` — wire-visible rename, needs an ingest alias + UI/SSE sweep.
- `runId` vs `testRunId` split across ingest responses — breaking for the published reporter; needs a coordinated dual-field release.
- Run-level `shardIndex` is sent by every reporter body and read by no handler (phantom contract field); `finish` never reads `shardTotal`.
- REST list-envelope and pagination dialects (bare array vs `{noun: []}` vs one `{items,total,limit,offset}`; window params named `runs`/`limit`/`days`/`buckets`/`cases`), PUT-vs-PATCH split, error-code conventions (400/404/409 for the same failure classes), MCP not-found conventions and `status_filter` snake_case one-off, session cookie named `h3` (documented in #398; renaming is a decision), and the absence of any wire-version handshake (a `wireVersion` field + reporter preflight against `GET /api/version` is the cheapest path).

## How was it tested?

- `npm run app:typecheck` (0 errors), `app:lint`, reporter `tsc --noEmit`, `@piwitests/core` suite (140 tests) — all clean.
- Full unit suite: **1446 passed**, including the new guards (per-tool docs assertion, widened wire fixtures, `normalizeTestCaseStatus` cases).
- The drift tests are the regression net for the contract changes: the widened fixtures fail on any one-sided rename of the four previously-unguarded fields, and the docs test fails on any future missing MCP tool row.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK6JDbdXGszeFx22QqJw11)_