### PR TITLE
docs: document screenshots and fix stale failure-evidence references

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ export default defineConfig({
       projectName: 'my-project',
     }],
   ],
-  use: { trace: 'retain-on-failure' },
+  use: { trace: 'retain-on-failure', screenshot: 'only-on-failure' },
 })
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,11 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 ## Recently shipped
 
+- **Branch-aware runs and baselines** — the reporter records the real branch on CI (from the provider's variables,
+  or `PIWI_BRANCH`) instead of a detached `HEAD`; runs carry a queryable `branch` column and a per-project default
+  branch; runs, flaky tests and MCP tools filter by branch; regression and visual-diff baselines prefer the same
+  branch, then the default branch; and PR feedback flags a failure that is already flaky on the default branch.
+  Tiers 1–2 of [proposals/first-class-branches.md](proposals/first-class-branches.md).
 - **Auto-heal pull requests** — when a locator breaks on the default branch and healing has high-confidence
   evidence, Piwi opens the fix PR itself: a branch, a deterministic one-line locator edit per broken call site, and
   an evidence-rich body, with the CI gate and fix verification closing the loop. GitHub, GitLab and Bitbucket; off by
@@ -73,9 +78,10 @@ Everything else — analytics, notifications, the CI gate, PR feedback, MCP, the
 
 ## Exploring
 
