### PR TITLE
fix(app): resolve the bundled trace viewer from playwright-core's install path

### DIFF
--- a/apps/application/nuxt.config.ts
+++ b/apps/application/nuxt.config.ts
@@ -1,10 +1,12 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import { cpSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { createRequire } from 'module';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const nodeRequire = createRequire(import.meta.url);
 
 const isDemo = process.env.PIWI_DEMO_MODE === 'true';
 
@@ -246,7 +248,7 @@ export default defineNuxtConfig({
         // These assets are bundled with playwright-core and served directly from
         // node_modules. During `nuxt build`, Nitro copies them to .output/public/.
         baseURL: '/trace-viewer',
-        dir: resolve(__dirname, '../node_modules/playwright-core/lib/vite/traceViewer'),
+        dir: resolve(dirname(nodeRequire.resolve('playwright-core/package.json')), 'lib/vite/traceViewer'),
         maxAge: 60 * 60 * 24,
       },
     ],

--- a/apps/application/tests/trace-viewer.spec.ts
+++ b/apps/application/tests/trace-viewer.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * The bundled Playwright trace viewer must be served at /trace-viewer/.
+ * Its files come from playwright-core via a nitro publicAssets entry, and
+ * Nitro silently skips a missing assets dir — a wrong path surfaces only as
+ * 404s at runtime, never as a build error.
+ */
+import { test, expect } from './fixtures';
+
+test.describe('Bundled trace viewer', () => {
+  test('serves the viewer page', async ({ request }) => {
+    const response = await request.get('/trace-viewer/index.html');
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain('<html');
+  });
+
+  test('serves the service worker the viewer loads traces through', async ({ request }) => {
+    const response = await request.get('/trace-viewer/sw.bundle.js');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('javascript');
+  });
+});


### PR DESCRIPTION
I have the second external PR in this repo for you.
This is the other thing I found while testing piwi. The rest seems to be working like I expected.
Also disclaimer again: Claude did the code again. And I validated the changes only on MacOS. I'm not Nuxt expert, so I can't say if its the right fix for the issue. Thats on you to decide.

## What & why

Fixes: #421 

## How was it tested?

Using `npm test`

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing (`apps/docs/`, README, or reporter README)
