### PR TITLE
fix(ai): support max_completion_tokens in OpenAI-compatible calls

### DIFF
--- a/apps/application/server/utils/ai-provider.ts
+++ b/apps/application/server/utils/ai-provider.ts
@@ -403,6 +403,8 @@ interface OpenAiAttempt {
   strictFormat: boolean;
   /** Send `opts.images` as `image_url` parts. */
   withImages: boolean;
+  /** Parameter name accepted by the OpenAI-compatible provider for the output limit. */
+  completionTokenParameter: 'max_tokens' | 'max_completion_tokens';
 }
 
 /**
@@ -424,7 +426,7 @@ function buildOpenAiBody(config: ResolvedAiRole, opts: AiCallOptions, attempt: O
 
   return {
     model: config.model,
-    max_tokens: opts.maxTokens ?? 8192,
+    [attempt.completionTokenParameter]: opts.maxTokens ?? 8192,
     temperature: 0,
     ...(responseFormat ? { response_format: responseFormat } : {}),
     messages: [
@@ -437,6 +439,15 @@ function buildOpenAiBody(config: ResolvedAiRole, opts: AiCallOptions, attempt: O
 /** A rejection from a text-only model handed `image_url` parts. */
 function rejectsImages(status: number, body: string): boolean {
   return status === 400 && /image|vision/i.test(body);
+}
+
+function rejectsMaxTokens(status: number, body: string, attempt: OpenAiAttempt): boolean {
+  return (
+    status === 400 &&
+    attempt.completionTokenParameter === 'max_tokens' &&
+    /max_tokens/i.test(body) &&
+    /max_completion_tokens/i.test(body)
+  );
 }
 
 /**
@@ -452,21 +463,39 @@ async function postOpenAiWithFallbacks(
   opts: AiCallOptions,
   model: string,
 ): Promise<{ res: Response; errorBody: string }> {
-  const attempt: OpenAiAttempt = { strictFormat: true, withImages: true };
-  let res = await send(attempt);
-  let errorBody = res.ok ? '' : await res.text().catch(() => '');
+  const attempt: OpenAiAttempt = {
+    strictFormat: true,
+    withImages: true,
+    completionTokenParameter: 'max_tokens',
+  };
+  const sendAttempt = async (): Promise<{ res: Response; errorBody: string }> => {
+    const res = await send(attempt);
+    return { res, errorBody: res.ok ? '' : await res.text().catch(() => '') };
+  };
 
-  if (!res.ok && opts.images?.length && rejectsImages(res.status, errorBody)) {
-    console.warn(`[ai-provider] ${model} rejected the attached image(s) — retrying text-only`);
-    attempt.withImages = false;
-    res = await send(attempt);
-    errorBody = res.ok ? '' : await res.text().catch(() => '');
-  }
+  let { res, errorBody } = await sendAttempt();
+  for (let retry = 0; retry < 3 && !res.ok; retry++) {
+    let retryWithUpdatedAttempt = false;
 
-  if (!res.ok && res.status === 400 && opts.jsonSchema && attempt.strictFormat) {
-    attempt.strictFormat = false;
-    res = await send(attempt);
-    errorBody = res.ok ? '' : await res.text().catch(() => '');
+    if (opts.images?.length && attempt.withImages && rejectsImages(res.status, errorBody)) {
+      console.warn(`[ai-provider] ${model} rejected the attached image(s) — retrying text-only`);
+      attempt.withImages = false;
+      retryWithUpdatedAttempt = true;
+    }
+
+    if (!retryWithUpdatedAttempt && rejectsMaxTokens(res.status, errorBody, attempt)) {
+      console.warn(`[ai-provider] ${model} requires max_completion_tokens — retrying with that parameter`);
+      attempt.completionTokenParameter = 'max_completion_tokens';
+      retryWithUpdatedAttempt = true;
+    }
+
+    if (!retryWithUpdatedAttempt && res.status === 400 && opts.jsonSchema && attempt.strictFormat) {
+      attempt.strictFormat = false;
+      retryWithUpdatedAttempt = true;
+    }
+
+    if (!retryWithUpdatedAttempt) break;
+    ({ res, errorBody } = await sendAttempt());
   }
 
   return { res, errorBody };

--- a/apps/application/tests/ai-diagnosis.spec.ts
+++ b/apps/application/tests/ai-diagnosis.spec.ts
@@ -62,8 +62,26 @@ function buildMockAiResponse(): AiDiagnosisResult {
 function startMockAiServer(port: number): http.Server {
   const server = http.createServer((req, res) => {
     if (req.method === 'POST' && req.url?.includes('/chat/completions')) {
-      req.on('data', () => {});
+      let body = '';
+      req.on('data', (chunk) => (body += chunk));
       req.on('end', () => {
+        const parsed = JSON.parse(body || '{}') as Record<string, unknown>;
+        if ('max_tokens' in parsed) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: {
+                message:
+                  "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+                type: 'invalid_request_error',
+                param: 'max_tokens',
+                code: 'unsupported_parameter',
+              },
+            }),
+          );
+          return;
+        }
+
         const diagResult = buildMockAiResponse();
         const responseContent = JSON.stringify(diagResult);
         const payload = {
@@ -107,6 +125,22 @@ function startStreamingMockAiServer(port: number): http.Server {
           parsed = JSON.parse(body || '{}');
         } catch {
           /* ignore */
+        }
+
+        if ('max_tokens' in parsed) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error: {
+                message:
+                  "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+                type: 'invalid_request_error',
+                param: 'max_tokens',
+                code: 'unsupported_parameter',
+              },
+            }),
+          );
+          return;
         }
 
         const diagResult = buildMockAiResponse();


### PR DESCRIPTION
## Summary

- Retry OpenAI-compatible chat-completions requests with `max_completion_tokens` when a provider rejects `max_tokens`.
- Preserve the existing image and JSON response-format fallback ladder.
- Extend synthetic normal and streaming diagnosis tests to emulate the provider rejection.

## Validation

- `npm run app:format:check`
- `npm run app:typecheck`
- `npm run app:build`
- `npx playwright test tests/ai-diagnosis.spec.ts --config=.playwright-openai-compat.config.ts` — 21 passed against an isolated local production server and synthetic mock provider.

No real gateway, model, credential, or E2E failure context was used.