-- **First-class branches** — reliable branch capture on CI (no more detached-HEAD blanks), runs filterable by
-  branch, baselines and flakiness scoped to the branch they belong to, and eventually a merge-readiness verdict per
-  branch. Design in [proposals/first-class-branches.md](proposals/first-class-branches.md).
+- **Branches as entities** — on top of the shipped branch column: a merge-readiness verdict per branch,
+  branch-class gate policies, cross-branch fix verification and retention by branch class, plus flakiness and trends
+  scoped to the default branch by default. Tier 3 of
+  [proposals/first-class-branches.md](proposals/first-class-branches.md).
 - **Exporting whole runs** — [offline export](https://piwitests.dev/offline-export) covers one execution and one failure cluster today; a whole run, and a
   test's history across runs, would follow the same shape.
 - **Self-sufficient trace archives** — an export can carry the trace files, but reading them still needs a Playwright

--- a/apps/application/tests/unit/docs-drift.test.ts
+++ b/apps/application/tests/unit/docs-drift.test.ts
@@ -32,12 +32,23 @@ describe('positioning line', () => {
 });
 
 describe('documented counts', () => {
-  test('every page claiming an MCP tool count states the real one', () => {
-    const claim = new RegExp(`\\b${MCP_TOOL_DEFS.length}\\b tools`);
-    for (const relative of ['apps/docs/mcp.md', 'apps/docs/comparison.md', 'ROADMAP.md']) {
-      const stated = read(relative).match(/\b(\d+) tools\b/);
-      if (!stated) continue;
-      expect(read(relative), `${relative} says "${stated[0]}", there are ${MCP_TOOL_DEFS.length}`).toMatch(claim);
+  // Every page on the docs site (the generated configuration.md included,
+  // when built) plus the repository-level pages that repeat the number.
+  const docsPages = (function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) return [];
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(path);
+      return entry.name.endsWith('.md') ? [relative(repoRoot, path)] : [];
+    });
+  })(join(repoRoot, 'apps/docs'));
+  const COUNT_SURFACES = [...docsPages, 'README.md', 'ROADMAP.md', 'DOCKER_HUB.md'];
+
+  test.each(COUNT_SURFACES)('%s states the real MCP tool count, if it states one', (relative) => {
+    for (const [claim, stated] of read(relative).matchAll(/\b(\d+) tools\b/g)) {
+      expect(Number(stated), `${relative} says "${claim}", there are ${MCP_TOOL_DEFS.length}`).toBe(
+        MCP_TOOL_DEFS.length,
+      );
     }
   });
 

--- a/apps/docs/ai-diagnosis.md
+++ b/apps/docs/ai-diagnosis.md
@@ -234,7 +234,7 @@ When the failure is a broken locator, the context includes an **Alternative Loca
   <figcaption>The Alternative locators panel — the broken locator, ranked replacements scored for stability, and a single recommended fix that preserves your locator style.</figcaption>
 </figure>
 
-This evidence is generated from the locator snapshots recorded by the [capture fixtures](./capture-fixtures) while tests run — make sure your specs import `test` from a fixtures file that extends `piwiFixtures`. Capture is gated by the default-on `captureLocators` reporter option. The same data drives the standalone **Alternative locators** panel on the test-case and cluster pages.
+This evidence is generated from the locator snapshots recorded by the [capture fixtures](./capture-fixtures) while tests run — make sure your specs import `test` from a fixtures file that extends `piwiFixtures`. Capture is gated by the default-on `captureLocators` reporter option. The same data drives the standalone **Alternative locators** panel on the [execution](./evidence#one-execution-diagnosis-first) and cluster pages.
 
 ## Fix plans for coding agents
 

--- a/apps/docs/ai-diagnosis.md
+++ b/apps/docs/ai-diagnosis.md
@@ -223,7 +223,7 @@ Every `suggestedFix.patch` is checked server-side, before it reaches you, agains
 | `invalid` | ❌ Invalid diff | The text isn't a parseable unified diff |
 | `unchecked` | Unverified | The target file wasn't in context, so the patch couldn't be validated |
 
-A wrong patch is worse than none, so the model is instructed to set `patch` to null unless it can quote the lines it changes from the `Source Files` / `Test Source` sections. The patch card offers **Copy**, **Copy `git apply` command**, and **Download `.patch`**; applying is always manual (the dashboard never writes to your repository).
+A wrong patch is worse than none, so the model is instructed to set `patch` to null unless it can quote the lines it changes from the `Source Files` / `Test Source` sections. The patch card offers **Copy**, **Copy `git apply` command**, and **Download `.patch`**; applying an AI-suggested patch is always manual — the dashboard never writes one to your repository. The one feature that does write to your repository is [auto-heal](./auto-heal): deterministic one-line locator edits taken from captured snapshots, never model output, and off by default.
 
 ## Locator healing
 

--- a/apps/docs/auto-heal.md
+++ b/apps/docs/auto-heal.md
@@ -1,9 +1,14 @@
+---
+title: Auto-heal PRs
+lang: en-US
+---
+
 # Auto-heal PRs
 
 When a locator breaks on your default branch and Piwi has high-confidence evidence for the replacement, it can open the
 fix pull request itself: a branch, a one-line locator edit per broken call site, and a body that shows the change, the
 score, where the replacement came from, and the command that verifies it. The CI gate runs on the PR like any other,
-and [fix verification](/ai-diagnosis) records the cluster as fixed once the tests pass.
+and [fix verification](./ai-diagnosis#did-the-fix-work) records the cluster as fixed once the tests pass.
 
 It is **off by default**, and even once on it acts only on projects you list. Writing to your repository is the
 strongest thing the dashboard does, so the posture is conservative by design.
@@ -23,7 +28,7 @@ strongest thing the dashboard does, so the posture is conservative by design.
 ## Requirements
 
 - **`PIWI_SITE_URL`** must be set, so the links in the PR body resolve.
-- An **SCM token with write scope**, resolved the same way as [PR feedback](/ci): a per-project token, falling back
+- An **SCM token with write scope**, resolved the same way as [PR feedback](./ci#pull-request-feedback): a per-project token, falling back
   to the global one. It needs:
   - **GitHub** — `repo` (classic), or a fine-grained token with `contents: write` + `pull_requests: write`.
   - **GitLab** — `api`.

--- a/apps/docs/backend-logs.md
+++ b/apps/docs/backend-logs.md
@@ -15,7 +15,7 @@ The mechanism is straightforward: the backend integration adds a `X-Piwi-Logs` r
 
 When backend logs are captured, they appear in:
 
-- **Test case detail → Traces & Console tab** — the "Network & backend logs" panel lists each captured request (method, status, response time, content type, and timestamp). Requests that returned server-side logs show an inline warning/error count and expand to reveal **every log entry attached to that exact request** — level, category, message, timestamp, and a collapsible stack trace. Requests are sorted so failures and those carrying error logs surface first, and a filter lets you narrow to "Failed" or "With logs".
+- **The [execution page](./evidence#one-execution-diagnosis-first) (`/test-run-cases/:id`)** — the **Network requests** card, in the evidence funnel of a failing execution's Diagnosis tab and in the Artifacts tab, lists each captured request (method, status, response time, content type, and timestamp). Requests that returned server-side logs show an inline warning/error count and expand to reveal **every log entry attached to that exact request** — level, category, message, timestamp, and a collapsible stack trace. Requests are sorted so failures and those carrying error logs surface first, and a filter lets you narrow to "Failed" or "With logs".
 - **AI diagnosis context** — warnings and errors are included automatically when diagnosing a failure cluster, giving the AI visibility into what went wrong on the server side
 
 Because the logs are stored per request (rather than as one flat list), you can immediately tell *which* HTTP call produced a given warning or error — the response and its server-side cause sit side by side.

--- a/apps/docs/capture-fixtures.md
+++ b/apps/docs/capture-fixtures.md
@@ -53,13 +53,13 @@ That's the entire setup — there is nothing to start, wrap, or await inside you
 | Data | Captured | Powers |
 |------|----------|--------|
 | **Network requests** — method, URL, status, duration, content type. Only API/document traffic (fetch, XHR, document); static assets are skipped | per request | *Slow API endpoints* table on the [run page](./ui-overview#test-run-detail) with `/api/users/:id`-style route normalization; [backend log correlation](./backend-logs) via the `X-Piwi-Logs` response header |
-| **Console entries** — `warning`, `error`, and `assert` messages with source location (`console.log` noise is not collected) | as they happen | Console card on the [test case page](./evidence#one-execution-diagnosis-first); [AI diagnosis](./ai-diagnosis) evidence |
+| **Console entries** — `warning`, `error`, and `assert` messages with source location (`console.log` noise is not collected) | as they happen | Console card on the [execution page](./evidence#one-execution-diagnosis-first); [AI diagnosis](./ai-diagnosis) evidence |
 | **Web Vitals** — TTFB, DOM Interactive, DOMContentLoaded, Load Complete, First Paint, First Contentful Paint, plus LCP, CLS and INP (Chromium-only) | at test teardown | Web vitals card with color-coded thresholds; [performance trends](./flaky-tests#performance) |
-| **ARIA snapshot** of the final page state | on failure | Failure evidence on the test-case and cluster pages; [AI diagnosis](./ai-diagnosis) context |
+| **ARIA snapshot** of the final page state | on failure | Failure evidence on the [execution](./evidence#one-execution-diagnosis-first) and cluster pages; [AI diagnosis](./ai-diagnosis) context |
 | **Locator snapshots** — element attributes, stable-ancestor anchors, and same-role position, plus ranked alternative locators (including rename-proof ancestor-scoped and name-free ones) for each element a test proves resolvable, stamped with the call site | after each successful action and each passing web-first assertion (`toBeVisible()`, `toHaveText()`, …) | [Locator healing](./reporter#locator-healing); when a failing name-based locator (`getByRole`, `getByText`, `getByLabel`, …) matches nothing, a fresh suggestion is attached to the test as a Playwright annotation |
 
 ::: tip Test source is captured without any fixture
-On a failure the reporter also reads the **call stack's in-project source** — the line that actually threw plus the callers above it (helpers, page objects), each as a small line-numbered snippet with the failing line marked. It needs no fixture (it comes from the stack trace plus the local source files) and renders as the **Test source** call stack on the [test-case](./evidence#one-execution-diagnosis-first) and cluster pages. `node_modules`/Playwright frames are skipped.
+On a failure the reporter also reads the **call stack's in-project source** — the line that actually threw plus the callers above it (helpers, page objects), each as a small line-numbered snippet with the failing line marked. It needs no fixture (it comes from the stack trace plus the local source files) and renders as the **Test source** call stack on the [execution](./evidence#one-execution-diagnosis-first) and cluster pages. `node_modules`/Playwright frames are skipped.
 :::
 
 ## With and without the fixtures

--- a/apps/docs/ci.md
+++ b/apps/docs/ci.md
@@ -281,6 +281,10 @@ network, or a missing API key against an instance with authentication enabled.
 **Traces are missing.** Traces have to be recorded before they can be uploaded — set
 `use: { trace: 'retain-on-failure' }` (or `'on-first-retry'`) in your Playwright config.
 
+**Screenshots are missing.** Same cause: Playwright's `screenshot` option defaults to `'off'`, so
+nothing is recorded for the reporter to upload. Set `use: { screenshot: 'only-on-failure' }` (or
+`'on'`) in your Playwright config; the reporter needs no option of its own.
+
 **A run is stuck as `interrupted`.** A live reporter heartbeats every ~15s; when a run goes quiet for
 two minutes — a cancelled job, an OOM-killed runner, a dropped network — the server marks it
 `interrupted` rather than leaving it `running` forever. If the reporter comes back (a long test, a

--- a/apps/docs/concepts.md
+++ b/apps/docs/concepts.md
@@ -69,7 +69,9 @@ the same run. So is each browser in a project matrix.
 
 This is the object at `/test-run-cases/:id` — the error, steps, trace, screenshots, console, network,
 Web Vitals, and (for a failure) the diagnosis view. When the docs say *execution* or *test-run case*,
-this is what they mean; when they say *test case*, they mean the identity above it.
+this is what they mean; when they say *test case*, they mean the identity above it. The run page's
+list still calls executions *cases* in a few labels (the counter, the search box, the title column) —
+same object, older name.
 
 The distinction matters in practice: "this test is flaky" is a statement about a **test case**, and
 "here is the stack trace" is a statement about one **execution**.
@@ -82,7 +84,7 @@ with its dynamic arguments masked. That hash is the **error fingerprint**.
 
 Every failed execution sharing a fingerprint joins one **failure cluster**. Fifty red tests caused by
 one broken endpoint become one cluster you triage once, with a status (open / resolved / ignored) and
-a note.
+a note. API routes and a few components say *failure groups* for the same thing.
 
 Fingerprints deliberately **ignore the failing stack frame**, so the same root cause reached from six
 different spec files stays one cluster. Full detail:

--- a/apps/docs/evidence.md
+++ b/apps/docs/evidence.md
@@ -42,6 +42,10 @@ Both keep a **Performance** tab (performance hints plus color-coded **Web Vitals
 
 ## Trace-powered deep views
 
+::: tip Screenshots are Playwright's to record
+The screenshots in **failure evidence** come from Playwright's `screenshot: 'only-on-failure'` `use` option (`'on'` records every test). Playwright's default is `'off'`, so with the option unset the block shows video and traces but no screenshot. Set it beside `trace` in your Playwright config; see [Basic configuration](./reporter#basic-configuration) on the reporter page.
+:::
+
 When an execution has an uploaded trace, two evidence blocks go deeper — no configuration beyond recording traces (`trace: 'retain-on-failure'` or `'on-first-retry'` in your Playwright config):
 
 - **Test source → Full stack** — the complete call stack of the failing action from the trace's stacks index, every frame with its real source read from the trace's embedded files (recorded by default with the Playwright test runner), the failing line highlighted, dependency frames folded, and Open-in-IDE links on each in-project frame. A toggle switches back to the reporter-captured frames.

--- a/apps/docs/getting-started.md
+++ b/apps/docs/getting-started.md
@@ -136,9 +136,12 @@ export default defineConfig({
   ],
   use: {
     trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
 })
 ```
+
+Both `use` options are Playwright's own: `trace` records the trace the dashboard's deep views read, and `screenshot` records the failure screenshot shown as evidence. Neither is on by default in Playwright, so without them a failing test uploads its error and steps but no trace or screenshot.
 
 Run your tests and results will appear in the dashboard:
 

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -115,7 +115,7 @@ Start from what you came here to do.
   how to [block a merge](/ci#blocking-a-merge) on the analysis rather than the exit code.
 - **Running it for a team** — [Deployment](/deployment), [Configuration](/configuration),
   [Authentication](/authentication), and [Privacy & data flow](/privacy).
-- **Letting an agent do the reading** — the [MCP server](/mcp) gives a coding agent 40 tools over your
+- **Letting an agent do the reading** — the [MCP server](/mcp) gives a coding agent 45 tools over your
   test history, and [AI diagnosis](/ai-diagnosis) explains a cluster against your actual git diff with
   a provider you configure. Both optional; a local model works.
 

--- a/apps/docs/reporter.md
+++ b/apps/docs/reporter.md
@@ -32,10 +32,13 @@ export default defineConfig({
   ],
   use: {
     trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
 })
 ```
+
+The `use` block is Playwright's, not Piwi's: `trace`, `screenshot` and `video` decide what Playwright records, and the reporter uploads whatever exists. Leave `screenshot` at its default (`'off'`) and the failure evidence has no screenshot to show.
 
 <a id="performance-metrics-web-vitals"></a>
 
@@ -85,7 +88,7 @@ export { expect } from '@playwright/test'
 
 These are only collected when `collectPerformanceMetrics` is `true` (the default). If fixture data does not appear in the dashboard, the most likely cause is that your test files import `test` from `@playwright/test` directly instead of from your fixtures file (see options A/B above).
 
-Any attachments Playwright records — including **videos** (`video: 'retain-on-failure'`) and screenshots — are uploaded automatically and shown as first-class evidence on the test-case and failure-cluster pages, alongside traces. Videos can be large, so pair `retain-on-failure` with periodic [storage cleanup](./storage#storage-management).
+Any attachments Playwright records — including **screenshots** (`screenshot: 'only-on-failure'`) and **videos** (`video: 'retain-on-failure'`) — are uploaded automatically and shown as first-class evidence on the [execution](./evidence#one-execution-diagnosis-first) and failure-cluster pages, alongside traces. Screenshots are the evidence most pages on this site count on, and Playwright records none unless the option is set. Videos can be large, so pair `retain-on-failure` with periodic [storage cleanup](./storage#storage-management).
 
 ## Configuration options
 
@@ -549,6 +552,7 @@ Uploaded traces open in the dashboard's **built-in, self-hosted trace viewer** �
 
 - Make sure an HTML reporter is configured: `['html', { outputFolder: 'playwright-report' }]`
 - Make sure traces are enabled: `use: { trace: 'retain-on-failure' }`
+- Make sure screenshots are enabled: `use: { screenshot: 'only-on-failure' }` — Playwright's default is `'off'`, so an unset option means no screenshot to upload
 - Check the dashboard server is running and accessible at `serverUrl`
 
 ### Fixture data not appearing (network, Web Vitals, console, ARIA snapshot, locator healing)

--- a/apps/docs/reporter.md
+++ b/apps/docs/reporter.md
@@ -81,9 +81,9 @@ export { expect } from '@playwright/test'
 ### What gets captured
 
 - **Network requests** — method, URL, status code, duration, resource type. Aggregated on the dashboard into a *Slow API endpoints* table grouped by `METHOD + normalized route` (e.g. `/api/users/:id`).
-- **Console entries** — `warning`, `error`, and `assert` messages with their source location, shown on the test case page and included in the AI diagnosis evidence.
+- **Console entries** — `warning`, `error`, and `assert` messages with their source location, shown on the [execution page](./evidence#one-execution-diagnosis-first) and included in the AI diagnosis evidence.
 - **Browser Web Vitals** — TTFB, DOM Interactive, DOMContentLoaded, Load Complete, First Paint, First Contentful Paint, plus Core Web Vitals (LCP, CLS, INP) — displayed with color-coded thresholds. LCP/CLS/INP come from buffered `PerformanceObserver` entries and are Chromium-only; INP needs at least one interaction, so it is often `n/a` in short tests.
-- **ARIA snapshot** — Captured automatically on failed/timed-out tests via `page.locator(':root').ariaSnapshot()`. Included in both the debug prompt (`/test-cases/:id`) and the cluster AI diagnosis context.
+- **ARIA snapshot** — Captured automatically on failed/timed-out tests via `page.locator(':root').ariaSnapshot()`. Included in the **Copy AI context** bundle on the [execution page](./evidence#one-execution-diagnosis-first)'s Diagnosis tab (`/test-run-cases/:id`) and in the cluster AI diagnosis context.
 - **Locator snapshots** — For each element a test proves resolvable — every successful action (click, fill, etc.) *and* every passing web-first assertion (`expect(locator).toBeVisible()`, `toHaveText()`, …) — the fixtures record the element's attributes and a ranked list of alternative locators, stamped with the call site. These power [locator healing](#locator-healing) when a locator later breaks. Gated by `captureLocators` (default on).
 
 These are only collected when `collectPerformanceMetrics` is `true` (the default). If fixture data does not appear in the dashboard, the most likely cause is that your test files import `test` from `@playwright/test` directly instead of from your fixtures file (see options A/B above).
@@ -189,7 +189,7 @@ By default, the reporter streams test results to the dashboard in real-time as t
 
 1. When tests start, the reporter creates a run on the server with `running` status
 2. As each test completes, results are sent in batches to the server
-3. With `liveFileUploads` (the default), each test's trace and attachments are uploaded right after the test finishes, so they are viewable on the test case page while the run is still in progress
+3. With `liveFileUploads` (the default), each test's trace and attachments are uploaded right after the test finishes, so they are viewable on the [execution page](./evidence#one-execution-diagnosis-first) while the run is still in progress
 4. The dashboard UI shows a live progress bar and test results as they arrive
 5. While a test runs, the steps it is executing (Playwright `pw:api` actions, `pw:expect` assertions, and hook/fixture steps) stream to the run page as they happen — each running test's row shows the step it is on right now. The polling attempts of `pw:assert` steps are deliberately not streamed; the persisted step events on a completed test still carry everything
 6. When tests finish, the reporter finalizes the run with the overall status
@@ -322,7 +322,7 @@ When a stored snapshot is found but the element's captured accessible name is pr
   <figcaption>Healing runs from the failure's own error text: stored history is matched by call site, then signature, then across tests — and every hit is sanity-checked against the failing page before anything is recommended.</figcaption>
 </figure>
 
-The result is shown as an **Alternative locators** panel on the test-case and failure-cluster pages, and folded into the AI diagnosis context so the model recommends a grounded fix (see [AI diagnosis](./ai-diagnosis#locator-healing)). A single **recommended fix** is highlighted — it keeps your original locator *style* where that style is stable enough (a minimal, idiomatic edit), and escalates to the sturdiest alternative (or advises adding a `data-testid`) only when the original style has nothing stable to fall back on.
+The result is shown as an **Alternative locators** panel on the [execution](./evidence#one-execution-diagnosis-first) and failure-cluster pages, and folded into the AI diagnosis context so the model recommends a grounded fix (see [AI diagnosis](./ai-diagnosis#locator-healing)). A single **recommended fix** is highlighted — it keeps your original locator *style* where that style is stable enough (a minimal, idiomatic edit), and escalates to the sturdiest alternative (or advises adding a `data-testid`) only when the original style has nothing stable to fall back on.
 
 <figure>
   <img src="/screenshots/locator-healing.png" alt="Alternative locators panel showing ranked replacement locators with stability scores and a recommended fix">

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -36,6 +36,7 @@ export default wrapConfig(
   defineConfig({
     use: {
       trace: 'retain-on-failure',
+      screenshot: 'only-on-failure',
     },
   }),
   {
@@ -79,6 +80,7 @@ export default defineConfig({
   ],
   use: {
     trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
   },
 })
 ```
@@ -325,6 +327,7 @@ Everything public — the reporter, config helpers, and the capture fixtures —
 
 - Ensure an HTML reporter is configured: `['html', { outputFolder: 'playwright-report' }]`
 - Ensure traces are enabled: `use: { trace: 'retain-on-failure' }`
+- Ensure screenshots are enabled: `use: { screenshot: 'only-on-failure' }` — Playwright's default is `'off'`
 - Check the dashboard server is running and accessible at `serverUrl`
 
 ### Fixture data not appearing (network, Web Vitals, console, ARIA, locator healing)

--- a/proposals/first-class-branches.md
+++ b/proposals/first-class-branches.md
@@ -1,9 +1,17 @@
 # First-class branches
 
 A proposal to promote the git branch from a display string inside a run's `metadata` JSON to a reliable, queryable,
-analysis-bearing dimension — and, in its final stage, to an entity with a lifecycle. Nothing here has shipped; the
-document argues the case, stages the work so each stage pays for itself, and records the alternatives and open
-questions.
+analysis-bearing dimension — and, in its final stage, to an entity with a lifecycle. The document argues the case,
+stages the work so each stage pays for itself, and records the alternatives and open questions.
+
+**Status.** Tiers 1 and 2 have shipped: the reporter resolves the branch from the CI provider's variables instead of
+recording a detached `HEAD`, honors a `PIWI_BRANCH` override and captures the pull-request number; `test_runs` carries
+an indexed scalar `branch` column; projects carry a `defaultBranch`, resolved from the SCM provider when unset; runs,
+the flaky leaderboard and the MCP tools take a `branch` filter; regression baselines and the visual-diff baseline
+prefer the same branch, then the default branch; and PR feedback exonerates a test that is also flaky on the default
+branch. Still open from Tier 2: scoping flakiness and trends to the default branch *by default* (the filter exists,
+the default does not). Tier 3 — branches as entities, the merge-readiness verdict, branch-class policies and retention
+— has not shipped and stays under *Exploring* in [`ROADMAP.md`](../ROADMAP.md). The design below is the original text.
 
 **Summary.** Branch is already load-bearing: pull-request feedback, the auto-heal policy, notification filters and
 the run-comparison diff all read it. But it is collected in a way that records the literal string `HEAD` on most CI

--- a/proposals/test-selection.md
+++ b/proposals/test-selection.md
@@ -2,7 +2,17 @@
 
 A design record for **selections**: named, data-driven subsets of a project's tests that the dashboard computes from
 the history it keeps, and that a developer, a CI job or an AI agent can actually *run* — `piwi run smoke` — instead of
-maintaining grep patterns and tag lists by hand. Status: proposal, nothing shipped.
+maintaining grep patterns and tag lists by hand.
+
+**Status.** M1 and M2 have shipped, and most of M3 and M4: the selection model with its catalog predicates and
+built-ins, `piwi select` / `piwi run` with duration-balanced `--shard` and `--fail-fast` ordering, run stamping, the
+`--require-selection` gate policy, the project's Selections tab with builder and live preview, the PR-feedback
+summary line, five MCP tools (`list_selections`, `resolve_selection`, `preview_selection`, `suggest_selections`,
+`analyze_selections`) with the `run-the-right-tests` skill, suggested tags and budgeted smoke mining, impact-from-diff
+over captured source frames, and selection health and drift analytics. Not shipped: applying tag suggestions back to
+the spec files as a pull request, suggestion digests through notifications, and route-level impact mapping behind a
+per-project config. The user guide is [Test selections](../apps/docs/test-selection.md) on the docs site; the design
+below is the original text.
 
 **Summary.** Piwi already knows which tests are fast, stable, flaky, slow, quarantined, recently broken, owned by
 whom, and which routes and source files each test actually exercised. Today that knowledge flows only into dashboards;


### PR DESCRIPTION
## What & why

The documentation slice of the quick wins from the failing-run data audit (audit §7, item 12, plus the docs rows of §4.6). Each claim was checked against the current files and the code before editing. One commit per item.

1. **Document the Playwright screenshot option.** Screenshots are promised as failure evidence on several pages, but `screenshot: 'only-on-failure'` appeared nowhere. It now sits beside `trace: 'retain-on-failure'` in every `use` block, with a note that the option is Playwright's and defaults to off, and a "Screenshots are missing" troubleshooting entry beside "Traces are missing".
   Files: `apps/docs/reporter.md`, `apps/docs/getting-started.md`, `apps/docs/evidence.md`, `apps/docs/ci.md`, `README.md`, `packages/reporter/README.md`.
2. **Fix stale references.** The ARIA-snapshot note pointed at a "debug prompt" on `/test-cases/:id`; it is now the **Copy AI context** action on the execution page's Diagnosis tab. The backend-logs page sent readers to a "Traces & Console tab" that no longer exists; the logs render inline in the **Network requests** card of the execution page (Diagnosis and Artifacts tabs). "Test case page" wording for the execution page is aligned with `concepts.md` and linked to the execution anchor.
   Files: `apps/docs/reporter.md`, `apps/docs/backend-logs.md`, `apps/docs/capture-fixtures.md`, `apps/docs/ai-diagnosis.md`.
3. **Scope the "never writes to your repository" claim.** An AI-suggested patch is never applied by the dashboard; auto-heal writes only deterministic locator edits and is off by default, linked from the patch section. `auto-heal.md` gets the `title:`/`lang:` frontmatter every other page has and relative `./` in-site links.
   Files: `apps/docs/ai-diagnosis.md`, `apps/docs/auto-heal.md`.
4. **Align the MCP tool count.** The landing page said 40; the registry has 45. The docs-drift test now scans every `.md` under `apps/docs/` plus `README.md`, `ROADMAP.md` and `DOCKER_HUB.md` and checks every numeric "N tools" claim, not just the first match on three fixed pages.
   Files: `apps/docs/index.md`, `apps/application/tests/unit/docs-drift.test.ts`.
5. **Mark shipped proposals as shipped.** Verified against the code: first-class branches Tiers 1–2 shipped (CI-aware branch capture with `PIWI_BRANCH`, `branch` column on `test_runs`, project `defaultBranch`, branch filters, branch-aware regression and visual-diff baselines, default-branch flake exoneration in PR feedback); still open are default-branch scoping of flakiness *by default* and all of Tier 3. Test selections M1–M2 and most of M3–M4 shipped (model, `piwi select`/`piwi run`, `--require-selection`, Selections tab, five MCP tools, suggestions, impact-from-diff, health/drift); not shipped are tag PRs, suggestion digests and route-level impact mapping. Each proposal gets a status paragraph; `ROADMAP.md` moves the shipped part to "Recently shipped" and keeps branches-as-entities under "Exploring". Proposal bodies are otherwise unchanged.
   Files: `proposals/first-class-branches.md`, `proposals/test-selection.md`, `ROADMAP.md`.
6. **Two terminology notes.** One sentence in the execution section of `concepts.md` says the run page's list still calls executions "cases" in a few labels; one sentence in the cluster section says API routes say "failure groups" for failure clusters.
   Files: `apps/docs/concepts.md`.

Nothing was left out. The audit document itself is not on this branch. No screenshot illustration changed, so `app:screens:check` was not needed.

## How was it tested?

- `apps/docs`: `npm install && npm run docs:build` — builds clean (the build fails on dead links).
- `apps/application`: `npx vitest run tests/unit/docs-drift.test.ts` — 112 tests pass. Negative check: reverting `index.md` to "40 tools" fails the new test with `apps/docs/index.md says "40 tools", there are 45`.
- `npx commitlint --from origin/main --to HEAD` — clean; `oxfmt --check` and `oxlint` on the changed test file — clean.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXM2BKeYdq2qYqxhkM4C6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXM2BKeYdq2qYqxhkM4C6c)_