### PR TITLE
fix(app): serve video attachments with media types

### DIFF
--- a/apps/application/server/api/files/[...path].get.ts
+++ b/apps/application/server/api/files/[...path].get.ts
@@ -171,6 +171,7 @@ export default eventHandler(async (event) => {
     'video/mp4',
     'video/ogg',
     'video/quicktime',
+    'video/x-msvideo',
     'font/woff2',
     'font/ttf',
   ]);
@@ -193,6 +194,7 @@ export default eventHandler(async (event) => {
     if (ext === '.mp4') return 'video/mp4';
     if (ext === '.ogg' || ext === '.ogv') return 'video/ogg';
     if (ext === '.mov') return 'video/quicktime';
+    if (ext === '.avi') return 'video/x-msvideo';
     if (ext === '.svg') return 'image/svg+xml';
     if (ext === '.woff' || ext === '.woff2') return 'font/woff2';
     if (ext === '.ttf') return 'font/ttf';

--- a/apps/application/server/api/files/[...path].get.ts
+++ b/apps/application/server/api/files/[...path].get.ts
@@ -167,6 +167,10 @@ export default eventHandler(async (event) => {
     'image/gif',
     'image/svg+xml',
     'image/webp',
+    'video/webm',
+    'video/mp4',
+    'video/ogg',
+    'video/quicktime',
     'font/woff2',
     'font/ttf',
   ]);
@@ -185,6 +189,10 @@ export default eventHandler(async (event) => {
     if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
     if (ext === '.gif') return 'image/gif';
     if (ext === '.webp') return 'image/webp';
+    if (ext === '.webm') return 'video/webm';
+    if (ext === '.mp4') return 'video/mp4';
+    if (ext === '.ogg' || ext === '.ogv') return 'video/ogg';
+    if (ext === '.mov') return 'video/quicktime';
     if (ext === '.svg') return 'image/svg+xml';
     if (ext === '.woff' || ext === '.woff2') return 'font/woff2';
     if (ext === '.ttf') return 'font/ttf';

--- a/apps/application/tests/case-files-live.spec.ts
+++ b/apps/application/tests/case-files-live.spec.ts
@@ -19,7 +19,7 @@ test.describe.serial('Live case file uploads', () => {
 
   const traceContent = Buffer.from('Mock Playwright live trace data');
   const traceHash = createHash('sha256').update(traceContent).digest('hex');
-  const screenshotContent = Buffer.from('PNG mock screenshot bytes');
+  const videoContent = Buffer.from('WebM mock video bytes');
 
   const caseWithFiles = {
     title: 'live test with files',
@@ -67,11 +67,11 @@ test.describe.serial('Live case file uploads', () => {
           mimeType: 'application/zip',
           buffer: traceContent,
         },
-        attach_meta: JSON.stringify([{ name: 'screenshot', contentType: 'image/png', originalName: 'failure.png' }]),
+        attach_meta: JSON.stringify([{ name: 'video', contentType: 'video/webm', originalName: 'failure.webm' }]),
         attach_file: {
-          name: 'failure.png',
-          mimeType: 'image/png',
-          buffer: screenshotContent,
+          name: 'failure.webm',
+          mimeType: 'video/webm',
+          buffer: videoContent,
         },
       },
     });
@@ -95,14 +95,27 @@ test.describe.serial('Live case file uploads', () => {
     const caseResponse = await request.get(`/api/test-run-cases/${caseWithFilesId}`);
     expect(caseResponse.ok()).toBeTruthy();
     const caseData = await caseResponse.json();
-    expect(caseData.attachments.length).toBe(1);
-    expect(caseData.attachments[0].name).toBe('screenshot');
-    expect(caseData.attachments[0].contentType).toBe('image/png');
+    expect(caseData.attachments).toHaveLength(1);
+    expect(caseData.attachments[0]).toMatchObject({ name: 'video', contentType: 'video/webm' });
 
     // The run is still running — live uploads must not require finish
     const runResponse = await request.get(`/api/test-runs/${runId}`);
     const runData = await runResponse.json();
     expect(runData.status).toBe('running');
+  });
+
+  test('serves video attachments inline with their video MIME type', async ({ request }) => {
+    const caseResponse = await request.get(`/api/test-run-cases/${caseWithFilesId}`);
+    expect(caseResponse.ok()).toBeTruthy();
+    const caseData = await caseResponse.json();
+    const video = caseData.attachments.find((attachment: { name: string }) => attachment.name === 'video');
+
+    expect(video).toBeDefined();
+    const fileResponse = await request.get(`/api/files/${video.path}`);
+
+    expect(fileResponse.ok()).toBeTruthy();
+    expect(fileResponse.headers()['content-type']).toContain('video/webm');
+    expect(fileResponse.headers()['content-disposition']).toBe('inline');
   });
 
   test('repeated upload for the same case is idempotent', async ({ request }) => {
@@ -116,11 +129,11 @@ test.describe.serial('Live case file uploads', () => {
           mimeType: 'application/zip',
           buffer: traceContent,
         },
-        attach_meta: JSON.stringify([{ name: 'screenshot', contentType: 'image/png', originalName: 'failure.png' }]),
+        attach_meta: JSON.stringify([{ name: 'video', contentType: 'video/webm', originalName: 'failure.webm' }]),
         attach_file: {
-          name: 'failure.png',
-          mimeType: 'image/png',
-          buffer: screenshotContent,
+          name: 'failure.webm',
+          mimeType: 'video/webm',
+          buffer: videoContent,
         },
       },
     });

--- a/apps/application/tests/case-files-live.spec.ts
+++ b/apps/application/tests/case-files-live.spec.ts
@@ -19,6 +19,7 @@ test.describe.serial('Live case file uploads', () => {
 
   const traceContent = Buffer.from('Mock Playwright live trace data');
   const traceHash = createHash('sha256').update(traceContent).digest('hex');
+  const screenshotContent = Buffer.from('PNG mock screenshot bytes');
   const videoContent = Buffer.from('WebM mock video bytes');
 
   const caseWithFiles = {
@@ -31,6 +32,24 @@ test.describe.serial('Live case file uploads', () => {
     location: 'tests/live.spec.ts:15:3',
     retries: 0,
   };
+
+  function buildCaseFilesMultipart() {
+    const form = new FormData();
+    form.set('streamToken', streamToken);
+    form.set('testCase', JSON.stringify(caseWithFiles));
+    form.set('trace_hash', traceHash);
+    form.append('trace', new Blob([traceContent], { type: 'application/zip' }), 'trace.zip');
+    form.set(
+      'attach_meta',
+      JSON.stringify([
+        { name: 'screenshot', contentType: 'image/png', originalName: 'failure.png' },
+        { name: 'video', contentType: 'video/webm', originalName: 'failure.webm' },
+      ]),
+    );
+    form.append('attach_file', new Blob([screenshotContent], { type: 'image/png' }), 'failure.png');
+    form.append('attach_file', new Blob([videoContent], { type: 'video/webm' }), 'failure.webm');
+    return form;
+  }
 
   test('start a streaming run and push test cases', async ({ request }) => {
     const startResponse = await request.post('/api/test-runs/start', {
@@ -56,24 +75,9 @@ test.describe.serial('Live case file uploads', () => {
     expect(eventsResponse.ok()).toBeTruthy();
   });
 
-  test('uploads a trace and an attachment for a running case', async ({ request }) => {
+  test('uploads a trace and attachments for a running case', async ({ request }) => {
     const response = await request.post(`/api/test-runs/${runId}/case-files`, {
-      multipart: {
-        streamToken,
-        testCase: JSON.stringify(caseWithFiles),
-        trace_hash: traceHash,
-        trace: {
-          name: 'trace.zip',
-          mimeType: 'application/zip',
-          buffer: traceContent,
-        },
-        attach_meta: JSON.stringify([{ name: 'video', contentType: 'video/webm', originalName: 'failure.webm' }]),
-        attach_file: {
-          name: 'failure.webm',
-          mimeType: 'video/webm',
-          buffer: videoContent,
-        },
-      },
+      multipart: buildCaseFilesMultipart(),
     });
 
     expect(response.ok()).toBeTruthy();
@@ -81,7 +85,7 @@ test.describe.serial('Live case file uploads', () => {
     expect(data.success).toBe(true);
     expect(typeof data.executionId).toBe('number');
     expect(data.traces).toBe(1);
-    expect(data.attachments).toBe(1);
+    expect(data.attachments).toBe(2);
     caseWithFilesId = data.executionId;
   });
 
@@ -95,8 +99,13 @@ test.describe.serial('Live case file uploads', () => {
     const caseResponse = await request.get(`/api/test-run-cases/${caseWithFilesId}`);
     expect(caseResponse.ok()).toBeTruthy();
     const caseData = await caseResponse.json();
-    expect(caseData.attachments).toHaveLength(1);
-    expect(caseData.attachments[0]).toMatchObject({ name: 'video', contentType: 'video/webm' });
+    expect(caseData.attachments).toHaveLength(2);
+    expect(caseData.attachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'screenshot', contentType: 'image/png' }),
+        expect.objectContaining({ name: 'video', contentType: 'video/webm' }),
+      ]),
+    );
 
     // The run is still running — live uploads must not require finish
     const runResponse = await request.get(`/api/test-runs/${runId}`);
@@ -104,38 +113,28 @@ test.describe.serial('Live case file uploads', () => {
     expect(runData.status).toBe('running');
   });
 
-  test('serves video attachments inline with their video MIME type', async ({ request }) => {
+  test('serves image and video attachments inline with their MIME types', async ({ request }) => {
     const caseResponse = await request.get(`/api/test-run-cases/${caseWithFilesId}`);
     expect(caseResponse.ok()).toBeTruthy();
     const caseData = await caseResponse.json();
-    const video = caseData.attachments.find((attachment: { name: string }) => attachment.name === 'video');
+    for (const expected of [
+      { name: 'screenshot', contentType: 'image/png' },
+      { name: 'video', contentType: 'video/webm' },
+    ]) {
+      const attachment = caseData.attachments.find((item: { name: string }) => item.name === expected.name);
 
-    expect(video).toBeDefined();
-    const fileResponse = await request.get(`/api/files/${video.path}`);
+      expect(attachment).toBeDefined();
+      const fileResponse = await request.get(`/api/files/${attachment.path}`);
 
-    expect(fileResponse.ok()).toBeTruthy();
-    expect(fileResponse.headers()['content-type']).toContain('video/webm');
-    expect(fileResponse.headers()['content-disposition']).toBe('inline');
+      expect(fileResponse.ok()).toBeTruthy();
+      expect(fileResponse.headers()['content-type']).toContain(expected.contentType);
+      expect(fileResponse.headers()['content-disposition']).toBe('inline');
+    }
   });
 
   test('repeated upload for the same case is idempotent', async ({ request }) => {
     const response = await request.post(`/api/test-runs/${runId}/case-files`, {
-      multipart: {
-        streamToken,
-        testCase: JSON.stringify(caseWithFiles),
-        trace_hash: traceHash,
-        trace: {
-          name: 'trace.zip',
-          mimeType: 'application/zip',
-          buffer: traceContent,
-        },
-        attach_meta: JSON.stringify([{ name: 'video', contentType: 'video/webm', originalName: 'failure.webm' }]),
-        attach_file: {
-          name: 'failure.webm',
-          mimeType: 'video/webm',
-          buffer: videoContent,
-        },
-      },
+      multipart: buildCaseFilesMultipart(),
     });
 
     expect(response.ok()).toBeTruthy();


### PR DESCRIPTION
Summary: serves common video attachment extensions with media MIME types; marks video responses inline; covers a reporter-style WebM case-file upload and download response.

Validation: formatting, lint, typecheck, and the isolated case-file Playwright regression passed (11 tests). The test ran locally on a fresh port and temporary storage because an unrelated process already held port 3000. No QA service was used.