### PR TITLE
docs(app): require sending UI screenshots to the user for user-facing changes

### DIFF
--- a/apps/application/AGENTS.md
+++ b/apps/application/AGENTS.md
@@ -119,6 +119,10 @@ the `SCENES` registry of `scripts/take-feature-screenshots.mjs`, run it (`node s
 report or PR. Scenes tagged `desktop` write to `.screens/`, which is **gitignored — those images are a report artifact,
 never committed**; the scene, kept current, is what's committed.
 
+**Always send those screenshots to the user in the conversation too — not only attach them to the PR.** A user-facing
+change is never reported as done without the pictures. When the change alters existing UI, send the before and the
+after; capture both narrow (~390 px) and wide (~1280 px) when the change is about layout or responsiveness.
+
 Scenes tagged `docs` are the exception: they write the committed illustrations in `apps/docs/public/screenshots/`, so
 the scene name _is_ the image name and `npm run app:screens:docs` regenerates every one of them.
 


### PR DESCRIPTION
## What & why

The app guide's **Feature screenshots (MUST follow)** rule already said to attach screenshots to the final report or PR, but it didn't say to surface them to the user in the conversation — so a UI change could be reported as done without the pictures ever being shown. This makes the delivery habit explicit: a user-facing UI change is never reported without its before/after screenshots sent to the user, captured at narrow (~390 px) and wide (~1280 px) widths when the change is about layout.

One paragraph added to `apps/application/AGENTS.md`; no code or behavior change.

## How was it tested?

Docs-only change (agent instructions). `commitlint --from HEAD~1 --to HEAD` passes; oxfmt left the file unchanged.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [ ] Tests added/updated for behavior changes — n/a (docs only)
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README) — this *is* the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANkyCfkze3sA71G2LPgsnp

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANkyCfkze3sA71G2LPgsnp)_