### PR TITLE
fix(docs): commit CNAME so the Pages deploy keeps the piwitests.dev domain

### DIFF
--- a/apps/docs/public/CNAME
+++ b/apps/docs/public/CNAME
@@ -1,0 +1,1 @@
+piwitests.dev


### PR DESCRIPTION
## What & why

The docs + demo site is published to the `piwitests.github.io` Pages repo by `peaceiris/actions-gh-pages`, which replaces the branch contents on every deploy. The repo committed **no `CNAME` file** and the deploy step passes no `cname:` input, so each publish drops the custom-domain marker — GitHub Pages then unlinks `piwitests.dev` and the apex host returns 404.

That is what happened when #413 merged: the resulting **Deploy Docs & Demo** run (commit `0289a18`, 2026-08-18T23:30Z) republished the site without a CNAME and took `piwitests.dev` down.

This commits `apps/docs/public/CNAME` (`piwitests.dev`). VitePress copies `public/` to the site root, so every deploy now re-publishes `CNAME` at the root and keeps the custom domain associated — durably, not just once.

## How was it tested?

- `npm run docs:build` emits `dist/CNAME` containing `piwitests.dev`, confirming the file lands at the published site root.

Still required outside this repo for the domain to resolve (unchanged by this PR): correct apex DNS (A/AAAA records to GitHub Pages) and the `piwitests.github.io` repo's Pages custom-domain setting. This change only stops each deploy from wiping the association.

## Checklist

- [x] PR title follows Conventional Commits (`fix(docs): …`)
- [x] Tests added/updated for behavior changes — n/a: static deploy asset with no runtime behavior; verified the build emits `dist/CNAME`
- [x] Docs updated if user-facing — the change is to the docs-site deploy output itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmzqU4XxXYrx3CyMx14rya

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmzqU4XxXYrx3CyMx14rya)_