### PR TITLE
feat(app): screenshot any route and seed the dev DB in one command

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: run-app
+description: Launch and drive the Piwi dashboard locally with seeded sample data, capture a screenshot of any route, and stop it again — the verified path for checking a UI or server change in the real app instead of rediscovering the setup.
+---
+
+# Run the dashboard locally
+
+Use this whenever you need to *see* a change working: a screen, a flow, an API response. It is the
+tested sequence; the pitfalls at the end each cost a previous session real time, so follow the
+commands as written rather than improvising with `nuxt dev` and a hand-rolled Playwright script.
+
+Everything runs from `apps/application/`. Node 24+, dependencies installed (`npm install` at the
+repo root).
+
+## Look at one page (the common case)
+
+One command boots a throwaway dev server on port 3050, creates and seeds the dev database on the
+first run, opens the route, waits for hydration and for the page to settle, screenshots it into
+`.screens/` (gitignored) and tears the server down:
+
+```bash
+npm run app:screens -- --route /test-run-cases/37?tab=diagnosis --expand --height 2400
+```
+
+- `--expand` unfolds every collapsed section first (evidence cards start folded).
+- `--height` is how you see more of a page: the dashboard scrolls inside a panel, so a full-page
+  screenshot of the document only ever shows one viewport. Use 2000–3000 for a detail page.
+- `--width` sets the viewport width (default 1280), `--name` the file stem.
+- Add `--url http://localhost:3000` to drive a server you already have running instead of booting one.
+
+Then read the image (`.screens/route-<slug>.png`) — a blank or half-loaded frame means the wait
+was cut short, not that the page is empty; retry once before concluding anything.
+
+The registered scenes (`npm run app:screens -- --list`) are the same machinery with curated routes and
+viewports; add one when a change adds or visibly reworks a screen (see the "Feature screenshots" rule
+in `apps/application/AGENTS.md`).
+
+## Keep a server running (iterating on a change)
+
+```bash
+npm run app:seed:dev        # sample data into .data/piwi.db — creates and migrates the DB if needed
+npm run app:dev:bg          # dev server on http://localhost:3000, detached, waits until ready
+```
+
+- Nuxt HMR picks up edits; there is no need to restart per change. Compile errors show up in
+  `.data/dev-server.log`, not in the browser.
+- The Playwright E2E config reuses a server already on port 3000 (`npm run app:test -- <spec>`), so one
+  background server serves both your screenshots and the specs.
+- Capture against it with `npm run app:screens -- --route <path> --url http://localhost:3000`.
+- Stop it with `node scripts/dev-server.mjs --stop` (also stops a stale one; the pid is recorded in
+  `.data/dev-server.pid`). Seeding needs the server stopped — SQLite holds a lock.
+
+## Check an API or find an id
+
+```bash
+curl -s localhost:3000/api/health
+curl -s "localhost:3000/api/test-run-cases/37" | head -c 800
+node scripts/db-query.mjs "select id, status from test_runs_cases where status='failed' order by id desc limit 5" --json
+```
+
+Authentication is off on a plain dev server, so no key is needed.
+
+## Seeded entry points
+
+The seed is generated deterministically from `scripts/generate-demo-seed.mjs`, so these ids are stable
+until a story is added to the generator; the docs scenes in `scripts/take-feature-screenshots.mjs`
+use the same ones and are the reference when in doubt.
+
+| Want to see | Route |
+|---|---|
+| A failing execution with screenshot, source, locators, console, network | `/test-run-cases/37?tab=diagnosis` |
+| A broken locator with ranked replacements | `/test-run-cases/13` |
+| A cluster with a stored, fix-verified AI diagnosis | `/failure-clusters/10` |
+| A cluster whose captured locator name looks renamed | `/failure-clusters/2` |
+| A run with insights, failure clusters and a workers timeline | `/test-runs/2` |
+| A project with flaky tests, quarantine and performance tabs | `/projects/1` |
+| A test case's history across runs | `/test-cases/1` |
+| An execution's history tab | `/test-run-cases/229?tab=history` |
+
+AI is not configured on the dev server: the diagnosis panels show their "not configured" state, and
+clusters without a stored title fall back to the deterministic one.
+
+## Pitfalls (each of these has already cost a session)
+
+- **Do not wait for `networkidle` without a timeout.** The run, execution and notification surfaces
+  hold a Server-Sent Events stream open, so the network never goes idle. The screens script waits for
+  `domcontentloaded`, Nuxt hydration and a bounded settle instead; copy that if you script Playwright
+  yourself.
+- **`fullPage: true` does nothing useful here.** The document does not scroll; the panel does. Use a
+  tall viewport or screenshot the panel element.
+- **A route compiles on its first hit** in dev mode — allow a 90 s navigation timeout the first time.
+- **Seeding and migrations need the server stopped** (`node scripts/dev-server.mjs --stop` first).
+- **`npm run app:seed:demo` rewrites `public/demo/seed.version.json`.** Revert it (`git checkout --`)
+  unless you changed the generator on purpose.
+- **Never start `nuxt dev` in the foreground of a tool call** — it blocks until the call times out.
+  `app:dev:bg` exists for that reason.
+- **`PIWI_DEMO_MODE=true` is not a dev-server flag.** To verify the demo itself, build it:
+  `npm run app:generate:demo && npm run app:check:demo:runtime`.
+- Screenshots and dev data live under `.screens/` and `.data/`, both gitignored; never commit them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ From `apps/application/`:
 | `npm run app:generate:demo` / `app:check:demo` | Build the demo SPA / verify every server route has a demo handler |
 | `npm run app:check:demo:runtime` | Drive the **built** demo from its real `/demo/` sub-path in a browser (run `app:generate:demo` first) |
 | `npm run app:screens -- <scene>` | Capture a feature screenshot — `app:screens:docs` for every committed docs illustration, `app:screens:check` to verify they all still have a scene |
