### PR TITLE
fix(settings): extract items from projects menu API response

### DIFF
--- a/apps/application/app/pages/settings/auto-heal.vue
+++ b/apps/application/app/pages/settings/auto-heal.vue
@@ -16,7 +16,10 @@ interface ProjectMenuItem {
 
 const toast = useToast();
 const { data: response, refresh } = await useFetch<AutoHealResponse>('/api/settings/auto-heal');
-const { data: projectsMenu } = await useFetch<ProjectMenuItem[]>('/api/projects/menu', { default: () => [] });
+const { data: projectsMenu } = await useFetch('/api/projects/menu', {
+  default: () => [] as ProjectMenuItem[],
+  transform: (r: { items: ProjectMenuItem[] }) => r.items,
+});
 
 const projectItems = computed(() => (projectsMenu.value ?? []).map((p) => ({ label: p.label || p.name, value: p.id })));
 


### PR DESCRIPTION
## What & why

The `/api/projects/menu` endpoint returns a response object with an `items` property containing the array of `ProjectMenuItem[]`. The previous code was treating the entire response as an array, which would cause type mismatches and runtime errors.

This change adds a `transform` function to the `useFetch` call to properly extract the `items` array from the response object, ensuring the data is correctly typed and structured for downstream usage.

## How was it tested?

The change is a straightforward data transformation fix that aligns the fetch response handling with the actual API contract. Existing application logic that consumes `projectsMenu` will continue to work correctly with the properly extracted data.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] No tests needed — straightforward API response handling fix
- [x] No docs changes required — internal implementation detail

https://claude.ai/code/session_01V5sNCDkLeufETPxTePAKau