### PR TITLE
fix(ui): shrink stacked mobile gutters on every page

### DIFF
--- a/apps/application/app/app.config.ts
+++ b/apps/application/app/app.config.ts
@@ -15,7 +15,22 @@ export default defineAppConfig({
       slots: {
         // Solid muted header so block headers clearly separate from the card
         // body in both modes (zinc-100 on white / zinc-800 on zinc-900).
-        header: 'px-3 py-3 sm:px-6 bg-muted',
+        // Below `sm` the header adds 10 px per side; from `sm` up it is `px-6`.
+        header: 'px-2.5 py-3 sm:px-6 bg-muted',
+        // Below `sm` a card adds 10 px of its own; with the 8 px panel gutter the
+        // first text stays within 20 px of the edge. From `sm` up the Nuxt UI
+        // default (`p-6`) applies.
+        body: 'max-sm:p-2.5',
+        footer: 'max-sm:p-2.5',
+      },
+    },
+    dashboardPanel: {
+      slots: {
+        // Below `sm` the page gutter is 8 px per side: small enough that a card's
+        // own padding keeps text within 20 px of the edge, large enough to hold
+        // panel-level controls (not wrapped in a card) off the edge. Vertical
+        // padding and the `sm`-and-up default (`p-6`) are the Nuxt UI defaults.
+        body: 'max-sm:px-2',
       },
     },
     table: {

--- a/apps/application/app/components/shared/CollapsibleSectionCard.vue
+++ b/apps/application/app/components/shared/CollapsibleSectionCard.vue
@@ -44,7 +44,7 @@ defineExpose({ setFolded, reveal });
 
 <template>
   <div ref="rootEl" class="scroll-mt-4">
-    <UCard :ui="{ header: 'p-3 sm:px-4 sm:py-3', body: folded ? 'p-0 sm:p-0' : '' }" :class="folded && 'divide-y-0'">
+    <UCard :ui="{ header: 'p-2.5 sm:px-4 sm:py-3', body: folded ? 'p-0 sm:p-0' : '' }" :class="folded && 'divide-y-0'">
       <template #header>
         <div class="flex items-center justify-between gap-2">
           <!-- role=button (not <button>) so the nested HelpHint button stays valid HTML -->

--- a/apps/application/app/components/shared/DetailPageLayout.vue
+++ b/apps/application/app/components/shared/DetailPageLayout.vue
@@ -62,7 +62,7 @@ const activeTabHelp = computed(() => props.tabItems.find((t) => t.value === acti
 
 <template>
   <!-- Mobile: the whole panel scrolls as one document. Desktop: fixed summary + independently scrolling tab body. -->
-  <div class="flex flex-col h-full gap-4 p-1 max-lg:overflow-y-auto lg:overflow-hidden">
+  <div class="flex flex-col h-full gap-4 sm:p-1 max-lg:overflow-y-auto lg:overflow-hidden">
     <div v-if="$slots.summary" class="lg:shrink-0">
       <div :class="summaryCollapsed ? 'max-lg:hidden' : ''">
         <slot name="summary" />
@@ -80,7 +80,7 @@ const activeTabHelp = computed(() => props.tabItems.find((t) => t.value === acti
     <!-- Tab switcher: a full-width select on phones, the same UTabs strip the
          project page uses from sm up. Sticky on mobile. -->
     <div
-      class="lg:shrink-0 max-lg:sticky max-lg:top-0 max-lg:z-10 max-lg:-mx-1 max-lg:bg-(--ui-bg-canvas) max-lg:px-1 max-lg:py-1.5"
+      class="lg:shrink-0 max-lg:sticky max-lg:top-0 max-lg:z-10 sm:max-lg:-mx-1 max-lg:bg-(--ui-bg-canvas) sm:max-lg:px-1 max-lg:py-1.5"
     >
       <USelect
         v-model="activeTab"

--- a/apps/application/app/components/shared/StatTile.vue
+++ b/apps/application/app/components/shared/StatTile.vue
@@ -22,7 +22,7 @@ withDefaults(
 </script>
 
 <template>
-  <div class="rounded-lg bg-gray-50 dark:bg-gray-900 p-3 min-w-0">
+  <div class="rounded-lg bg-gray-50 dark:bg-gray-900 p-2.5 sm:p-3 min-w-0">
     <p class="text-xs font-medium text-gray-500 uppercase tracking-wider inline-flex items-center gap-1 max-w-full">
       <slot name="label">{{ label }}</slot>
     </p>

--- a/apps/application/app/components/shared/TableScroller.vue
+++ b/apps/application/app/components/shared/TableScroller.vue
@@ -2,9 +2,9 @@
 /**
  * Horizontal-scroll wrapper for wide content (tables, charts, diffs) so it
  * scrolls in place instead of stretching the page on small screens. Optionally
- * bleeds to the card edge on mobile (`-mx-4`) for full-width swiping, and
- * applies a `minWidth` to the inner content so columns keep a readable width
- * while the wrapper scrolls.
+ * bleeds to the card edge on mobile (`-mx-2.5`, matching the card body padding
+ * below `sm`) for full-width swiping, and applies a `minWidth` to the inner
+ * content so columns keep a readable width while the wrapper scrolls.
  *
  * Usage: `<TableScroller min-width="56rem"><UTable ... /></TableScroller>`
  */
@@ -20,7 +20,7 @@ withDefaults(
 </script>
 
 <template>
-  <div class="overflow-x-auto" :class="bleed ? '-mx-4 px-4 sm:mx-0 sm:px-0' : ''">
+  <div class="overflow-x-auto" :class="bleed ? '-mx-2.5 px-2.5 sm:mx-0 sm:px-0' : ''">
     <div :style="minWidth ? { minWidth } : undefined">
       <slot />
     </div>


### PR DESCRIPTION
## What & why

On a phone (~390 px) every screen wasted horizontal room: the dashboard panel kept its desktop body padding (`p-4` = 16 px) **and** every card inside it kept its own desktop padding (`p-4` / `p-6` = 16–24 px), so the two stacked to roughly 32 px per side before any text — about a fifth of the screen.

This fixes it at the **theme level** so it reaches every page without editing pages. Below the `sm` breakpoint:

- **Panel gutter → 8 px** (`dashboardPanel.body` `max-sm:px-2`). Small enough to reclaim the desktop padding, large enough that panel-level controls (not wrapped in a card) stay off the edge.
- **Card body / footer → 10 px** (`card.body` / `card.footer` `max-sm:p-2.5`), **card header → 10 px** (`px-2.5`, was `px-3`).
- So the first text inside a card lands at **8 + 10 = ~18 px** from the edge, comfortably under 20 px, while non-card controls sit at the 8 px floor.

Shared primitives that hard-coded the desktop padding were aligned to the same gutters (all keep their `sm`-and-up values, so desktop is unchanged):

- `DetailPageLayout` — drops its 4 px inset (`p-1` → `sm:p-1`) and the sticky tab-bar bleed that offset it below `sm`.
- `TableScroller` — bleed `-mx-4` → `-mx-2.5`, so a full-width table still lines up with the new card edge.
- `StatTile` — `p-3` → `p-2.5 sm:p-3`.
- `CollapsibleSectionCard` header — `p-3` → `p-2.5 sm:px-4 sm:py-3`.

`FilterToolbar` and `SectionCard` add no padding of their own (they inherit the theme), so they needed no change.

### Measured gutters at 390 px (distance from the viewport edge to the first text pixel inside a card)

| Route | Before | After |
|---|---:|---:|
| `/projects/1` | 28 px | **18 px** ✅ |
| `/settings/ai` | 28 px | **18 px** ✅ |
| `/test-runs/2` | 20 px¹ | **8 px**¹ ✅ |
| `/` | 56 px | 42 px² |
| `/test-run-cases/37` | 59 px | 45 px² |
| `/failure-clusters/10` | 61 px | 47 px² |
| `/test-cases/1` | 58 px | 45 px² |

¹ The run page's default tab is a list of rows, not `UCard`s; the number is the leftmost panel-level control, now at the 8 px panel floor. Its cards follow the same 8 + 10 = 18 px pattern.

² These four pages still add their **own** page-level wrapper padding inside `#body`, which stacks on top of the theme gutter. That padding lives in `app/pages/` and is out of this PR's scope (see follow-ups). The theme change still cuts each of them by ~14 px; once the wrapper is removed they reach ≤ 20 px like the others.

- **No horizontal page scroll** on any of the seven routes at **390 px and 360 px** (`document.documentElement.scrollWidth === innerWidth`, overflow 0 everywhere).
- **1280 px is pixel-identical to `main`** — a pixel diff of the seven routes at 1280 px shows 0 differing pixels (every override is `max-sm:`-gated or `sm:`-overridden).

### Follow-ups (out of scope — page-level padding in `app/pages/`, which I was asked not to edit)

The theme change reaches these pages, but their own wrapper `<div>` keeps the gutter above 20 px until it is removed. Three are being rebuilt in parallel (plan PRs 4/6/7) and will drop the wrapper there:

- `app/pages/index.vue:262` — `class="p-6 space-y-8"` (and the stat strip `px-6 py-4` at `:282`).
- `app/pages/test-run-cases/[id].vue:441` — `class="… p-4 max-w-6xl mx-auto w-full"`.
- `app/pages/failure-clusters/[id].vue:339` — `class="… p-4 max-w-6xl mx-auto w-full"`.
- `app/pages/test-cases/[id].vue:139` — `class="… p-4"`.

No `-mx-4` card-edge bleed in the `run/`, `cluster/`, `project/`, `test-case/` component folders misaligns with the new card padding: the only hand-rolled one (`project/ProjectTrendTable.vue:102`) is `hidden md:block`, so it is never shown below `sm` where `sm:mx-0` has already reset the bleed.

## How was it tested?

- `npm run app:typecheck`, `npm run app:lint`, `npm run app:format:check` — pass.
- `npm run app:test:unit` — 1830 tests pass (135 files).
- Responsive / mobile E2E (`tests/mobile-responsiveness.spec.ts`, `tests/dashboard-ui.spec.ts`, the specs matching `390|375|setViewportSize`) — 35/35 pass, including the "no horizontal overflow at 375 px" and "wide tables scroll in place" checks.
- Gutters measured with Playwright at 390 px and 360 px against the seeded dev app, before and after (numbers above).
- 1280 px screenshots pixel-diffed against `main` (0 differing pixels).
- Before/after screenshots at 390 px of all seven routes captured and shared with the requester (they cannot be embedded here from this environment).

## Checklist

- [x] PR title follows Conventional Commits (`fix(ui): …`)
- [x] Tests: no behavior change; verified against the existing responsive E2E suite (no new tests needed for a theme-padding change)
- [x] Docs: no user-facing doc states the padding, so none needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4JDWGzEDKJbRxuXtLLNL9

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4JDWGzEDKJbRxuXtLLNL9)_