### PR TITLE
docs(docs): fix the dead /docs link that fails the VitePress build

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -30,8 +30,11 @@ There is **no `apps/docs/api.md`, and you must not create one.** The auto-genera
 self-contained in-app reference at `/docs` in the running app are the single source of truth for API documentation —
 the in-app page renders the spec with no third-party CDN, so it works offline and air-gapped.
 
-When documenting a feature here, link to `[API docs](/docs)` (self-hosted) or the live demo
-(`https://piwitests.github.io/demo/docs`) rather than inlining endpoint descriptions. Endpoint documentation is
+When documenting a feature here, link to the live demo reference
+(`[API docs](https://piwitests.github.io/demo/docs)`) and refer to the self-hosted reference as inline code
+`/docs` rather than inlining endpoint descriptions. Do **not** write a bare `[API docs](/docs)` markdown link:
+`/docs` is a route on the running app, not a page on this docs site, so VitePress's dead-link check fails the
+build. Endpoint documentation is
 authored in the handler's `defineRouteMeta({ openAPI: … })` block — see
 [`../application/AGENTS.md`](../application/AGENTS.md#openapi-annotations).
 

--- a/apps/docs/authentication.md
+++ b/apps/docs/authentication.md
@@ -206,7 +206,7 @@ Both edit the same underlying assignments, so use whichever is more convenient.
 
 When authentication is enabled:
 
-- Every endpoint requires an authenticated caller — a session cookie or an API key — with the role the endpoint declares (listed per endpoint in the [API docs](/docs)). The exceptions are `GET /api/health`, `GET /api/version`, the auth flows themselves (login, initial setup, password reset, email verification, OAuth), and the live-run streaming endpoints, which authenticate with per-run stream tokens instead.
+- Every endpoint requires an authenticated caller — a session cookie or an API key — with the role the endpoint declares (listed per endpoint in the [API docs](https://piwitests.github.io/demo/docs)). The exceptions are `GET /api/health`, `GET /api/version`, the auth flows themselves (login, initial setup, password reset, email verification, OAuth), and the live-run streaming endpoints, which authenticate with per-run stream tokens instead.
 - The reporter's submission endpoints (`/api/test-runs/submit` and `/api/test-runs/upload`) accept both session cookies and API keys.
 
 ## API keys


### PR DESCRIPTION
## What & why

The **"Deploy Docs & Demo"** workflow has been failing on `main` since Aug 7 (last green: `9eecaba`) — the VitePress build errors out on a dead link:

```
(!) Found dead link /docs in file authentication.md
[vitepress] 1 dead link(s) found.
```

`apps/docs/authentication.md` linked the API reference as `[API docs](/docs)`. `/docs` is a route on the **running app** (the self-contained OpenAPI reference), not a page on this docs **site**, so VitePress's dead-link check rejects it and fails the whole `build-and-deploy` job (which also blocks the demo generation + Pages deploy).

This is pre-existing (it predates and is unrelated to the recent stabilization merge #403, which never touched this file). This PR:

- Points the link at the live demo reference (`https://piwitests.github.io/demo/docs`), matching how every other docs page (`ai-diagnosis.md`, `getting-started.md`, `timeline-markers.md`, …) references the API docs.
- Corrects the `apps/docs/AGENTS.md` guidance, which recommended the bare `[API docs](/docs)` link — the exact pattern that breaks the build — so this doesn't recur.

## How was it tested?

Ran the workflow's build step locally — it now passes:

```
$ npm run docs:build   # (docs:gen && vitepress build)
✓ building client + server bundles...
✓ rendering pages...
✓ generating sitemap...
build complete in 7.73s.
```

(fails on `main` today with the dead-link error above). Also swept the docs for any other real `](/docs…)` markdown links — this was the only one.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes — N/A (docs-only, verified via the docs build)
- [x] Docs updated if user-facing (`apps/docs/authentication.md`, `apps/docs/AGENTS.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhBPUmBXUVHDgqKC9mi49e

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhBPUmBXUVHDgqKC9mi49e)_