### PR TITLE
fix(app): keep sandboxed HTML reports usable

### DIFF
--- a/apps/application/server/api/files/[...path].get.ts
+++ b/apps/application/server/api/files/[...path].get.ts
@@ -5,6 +5,7 @@ import { getStorage } from '../../storage';
 import { gunzip } from 'zlib';
 import { promisify } from 'util';
 import { reconstructTraceZip } from '../../utils/trace-reconstruct';
+import { prepareHtmlReport } from '../../utils/html-report';
 import sharp from 'sharp';
 
 defineRouteMeta({
@@ -233,6 +234,14 @@ export default eventHandler(async (event) => {
     setResponseHeader(event, 'Content-Security-Policy', 'sandbox allow-scripts');
   }
 
+  function prepareHtmlResponse(content: Buffer): Buffer {
+    const prepared = prepareHtmlReport(content);
+    applyHtmlCsp();
+    applyInlineDisposition('text/html');
+    setResponseHeader(event, 'Content-Length', prepared.length);
+    return prepared;
+  }
+
   /**
    * SVGs can embed scripts that execute when the file is opened top-level. A
    * no-scripts sandbox renders it as an inert image and blocks any network
@@ -268,10 +277,7 @@ export default eventHandler(async (event) => {
         const htmlContent = await findInArchive(fileContent, 'index.html');
         if (htmlContent) {
           setResponseHeader(event, 'Content-Type', 'text/html');
-          applyHtmlCsp();
-          applyInlineDisposition('text/html');
-          setResponseHeader(event, 'Content-Length', htmlContent.length);
-          return htmlContent;
+          return prepareHtmlResponse(htmlContent);
         }
       } catch {
         // Fall through to serve raw gzip
@@ -300,7 +306,7 @@ export default eventHandler(async (event) => {
     setResponseHeader(event, 'Content-Length', fileContent.length);
     applyInlineDisposition(contentType);
     if (contentType === 'text/html') {
-      applyHtmlCsp();
+      return prepareHtmlResponse(fileContent);
     } else if (contentType === 'image/svg+xml') {
       applySvgCsp();
     }
@@ -312,10 +318,7 @@ export default eventHandler(async (event) => {
   if (await storage.exists(indexPath)) {
     const fileContent = await storage.readFile(indexPath);
     setResponseHeader(event, 'Content-Type', 'text/html');
-    applyHtmlCsp();
-    applyInlineDisposition('text/html');
-    setResponseHeader(event, 'Content-Length', fileContent.length);
-    return fileContent;
+    return prepareHtmlResponse(fileContent);
   }
 
   // 3. Try path + .gz (compressed archive - decompress and serve index.html)
@@ -326,10 +329,7 @@ export default eventHandler(async (event) => {
       const htmlContent = await findInArchive(gzContent, 'index.html');
       if (htmlContent) {
         setResponseHeader(event, 'Content-Type', 'text/html');
-        applyHtmlCsp();
-        applyInlineDisposition('text/html');
-        setResponseHeader(event, 'Content-Length', htmlContent.length);
-        return htmlContent;
+        return prepareHtmlResponse(htmlContent);
       }
     } catch {
       // Fall through to 404

--- a/apps/application/server/utils/html-report.ts
+++ b/apps/application/server/utils/html-report.ts
@@ -1,0 +1,142 @@
+export const HTML_REPORT_BOOTSTRAP = `
+(() => {
+  function createStorage() {
+    const values = Object.create(null);
+
+    function has(key) {
+      return Object.prototype.hasOwnProperty.call(values, key);
+    }
+
+    const target = {
+      clear() {
+        for (const key of Object.keys(values)) delete values[key];
+      },
+      getItem(key) {
+        key = String(key);
+        return has(key) ? values[key] : null;
+      },
+      key(index) {
+        return Object.keys(values)[index] ?? null;
+      },
+      removeItem(key) {
+        delete values[String(key)];
+      },
+      setItem(key, value) {
+        values[String(key)] = String(value);
+      },
+    };
+
+    Object.defineProperty(target, 'length', {
+      configurable: false,
+      enumerable: false,
+      get: () => Object.keys(values).length,
+    });
+
+    return new Proxy(target, {
+      deleteProperty(object, key) {
+        if (typeof key === 'string' && !(key in object)) {
+          delete values[key];
+          return true;
+        }
+        return Reflect.deleteProperty(object, key);
+      },
+      get(object, key, receiver) {
+        if (typeof key === 'string' && !(key in object)) return has(key) ? values[key] : null;
+        return Reflect.get(object, key, receiver);
+      },
+      getOwnPropertyDescriptor(object, key) {
+        if (typeof key === 'string' && has(key) && !(key in object)) {
+          return { configurable: true, enumerable: true, value: values[key], writable: true };
+        }
+        return Reflect.getOwnPropertyDescriptor(object, key);
+      },
+      ownKeys(object) {
+        return [...new Set([...Reflect.ownKeys(object), ...Object.keys(values)])];
+      },
+      set(object, key, value, receiver) {
+        if (typeof key === 'string' && !(key in object)) {
+          values[key] = String(value);
+          return true;
+        }
+        return Reflect.set(object, key, value, receiver);
+      },
+    });
+  }
+
+  function installStorage(name) {
+    try {
+      Object.defineProperty(window, name, {
+        configurable: true,
+        enumerable: true,
+        value: createStorage(),
+      });
+    } catch {
+      // The browser keeps its native storage property when it cannot be replaced.
+    }
+  }
+
+  installStorage('localStorage');
+  installStorage('sessionStorage');
+
+  const addEventListener = window.addEventListener.bind(window);
+  const removeEventListener = window.removeEventListener.bind(window);
+  const wrappedListeners = new WeakMap();
+
+  function isFocusEvent(type) {
+    return type === 'focus' || type === 'blur';
+  }
+
+  window.addEventListener = function (type, listener, options) {
+    if (!isFocusEvent(type) || typeof listener !== 'function') {
+      return addEventListener(type, listener, options);
+    }
+
+    let wrapped = wrappedListeners.get(listener);
+    if (!wrapped) {
+      wrapped = function (event) {
+        try {
+          return listener.call(this, event);
+        } catch (error) {
+          if (error && typeof error === 'object' && error.name === 'SecurityError') return;
+          throw error;
+        }
+      };
+      wrappedListeners.set(listener, wrapped);
+    }
+    return addEventListener(type, wrapped, options);
+  };
+
+  window.removeEventListener = function (type, listener, options) {
+    const wrapped = typeof listener === 'function' ? wrappedListeners.get(listener) : undefined;
+    return removeEventListener(type, wrapped ?? listener, options);
+  };
+})();
+`;
+
+const HTML_REPORT_BOOTSTRAP_TAG = `<script>${HTML_REPORT_BOOTSTRAP}</script>`;
+
+/**
+ * Add opaque-origin compatibility before the report's own scripts execute.
+ * The storage facade is scoped to this document and is never persisted.
+ */
+export function prepareHtmlReport(content: Buffer): Buffer {
+  const source = content.toString('utf8');
+  const headEnd = /<\/head\s*>/i.exec(source);
+  if (headEnd && headEnd.index !== undefined) {
+    const headStart = /<head(?:\s[^>]*)?>/i.exec(source);
+    const headContentStart = headStart ? headStart.index + headStart[0].length : 0;
+    const headContent = source.slice(headContentStart, headEnd.index);
+    const firstHeadScript = /<script(?:\s|>)/i.exec(headContent);
+    const insertionPoint = firstHeadScript ? headContentStart + firstHeadScript.index : headEnd.index;
+    return Buffer.from(`${source.slice(0, insertionPoint)}${HTML_REPORT_BOOTSTRAP_TAG}${source.slice(insertionPoint)}`);
+  }
+
+  const firstScript = /<script(?:\s|>)/i.exec(source);
+  if (firstScript && firstScript.index !== undefined) {
+    return Buffer.from(
+      `${source.slice(0, firstScript.index)}${HTML_REPORT_BOOTSTRAP_TAG}${source.slice(firstScript.index)}`,
+    );
+  }
+
+  return Buffer.from(`${HTML_REPORT_BOOTSTRAP_TAG}${source}`);
+}

--- a/apps/application/shared/test-project-names.ts
+++ b/apps/application/shared/test-project-names.ts
@@ -70,6 +70,7 @@ export const PROJECT = {
   GZIP_SERVE: 'gzip-serve-test-project',
   GZIP_TEST: 'gzip-test-project',
   HEARTBEAT_TEST: 'heartbeat-test',
+  HTML_REPORT_SANDBOX: 'html-report-sandbox-test',
   HISTORY: 'history-test',
   IMPORT_BLOB: 'import-blob-test',
   IMPORT_BLOB_UI: 'import-blob-ui-test',

--- a/apps/application/tests/file-upload.spec.ts
+++ b/apps/application/tests/file-upload.spec.ts
@@ -369,6 +369,81 @@ test.describe('File Upload API Tests', () => {
     }
   });
 
+  test('renders an HTML report with opaque-origin storage isolation', async ({ request, page }) => {
+    const htmlReport = Buffer.from(`
+      <!doctype html>
+      <html>
+        <head><title>Sandboxed report</title></head>
+        <body>
+          <h1>Sandboxed report</h1>
+          <script>
+            window.addEventListener('focus', (event) => event.target.document.nodeType);
+            window.onload = () => {
+              document.body.dataset.reportReady = localStorage.getItem('piwi-report-isolation') || 'ready';
+            };
+          </script>
+        </body>
+      </html>
+    `);
+
+    await page.goto('/');
+    await page.evaluate(() => localStorage.setItem('piwi-report-isolation', 'dashboard-value'));
+
+    const uploadResponse = await request.post('/api/test-runs/upload', {
+      multipart: {
+        projectName: PROJECT.HTML_REPORT_SANDBOX,
+        testRun: JSON.stringify({
+          status: 'passed',
+          startTime: new Date().toISOString(),
+          duration: 1000,
+          totalTests: 1,
+          passedTests: 1,
+          failedTests: 0,
+          skippedTests: 0,
+        }),
+        testCases: JSON.stringify([{ title: 'sandboxed report', status: 'passed', duration: 100 }]),
+        htmlReport: {
+          name: 'index.html',
+          mimeType: 'text/html',
+          buffer: htmlReport,
+        },
+      },
+    });
+    if (!uploadResponse.ok()) {
+      throw new Error(`Report upload failed with ${uploadResponse.status()}: ${await uploadResponse.text()}`);
+    }
+
+    const uploadData = await uploadResponse.json();
+    const reportPath = uploadData.reports?.[0]?.path;
+    expect(reportPath).toBeDefined();
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+    const reportResponse = await page.goto(`/api/files/${reportPath}`);
+    expect(reportResponse?.headers()['content-security-policy']).toBe('sandbox allow-scripts');
+
+    await expect(page.locator('h1')).toHaveText('Sandboxed report');
+    await expect(page.locator('body')).toHaveAttribute('data-report-ready', 'ready');
+
+    const isolation = await page.evaluate(() => ({
+      cookie: (() => {
+        try {
+          return document.cookie;
+        } catch (error) {
+          return error instanceof DOMException ? error.name : 'blocked';
+        }
+      })(),
+      storedDashboardValue: localStorage.getItem('piwi-report-isolation'),
+    }));
+    expect(isolation.cookie).toBe('SecurityError');
+    expect(isolation.storedDashboardValue).toBeNull();
+    expect(
+      pageErrors.some((message) =>
+        /Failed to read a named property|Failed to read the 'localStorage' property/.test(message),
+      ),
+    ).toBe(false);
+  });
+
   test('should prevent path traversal in file download', async ({ request }) => {
     const response = await request.get('/api/files/../../../etc/passwd');
     expect(response.status()).toBeGreaterThan(400);

--- a/apps/application/tests/gzip-compression.spec.ts
+++ b/apps/application/tests/gzip-compression.spec.ts
@@ -207,6 +207,7 @@ test.describe('Gzip Compression Tests', () => {
 
       const htmlContent = await downloadResponse.text();
       expect(htmlContent).toContain('Playwright Test Report');
+      expect(htmlContent).toContain('localStorage');
     }
   });
 

--- a/apps/application/tests/unit/html-report.test.ts
+++ b/apps/application/tests/unit/html-report.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import vm from 'node:vm';
+import { HTML_REPORT_BOOTSTRAP, prepareHtmlReport } from '../../server/utils/html-report';
+
+describe('prepareHtmlReport', () => {
+  test('runs the compatibility bootstrap before the report script', () => {
+    const output = prepareHtmlReport(
+      Buffer.from('<!doctype html><html><head><script src="./report.js"></script></head><body></body></html>'),
+    ).toString('utf8');
+
+    expect(output.indexOf('<script>')).toBeGreaterThan(-1);
+    expect(output.indexOf('localStorage')).toBeLessThan(output.indexOf('./report.js'));
+  });
+
+  test('injects before the first script when the document has no head', () => {
+    const output = prepareHtmlReport(Buffer.from('<script>window.reportReady = true;</script>')).toString('utf8');
+
+    expect(output.indexOf('<script>')).toBe(0);
+    expect(output.indexOf('window.reportReady')).toBeGreaterThan(output.indexOf('localStorage'));
+  });
+});
+
+describe('HTML_REPORT_BOOTSTRAP', () => {
+  test('provides isolated ephemeral storage with Web Storage methods and properties', () => {
+    const listeners = new Map<string, EventListener>();
+    const window = {
+      addEventListener(type: string, listener: EventListener) {
+        listeners.set(type, listener);
+      },
+      removeEventListener(type: string) {
+        listeners.delete(type);
+      },
+    } as unknown as Window;
+
+    vm.runInNewContext(HTML_REPORT_BOOTSTRAP, { window });
+
+    window.localStorage.setItem('theme', 'dark');
+    window.sessionStorage.setItem('session', 'one');
+    expect(window.localStorage.getItem('theme')).toBe('dark');
+    expect(window.localStorage.theme).toBe('dark');
+    expect(window.localStorage.length).toBe(1);
+    expect(window.sessionStorage.getItem('theme')).toBeNull();
+    expect(window.sessionStorage.getItem('session')).toBe('one');
+  });
+
+  test('contains the reported focus SecurityError without hiding other errors', () => {
+    let focusListener: EventListener | undefined;
+    const window = {
+      addEventListener(type: string, listener: EventListener) {
+        if (type === 'focus') focusListener = listener;
+      },
+      removeEventListener() {},
+    } as unknown as Window;
+
+    vm.runInNewContext(HTML_REPORT_BOOTSTRAP, { window });
+
+    window.addEventListener('focus', (event) => {
+      void event.target!.document;
+    });
+    const target = {} as EventTarget & { document: unknown };
+    Object.defineProperty(target, 'document', {
+      get() {
+        const error = new Error('cross-origin');
+        error.name = 'SecurityError';
+        throw error;
+      },
+    });
+    expect(() => focusListener?.({ target } as FocusEvent)).not.toThrow();
+
+    window.addEventListener('focus', () => {
+      throw new Error('report failure');
+    });
+    expect(() => focusListener?.({ target: window } as FocusEvent)).toThrow('report failure');
+  });
+});

--- a/apps/docs/privacy.md
+++ b/apps/docs/privacy.md
@@ -42,6 +42,10 @@ context before it's sent, and you can cap its size. See
 - **The API reference.** `/docs` is rendered in-app from your instance's own OpenAPI spec, with no
   third-party CDN, so it works offline.
 - **Screenshots, videos, HTML reports.** Stored on your disk or your S3 bucket, served by your instance.
+- **HTML report execution.** Reports run with scripts enabled inside a CSP sandbox with a unique opaque origin. Piwi
+  provides the report with an in-memory Web Storage facade so Playwright's settings UI works; it is discarded with the
+  report document and cannot read the dashboard's cookies or local storage. Uploaded reports remain untrusted active
+  content.
 - **Your IDE mapping.** The [Open in IDE](./ide-integration) workspace root lives in your browser's
   local storage, because the source is on your machine, not the server's. It is never sent to the
   dashboard.


### PR DESCRIPTION
## What & why

Playwright HTML reports are served with `Content-Security-Policy: sandbox allow-scripts`, which intentionally gives uploaded active content a unique opaque origin. That protects the dashboard's cookies and Web Storage, but Playwright's report runtime accesses `localStorage` and handles focus events by reading the event window's document. Browsers therefore raise `SecurityError` and leave the report unusable.

This change injects a compatibility bootstrap before the report's own scripts:

- provides document-scoped, in-memory `localStorage` and `sessionStorage` facades;
- contains the known focus/blur cross-origin `SecurityError`;
- keeps the opaque-origin CSP sandbox unchanged—no `allow-same-origin` relaxation;
- applies consistently to raw, directory-index, and compressed HTML reports.

The storage facade is discarded with the report document and cannot read dashboard cookies or persisted dashboard storage. Documentation now states that uploaded reports remain untrusted active content.

This builds on the existing opaque-origin security boundary and HTML/video artifact-serving work.

## How was it tested?

- Full application unit suite: 1,617 tests passed.
- Focused browser regression verifies report rendering, absence of the reported SecurityErrors, opaque-origin cookie isolation, and dashboard-storage isolation.
- Compressed/gzip report serving regression passed.
- Application typecheck, lint, formatting check, and production build passed.
- Focused HTML-report unit tests passed.
- Commitlint and diff checks passed.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)
