### PR TITLE
feat: add companion tools card and improve streaming error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ Import `test` from this file in your specs instead of `@playwright/test` — tha
 Details in the [capture fixtures guide](https://piwitests.dev/capture-fixtures); a runnable
 project lives in [`examples/playwright-fixtures`](./examples/playwright-fixtures).
 
+Steps 2–4 are also one command, if you prefer:
+`npx @piwitests/reporter init --server-url http://localhost:3000 --project my-project` — idempotent,
+and anything it won't rewrite is reported as a manual step with the exact change to make. See
+[Getting started → Fast path](https://piwitests.dev/getting-started#fast-path-one-command).
+
 In CI, set `PIWI_DASHBOARD_URL` (and `PIWI_API_KEY` if auth is on) and you're done — branch, commit, CI
 metadata and `--shard` merging are detected automatically. See
 [CI & sharding](https://piwitests.dev/ci).

--- a/apps/application/app/components/layout/CompanionToolsCard.vue
+++ b/apps/application/app/components/layout/CompanionToolsCard.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+/**
+ * The tools that ship alongside the dashboard but install elsewhere — the
+ * browser extension, the desktop app, the reporter CLI, MCP agent access and
+ * the IDE hand-off. Unlike the capability ladder above it, none of these leave
+ * evidence on the instance, so the card is informative rather than detected.
+ */
+const isDesktop = useIsDesktop();
+</script>
+
+<template>
+  <SectionCard icon="i-lucide-blocks" title="Companion tools" data-shot="companion-tools">
+    <template #subtitle>
+      Separate installs that work with this dashboard — none is required, each picks up where the dashboard leaves off.
+    </template>
+
+    <ul class="divide-y divide-default">
+      <li class="flex gap-4 py-4 first:pt-0 last:pb-0">
+        <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-dimmed">
+          <UIcon name="i-lucide-mouse-pointer-click" class="size-5" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-medium mb-1">Piwi Picker browser extension</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            Pick ranked, uniqueness-checked Playwright locators from any live page, record interactions into a spec, and
+            match recordings against a project's test-function catalog. Works standalone — connecting to this instance
+            is opt-in.
+          </p>
+          <div class="flex items-center gap-3 mt-2 text-sm">
+            <UButton
+              to="https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe"
+              target="_blank"
+              size="xs"
+              variant="soft"
+              icon="i-lucide-download"
+            >
+              Chrome Web Store
+            </UButton>
+            <DocLink to="extension" class="text-sm">Docs</DocLink>
+          </div>
+        </div>
+      </li>
+
+      <li v-if="!isDesktop" class="flex gap-4 py-4 first:pt-0 last:pb-0">
+        <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-dimmed">
+          <UIcon name="i-lucide-monitor" class="size-5" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-medium mb-1">Desktop app</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            This same dashboard as a local app — no Docker or Node needed, and the reporter finds it automatically when
+            nothing else is configured. For one developer's own history on a laptop.
+          </p>
+          <div class="flex items-center gap-3 mt-2 text-sm">
+            <DocLink to="desktop" class="text-sm">Docs</DocLink>
+          </div>
+        </div>
+      </li>
+
+      <li class="flex gap-4 py-4 first:pt-0 last:pb-0">
+        <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-dimmed">
+          <UIcon name="i-lucide-terminal" class="size-5" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-medium mb-1">Reporter CLI</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            The reporter package doubles as a CLI:
+            <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">init</code> wires a Playwright project in one
+            command, <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">gate</code> fails a build on this
+            dashboard's analysis instead of the raw exit code, and
+            <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">run</code> /
+            <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">select</code> execute a named test selection.
+          </p>
+          <div class="flex items-center gap-3 mt-2 text-sm">
+            <DocLink to="getting-started#fast-path-one-command" class="text-sm">init</DocLink>
+            <DocLink to="ci#blocking-a-merge" class="text-sm">gate</DocLink>
+            <DocLink to="test-selection" class="text-sm">run &amp; select</DocLink>
+          </div>
+        </div>
+      </li>
+
+      <li class="flex gap-4 py-4 first:pt-0 last:pb-0">
+        <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-dimmed">
+          <UIcon name="i-lucide-bot" class="size-5" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-medium mb-1">MCP server &amp; agent skills</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            AI agents query runs, flaky tests, clusters and diagnoses over MCP, and the reporter CLI installs SKILL.md
+            workflows — investigate a failure, apply a healed locator, stabilize flaky tests — into your test project.
+          </p>
+          <div class="flex items-center gap-3 mt-2 text-sm">
+            <UButton to="/mcp" size="xs" variant="soft" icon="i-lucide-plug">MCP setup</UButton>
+            <DocLink to="mcp#agent-skills" class="text-sm">Skills docs</DocLink>
+          </div>
+        </div>
+      </li>
+
+      <li class="flex gap-4 py-4 first:pt-0 last:pb-0">
+        <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-elevated text-dimmed">
+          <UIcon name="i-lucide-code" class="size-5" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-medium mb-1">Open in IDE</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            Every source path in the dashboard is a click away from your editor — VS Code, JetBrains, or a custom URL
+            scheme. Configured per browser from any source path, since the source lives on your machine.
+          </p>
+          <div class="flex items-center gap-3 mt-2 text-sm">
+            <DocLink to="ide-integration" class="text-sm">Docs</DocLink>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </SectionCard>
+</template>

--- a/apps/application/app/components/layout/GetStartedWizard.vue
+++ b/apps/application/app/components/layout/GetStartedWizard.vue
@@ -141,6 +141,15 @@ const steps = computed<Array<WizardStep & { id: number }>>(() => {
 const STEP_COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six'];
 const stepCountWord = computed(() => STEP_COUNT_WORDS[steps.value.length] ?? String(steps.value.length));
 
+// The one-command setup from the reporter CLI. Not shown on desktop: `init`
+// writes a serverUrl into the project, which would suppress the reporter's
+// automatic desktop-app discovery.
+const initCode = computed(() => {
+  const flags = [`--server-url ${serverUrl.value}`, `--project my-project`];
+  if (authEnabled.value) flags.push(`--api-key <your-api-key>`);
+  return `npx @piwitests/reporter init ${flags.join(' ')}`;
+});
+
 const goFurtherOpen = ref(false);
 </script>
 
@@ -161,6 +170,25 @@ const goFurtherOpen = ref(false);
     </template>
 
     <div>
+      <div
+        v-if="!isDesktop"
+        class="mb-6 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3"
+        data-shot="wizard-fast-path"
+      >
+        <div class="flex items-center gap-2 mb-1">
+          <UIcon name="i-lucide-zap" class="size-4 text-primary shrink-0" />
+          <h3 class="font-medium text-sm">Fast path — one command</h3>
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+          From your Playwright project,
+          <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">init</code>
+          installs the reporter, wires your config, creates the capture-fixtures file and drops the agent skills.
+          Idempotent — anything it won't rewrite is reported as a manual step with the exact change to make. Prefer to
+          wire it up by hand? The steps below do the same.
+        </p>
+        <CodeBlock :code="initCode" lang="bash" />
+      </div>
+
       <div v-for="(step, index) in steps" :key="step.id" class="flex gap-4">
         <!-- Step indicator + vertical connector -->
         <div class="flex flex-col items-center shrink-0">

--- a/apps/application/app/components/shared/LocatorHealingPanel.vue
+++ b/apps/application/app/components/shared/LocatorHealingPanel.vue
@@ -642,7 +642,16 @@ const visibleAlternatives = computed<RankedLocator[]>(() =>
           >Enable Piwi dashboard fixtures</DocLink
         >
         to capture element attributes at test time, or use “Pick from snapshot” above to choose a locator by hand on the
-        failure-time page.
+        failure-time page. In local headed runs,
+        <DocLink
+          to="reporter#pick-a-replacement-locator-on-the-failing-page-local-runs"
+          no-icon
+          class="text-primary hover:underline"
+          >pickLocatorOnFailure</DocLink
+        >
+        opens the same picker on the still-open failing page, and the
+        <DocLink to="extension" no-icon class="text-primary hover:underline">Piwi Picker browser extension</DocLink>
+        picks from any live page without a test run.
       </template>
     </UAlert>
   </component>

--- a/apps/application/app/components/shared/ShareLinksModal.vue
+++ b/apps/application/app/components/shared/ShareLinksModal.vue
@@ -178,6 +178,11 @@ function linkState(link: ShareLinkSummary): { label: string; color: 'success' | 
           </div>
         </div>
         <EmptyState v-else-if="settings?.enabled" text="No share links yet for this page." />
+
+        <p class="text-xs text-gray-400">
+          A link renders the same bounded report as an offline export, live at view time —
+          <DocLink to="share-links" no-icon class="text-primary hover:underline">how share links work</DocLink>.
+        </p>
       </div>
     </template>
   </UModal>

--- a/apps/application/app/pages/mcp.vue
+++ b/apps/application/app/pages/mcp.vue
@@ -379,6 +379,20 @@ const windsurfSnippet = computed(() =>
           </div>
         </SectionCard>
 
+        <!-- Agent skills -->
+        <SectionCard icon="i-lucide-graduation-cap" title="Agent skills" help="mcp.skills" data-shot="mcp-agent-skills">
+          <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            The tools above give an agent read access to your results; <strong>skills</strong> tell it what to
+            <em>do</em> with them — investigate a failed run, apply a healed locator at its call site, stabilize the
+            highest-impact flaky tests. Each skill is a portable <code class="font-mono">SKILL.md</code> file that
+            prefers this MCP server and falls back to the dashboard UI. Install them into your test project with the
+            reporter CLI (<code class="font-mono">npx @piwitests/reporter init</code>
+            already does this as part of setup):
+          </p>
+          <CodeBlock code="npx @piwitests/reporter skills add" lang="bash" class="mb-3" />
+          <DocLink to="mcp#agent-skills" class="text-sm">What each skill does</DocLink>
+        </SectionCard>
+
         <!-- Authentication -->
         <SectionCard icon="i-lucide-key" title="Authentication" help="mcp.auth">
           <div class="space-y-3 text-sm text-gray-600 dark:text-gray-400">

--- a/apps/application/app/pages/projects/[id]/index.vue
+++ b/apps/application/app/pages/projects/[id]/index.vue
@@ -1048,9 +1048,10 @@ const comparisonColumns: TableColumn<ComparisonRow>[] = [
               <p class="text-xs text-gray-400 max-w-sm">
                 Point the reporter's <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">projectName</code> at
                 <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">{{ project?.name }}</code> to send results here
-                — see the
-                <DocLink to="reporter" no-icon class="text-primary hover:underline">reporter docs</DocLink> for setup
-                instructions.
+                — <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">npx @piwitests/reporter init</code> wires a
+                Playwright project in one command, or see the
+                <DocLink to="reporter" no-icon class="text-primary hover:underline">reporter docs</DocLink> for manual
+                setup.
               </p>
             </EmptyState>
           </UCard>

--- a/apps/application/app/pages/projects/[id]/selections.vue
+++ b/apps/application/app/pages/projects/[id]/selections.vue
@@ -370,7 +370,15 @@ function saveSmoke(testCaseIds: number[]) {
             v-else-if="selections.length === 0"
             icon="i-lucide-list-filter"
             text="No selections yet — create one, or run a built-in with piwi run failed."
-          />
+          >
+            <p class="text-xs text-gray-400 max-w-sm">
+              Selections are named subsets — smoke, recently broken, a time budget — that the reporter CLI's
+              <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">piwi run</code> and
+              <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">piwi select</code> resolve against this dashboard
+              — see the
+              <DocLink to="test-selection" no-icon class="text-primary hover:underline">test selection docs</DocLink>.
+            </p>
+          </EmptyState>
           <div v-else class="divide-y divide-gray-200 dark:divide-gray-800">
             <div
               v-for="selection in selections"

--- a/apps/application/app/pages/projects/[id]/test-functions.vue
+++ b/apps/application/app/pages/projects/[id]/test-functions.vue
@@ -408,12 +408,14 @@ function describeSteps(entry: TestFunctionInfo): string {
 
     <template #body>
       <div class="p-4 space-y-4">
-        <SectionCard
-          title="Test function catalog"
-          icon="i-lucide-function-square"
-          :count="entries.length || null"
-          subtitle="Page-object methods and helpers the Piwi Picker extension matches a recording against, to generate calls to your own code instead of raw locator lines."
-        >
+        <SectionCard title="Test function catalog" icon="i-lucide-function-square" :count="entries.length || null">
+          <template #subtitle>
+            Page-object methods and helpers the
+            <DocLink to="extension#connecting-to-a-piwi-instance" no-icon class="text-primary hover:underline"
+              >Piwi Picker extension</DocLink
+            >
+            matches a recording against, to generate calls to your own code instead of raw locator lines.
+          </template>
           <template #actions>
             <UButton label="Add function" icon="i-lucide-plus" size="sm" @click="openAdd" />
           </template>
@@ -423,7 +425,20 @@ function describeSteps(entry: TestFunctionInfo): string {
             v-else-if="entries.length === 0"
             icon="i-lucide-function-square"
             text="No functions registered yet — add one, or extract one from a recording in the extension."
-          />
+          >
+            <p class="text-xs text-gray-400 max-w-sm">
+              The extension is a separate install:
+              <a
+                href="https://chromewebstore.google.com/detail/piwi-picker/pakhnokpjboejcghgcmkjlpnogfjihhe"
+                target="_blank"
+                rel="noopener"
+                class="text-primary hover:underline"
+                >Piwi Picker on the Chrome Web Store</a
+              >
+              (Chrome and Edge) — setup in the
+              <DocLink to="extension" no-icon class="text-primary hover:underline">extension docs</DocLink>.
+            </p>
+          </EmptyState>
           <div v-else class="divide-y divide-gray-200 dark:divide-gray-800">
             <div v-for="entry in entries" :key="entry.id" class="py-3 flex items-start justify-between gap-3">
               <div class="min-w-0 space-y-1">

--- a/apps/application/app/pages/projects/index.vue
+++ b/apps/application/app/pages/projects/index.vue
@@ -371,9 +371,13 @@ const columns: TableColumn<ProjectWithStats>[] = [
 
       <EmptyState v-else icon="i-lucide-rocket" text="No projects yet">
         <p class="text-xs text-gray-400 max-w-sm">
-          Projects are created automatically once the reporter submits its first run — see the
-          <NuxtLink to="/" class="text-primary hover:underline">home page</NuxtLink> for a copy-paste setup snippet, or
-          the <DocLink to="reporter" no-icon class="text-primary hover:underline">reporter docs</DocLink>.
+          Projects are created automatically once the reporter submits its first run —
+          <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">npx @piwitests/reporter init</code> wires a Playwright
+          project in one command. See the <NuxtLink to="/" class="text-primary hover:underline">home page</NuxtLink> for
+          a copy-paste setup, or the
+          <DocLink to="getting-started#fast-path-one-command" no-icon class="text-primary hover:underline"
+            >getting-started docs</DocLink
+          >.
         </p>
         <UButton
           icon="i-lucide-plus"

--- a/apps/application/app/pages/setup.vue
+++ b/apps/application/app/pages/setup.vue
@@ -135,6 +135,8 @@ const activeCount = computed(() => rows.value.filter((r) => r.active).length);
             </li>
           </ul>
         </UCard>
+
+        <CompanionToolsCard />
       </div>
     </template>
   </UDashboardPanel>

--- a/apps/application/app/utils/help-content.ts
+++ b/apps/application/app/utils/help-content.ts
@@ -644,6 +644,11 @@ export const HELP_TOPICS = {
     text: 'Copy-paste configuration to connect Claude Code, Cursor, VS Code and other MCP clients to this server.',
     doc: 'mcp#client-setup',
   },
+  'mcp.skills': {
+    title: 'Agent skills',
+    text: 'Portable SKILL.md workflow instructions for AI coding agents — investigate a failure, apply a healed locator, stabilize flaky tests. Installed into your test project by the reporter CLI; each one prefers this MCP server and falls back to the dashboard UI.',
+    doc: 'mcp#agent-skills',
+  },
 
   // ── Shared ────────────────────────────────────────────────────────────
   'shared.entity-links': {

--- a/apps/application/app/utils/setup-capabilities.ts
+++ b/apps/application/app/utils/setup-capabilities.ts
@@ -59,6 +59,16 @@ export const SETUP_CAPABILITIES: SetupCapabilityCopy[] = [
     doc: 'capture-fixtures',
   },
   {
+    id: 'backend-logs',
+    title: 'Backend logs',
+    summary:
+      'Server-side warnings, errors and spans captured during each test and shown next to the network request that triggered them.',
+    how: 'Install a Piwi instrumentation package in the app under test — @piwitests/instrumentation-nitro on npm, or PiwiTests.Instrumentation.AspNetCore on NuGet.',
+    icon: 'i-lucide-server',
+    doc: 'backend-logs',
+    optional: true,
+  },
+  {
     id: 'clustering',
     title: 'Failure clustering',
     summary: 'Forty red tests collapsed into the three root causes behind them, each triaged once.',

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -481,6 +481,31 @@ const SCENES = [
     },
   },
 
+  {
+    name: 'setup-companion-tools',
+    description: 'Setup page: the companion-tools card below the capability ladder',
+    route: '/setup',
+    viewport: { width: 1280, height: 2600 },
+    of: '[data-shot="companion-tools"]',
+    pad: 12,
+  },
+  {
+    name: 'wizard-fast-path',
+    description: 'Get-started wizard: the one-command init fast path above the manual steps',
+    route: '/setup',
+    viewport: { width: 1280, height: 2600 },
+    of: '[data-shot="wizard-fast-path"]',
+    pad: 12,
+  },
+  {
+    name: 'mcp-agent-skills',
+    description: 'MCP page: the agent-skills section with the install command',
+    route: '/mcp',
+    viewport: { width: 1280, height: 2400 },
+    of: '[data-shot="mcp-agent-skills"]',
+    pad: 12,
+  },
+
   // ── Desktop shell (report artifacts) ──────────────────────────────────────
   {
     name: 'desktop-nav',

--- a/apps/application/shared/handlers/setup-status.ts
+++ b/apps/application/shared/handlers/setup-status.ts
@@ -36,6 +36,7 @@ export type SetupCapabilityId =
   | 'reporter'
   | 'fixtures'
   | 'locator-healing'
+  | 'backend-logs'
   | 'clustering'
   | 'ai'
   | 'notifications'
@@ -65,6 +66,7 @@ export async function getSetupStatus(db: DrizzleDB): Promise<SetupStatus> {
     hasRuns,
     hasNetwork,
     hasLocators,
+    hasServerTraces,
     hasClusters,
     hasAiSetting,
     hasChannels,
@@ -76,6 +78,14 @@ export async function getSetupStatus(db: DrizzleDB): Promise<SetupStatus> {
     exists(db, db.select({ id: testRuns.id }).from(testRuns).limit(1)),
     exists(db, db.select({ id: networkRequests.id }).from(networkRequests).limit(1)),
     exists(db, db.select({ id: locatorSnapshots.id }).from(locatorSnapshots).limit(1)),
+    exists(
+      db,
+      db
+        .select({ id: networkRequests.id })
+        .from(networkRequests)
+        .where(isNotNull(networkRequests.serverTraces))
+        .limit(1),
+    ),
     exists(db, db.select({ id: failureClusters.id }).from(failureClusters).limit(1)),
     exists(db, db.select({ key: appSettings.key }).from(appSettings).where(eq(appSettings.key, 'ai')).limit(1)),
     exists(db, db.select({ id: notificationChannels.id }).from(notificationChannels).limit(1)),
@@ -95,6 +105,7 @@ export async function getSetupStatus(db: DrizzleDB): Promise<SetupStatus> {
     { id: 'reporter', active: hasRuns },
     { id: 'fixtures', active: hasNetwork },
     { id: 'locator-healing', active: hasLocators },
+    { id: 'backend-logs', active: hasServerTraces },
     { id: 'clustering', active: hasClusters },
     { id: 'ai', active: hasAiSetting || aiFromEnv },
     { id: 'notifications', active: hasChannels },

--- a/apps/application/tests/unit/docs-drift.test.ts
+++ b/apps/application/tests/unit/docs-drift.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { MCP_TOOL_DEFS } from '#shared/mcp-tools';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
@@ -63,16 +63,20 @@ describe('docs pages the app deep-links into', () => {
       .trim()
       .replace(/\s+/g, '-');
 
-  const sources = [
-    'apps/application/app/utils/help-content.ts',
-    'apps/application/app/components/test-case/TestCaseNetworkRequests.vue',
-    'apps/application/app/components/test-case/TestSourceCard.vue',
-  ];
+  // Every .vue/.ts file under app/ — any of them may carry a `doc: '…'`
+  // registry field or a static `DocLink to="…"`.
+  const sources = (function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(path);
+      return /\.(vue|ts)$/.test(entry.name) ? [relative(repoRoot, path)] : [];
+    });
+  })(join(repoRoot, 'apps/application/app'));
 
   const targets = [
     ...new Set(
-      sources.flatMap((relative) => {
-        const contents = read(relative);
+      sources.flatMap((source) => {
+        const contents = read(source);
         return [
           ...[...contents.matchAll(/doc: '([^']+)'/g)].map((m) => m[1]!),
           ...[...contents.matchAll(/DocLink\s+to="([^"]+)"/g)].map((m) => m[1]!),

--- a/apps/application/tests/unit/setup-status.test.ts
+++ b/apps/application/tests/unit/setup-status.test.ts
@@ -78,6 +78,30 @@ describe('getSetupStatus', () => {
     const active = await activeIds(db);
     expect(active.has('fixtures')).toBe(true);
     expect(active.has('locator-healing')).toBe(false);
+    expect(active.has('backend-logs')).toBe(false);
+  });
+
+  test('a network request carrying server traces activates the backend-logs capability', async () => {
+    await db.insert(schema.projects).values({ id: 1, name: 'checkout' });
+    const [run] = await db
+      .insert(schema.testRuns)
+      .values({ projectId: 1, status: 'passed', startTime: new Date(), duration: 1, totalTests: 1, passedTests: 1 })
+      .returning({ id: schema.testRuns.id });
+    await db.insert(schema.testCases).values({ id: 1, projectId: 1, filePath: 'a.spec.ts', title: 'a' });
+    const [runCase] = await db
+      .insert(schema.testRunsCases)
+      .values({ testRunId: run!.id, testCaseId: 1, status: 'passed', duration: 1 })
+      .returning({ id: schema.testRunsCases.id });
+    await db.insert(schema.networkRequests).values({
+      testRunsCaseId: runCase!.id,
+      testRunId: run!.id,
+      url: 'https://example.test/api',
+      method: 'GET',
+      status: 200,
+      serverTraces: [{ name: 'db.query', durationMs: 12 }],
+    });
+
+    expect((await activeIds(db)).has('backend-logs')).toBe(true);
   });
 
   test('detection is evidence-based, not config-based: a defined tag activates tags', async () => {

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -153,6 +153,7 @@ export default defineConfig({
           { text: 'Browser extension', link: '/extension' },
           { text: 'Open in IDE', link: '/ide-integration' },
           { text: 'MCP server', link: '/mcp' },
+          { text: 'Agent skills', link: '/mcp#agent-skills' },
           { text: 'API docs (interactive)', link: 'https://piwitests.dev/demo/docs' },
         ],
       },

--- a/apps/docs/reporter.md
+++ b/apps/docs/reporter.md
@@ -92,7 +92,7 @@ Any attachments Playwright records — including **videos** (`video: 'retain-on-
 | Option                      | Type     | Default                   | Description                                                                                 |
 |-----------------------------|----------|---------------------------|---------------------------------------------------------------------------------------------|
 | `enabled`                   | boolean  | `true` when `serverUrl` is set | Explicitly turn the reporter off without removing it from the config                   |
-| `serverUrl`                 | string   | `'http://localhost:3000'` | URL of the Piwi Dashboard server                                                            |
+| `serverUrl`                 | string   | —                         | URL of the Piwi Dashboard server. With none set anywhere, the reporter looks for the [desktop app](#finding-the-desktop-app-automatically), and disables itself when that finds nothing either |
 | `projectName`               | string   | `'default-project'`       | Name of the project to report results under                                                 |
 | `uploadTraces`              | boolean  | `true`                    | Upload trace files to the dashboard                                                         |
 | `uploadReport`              | boolean  | `true`                    | Upload the Playwright HTML report                                                           |
@@ -126,7 +126,7 @@ Any attachments Playwright records — including **videos** (`video: 'retain-on-
 
 ### Environment variables
 
-Every option above can also be set via a `PIWI_*` environment variable. Env vars are fallbacks — an option passed in the reporter config takes precedence. The one exception is `PIWI_VERBOSE`, which wins over both the default and an explicit option (useful for toggling debug output without editing the config). The mapping is centralized in `src/internal/config/env.ts` (`PIWI_ENV_KEYS`):
+The options in the table below can also be set via a `PIWI_*` environment variable. Env vars are fallbacks — an option passed in the reporter config takes precedence. The one exception is `PIWI_VERBOSE`, which wins over both the default and an explicit option (useful for toggling debug output without editing the config). The mapping is centralized in `src/internal/config/env.ts` (`PIWI_ENV_KEYS`). The remaining options — `enabled`, `reports`, `projectDescription`, `relatedIssue`, `ciInfo`, `tags`, `customData`, `collectScmInfo`, `collectCiInfo` and `collectPerformanceMetrics` — are config-only:
 
 | Env var                         | Option                  | Format          |
 |---------------------------------|-------------------------|-----------------|

--- a/apps/docs/reporter.md
+++ b/apps/docs/reporter.md
@@ -370,6 +370,8 @@ A confirmed pick is recorded in three places:
 
 The gate is identical to `inspectOnFailure` (headed browser, never under CI, final attempt only), and the picker suppresses the page's own click handlers while active, so picking can't navigate or mutate the failing page. Picking never rewrites your test — it records the choice so you (or the dashboard) can apply it.
 
+The same picker engine also ships as the [Piwi Picker browser extension](./extension) — pick ranked, uniqueness-checked locators from any live page in Chrome or Edge, with no test run and no server required.
+
 ## Automatic metadata collection
 
 ### SCM information (Git)

--- a/apps/docs/reporter.md
+++ b/apps/docs/reporter.md
@@ -560,6 +560,15 @@ Uploaded traces open in the dashboard's **built-in, self-hosted trace viewer** �
 
 - Verify `serverUrl` is correct and the server is running
 - Check network connectivity and firewall settings
+- A run the reporter could not deliver — dashboard down, or a 401 because no
+  credential was configured — is not lost: a recovery copy of the results is
+  saved locally and submitted automatically on the next run for the same
+  project, in streaming and batch mode alike. The recovery copy carries the
+  results only, not traces, reports or attachments.
+- When live streaming is interrupted mid-run, the reporter warns once, buffers
+  the events, and keeps retrying; delivery retries at the end of the run can
+  add a few minutes of teardown while the dashboard stays unreachable, after
+  which the run falls back to the batch submit.
 
 ## With authentication enabled
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     },
     "apps/application": {
       "name": "@piwitests/dashboard",
-      "version": "0.25.0",
+      "version": "0.26.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",
@@ -80,7 +80,7 @@
     },
     "apps/extension": {
       "name": "@piwitests/extension",
-      "version": "0.25.0",
+      "version": "0.26.1",
       "dependencies": {
         "@piwitests/core": "*",
         "@piwitests/picker-dom": "*"
@@ -94,7 +94,7 @@
     },
     "integrations/nitro": {
       "name": "@piwitests/instrumentation-nitro",
-      "version": "0.25.0",
+      "version": "0.26.1",
       "license": "MIT",
       "peerDependencies": {
         "consola": ">=3.0.0",
@@ -24833,11 +24833,11 @@
     },
     "packages/core": {
       "name": "@piwitests/core",
-      "version": "0.25.0"
+      "version": "0.26.1"
     },
     "packages/picker-dom": {
       "name": "@piwitests/picker-dom",
-      "version": "0.25.0",
+      "version": "0.26.1",
       "dependencies": {
         "@piwitests/core": "*"
       },
@@ -24847,7 +24847,7 @@
     },
     "packages/reporter": {
       "name": "@piwitests/reporter",
-      "version": "0.25.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -24869,7 +24869,7 @@
     },
     "packages/server": {
       "name": "@piwitests/server",
-      "version": "0.25.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "0.17.4",

--- a/packages/reporter/src/internal/streaming/stream-manager.ts
+++ b/packages/reporter/src/internal/streaming/stream-manager.ts
@@ -222,7 +222,9 @@ export class StreamManager {
             `Falling back to batch upload at the end of the run.`,
         );
       } else {
-        this.logger.debug(`Streaming not available: ${errorMessage(error)}. Will use batch mode.`);
+        this.logger.warn(
+          `Live streaming is unavailable (${errorMessage(error)}) — results will be submitted in one batch when the run finishes.`,
+        );
       }
       this._enabled = false;
     }
@@ -269,9 +271,9 @@ export class StreamManager {
           this.lastActivityAt = Date.now();
           return true;
         },
-        () => {
+        (error) => {
           this.pendingEvents = events.concat(this.pendingEvents);
-          this.scheduleRetry();
+          this.scheduleRetry(errorMessage(error));
           return false;
         },
       );
@@ -280,9 +282,12 @@ export class StreamManager {
     return promise;
   }
 
-  private scheduleRetry(): void {
+  private scheduleRetry(reason: string): void {
     if (this.retryTimer) return;
     this.retryCount++;
+    if (this.retryCount === 1) {
+      this.logger.warn(`Streaming to the dashboard was interrupted (${reason}) — events are buffered and retried.`);
+    }
     const delay = Math.min(1000 * Math.pow(2, this.retryCount - 1), this.maxRetryDelay);
     this.logger.debug(`Will retry streaming flush in ${delay}ms (attempt ${this.retryCount})`);
 
@@ -340,40 +345,63 @@ export class StreamManager {
     }
   }
 
+  /** Clear a scheduled flush retry so its timer cannot fire after the run wraps up. */
+  private clearRetryTimer(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
   /** Drain all pending and buffered events before the run finishes. Retries up to 10 times with exponential back-off. */
   async drain(): Promise<void> {
     this.stopHeartbeat();
+    this.clearRetryTimer();
     if (!this._enabled) {
       this.pendingEvents = [];
       this.flushPromises = [];
       return;
     }
 
-    const MAX_ATTEMPTS = 10;
-    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-      if (this._enabled && this.pendingEvents.length > 0) this.flush();
-      if (this.flushPromises.length > 0) {
-        await Promise.allSettled(this.flushPromises);
-        this.flushPromises = [];
-      }
-      if (this.pendingEvents.length === 0) {
-        const buffered = this.streamBuffer.load();
-        if (buffered.length > 0) {
-          this.pendingEvents = buffered;
-          this.streamBuffer.clear();
-          continue;
+    try {
+      const MAX_ATTEMPTS = 10;
+      for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        if (this._enabled && this.pendingEvents.length > 0) this.flush();
+        if (this.flushPromises.length > 0) {
+          await Promise.allSettled(this.flushPromises);
+          this.flushPromises = [];
         }
-        return;
+        if (this.pendingEvents.length === 0) {
+          const buffered = this.streamBuffer.load();
+          if (buffered.length > 0) {
+            this.pendingEvents = buffered;
+            this.streamBuffer.clear();
+            continue;
+          }
+          return;
+        }
+        if (attempt === 0) {
+          this.logger.warn(
+            `The dashboard has not accepted ${this.pendingEvents.length} live event(s) yet — retrying delivery before the final submit (this can take a few minutes)...`,
+          );
+        }
+        this.logger.debugError(
+          `${this.pendingEvents.length} events pending, retrying (attempt ${attempt + 1}/${MAX_ATTEMPTS})...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt), 10000)));
       }
-      this.logger.debugError(
-        `${this.pendingEvents.length} events pending, retrying (attempt ${attempt + 1}/${MAX_ATTEMPTS})...`,
-      );
-      await new Promise((resolve) => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt), 10000)));
-    }
 
-    if (this.pendingEvents.length > 0) {
-      this.streamBuffer.append(this.pendingEvents);
-      this.pendingEvents = [];
+      if (this.pendingEvents.length > 0) {
+        this.logger.warn(
+          `Could not deliver ${this.pendingEvents.length} live event(s) to the dashboard — continuing with the end-of-run submit.`,
+        );
+        this.streamBuffer.append(this.pendingEvents);
+        this.pendingEvents = [];
+      }
+    } finally {
+      // Flush failures inside the loop re-arm the retry timer; the drain is the
+      // last delivery attempt, so nothing may stay scheduled past it.
+      this.clearRetryTimer();
     }
   }
 

--- a/packages/reporter/src/internal/submit/run-submitter.ts
+++ b/packages/reporter/src/internal/submit/run-submitter.ts
@@ -107,8 +107,13 @@ export class RunSubmitter {
       auth = sm?.auth ?? (await this.httpClient.resolveAuth(run.options));
     } catch (error) {
       this.logger.error(`Authentication failed: ${errorMessage(error)}`);
+      this.saveRecovery(this.buildRunPayload(run, overallStatus, duration));
       throw error;
     }
+
+    // A streaming session retries the recovery file when it opens; without one,
+    // retry it here so a saved payload still reaches the server.
+    if (!sm) await this.recovery.tryUpload(this.httpClient, auth);
 
     let outcome: SubmitOutcome = { done: false, output: null };
 
@@ -255,17 +260,15 @@ export class RunSubmitter {
     duration: number,
     auth: string | null,
   ): Promise<SubmitOutcome> {
+    const payload = this.buildRunPayload(run, overallStatus, duration);
     try {
-      const response = await this.uploader.uploadWithFiles(
-        this.buildRunPayload(run, overallStatus, duration),
-        this.reportOptions(run),
-        auth,
-      );
+      const response = await this.uploader.uploadWithFiles(payload, this.reportOptions(run), auth);
       this.recovery.clear();
       return { done: true, output: this.buildOutput(response?.runId, response?.projectId, run, overallStatus) };
     } catch (error) {
       if (error instanceof HttpError && error.status === 401 && !auth) {
         this.logAuthRequired(run.options.serverUrl);
+        this.saveRecovery(payload);
         throw error;
       }
       this.logger.warn(`Failed to upload with files: ${errorMessage(error)}`);
@@ -290,6 +293,7 @@ export class RunSubmitter {
       // configuration error — throw so the caller knows it's fatal.
       if (error instanceof HttpError && error.status === 401 && !auth) {
         this.logAuthRequired(run.options.serverUrl);
+        this.saveRecovery(payload);
         throw error;
       }
       this.logger.error(`All upload methods failed: ${errorMessage(error)}`);
@@ -297,12 +301,18 @@ export class RunSubmitter {
         `Saved a local recovery copy — it will be uploaded automatically on your next test run. ` +
           `If this keeps happening, check that serverUrl (${run.options.serverUrl ?? 'not set'}) is correct and reachable.`,
       );
-      // Save the wire-serialized form so the recovery file matches the
-      // original submit payload (no raw attachments / internal fields).
-      this.recovery.save(serializeRun(payload, { includeTestCases: true }));
+      this.saveRecovery(payload);
       // The ladder is exhausted; nothing to surface to CI.
       return { done: true, output: null };
     }
+  }
+
+  /**
+   * Persist the wire-serialized payload (no raw attachments / internal fields)
+   * so a later run can retry the submit.
+   */
+  private saveRecovery(payload: RunPayload): void {
+    this.recovery.save(serializeRun(payload, { includeTestCases: true }));
   }
 
   /** Log one actionable line explaining how to fix a 401 caused by a missing credential. */

--- a/packages/reporter/tests/submit-ladder.spec.ts
+++ b/packages/reporter/tests/submit-ladder.spec.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { PiwiDashboardReporter } from '../src/public/reporter.js';
+import { hashForProject } from '../src/internal/support/instance-id.js';
 import {
   startServer,
   jsonRes,
@@ -20,13 +21,13 @@ const STREAM_PREFIX = 'piwi-dashboard-stream-';
 const SETUP_PREFIX = 'piwi-dashboard-setup-';
 
 function cleanupProjectArtifacts(projectName: string): void {
-  // Recovery and stream-buffer files are keyed by a sha1 of the project name.
-  // We don't know the hash here, so sweep tmpdir for piwi-dashboard-* files
-  // matching this test run's marker.
+  // Recovery and stream-buffer files are keyed by a sha1 hash of the project
+  // name, so match on the hash rather than the raw name.
   const tmp = os.tmpdir();
+  const hash = hashForProject(projectName);
   for (const f of fs.readdirSync(tmp)) {
     if (f.startsWith(RECOVERY_PREFIX) || f.startsWith(STREAM_PREFIX) || f.startsWith(SETUP_PREFIX)) {
-      if (f.includes(projectName)) {
+      if (f.includes(hash) || f.includes(projectName)) {
         try {
           fs.unlinkSync(path.join(tmp, f));
         } catch {
@@ -35,6 +36,10 @@ function cleanupProjectArtifacts(projectName: string): void {
       }
     }
   }
+}
+
+function recoveryFilePath(projectName: string): string {
+  return path.join(os.tmpdir(), `${RECOVERY_PREFIX}${hashForProject(projectName)}.json`);
 }
 
 async function runOneTest(reporter: PiwiDashboardReporter, title: string, status = 'passed'): Promise<void> {
@@ -252,14 +257,50 @@ describe('PiwiDashboardReporter submit/fallback ladder', () => {
     await runOneTest(reporter, 'recovery-test');
 
     // A recovery file should now exist in tmpdir for this project.
-    const tmp = os.tmpdir();
-    const files = fs.readdirSync(tmp).filter((f) => f.startsWith(RECOVERY_PREFIX));
-    expect(files.length > 0, 'expected a recovery file to be written').toBeTruthy();
-    const recovered = JSON.parse(fs.readFileSync(path.join(tmp, files[0]), 'utf8'));
+    const recovered = JSON.parse(fs.readFileSync(recoveryFilePath(projectName), 'utf8'));
     expect(recovered.projectName).toBe(projectName);
   });
 
-  it('401 with no auth propagates (does not fall back)', async () => {
+  it('batch mode retries a saved recovery payload on the next run', async () => {
+    server = await startServer((_req, res) => textRes(res, 500, 'down'));
+    const failing = new PiwiDashboardReporter({
+      serverUrl: server.url,
+      projectName,
+      streaming: false,
+      uploadReport: false,
+      uploadTraces: false,
+      liveFileUploads: false,
+    });
+    await runOneTest(failing, 'lost-run-test');
+    await server.close();
+    expect(fs.existsSync(recoveryFilePath(projectName)), 'expected a recovery file after the failed run').toBe(true);
+
+    const submits: any[] = [];
+    server = await startServer((req, res) => {
+      if (req.url === '/api/test-runs/submit') {
+        submits.push(JSON.parse(req.body));
+        jsonRes(res, 200, { runId: 30 + submits.length, projectId: 20 });
+      } else {
+        textRes(res, 404, 'nope');
+      }
+    });
+    const reporter = new PiwiDashboardReporter({
+      serverUrl: server.url,
+      projectName,
+      streaming: false,
+      uploadReport: false,
+      uploadTraces: false,
+      liveFileUploads: false,
+    });
+    await runOneTest(reporter, 'second-run-test');
+
+    const titles = submits.map((s) => s.testCases[0].title);
+    expect(titles, `submits: ${titles.join(', ')}`).toContain('lost-run-test');
+    expect(titles, `submits: ${titles.join(', ')}`).toContain('second-run-test');
+    expect(fs.existsSync(recoveryFilePath(projectName)), 'recovery file is cleared after the retry').toBe(false);
+  });
+
+  it('401 with no auth propagates (does not fall back) and saves a recovery copy', async () => {
     server = await startServer((req, res) => {
       if (req.url === '/api/test-runs/submit') {
         textRes(res, 401, 'unauthorized');
@@ -280,5 +321,10 @@ describe('PiwiDashboardReporter submit/fallback ladder', () => {
       reports: [{ type: 'missing-type', dir: '/nonexistent' }],
     });
     await expect(runOneTest(reporter, 'auth-fail-test')).rejects.toThrow(/401/);
+
+    // The run is not lost: a recovery copy is written before the throw.
+    const recovered = JSON.parse(fs.readFileSync(recoveryFilePath(projectName), 'utf8'));
+    expect(recovered.projectName).toBe(projectName);
+    expect(recovered.testCases[0].title).toBe('auth-fail-test');
   });
 });


### PR DESCRIPTION
## What & why

This PR improves the onboarding experience and error handling across the dashboard and reporter:

**Dashboard improvements:**
- Add a new "Companion tools" card on the setup page that documents the browser extension, desktop app, reporter CLI, MCP server, and IDE integration — all the tools that work alongside the dashboard
- Add a "Fast path" section to the get-started wizard showing the one-command `npx @piwitests/reporter init` setup
- Add "Agent skills" section to the MCP page explaining how to install portable SKILL.md workflows
- Enhance empty states on test functions, selections, and projects pages with links to relevant companion tools and docs
- Add "backend-logs" as a new setup capability (detected when network requests carry server traces)
- Update docs-drift test to scan all `.vue` and `.ts` files under `app/` for doc links, not just a hardcoded list

**Reporter improvements:**
- Improve streaming error messages: change debug logs to warnings when streaming is unavailable or interrupted, with clearer context about buffering and retries
- Add reason parameter to retry scheduling so users understand why events are being buffered
- Improve drain-phase logging to show progress during final delivery attempts
- Save recovery copies before throwing auth errors (401), so failed runs aren't lost even when auth is misconfigured
- Retry saved recovery payloads in batch mode on the next run, not just during streaming sessions
- Clear retry timers in drain phase to prevent timers firing after the run completes

**Test improvements:**
- Add test for recovery file retry on subsequent runs
- Add test for backend-logs capability detection
- Update recovery file cleanup to use the project hash instead of raw name matching

## How was it tested

- Added unit tests for recovery file retry behavior and backend-logs detection
- Updated existing submit-ladder tests to verify recovery copies are saved on auth failures
- Existing streaming and batch-mode tests continue to pass
- Feature screenshots added for companion-tools, wizard-fast-path, and mcp-agent-skills sections

## Checklist

- [x] PR title follows Conventional Commits (`feat(...)`)
- [x] Tests added for new behavior (recovery retry, backend-logs detection)
- [x] Docs updated (reporter.md, README.md, help-content.ts, docs config)
- [x] User-facing strings improved (error messages, empty states, setup guidance)

https://claude.ai/code/session_01NZ8DgBw8HQjcNokFQwkXvg