### PR TITLE
docs: commit the 1.0 stabilization decision list as a living record

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,8 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 ## Next
 
-- **1.0 stabilization** — settle the wire format and API surface, then commit to semver stability.
+- **1.0 stabilization** — settle the wire format and API surface, then commit to semver stability. The outstanding
+  decisions are catalogued in [proposals/1.0-stabilization.md](proposals/1.0-stabilization.md).
 
 ## Exploring
 

--- a/proposals/1.0-stabilization.md
+++ b/proposals/1.0-stabilization.md
@@ -1,0 +1,182 @@
+# 1.0 stabilization — the decision list
+
+ROADMAP's Next section holds one item: settle the wire format and API surface, then commit to semver stability. A
+full audit of the HTTP surface (160 routes), the reporter↔server wire contract, the 40-tool MCP registry and the CLI
+produced two kinds of findings: inconsistencies cheap to fix immediately (shipped in #398/#400 — summarized at the
+bottom), and **decisions** — places where 1.0 freezes whatever is chosen, so choosing has to happen first. This
+document is the durable home for those decisions; the numbers below are stable references. When a decision ships,
+move its entry to "Settled" with the PR number.
+
+Every claim was verified against `main` after #398, #399 and #400 merged.
+
+## Open decisions
+
+### D1. Run-status spelling: `initialising`
+
+`TestRunStatus` mixes `initialising` (British) with `finalizing` (American) (`apps/application/shared/types.ts`).
+The value is wire-visible: stored on runs, streamed as the `run-initialising` SSE event, offered by MCP `list_runs`,
+filtered by the UI. Renaming after 1.0 breaks old reporters' streamed runs and every stored row.
+**Recommendation:** rename to `initializing` before 1.0 with an ingest alias for the old spelling and a read-side
+coalesce, mirroring how the per-case `timedOut` normalization was done in #400.
+
+### D2. Ingest response id field: `runId` vs `testRunId`
+
+The streaming endpoints (`start`, `setup`, `begin`) answer `{ success, runId, … }` while `submit`, `finish`,
+`upload` and import answer `testRunId` — same concept, two names, both parsed by the published reporter
+(`packages/reporter/src/internal/submit/`). The MCP field-naming glossary already legislates `runId` for references.
+**Recommendation:** emit both fields from the endpoints that change, for one release, then drop the loser;
+coordinate with a reporter release that reads whichever is present.
+
+### D3. Phantom shard fields
+
+Every reporter body sends run-level `shardIndex`; no ingest handler reads it (only `shardTotal`), and `finish` reads
+neither. The field sits in all three run payload types and the OpenAPI schemas — a contract 1.0 would freeze without
+anything behind it. **Recommendation:** either persist it (a `shard_index` column is plausibly useful for debugging
+shard merges) or delete it from the payload types and OpenAPI now; keep ignoring it at ingest either way so old
+reporters stay compatible.
+
+### D4. Wire versioning and the compatibility policy
+
+There is no wire-format version anywhere in the reporter↔server exchange: `reporterVersion` is stored but never
+branched on, unknown fields are silently ignored, missing fields silently default, and the reporter's only
+compatibility mechanism is the any-error fallback ladder (streaming → upload → submit). Nothing pins reporter
+*bytes* to server *handlers* — the drift test pins the declared types, which the ingest handlers do not use.
+**Recommendation, as a package:** (a) write the policy down — "the server accepts payloads from any ≥1.0 reporter;
+unknown fields are ignored" — in the OpenAPI description and `upgrading.md`, including which side to upgrade first;
+(b) add a `wireVersion` field the server echoes and can someday reject with a distinguishable status; (c) have the
+reporter preflight `GET /api/version` (unauthenticated, already exists) and log when a feature will degrade;
+(d) add a golden-payload fixture test replaying canned 1.0 `submit`/`events`/`finish` bodies against the real ingest
+routes, so "old reporters keep working" is CI-checked rather than hoped.
+
+### D5. Execution naming and its URL home
+
+The execution concept has four wire names: the `test-run-cases` URL family, `testRunsCaseId` in diagnose/case-files
+bodies, `executionId` in gate facts and notification payloads, and `entity_links`' stored `test_runs_case` value —
+plus run detail's `testCases[]` whose `id` is the execution id with no `testCaseId` alongside. Separately, the eight
+evidence routes live under `/api/test-runs/[id]/cases/[caseId]/…` where the run id is deliberately not enforced,
+while detail/diagnosis/export live under `/api/test-run-cases/[id]/…` — two URL spellings for one entity, one of
+them asserting a containment the server does not check. **Recommendation:** extend the MCP glossary
+(`executionId` for the record, `testCaseId` for stable identity) to REST with one-release dual fields where the
+reporter or `piwi gate` parses the response; pick `/test-run-cases/[id]/…` as the canonical home and re-expose the
+evidence routes there, keeping the nested paths as aliases until 2.0.
+
+### D6. List envelopes and pagination dialects
+
+Lists come back three ways: `{ <noun>: [...] }` envelopes on the CRUD family, bare arrays on analytics routes, and
+exactly one `{ items, total, limit, offset }` (the test-case catalog); MCP uses `{ items, nextCursor }`. Window
+params are named five ways (`limit`, `offset`, `runs`, `days`, `buckets`, `cases`), with `runs` and `limit` meaning
+the same thing on sibling routes. Bare arrays cannot grow metadata without a break. **Recommendation:** wrap the
+UI-only bare-array routes in named envelopes pre-1.0 (invisible to the reporter), settle `limit`/`offset` as the
+pagination vocabulary with old names accepted as aliases for one release, and document `days`/`buckets` as domain
+windows rather than pagination.
+
+### D7. PUT vs PATCH
+
+Eleven PUT routes and seven PATCH routes carry identical partial-update semantics — the split is historical, not
+semantic (`tags`/`markers`/`projects`/`test-functions` update via PUT with all-optional bodies; `subscriptions`/
+`links`/`users`/`test-runs` via PATCH). **Recommendation:** converge on PATCH for partial updates before the verbs
+land in the frozen OpenAPI; keep PUT only where the body genuinely replaces (member/assignment lists).
+
+### D8. Error response conventions
+
+Same failure class, different statuses: a missing notification channel is 400 (subscription create), 404 (channel
+test/delete) or 403 (subscription patch); duplicate names are 409 (test functions) but 400 (projects, tags, users);
+env-managed settings conflicts are an explicit 409 (`wasted-waits`) but a silent partial-apply 200 (`settings/ai`).
+The three "test the destination" endpoints return 200 `{ success: false, error }` — a deliberate second error
+channel nothing documents. And no error carries a machine-readable code: the contract is prose `message` strings
+plus zod issues on the third of routes that validate with zod. **Recommendation:** 404 for missing, 409 for
+uniqueness conflicts, one documented semantic for env-managed conflicts; document the soft-fail family in OpenAPI;
+decide *now* whether 1.0's error contract is `{ statusCode, message }` prose (freezing message strings) or gains an
+additive `errorCode` field while that is still non-breaking.
+
+### D9. Create and update response shapes
+
+Creates answer four ways: `{ noun }` (tags, links, markers, projects, test functions), `{ success, noun }`
+(channels, users), `{ success, nounId }` (subscriptions), and a bare credentials object (API keys). `PATCH
+/api/test-runs/[id]` invents `{ success, testRunId, label }` while sibling updates return the entity.
+**Recommendation:** settle `{ noun }` for creates and entity-returning updates; add fields additively to the
+outliers and keep the old keys until 2.0.
+
+### D10. Query parsing
+
+Four number-parsing idioms (`parseInt` with and without radix, `Number()`, zod coerce) with divergent
+garbage-handling — 400, silent default, or silently dropping a filter (`GET /api/subscriptions?projectId=abc`
+returns everything visible). Boolean params have five accepted spellings across routes. **Recommendation:** one
+`requireIntQuery`/`optionalIntQuery`/`queryFlag` helper trio with clamp-and-400 semantics, applied to the ~15
+query-parsing routes; accepting more spellings is additive, so this can also ride after 1.0 — decide whether the
+strictness change ships before the freeze.
+
+### D11. MCP input conventions
+
+`get_run.status_filter` is the single snake_case parameter among 40 camelCase tools. Entity-id params vary for the
+same entity (`id` vs `testRunsCaseId` vs `clusterId`), and pagination idioms vary (cursor+`pageSize`, `offset`,
+`limit`, `runs`). Not-found surfacing follows four conventions (null, empty containers, sentinel objects, soft
+`{error}` payloads) and a thrown handler error becomes a JSON-RPC protocol error rather than a tool result with
+`isError: true` — which MCP clients render as a transport failure. `list_tags` is instance-wide but described as a
+project catalog. Tool and parameter renames are free today and breaking the moment 1.0 ships.
+**Recommendation:** rename `status_filter` → `statusFilter`, settle the id/pagination conventions to match the
+glossary, map handler throws to `isError` tool results, and reword `list_tags`.
+
+### D12. Reporter configuration surface
+
+Env names diverge from option names in ways that freeze at 1.0: `inspectOnFailure` → `PIWI_INSPECT_ON_FAIL`,
+`pickLocatorOnFailure` → `PIWI_PICK_LOCATOR_ON_FAIL`, `ai.mode` → `PIWI_AI`, `ai.maxSteps` →
+`PIWI_AI_MAX_FLOW_STEPS`; `PIWI_AI_UPDATE` lives outside the `PIWI_ENV_KEYS` single-source map. The master switch
+`collectPerformanceMetrics` has no env var while its three sub-toggles do. Docs drift: `reporter.md` claims every
+option has an env var (false for ten), documents a `serverUrl` default that does not exist, and the npm README's
+options table is roughly ten options behind with no drift test covering it. **Recommendation:** add the missing
+env var and register `PIWI_AI_UPDATE`; either rename the divergent vars now with old names as aliases or bless them
+in the docs as-is; regenerate the README table (or point it at the docs site) and fix the two false claims.
+
+### D13. CLI flag semantics
+
+`--project` means the Piwi project in `piwi init` but the *Playwright* project in `piwi ai resolve`; `--dir` means
+the skills directory in `piwi skills add` but the AI-artifacts directory in `piwi ai check` while `init` calls the
+former `--skills-dir`. Flag names are frozen contract for CI scripts at 1.0. Also `ci.md`'s table gloss of
+`--require-tag` omits that a tag matching no test is itself a violation. **Recommendation:** rename
+`ai resolve --project` → `--pw-project` (keeping the old flag as a hidden alias) and align `--dir` naming; fix the
+doc gloss.
+
+### D14. Session cookie name
+
+The sealed session cookie is h3's default `h3` (documented truthfully in the OpenAPI since #398). Renaming it (e.g.
+`piwi_session`) costs every signed-in user one re-login; keeping it means the name `h3` is public API forever.
+**Recommendation:** rename in a pre-1.0 minor and say so in the release notes — the one-time cost is small while
+the install base is.
+
+### D15. Write the informal contracts down
+
+Not changes — documentation debts that become contract at 1.0: the multipart field-name mix (camelCase alongside
+`trace_<i>`/`report_<type>`/`attach_meta_<i>`, plus the legacy `htmlReport` field still accepted); the `type:
+'complete'` discriminant sent in batch payloads but undeclared in `TestCasePayload`; and the split time encoding
+(run-level `startTime` ISO-8601 vs case/attempt/step `startedAt` epoch-ms) which is fine but stated nowhere.
+**Recommendation:** declare all three in the wire types/OpenAPI as-is; drop `htmlReport` only if no external
+producer used it.
+
+### D16. Small route-level oddities
+
+`GET /api/test-cases/[id]/stability-trend` has no first-party consumer (only MCP calls the shared handler) — wire
+the UI to it or mark it experimental before freezing its shape. Quarantine release passes mutation metadata as a
+query param on DELETE, unlike every other mutation. The three diagnosis POSTs accept `force` only in the query
+string and leave it undeclared in their OpenAPI. Several routes implement query params their OpenAPI omits
+(`performance`, `slow-tests`, cluster `commits`, merge-suggestion `status`, diagnosis-context params, file-serving
+`contentType`/`compress`), and a handful of routes are tagged into the wrong `/docs` group. All cheap, none
+behavior-changing except the DELETE body move.
+
+## Settled (for reference)
+
+Decided and shipped while the audit was fresh:
+
+- **Per-case timeout vocabulary** — ingest normalizes Playwright's `timedOut` to the canonical lowercase at the
+  single write path; every reader accepts both spellings; the notification filter that silently dropped stored
+  camelCase rows is fixed (#400).
+- **Credential hygiene** — execution detail no longer returns the live `streamToken`; run/execution/project-update
+  responses no longer embed the encrypted `scmToken` (#400).
+- **MCP surface truths** — `list_runs` offers the real status vocabulary; the handshake reports the actual app
+  version; `get_fix_plan` is documented and a drift test now requires every registered tool name in the docs (#400).
+- **Wire contract honesty** — `hasPendingUploads` declared; dead `projectName` removed; the drift test covers the
+  four previously unguarded fields; multipart upload maps `suitePath`/`suiteConfig`/`testAnnotations` (#400).
+- **OpenAPI/status hygiene** — every `/api` route has meta; AI-not-configured is 503 everywhere; `message` not
+  `statusMessage`; tag casing; roles declared on the two routes that omitted them (#400).
+- **Auth rate limiting** — `Retry-After` on throttled auth responses; `PIWI_TRUST_PROXY` for real client addresses
+  behind a proxy; the session cookie documented as `h3` pending D14 (#398).


### PR DESCRIPTION
## What & why

The pre-1.0 decisions my API/wire/MCP/CLI audit deliberately left open were catalogued only in #400's PR description — a home that ages invisibly (three merges later, some entries were already settled there with nothing marking them so). This PR moves the list into the repository as `proposals/1.0-stabilization.md`, following the design-record convention #399 established:

- **D1–D16 with stable numbers**, each stating the decision to make, the current state with concrete references, and a recommendation — from the wire-visible renames (`initialising`, `runId`/`testRunId`, the execution concept's four names) through the compatibility-policy package (wireVersion, `/api/version` preflight, golden-payload fixtures, a written skew policy) to REST/MCP/CLI convention choices and the "write the informal contracts down" items.
- **A Settled section** recording what #398/#400 already decided (timeout vocabulary, credential strips, MCP truths, drift-test coverage, status-code hygiene, `Retry-After`/trust-proxy), so the document reads as current rather than as a snapshot.
- **Every claim re-verified against `main` after #398, #399 and #400 merged** — e.g. the `statusMessage` and AI-503 items moved to Settled; `initialising`, `status_filter`, the phantom `shardIndex` and the rest confirmed still outstanding.
- ROADMAP's "1.0 stabilization" bullet now links to the document, so the working agreement is one hop from the public roadmap: when a decision ships, its entry moves to Settled with the PR number.

## How was it tested?

Documentation-only. Reference checks were run against current `main` (grep-verified per entry); no code changes, no generated files touched.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes — N/A (documentation)
- [ ] Docs updated if user-facing (`apps/docs/`, README, or reporter README) — N/A (contributor-facing record)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK6JDbdXGszeFx22QqJw11)_