+| `npm run app:screens -- --route <path> [--expand] [--height N]` | Screenshot any page without registering a scene — boots and seeds its own server; the `run-app` skill (`.claude/skills/run-app/SKILL.md`) is the full recipe for running and driving the app |
 | `npm run app:generate:deploy` | Regenerate the one-click deploy manifests (`render.yaml`, `fly.toml`, `deploy/`) |
 | `node scripts/db-query.mjs "<sql>" [--json]` | Query the local SQLite DB directly |
 

--- a/apps/application/AGENTS.md
+++ b/apps/application/AGENTS.md
@@ -438,6 +438,11 @@ apply the cursor in memory on the same axis as the emitted cursor, or paging loo
 
 ## Running the app locally to verify a change
 
+The step-by-step recipe, the seeded routes worth opening and the pitfalls live in the `run-app` skill
+(`.claude/skills/run-app/SKILL.md`) — read it first. The short form: `npm run app:screens -- --route <path> --expand
+--height 2400` screenshots any page against a throwaway server it boots and seeds itself, and `npm run app:seed:dev`
+followed by `npm run app:dev:bg` gives you a server on port 3000 to iterate against.
+
 When you need to see a change working — a UI tweak, a flow, a screenshot — run a **plain (non-demo) dev server backed by
 a dev DB seeded from the demo data**:
 
@@ -449,8 +454,11 @@ npm run app:seed:dev                             # 3. load sample data (server m
 NUXT_IGNORE_LOCK=1 npx nuxt dev --port 3002      # 4. plain dev server, auth disabled by default
 ```
 
-`app:seed:dev` is idempotent (`INSERT OR IGNORE`); to refresh stale rows wipe `.data` and repeat from step 2. Drive the
-app with Playwright — `scripts/take-demo-screenshots.mjs` is a working harness.
+`app:seed:dev` creates and migrates a missing or empty dev DB itself, so step 2 is only needed when you want a clean
+schema by hand; it is idempotent (`INSERT OR IGNORE`), and to refresh stale rows wipe `.data` and re-run it. Drive the
+app with Playwright — `scripts/take-feature-screenshots.mjs` (`--route`, `--url`) is the working harness, and its
+`settlePage` is the wait strategy to copy: the run and execution pages hold an SSE stream open, so a bare
+`networkidle` never resolves, and the page scrolls inside a panel, so `fullPage` captures a single viewport.
 
 **Caveats that cost real debugging time:**
 

--- a/apps/application/scripts/seed-dev-from-demo.mjs
+++ b/apps/application/scripts/seed-dev-from-demo.mjs
@@ -6,10 +6,13 @@
  *   node scripts/seed-dev-from-demo.mjs
  *
  * The dev server must NOT be running while this script runs (DB lock).
- * The script is idempotent: existing rows are skipped on conflict.
+ * The script is idempotent: existing rows are skipped on conflict. A missing
+ * seed file is generated and a missing or empty dev database is created and
+ * migrated first, so a fresh checkout seeds with this one command.
  */
 
-import { readFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
@@ -18,11 +21,27 @@ const require = createRequire(import.meta.url);
 const { createClient } = require('@libsql/client');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const sqlPath = join(__dirname, '../public/demo/seed.sql');
-const dbPath = join(__dirname, '../.data/piwi.db');
+const appDir = join(__dirname, '..');
+const sqlPath = join(appDir, 'public/demo/seed.sql');
+const dbPath = join(appDir, '.data/piwi.db');
 
+if (!existsSync(sqlPath)) {
+  console.log('No demo seed yet — generating public/demo/seed.sql…');
+  execSync('npm run app:seed:demo', { cwd: appDir, stdio: 'inherit' });
+}
 const sql = readFileSync(sqlPath, 'utf8');
-const db = createClient({ url: `file:${dbPath}` });
+
+// The dev schema comes from the Drizzle migrations, not from the seed: run them
+// when the database is missing or still empty, then open it for the inserts.
+mkdirSync(join(appDir, '.data'), { recursive: true });
+let db = createClient({ url: `file:${dbPath}` });
+const schema = await db.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'test_runs'");
+if (schema.rows.length === 0) {
+  console.log('Dev database has no schema yet — running the migrations…');
+  db.close();
+  execSync('npm run db:migrate', { cwd: appDir, stdio: 'inherit' });
+  db = createClient({ url: `file:${dbPath}` });
+}
 
 /**
  * Split a SQL script into statements on `;`, ignoring semicolons that sit

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -14,10 +14,18 @@
  *   node scripts/take-feature-screenshots.mjs --url http://localhost:3002
  *   node scripts/take-feature-screenshots.mjs --freeze-now 2026-08-02T09:00:00Z
  *   node scripts/take-feature-screenshots.mjs <scene> --out ../docs/public/screenshots
+ *   node scripts/take-feature-screenshots.mjs --route /test-run-cases/37 --expand --height 2400
  *
  * Without --url the script boots its own dev server on port 3050 and tears it
  * down at the end; a missing dev DB is created and seeded first. With --url it
  * drives the server you point it at.
+ *
+ * `--route <path>` captures one page without registering a scene — the way to
+ * look at any screen while verifying a change. It gets the same server, the
+ * same hydration and settle waits, and writes `.screens/route-<slug>.png`.
+ * `--expand` unfolds every collapsed section first; `--width` and `--height`
+ * size the viewport (the dashboard scrolls inside a panel, so a taller viewport
+ * is how more of a page gets into one image); `--name` picks the file stem.
  *
  * Every scene declares a `mode`: `web` (the default) captures the dashboard as
  * a browser serves it, `desktop` captures the Tauri shell — the server runs
@@ -1014,7 +1022,20 @@ function checkDocsImages() {
 }
 
 function parseArgs(argv) {
-  const flags = { scenes: [], tag: null, url: null, out: null, freezeNow: null, list: false, check: false };
+  const flags = {
+    scenes: [],
+    tag: null,
+    url: null,
+    out: null,
+    freezeNow: null,
+    list: false,
+    check: false,
+    route: null,
+    width: null,
+    height: null,
+    expand: false,
+    name: null,
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--list') flags.list = true;
@@ -1023,10 +1044,41 @@ function parseArgs(argv) {
     else if (arg === '--url') flags.url = argv[++i];
     else if (arg === '--out') flags.out = resolve(process.cwd(), argv[++i]);
     else if (arg === '--freeze-now') flags.freezeNow = argv[++i];
+    else if (arg === '--route') flags.route = argv[++i];
+    else if (arg === '--width') flags.width = Number(argv[++i]);
+    else if (arg === '--height') flags.height = Number(argv[++i]);
+    else if (arg === '--expand') flags.expand = true;
+    else if (arg === '--name') flags.name = argv[++i];
     else if (arg.startsWith('--')) throw new Error(`unknown flag: ${arg}`);
     else flags.scenes.push(arg);
   }
   return flags;
+}
+
+/**
+ * The one-off scene behind `--route`: one page, captured like a registered
+ * scene but never listed and never checked against the docs images.
+ */
+function adHocScene(flags) {
+  if (!flags.route.startsWith('/')) throw new Error(`--route needs an absolute path, got "${flags.route}"`);
+  for (const [flag, value] of [
+    ['--width', flags.width],
+    ['--height', flags.height],
+  ]) {
+    if (value != null && !(Number.isInteger(value) && value > 0)) throw new Error(`${flag} needs a positive integer`);
+  }
+  const slug =
+    flags.route
+      .replace(/^\//, '')
+      .replace(/[^a-z0-9]+/gi, '-')
+      .replace(/^-|-$/g, '') || 'home';
+  return {
+    name: flags.name ?? `route-${slug}`,
+    route: flags.route,
+    viewport: { width: flags.width ?? DEFAULT_VIEWPORT.width, height: flags.height ?? DEFAULT_VIEWPORT.height },
+    expandAll: flags.expand,
+    out: 'screens',
+  };
 }
 
 function selectScenes(flags) {
@@ -1087,6 +1139,21 @@ async function captureScene(browser, scene, { base, outDir, freezeNow }) {
       .locator(`${selector} [role="button"][aria-expanded="true"]`)
       .first()
       .waitFor({ state: 'visible', timeout: 10_000 });
+    await settle();
+  };
+
+  /**
+   * Unfold every collapsed section on the page. Each click shrinks the set of
+   * folded toggles (and may reveal new ones), so the first match is clicked
+   * until none is left, with a ceiling so a toggle that never flips cannot
+   * loop forever.
+   */
+  const expandAll = async () => {
+    const folded = page.locator('main [role="button"][aria-expanded="false"]');
+    for (let i = 0; i < 40 && (await folded.count()) > 0; i++) {
+      await folded.first().click();
+      await page.waitForTimeout(100);
+    }
     await settle();
   };
 
@@ -1187,6 +1254,7 @@ async function captureScene(browser, scene, { base, outDir, freezeNow }) {
     if (scene.prepare) await scene.prepare({ base, request: context.request });
     await goto(scene.route ?? '/');
     for (const selector of scene.expand ?? []) await expand(selector);
+    if (scene.expandAll) await expandAll();
     if (scene.run) {
       await scene.run({ page, base, shoot, goto, settle, openTab, expand, annotate, clear });
     }
@@ -1216,7 +1284,7 @@ async function main() {
     return;
   }
 
-  const scenes = selectScenes(flags);
+  const scenes = flags.route ? [adHocScene(flags)] : selectScenes(flags);
   const freezeNow = flags.freezeNow ? new Date(flags.freezeNow) : null;
   if (freezeNow && Number.isNaN(freezeNow.getTime())) {
     throw new Error(`--freeze-now needs an ISO timestamp, got "${flags.freezeNow}"`);


### PR DESCRIPTION
## What & why

Every agent session that had to *look* at the app rediscovered the same four traps before getting a screenshot: `app:seed:dev` fails on a fresh checkout until the migrations have run, a bare `networkidle` wait never resolves because the run and execution pages hold an SSE stream open, `fullPage: true` captures a single viewport because the dashboard scrolls inside a panel, and the first hit on a route compiles for a minute. The machinery to avoid all of that already existed in `scripts/take-feature-screenshots.mjs` and in the "Running the app locally" section of the app guide — it just was not where an agent (or a new contributor) looks first.

This change makes the verified path the obvious one:

- **`npm run app:screens -- --route <path> [--expand] [--width N] [--height N] [--name stem]`** captures one page without registering a scene, against the same throwaway server and the same hydration/settle waits the docs scenes use. `--expand` unfolds every collapsed section first; a tall `--height` is how more of a panel-scrolling page fits in one image. Output lands in `.screens/` (gitignored).
- **`npm run app:seed:dev`** now generates a missing `public/demo/seed.sql` and creates and migrates a missing or empty dev database before inserting, so a fresh checkout seeds with one command instead of failing with an opaque SQLite error.
- **A `run-app` project skill** (`.claude/skills/run-app/SKILL.md`) records the recipe, the seeded routes worth opening (failing execution, broken locator, fix-verified cluster, run with insights, …) and the pitfalls, so the harness's `run` skill picks it up instead of improvising.
- Both agent guides point at the skill and the new flag.

## How was it tested?

- Deleted `.data/piwi.db` and ran `npm run app:seed:dev`: it ran the migrations itself, then inserted 4117 rows and rebased the timestamps.
- `npm run app:screens -- --route "/test-run-cases/37?tab=diagnosis" --expand --height 2400`: booted the throwaway server on port 3050, expanded the folded cards and wrote `.screens/route-test-run-cases-37-tab-diagnosis.png` in about two minutes; the image shows the whole Diagnosis tab with every section open.
- `npm run app:lint` and `npm run app:format:check` pass; `node --check` on both scripts.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — tooling scripts, exercised end to end as above; no unit-tested behavior changed
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README) — contributor-facing only: `AGENTS.md`, `apps/application/AGENTS.md`, the new skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQh21QRnWnQ7GQrNy2YiAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQh21QRnWnQ7GQrNy2YiAT)_