### PR TITLE
feat(app): diff a flaky test's failing and passing attempts

### DIFF
--- a/apps/application/app/components/test-case/AttemptsCard.vue
+++ b/apps/application/app/components/test-case/AttemptsCard.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+/**
+ * The Attempts tab for a flaky test: a strip of every attempt (retry number,
+ * status, duration, a "this one" marker on the opened execution), and below it
+ * "what differed" between the failing attempt and the attempt that passed on
+ * retry — the flakiness fingerprint. The diff is loaded lazily from
+ * `/attempt-diff` when the tab is first opened (this card mounts under a `v-if`).
+ *
+ * Each difference cites an evidence section; the chip switches to that evidence
+ * tab through the page's section locator — the same mechanism a clue uses.
+ */
+import type { AttemptDiffEntry } from '#shared/attempt-diff';
+import type { AttemptDiffResult } from '#shared/handlers/test-cases';
+import { useClusterSectionLocator } from '~/composables/useClusterSectionLocator';
+
+const props = defineProps<{
+  testRunsCaseId: number;
+  /** Every attempt of this execution, already fetched at page level. */
+  attempts: Array<{ retry: number; status: string; duration: number | null; executionId: number | null }>;
+}>();
+
+const { data, status } = await useFetch<AttemptDiffResult>(`/api/test-run-cases/${props.testRunsCaseId}/attempt-diff`);
+
+const locator = useClusterSectionLocator();
+
+const orderedAttempts = computed(() => [...(props.attempts ?? [])].sort((a, b) => (a.retry ?? 0) - (b.retry ?? 0)));
+
+const differences = computed<AttemptDiffEntry[]>(() => data.value?.differences ?? []);
+const applicable = computed(() => data.value?.applicable === true);
+
+// ── Per-kind presentation ──────────────────────────────────────────────────
+const KIND_ICON: Record<AttemptDiffEntry['kind'], string> = {
+  error: 'i-lucide-circle-x',
+  network: 'i-lucide-arrow-left-right',
+  console: 'i-lucide-terminal',
+  step: 'i-lucide-list-checks',
+  duration: 'i-lucide-timer',
+  'page-state': 'i-lucide-database',
+  aria: 'i-lucide-scan-text',
+};
+
+/** Where a difference's citation jumps — evidence section id → readable tab name. */
+const SECTION_LABEL: Record<string, string> = {
+  executionError: 'Error',
+  networkRequests: 'Network',
+  console: 'Console',
+  steps: 'Timeline',
+  appState: 'State',
+  ariaSnapshot: 'Screen',
+};
+
+function onlyLabel(entry: AttemptDiffEntry): { text: string; class: string } {
+  if (entry.only === 'failing') {
+    return { text: 'only on the failing attempt', class: 'text-red-600 dark:text-red-400 bg-red-500/10' };
+  }
+  if (entry.only === 'passing') {
+    return { text: 'only on the passing attempt', class: 'text-green-600 dark:text-green-400 bg-green-500/10' };
+  }
+  return { text: 'changed', class: 'text-amber-600 dark:text-amber-400 bg-amber-500/10' };
+}
+
+function citationLabel(entry: AttemptDiffEntry): string | null {
+  const section = entry.ref?.section;
+  if (!section || !locator.canLocate(section)) return null;
+  return SECTION_LABEL[section] ?? null;
+}
+
+function reveal(entry: AttemptDiffEntry) {
+  const section = entry.ref?.section;
+  if (section && locator.canLocate(section)) locator.open(section);
+}
+
+function attemptLabel(retry: number): string {
+  return retry === 0 ? 'Attempt 1' : `Retry ${retry}`;
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- ── Attempt strip ──────────────────────────────────────────────────── -->
+    <SectionCard embedded icon="i-lucide-repeat" title="Attempts" help="case.attempts">
+      <ul class="flex flex-col sm:flex-row sm:flex-wrap gap-2">
+        <li
+          v-for="attempt in orderedAttempts"
+          :key="attempt.retry"
+          class="flex items-center gap-2 rounded-md border border-default px-2.5 py-1.5 text-sm"
+          :class="attempt.executionId === testRunsCaseId ? 'bg-primary/5 border-primary/40' : ''"
+        >
+          <span class="font-medium whitespace-nowrap">{{ attemptLabel(attempt.retry) }}</span>
+          <StatusChip :status="attempt.status" size="xs" />
+          <DurationValue :ms="attempt.duration" class="text-muted tabular-nums" />
+          <span v-if="attempt.executionId === testRunsCaseId" class="text-xs text-primary font-medium whitespace-nowrap"
+            >this one</span
+          >
+          <ULink
+            v-else-if="attempt.executionId"
+            :to="`/test-run-cases/${attempt.executionId}`"
+            class="text-xs text-primary hover:underline whitespace-nowrap"
+            >open</ULink
+          >
+        </li>
+      </ul>
+    </SectionCard>
+
+    <!-- ── What differed ──────────────────────────────────────────────────── -->
+    <SectionCard embedded icon="i-lucide-git-compare" title="What differed" help="case.attempts">
+      <LoadingState v-if="status === 'pending'" text="Comparing attempts…" />
+
+      <EmptyState
+        v-else-if="!applicable"
+        icon="i-lucide-repeat"
+        text="No failing-and-passing pair to compare — this needs one attempt that failed and one that passed."
+      />
+
+      <EmptyState
+        v-else-if="differences.length === 0"
+        icon="i-lucide-equal"
+        text="The failing and passing attempts left no different evidence — the flakiness is not visible in the captured signals."
+      />
+
+      <ul v-else class="space-y-2.5">
+        <li
+          v-for="(entry, i) in differences"
+          :key="i"
+          class="flex items-start gap-2.5 rounded-md border border-default p-2.5"
+        >
+          <UIcon :name="KIND_ICON[entry.kind]" class="size-4 shrink-0 mt-0.5 text-muted" />
+          <div class="min-w-0 flex-1 space-y-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span
+                class="rounded px-1.5 py-0.5 text-xs font-medium whitespace-nowrap"
+                :class="onlyLabel(entry).class"
+                >{{ onlyLabel(entry).text }}</span
+              >
+              <span class="text-sm font-medium break-words">{{ entry.summary }}</span>
+            </div>
+            <pre
+              v-if="entry.detail"
+              class="text-xs text-muted font-mono whitespace-pre-wrap break-words max-h-32 overflow-y-auto"
+              >{{ entry.detail }}</pre>
+            <button
+              v-if="citationLabel(entry)"
+              type="button"
+              class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              @click="reveal(entry)"
+            >
+              <UIcon name="i-lucide-arrow-up-right" class="size-3" />
+              View in {{ citationLabel(entry) }}
+            </button>
+          </div>
+        </li>
+      </ul>
+    </SectionCard>
+  </div>
+</template>

--- a/apps/application/app/components/test-case/AttemptsCard.vue
+++ b/apps/application/app/components/test-case/AttemptsCard.vue
@@ -81,7 +81,7 @@ function attemptLabel(retry: number): string {
 </script>
 
 <template>
-  <div class="space-y-4">
+  <div class="space-y-4" data-shot="attempts-diff">
     <!-- ── Attempt strip ──────────────────────────────────────────────────── -->
     <SectionCard embedded icon="i-lucide-repeat" title="Attempts" help="case.attempts">
       <ul class="flex flex-col sm:flex-row sm:flex-wrap gap-2">

--- a/apps/application/app/components/test-case/AttemptsCard.vue
+++ b/apps/application/app/components/test-case/AttemptsCard.vue
@@ -23,7 +23,12 @@ const { data, status } = await useFetch<AttemptDiffResult>(`/api/test-run-cases/
 
 const locator = useClusterSectionLocator();
 
-const orderedAttempts = computed(() => [...(props.attempts ?? [])].sort((a, b) => (a.retry ?? 0) - (b.retry ?? 0)));
+// The endpoint's attempt list is authoritative (it unions every attempt row);
+// the page-level `attempts` prop is the fallback while the diff is loading.
+const orderedAttempts = computed(() => {
+  const source = data.value?.attempts?.length ? data.value.attempts : (props.attempts ?? []);
+  return [...source].sort((a, b) => (a.retry ?? 0) - (b.retry ?? 0));
+});
 
 const differences = computed<AttemptDiffEntry[]>(() => data.value?.differences ?? []);
 const applicable = computed(() => data.value?.applicable === true);

--- a/apps/application/app/components/test-case/EvidenceTabs.vue
+++ b/apps/application/app/components/test-case/EvidenceTabs.vue
@@ -104,6 +104,12 @@ const stateHasData = computed(() => Boolean(pageState.value));
 const performanceHasData = computed(() => Boolean(webVitals.value) || performanceHints.value.length > 0);
 const timelineHasData = computed(() => steps.value.length > 0);
 
+// Every attempt of this execution (each retry is its own row), already fetched.
+const attemptsList = computed<
+  Array<{ retry: number; status: string; duration: number | null; executionId: number | null }>
+>(() => props.testCase?.attempts ?? []);
+const hasMultipleAttempts = computed(() => attemptsList.value.length > 1);
+
 interface TabDef {
   value: TabValue;
   label: string;
@@ -113,6 +119,13 @@ interface TabDef {
 }
 const tabs = computed<TabDef[]>(() => [
   { value: 'timeline', label: 'Timeline', icon: 'i-lucide-activity', hasData: timelineHasData.value, count: null },
+  {
+    value: 'attempts',
+    label: 'Attempts',
+    icon: 'i-lucide-repeat',
+    hasData: hasMultipleAttempts.value,
+    count: hasMultipleAttempts.value ? attemptsList.value.length : null,
+  },
   { value: 'screen', label: 'Screen', icon: 'i-lucide-camera', hasData: screenHasData.value, count: null },
   { value: 'source', label: 'Source', icon: 'i-lucide-file-code-2', hasData: sourceHasData.value, count: null },
   {
@@ -280,6 +293,12 @@ defineExpose({ canLocate, revealSection, selectTab: (t: TabValue) => (activeTab.
             </template>
           </ClientOnly>
         </SectionCard>
+      </div>
+
+      <!-- ── Attempts ─────────────────────────────────────────────── -->
+      <!-- Lazy: this card mounts only when the tab opens, fetching the diff then. -->
+      <div v-else-if="activeTab === 'attempts'" class="scroll-mt-4">
+        <AttemptsCard :test-runs-case-id="testRunsCaseId" :attempts="attemptsList" />
       </div>
 
       <!-- ── Screen ───────────────────────────────────────────────── -->

--- a/apps/application/app/demo/api/router.ts
+++ b/apps/application/app/demo/api/router.ts
@@ -97,6 +97,7 @@ import {
   getTestCaseStabilityTrend,
   getFailureTimeline,
   getFailureClues,
+  getAttemptDiff,
 } from '#shared/handlers/test-cases';
 import {
   getFailureCluster,
@@ -966,6 +967,14 @@ const routes: RouteEntry[] = [
     handler: async (m, _b, _q, ctx) => {
       await assertDemoEntityScope(ctx, 'execution', +m[1]!);
       return getFailureClues(await getDemoDb(), +m[1]!);
+    },
+  },
+  {
+    method: 'GET',
+    pattern: /^\/api\/test-run-cases\/(\d+)\/attempt-diff$/,
+    handler: async (m, _b, _q, ctx) => {
+      await assertDemoEntityScope(ctx, 'execution', +m[1]!);
+      return getAttemptDiff(await getDemoDb(), +m[1]!);
     },
   },
   {

--- a/apps/application/app/utils/evidence-sections.ts
+++ b/apps/application/app/utils/evidence-sections.ts
@@ -4,7 +4,15 @@
  * time, whether a citation is locatable). Kept out of the component so the
  * page's section locator gives the same answer during SSR and on the client.
  */
-export type EvidenceTabValue = 'timeline' | 'screen' | 'source' | 'network' | 'console' | 'state' | 'performance';
+export type EvidenceTabValue =
+  | 'timeline'
+  | 'attempts'
+  | 'screen'
+  | 'source'
+  | 'network'
+  | 'console'
+  | 'state'
+  | 'performance';
 
 export const EVIDENCE_SECTION_TAB: Record<string, EvidenceTabValue> = {
   steps: 'timeline',

--- a/apps/application/app/utils/help-content.ts
+++ b/apps/application/app/utils/help-content.ts
@@ -331,6 +331,11 @@ export const HELP_TOPICS = {
     text: 'A snapshot of the accessibility tree at the moment of failure — what assistive tech saw, and useful grounding for AI diagnosis. An empty card says whether it was not captured (add the capture fixtures) or captured with nothing to snapshot; with a trace and no fixtures it is recovered from the trace\'s error context and marked "derived from the trace".',
     doc: 'ai-diagnosis#what-a-diagnosis-contains',
   },
+  'case.attempts': {
+    title: 'Attempts',
+    text: 'When a test failed then passed on retry, this compares the failing attempt against the passing one and lists what differed — the error that was there then gone, a request that failed on only one attempt, a console error, a slower step, a duration or page-state change. Each difference links to the evidence it came from. That delta is the flakiness fingerprint, and it feeds the root-cause classifier.',
+    doc: 'flaky-tests#flaky-test-detection',
+  },
 
   // ── Test case across runs ─────────────────────────────────────────────
   'case.history-chart': {

--- a/apps/application/public/demo/seed.version.json
+++ b/apps/application/public/demo/seed.version.json
@@ -1,4 +1,4 @@
 {
-  "hash": "33cc69e77068a46f90437552d8cef1d8fb682ceaf6bced6d9b625208ed6b80bf",
-  "generatedAt": "2026-09-04T21:35:52.006Z"
+  "hash": "e14dde863f4a37a923679bdcfbcfb9923fad411b719e3fa9cd1f971ef6c86fee",
+  "generatedAt": "2026-09-03T20:36:40.958Z"
 }

--- a/apps/application/public/demo/seed.version.json
+++ b/apps/application/public/demo/seed.version.json
@@ -1,4 +1,4 @@
 {
-  "hash": "e14dde863f4a37a923679bdcfbcfb9923fad411b719e3fa9cd1f971ef6c86fee",
-  "generatedAt": "2026-09-03T20:36:40.958Z"
+  "hash": "33cc69e77068a46f90437552d8cef1d8fb682ceaf6bced6d9b625208ed6b80bf",
+  "generatedAt": "2026-09-04T21:35:52.006Z"
 }

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -363,6 +363,19 @@ const SCENES = [
 
   // ── Feature states (report artifacts) ─────────────────────────────────────
   {
+    name: 'attempt-diff',
+    description: 'Attempts tab: every attempt, and what differed between the failing and passing attempt',
+    // Execution 21 is a flaky test that passed on retry, so the Attempts tab holds a diff.
+    route: '/test-run-cases/21',
+    viewport: { width: 1280, height: 1000 },
+    of: '[data-shot="attempts-diff"]',
+    pad: 12,
+    async run({ shoot, openTab }) {
+      await openTab('Attempts');
+      await shoot();
+    },
+  },
+  {
     name: 'execution-history',
     description: 'Execution page opened straight onto its History tab (duration trend + executions)',
     route: '/test-run-cases/229?tab=history',

--- a/apps/application/server/api/test-run-cases/[id]/attempt-diff.get.ts
+++ b/apps/application/server/api/test-run-cases/[id]/attempt-diff.get.ts
@@ -1,0 +1,30 @@
+import { getAttemptDiff } from '#shared/handlers/test-cases';
+import {
+  requireResolvedProjectAccess,
+  requireRouteId,
+  resolveTestRunCaseProjectId,
+} from '../../../utils/project-access';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Run Cases'],
+    summary: "Diff a flaky test's failing and passing attempts",
+    description:
+      'Compares the failing and passing attempts of one flaky execution — the failing attempt this id belongs to against the first later attempt that passed, or, when this id is the passing attempt, the last prior failing one. Returns an ordered list of what differed (the error present on the failing attempt and gone on the pass, a request that failed on only one attempt, a console error/warning on only one, a step that errored or slowed, a duration delta, a page-state/URL change, an ARIA structural change), most-diagnostic first, plus a compact summary of each compared attempt. `applicable` is false when the execution has only one attempt or no failing/passing pair exists.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'integer' }, description: 'Test run case id' },
+    ],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'test run case ID');
+
+  // Authorize by the execution's own project: this id may be opened from the
+  // cluster page, where it can belong to a run in another project.
+  const { db } = await requireResolvedProjectAccess(event, id, resolveTestRunCaseProjectId, 'Test run case');
+
+  // Don't 404 — "not applicable" (one attempt, or no pair) is a valid answer.
+  return getAttemptDiff(db, id);
+});

--- a/apps/application/shared/attempt-diff.ts
+++ b/apps/application/shared/attempt-diff.ts
@@ -1,0 +1,420 @@
+/**
+ * Diff two attempts of the same test — the attempt that failed against the one
+ * that passed on retry. The result is the flakiness fingerprint: what was
+ * different the one time the test failed. Computed entirely from evidence Piwi
+ * already stores per attempt (each attempt is its own execution row), so no new
+ * capture is needed.
+ *
+ * Pure and dependency-light: it never throws on partial data. An attempt with no
+ * fixtures simply yields fewer diff rows — an error-only pair still produces the
+ * error row. Shared by the REST endpoint and the demo mirror, and its
+ * network/console signal feeds the flaky root-cause classifier.
+ */
+import type { ParsedPlaywrightError } from '#shared/error-parse';
+import type { PageStateLike } from '#shared/page-state';
+
+/** One attempt's evidence, as loaded from its execution row. All fields optional. */
+export interface AttemptEvidence {
+  error?: string | null;
+  parsedError?: ParsedPlaywrightError | null;
+  steps?: AttemptStep[] | null;
+  networkRequests?: AttemptNetworkRequest[] | null;
+  consoleLogs?: AttemptConsoleEntry[] | null;
+  pageState?: PageStateLike | null;
+  ariaSnapshot?: string | null;
+  duration?: number | null;
+}
+
+export interface AttemptStep {
+  title: string;
+  duration?: number | null;
+  category?: string | null;
+  failed?: boolean | null;
+  error?: { message?: string } | null;
+}
+
+export interface AttemptNetworkRequest {
+  method?: string | null;
+  url?: string | null;
+  status?: number | null;
+  duration?: number | null;
+  resourceType?: string | null;
+}
+
+export interface AttemptConsoleEntry {
+  type?: string | null;
+  text?: string | null;
+}
+
+export type AttemptDiffKind = 'error' | 'network' | 'console' | 'step' | 'duration' | 'page-state' | 'aria';
+
+export interface AttemptDiffEntry {
+  kind: AttemptDiffKind;
+  /** One-line description of the difference. */
+  summary: string;
+  /** Longer text (an error body, a request line, a step message); null when the summary says it all. */
+  detail: string | null;
+  /**
+   * Which attempt the evidence sits on. Omitted for a symmetric "changed"
+   * difference present on both (a duration delta, a moved URL).
+   */
+  only?: 'failing' | 'passing';
+  /** The evidence section this difference cites, for a jump-to chip. */
+  ref?: { section: string };
+}
+
+/** The ordered list of differences, most-diagnostic first. */
+export type AttemptDiff = AttemptDiffEntry[];
+
+/** Kinds in most-diagnostic-first order; used to rank the final list. */
+const KIND_RANK: Record<AttemptDiffKind, number> = {
+  error: 0,
+  network: 1,
+  console: 2,
+  step: 3,
+  duration: 4,
+  'page-state': 5,
+  aria: 6,
+};
+
+/** A request is treated as failed when the server erred or the request never completed. */
+function requestFailed(status: number | null | undefined): boolean {
+  const s = status ?? 0;
+  return s === 0 || s >= 500;
+}
+
+function requestKey(r: AttemptNetworkRequest): string {
+  return `${(r.method ?? 'GET').toUpperCase()} ${stripQuery(r.url ?? '')}`;
+}
+
+/** Drop the query string so the same endpoint keyed by different params still matches. */
+function stripQuery(url: string): string {
+  const q = url.indexOf('?');
+  return q === -1 ? url : url.slice(0, q);
+}
+
+/** Normalize a console message to a stable key (collapse whitespace, cap length). */
+function consoleKey(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, 200).toLowerCase();
+}
+
+function firstLine(text: string): string {
+  const line = text.split('\n').find((l) => l.trim().length > 0) ?? text;
+  return line.trim();
+}
+
+/** A short headline for an error, preferring the parsed message head. */
+function errorHeadline(evidence: AttemptEvidence): string {
+  const head = evidence.parsedError?.messageHead?.trim();
+  if (head) return firstLine(head);
+  return evidence.error ? firstLine(evidence.error) : 'Error';
+}
+
+/** Roles that mark a structural node in a Playwright ARIA (YAML) snapshot. */
+const ARIA_STRUCTURAL_ROLES = new Set([
+  'banner',
+  'navigation',
+  'main',
+  'complementary',
+  'contentinfo',
+  'region',
+  'search',
+  'form',
+  'article',
+  'heading',
+  'dialog',
+  'alertdialog',
+  'tablist',
+  'tabpanel',
+]);
+
+/**
+ * Region-header-level nodes of an ARIA snapshot: the landmark and heading lines,
+ * as `role "name"`. Playwright snapshots are YAML (`- heading "Title" [level=1]`),
+ * so this reads the structure without touching raw HTML.
+ */
+function ariaStructure(snapshot: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of snapshot.split('\n')) {
+    const m = /^\s*-\s*([a-zA-Z]+)(?:\s+"([^"]*)")?/.exec(raw);
+    if (!m) continue;
+    const role = m[1]!.toLowerCase();
+    if (!ARIA_STRUCTURAL_ROLES.has(role)) continue;
+    out.add(m[2] ? `${role} "${m[2]}"` : role);
+  }
+  return out;
+}
+
+/** A duration difference below this (ms) is noise, not a signal. */
+const DURATION_DELTA_MS = 1000;
+/** A step is "much slower" on one side when it is at least this many ms and twice the other. */
+const STEP_SLOW_DELTA_MS = 1000;
+/** Cap per-category diff rows so a noisy attempt does not flood the list. */
+const MAX_PER_CATEGORY = 5;
+
+/**
+ * Diff the failing attempt against the passing one. The two are the same test in
+ * the same run on the same browser, one retry apart.
+ */
+export function diffAttempts(failing: AttemptEvidence, passing: AttemptEvidence): AttemptDiff {
+  const diffs: AttemptDiffEntry[] = [];
+
+  // ── Error: present on the failing attempt, gone on the pass ────────────────
+  const failError = failing.error?.trim() ? failing.error.trim() : null;
+  const passError = passing.error?.trim() ? passing.error.trim() : null;
+  if (failError && failError !== passError) {
+    diffs.push({
+      kind: 'error',
+      summary: errorHeadline(failing),
+      detail: failError,
+      only: 'failing',
+      ref: { section: 'executionError' },
+    });
+  } else if (passError && !failError) {
+    diffs.push({
+      kind: 'error',
+      summary: errorHeadline(passing),
+      detail: passError,
+      only: 'passing',
+      ref: { section: 'executionError' },
+    });
+  }
+
+  // ── Network: a request that failed on one attempt but not the other ────────
+  const failNet = failing.networkRequests ?? [];
+  const passNet = passing.networkRequests ?? [];
+  const failFailedKeys = failedRequestKeys(failNet);
+  const passFailedKeys = failedRequestKeys(passNet);
+  for (const [side, req] of orderedRequestDiff(failNet, passNet, failFailedKeys, passFailedKeys)) {
+    diffs.push({
+      kind: 'network',
+      summary: `${requestKey(req)} → ${req.status ?? 0}`,
+      detail: req.url && req.url !== stripQuery(req.url) ? req.url : null,
+      only: side,
+      ref: { section: 'networkRequests' },
+    });
+  }
+
+  // ── Console: an error/warning logged on only one attempt ───────────────────
+  for (const entry of onlyConsoleEntries(failing.consoleLogs ?? [], passing.consoleLogs ?? [], 'failing')) {
+    diffs.push(entry);
+  }
+  for (const entry of onlyConsoleEntries(passing.consoleLogs ?? [], failing.consoleLogs ?? [], 'passing')) {
+    diffs.push(entry);
+  }
+
+  // ── Steps: a step that errored, or was much slower, on one attempt ─────────
+  for (const entry of stepDiffs(failing.steps ?? [], passing.steps ?? [])) {
+    diffs.push(entry);
+  }
+
+  // ── Duration: the whole attempt ran meaningfully longer or shorter ─────────
+  const fd = failing.duration;
+  const pd = passing.duration;
+  if (fd != null && pd != null && Math.abs(fd - pd) >= DURATION_DELTA_MS) {
+    const slower = fd > pd;
+    diffs.push({
+      kind: 'duration',
+      summary: `Failing attempt was ${formatMs(Math.abs(fd - pd))} ${slower ? 'slower' : 'faster'}`,
+      detail: `${formatMs(fd)} on the failing attempt vs ${formatMs(pd)} on the pass`,
+      ref: { section: 'steps' },
+    });
+  }
+
+  // ── Page state / URL: where each attempt ended, and what storage it held ───
+  for (const entry of pageStateDiffs(failing.pageState ?? null, passing.pageState ?? null)) {
+    diffs.push(entry);
+  }
+
+  // ── ARIA: a structural node present on only one attempt ────────────────────
+  if (failing.ariaSnapshot && passing.ariaSnapshot) {
+    for (const entry of ariaDiffs(failing.ariaSnapshot, passing.ariaSnapshot)) {
+      diffs.push(entry);
+    }
+  }
+
+  return stableSortByKind(diffs);
+}
+
+function failedRequestKeys(requests: AttemptNetworkRequest[]): Map<string, AttemptNetworkRequest> {
+  const map = new Map<string, AttemptNetworkRequest>();
+  for (const r of requests) {
+    if (requestFailed(r.status)) map.set(requestKey(r), r);
+  }
+  return map;
+}
+
+/** Failed requests present on one side only, failing side first, capped. */
+function orderedRequestDiff(
+  _failNet: AttemptNetworkRequest[],
+  _passNet: AttemptNetworkRequest[],
+  failFailed: Map<string, AttemptNetworkRequest>,
+  passFailed: Map<string, AttemptNetworkRequest>,
+): Array<['failing' | 'passing', AttemptNetworkRequest]> {
+  const out: Array<['failing' | 'passing', AttemptNetworkRequest]> = [];
+  for (const [key, req] of failFailed) {
+    if (!passFailed.has(key)) out.push(['failing', req]);
+    if (out.length >= MAX_PER_CATEGORY) return out;
+  }
+  for (const [key, req] of passFailed) {
+    if (!failFailed.has(key)) out.push(['passing', req]);
+    if (out.length >= MAX_PER_CATEGORY) return out;
+  }
+  return out;
+}
+
+function onlyConsoleEntries(
+  side: AttemptConsoleEntry[],
+  other: AttemptConsoleEntry[],
+  only: 'failing' | 'passing',
+): AttemptDiffEntry[] {
+  const otherKeys = new Set(other.filter((e) => isConsoleProblem(e)).map((e) => consoleKey(e.text ?? '')));
+  const seen = new Set<string>();
+  const out: AttemptDiffEntry[] = [];
+  for (const e of side) {
+    if (!isConsoleProblem(e)) continue;
+    const text = (e.text ?? '').trim();
+    if (!text) continue;
+    const key = consoleKey(text);
+    if (otherKeys.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      kind: 'console',
+      summary: `Console ${consoleLevel(e)} on only the ${only} attempt`,
+      detail: text,
+      only,
+      ref: { section: 'console' },
+    });
+    if (out.length >= MAX_PER_CATEGORY) break;
+  }
+  return out;
+}
+
+function isConsoleProblem(e: AttemptConsoleEntry): boolean {
+  const t = (e.type ?? '').toLowerCase();
+  return t === 'error' || t === 'warning' || t === 'warn';
+}
+
+function consoleLevel(e: AttemptConsoleEntry): string {
+  const t = (e.type ?? '').toLowerCase();
+  return t === 'error' ? 'error' : 'warning';
+}
+
+function stepDiffs(failSteps: AttemptStep[], passSteps: AttemptStep[]): AttemptDiffEntry[] {
+  const passByTitle = new Map<string, AttemptStep>();
+  for (const s of passSteps) {
+    if (!passByTitle.has(s.title)) passByTitle.set(s.title, s);
+  }
+  const out: AttemptDiffEntry[] = [];
+  for (const s of failSteps) {
+    const twin = passByTitle.get(s.title);
+    const failed = Boolean(s.failed || s.error?.message);
+    if (failed && !(twin && (twin.failed || twin.error?.message))) {
+      out.push({
+        kind: 'step',
+        summary: `Step "${s.title}" errored on only the failing attempt`,
+        detail: s.error?.message ?? null,
+        only: 'failing',
+        ref: { section: 'steps' },
+      });
+    } else if (twin && s.duration != null && twin.duration != null) {
+      const delta = s.duration - twin.duration;
+      if (delta >= STEP_SLOW_DELTA_MS && s.duration >= 2 * twin.duration) {
+        out.push({
+          kind: 'step',
+          summary: `Step "${s.title}" was ${formatMs(delta)} slower on the failing attempt`,
+          detail: `${formatMs(s.duration)} vs ${formatMs(twin.duration)}`,
+          only: 'failing',
+          ref: { section: 'steps' },
+        });
+      }
+    }
+    if (out.length >= MAX_PER_CATEGORY) break;
+  }
+  return out;
+}
+
+function pageStateDiffs(failing: PageStateLike | null, passing: PageStateLike | null): AttemptDiffEntry[] {
+  if (!failing || !passing) return [];
+  const out: AttemptDiffEntry[] = [];
+  if (failing.url && passing.url && failing.url !== passing.url) {
+    out.push({
+      kind: 'page-state',
+      summary: 'The page ended on a different URL',
+      detail: `${failing.url} on the failing attempt vs ${passing.url} on the pass`,
+      ref: { section: 'appState' },
+    });
+  }
+  const storageChanges = [
+    keyDiffLine('localStorage', failing.localStorage, passing.localStorage),
+    keyDiffLine('sessionStorage', failing.sessionStorage, passing.sessionStorage),
+    keyDiffLine('cookies', failing.cookies, passing.cookies),
+  ].filter((l): l is string => l != null);
+  for (const line of storageChanges) {
+    out.push({ kind: 'page-state', summary: line, detail: null, ref: { section: 'appState' } });
+  }
+  return out;
+}
+
+/** A one-line summary of which storage/cookie keys the failing attempt gained or lost. */
+function keyDiffLine(
+  label: string,
+  failing: Array<{ key?: string; name?: string }> | null | undefined,
+  passing: Array<{ key?: string; name?: string }> | null | undefined,
+): string | null {
+  const nameOf = (e: { key?: string; name?: string }) => e.key ?? e.name ?? '';
+  const f = new Set((failing ?? []).map(nameOf).filter(Boolean));
+  const p = new Set((passing ?? []).map(nameOf).filter(Boolean));
+  const added = [...f].filter((k) => !p.has(k));
+  const removed = [...p].filter((k) => !f.has(k));
+  if (added.length === 0 && removed.length === 0) return null;
+  const parts: string[] = [];
+  if (added.length > 0) parts.push(`had ${added.join(', ')}`);
+  if (removed.length > 0) parts.push(`was missing ${removed.join(', ')}`);
+  return `${label}: the failing attempt ${parts.join('; ')}`;
+}
+
+function ariaDiffs(failing: string, passing: string): AttemptDiffEntry[] {
+  const f = ariaStructure(failing);
+  const p = ariaStructure(passing);
+  const out: AttemptDiffEntry[] = [];
+  for (const node of f) {
+    if (!p.has(node)) {
+      out.push({
+        kind: 'aria',
+        summary: `${node} was present on only the failing attempt`,
+        detail: null,
+        only: 'failing',
+        ref: { section: 'ariaSnapshot' },
+      });
+    }
+    if (out.length >= MAX_PER_CATEGORY) return out;
+  }
+  for (const node of p) {
+    if (!f.has(node)) {
+      out.push({
+        kind: 'aria',
+        summary: `${node} was present on only the passing attempt`,
+        detail: null,
+        only: 'passing',
+        ref: { section: 'ariaSnapshot' },
+      });
+    }
+    if (out.length >= MAX_PER_CATEGORY) return out;
+  }
+  return out;
+}
+
+/** Order by kind rank, keeping insertion order within a kind (a stable sort). */
+function stableSortByKind(diffs: AttemptDiffEntry[]): AttemptDiffEntry[] {
+  return diffs
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => KIND_RANK[a.entry.kind] - KIND_RANK[b.entry.kind] || a.index - b.index)
+    .map(({ entry }) => entry);
+}
+
+function formatMs(ms: number): string {
+  const v = Math.round(ms);
+  if (v < 1000) return `${v} ms`;
+  return `${(v / 1000).toFixed(v % 1000 === 0 ? 0 : 1)} s`;
+}

--- a/apps/application/shared/flaky-classify.ts
+++ b/apps/application/shared/flaky-classify.ts
@@ -13,8 +13,18 @@ interface ClassifyInput {
   stepNames: string[];
   networkErrorCount: number;
   status5xxCount: number;
+  /**
+   * How many of the test's recent flaky executions had a request that failed (or
+   * returned 5xx) on the failing attempt but not on the attempt that passed on
+   * retry. That delta is the sharpest available evidence that the flakiness is a
+   * network problem, so each vote weighs several keyword matches.
+   */
+  attemptDiffNetworkVotes?: number;
   browserDistribution: Record<string, number>;
 }
+
+/** Weight of one attempt-diff network vote, in keyword-match equivalents. */
+const ATTEMPT_DIFF_NETWORK_WEIGHT = 3;
 
 const TIMING_KEYWORDS = [
   'timeout',
@@ -84,7 +94,11 @@ export function classifyFlakyRootCause(input: ClassifyInput): FlakyRootCause {
   }
 
   const timingCount = countKeywordMatches(allTexts, TIMING_KEYWORDS);
-  const networkCount = countKeywordMatches(allTexts, NETWORK_KEYWORDS) + input.networkErrorCount + input.status5xxCount;
+  const networkCount =
+    countKeywordMatches(allTexts, NETWORK_KEYWORDS) +
+    input.networkErrorCount +
+    input.status5xxCount +
+    (input.attemptDiffNetworkVotes ?? 0) * ATTEMPT_DIFF_NETWORK_WEIGHT;
   const assertionCount = countKeywordMatches(allTexts, ASSERTION_MARKERS);
 
   // Assertion requires NO timing/network keywords present

--- a/apps/application/shared/handlers/flaky-classify.ts
+++ b/apps/application/shared/handlers/flaky-classify.ts
@@ -4,10 +4,14 @@
  * handler run the exact same query + classification + write, never two
  * hand-mirrored copies.
  */
-import { eq, and, desc } from 'drizzle-orm';
-import { testCases, testRunsCases, testRuns } from '../../server/database/schema';
+import { eq, and, desc, gt, inArray } from 'drizzle-orm';
+import { testCases, testRunsCases, testRuns, networkRequests } from '../../server/database/schema';
 import { classifyFlakyRootCause, type FlakyRootCause } from '../flaky-classify';
+import { getAttemptDiff } from './test-cases';
 import type { DrizzleDB } from './db';
+
+/** How many recent flaky executions to diff for the attempt-diff network vote. */
+const ATTEMPT_DIFF_SAMPLE = 10;
 
 export async function classifyAndPersistFlakyRootCause(
   db: DrizzleDB,
@@ -63,12 +67,48 @@ export async function classifyAndPersistFlakyRootCause(
     }
   }
 
+  // Count the failed requests actually captured across the recent failing
+  // attempts — the classifier's network signal was long fed a dead 0 here.
+  let networkErrorCount = 0;
+  let status5xxCount = 0;
+  const failingIds = recentFailures.map((r) => r.id);
+  if (failingIds.length > 0) {
+    const netRows = await db
+      .select({ status: networkRequests.status })
+      .from(networkRequests)
+      .where(inArray(networkRequests.testRunsCaseId, failingIds));
+    for (const nr of netRows) {
+      const s = nr.status ?? 0;
+      if (s === 0) networkErrorCount++;
+      else if (s >= 500) status5xxCount++;
+    }
+  }
+
+  // The sharpest network signal: a recent flaky execution whose failing attempt
+  // had a request that failed (or 5xx'd) and the passing attempt did not.
+  let attemptDiffNetworkVotes = 0;
+  const flakyExecutions = await db
+    .select({ id: testRunsCases.id })
+    .from(testRunsCases)
+    .where(
+      and(eq(testRunsCases.testCaseId, testCaseId), eq(testRunsCases.status, 'passed'), gt(testRunsCases.retries, 0)),
+    )
+    .orderBy(desc(testRunsCases.createdAt))
+    .limit(ATTEMPT_DIFF_SAMPLE);
+  for (const exec of flakyExecutions) {
+    const diff = await getAttemptDiff(db, exec.id);
+    if (diff.differences.some((d) => d.kind === 'network' && d.only === 'failing')) {
+      attemptDiffNetworkVotes++;
+    }
+  }
+
   const rootCause = classifyFlakyRootCause({
     errorMessages,
     stepErrors,
     stepNames,
-    networkErrorCount: 0,
-    status5xxCount: 0,
+    networkErrorCount,
+    status5xxCount,
+    attemptDiffNetworkVotes,
     browserDistribution,
   });
 

--- a/apps/application/shared/handlers/test-cases.ts
+++ b/apps/application/shared/handlers/test-cases.ts
@@ -17,6 +17,7 @@ import { buildFailureVerdict } from '../failure-verdict';
 import { buildFailureTimeline, type FailureTimeline, type TimelineCallsite } from '../failure-timeline';
 import { buildFailureClues, type FailureClue } from '../failure-clues';
 import { parsePlaywrightError } from '../error-parse';
+import { diffAttempts, type AttemptDiffEntry, type AttemptEvidence } from '../attempt-diff';
 import { getLocatorHealing } from '../../server/utils/locator-healing';
 import { getEnvironmentDiff } from '../../server/utils/environment-diff';
 import type { PageStateLike } from '../page-state';
@@ -664,6 +665,138 @@ export async function getFailureClues(
 function startedAtMs(value: unknown): number | null {
   if (value instanceof Date) return value.getTime();
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** A per-attempt summary for the compared pair. */
+export interface AttemptDiffSummary {
+  executionId: number;
+  retry: number;
+  status: string;
+  duration: number | null;
+}
+
+export interface AttemptDiffResult {
+  /** True only when a failing attempt and a passing attempt could be paired. */
+  applicable: boolean;
+  /** Why a diff could not be produced. */
+  reason?: 'not-found' | 'single-attempt' | 'no-pair';
+  /** The failing attempt of the pair. */
+  failing?: AttemptDiffSummary;
+  /** The passing attempt of the pair. */
+  passing?: AttemptDiffSummary;
+  /** Which attempt the opened execution is, so the UI can mark "this one". */
+  currentExecutionId?: number;
+  /** The ordered differences; empty when not applicable. */
+  differences: AttemptDiffEntry[];
+}
+
+function isFailingStatus(status: string | null | undefined): boolean {
+  return status === 'failed' || status === 'timedOut' || status === 'timedout';
+}
+
+/** Load one attempt's evidence from its execution row and network rows. */
+async function loadAttemptEvidence(
+  db: DrizzleDB,
+  row: {
+    id: number;
+    error: string | null;
+    steps: unknown;
+    consoleLogs: unknown;
+    pageState: unknown;
+    duration: number | null;
+  },
+): Promise<AttemptEvidence> {
+  const [evidence, networkRequestRows] = await Promise.all([
+    inlineCasePayloads(db, row as any),
+    db.select().from(networkRequests).where(eq(networkRequests.testRunsCaseId, row.id)),
+  ]);
+  return {
+    error: row.error,
+    parsedError: row.error ? parsePlaywrightError(row.error) : null,
+    steps: (row.steps as AttemptEvidence['steps']) ?? null,
+    networkRequests: networkRequestRows.map((nr) => ({
+      method: nr.method,
+      url: nr.url,
+      status: nr.status,
+      duration: nr.duration,
+      resourceType: nr.resourceType,
+    })),
+    consoleLogs: (row.consoleLogs as AttemptEvidence['consoleLogs']) ?? null,
+    pageState: (row.pageState as AttemptEvidence['pageState']) ?? null,
+    ariaSnapshot: evidence.ariaSnapshot ?? null,
+    duration: row.duration ?? null,
+  };
+}
+
+/**
+ * Diff the failing and passing attempts of one flaky execution. Resolves this
+ * execution's sibling attempts (same run, test case and browser), pairs the
+ * failing attempt with the passing one — the failing attempt this id belongs to
+ * against the first later attempt that passed, or, when this id is the passing
+ * one, the last prior failing attempt — loads both rows' evidence through the
+ * same helpers the execution detail reads, and hands them to the pure
+ * `diffAttempts`. Returns `applicable: false` when there is only one attempt or
+ * no failing/passing pair exists. Shared by the REST endpoint and the demo
+ * mirror. Never 404s: "not applicable" is a valid answer.
+ */
+export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<AttemptDiffResult> {
+  const [current] = await db.select().from(testRunsCases).where(eq(testRunsCases.id, id));
+  if (!current) return { applicable: false, reason: 'not-found', differences: [] };
+
+  const siblings = await db
+    .select()
+    .from(testRunsCases)
+    .where(
+      and(
+        eq(testRunsCases.testRunId, current.testRunId),
+        eq(testRunsCases.testCaseId, current.testCaseId),
+        current.browserName
+          ? eq(testRunsCases.browserName, current.browserName)
+          : sql`${testRunsCases.browserName} IS NULL`,
+      ),
+    );
+  siblings.sort((a: any, b: any) => (a.retries ?? 0) - (b.retries ?? 0));
+
+  if (siblings.length < 2) return { applicable: false, reason: 'single-attempt', differences: [] };
+
+  const currentRetry = current.retries ?? 0;
+  let failingRow: (typeof siblings)[number] | undefined;
+  let passingRow: (typeof siblings)[number] | undefined;
+
+  if (isFailingStatus(current.status)) {
+    failingRow = current;
+    // The first later attempt that passed.
+    passingRow = siblings.find((s: any) => (s.retries ?? 0) > currentRetry && s.status === 'passed');
+  } else if (current.status === 'passed') {
+    passingRow = current;
+    // The last prior attempt that failed.
+    failingRow = [...siblings].reverse().find((s: any) => (s.retries ?? 0) < currentRetry && isFailingStatus(s.status));
+  }
+
+  if (!failingRow || !passingRow)
+    return { applicable: false, reason: 'no-pair', differences: [], currentExecutionId: id };
+
+  const [failingEvidence, passingEvidence] = await Promise.all([
+    loadAttemptEvidence(db, failingRow),
+    loadAttemptEvidence(db, passingRow),
+  ]);
+
+  const differences = diffAttempts(failingEvidence, passingEvidence);
+
+  const summarize = (row: (typeof siblings)[number]): AttemptDiffSummary => ({
+    executionId: row.id,
+    retry: row.retries ?? 0,
+    status: row.status,
+    duration: row.duration ?? null,
+  });
+
+  return {
+    applicable: true,
+    failing: summarize(failingRow),
+    passing: summarize(passingRow),
+    currentExecutionId: id,
+    differences,
+  };
 }
 
 export async function getTestRunCaseTraces(db: DrizzleDB, id: number) {

--- a/apps/application/shared/handlers/test-cases.ts
+++ b/apps/application/shared/handlers/test-cases.ts
@@ -669,10 +669,18 @@ function startedAtMs(value: unknown): number | null {
 
 /** A per-attempt summary for the compared pair. */
 export interface AttemptDiffSummary {
-  executionId: number;
+  /** The sibling execution row for this attempt, or null when it was not stored separately. */
+  executionId: number | null;
   retry: number;
   status: string;
   duration: number | null;
+}
+
+/** One attempt's recorded outcome, as stored in the row's `attempts` JSON. */
+interface AttemptMeta {
+  retry: number;
+  status: string;
+  duration?: number | null;
 }
 
 export interface AttemptDiffResult {
@@ -729,21 +737,26 @@ async function loadAttemptEvidence(
 }
 
 /**
- * Diff the failing and passing attempts of one flaky execution. Resolves this
- * execution's sibling attempts (same run, test case and browser), pairs the
- * failing attempt with the passing one — the failing attempt this id belongs to
- * against the first later attempt that passed, or, when this id is the passing
- * one, the last prior failing attempt — loads both rows' evidence through the
- * same helpers the execution detail reads, and hands them to the pure
- * `diffAttempts`. Returns `applicable: false` when there is only one attempt or
- * no failing/passing pair exists. Shared by the REST endpoint and the demo
- * mirror. Never 404s: "not applicable" is a valid answer.
+ * Diff the failing and passing attempts of one flaky execution. The per-attempt
+ * outcomes come from the row's `attempts` JSON (recorded on every attempt row);
+ * a real reporter run also stores each attempt as its own execution row, so its
+ * full evidence — error, network, console, page state, ARIA — is loaded through
+ * the same helpers the execution detail reads. When only the final attempt was
+ * stored (the demo/dev seed collapses retries), the missing attempt contributes
+ * just its recorded duration, so a timing difference still shows.
+ *
+ * Pairs the failing attempt with the passing one — the failing attempt this id
+ * belongs to against the first later attempt that passed, or, when this id is
+ * the passing one, the last prior failing attempt — and hands the pair to the
+ * pure `diffAttempts`. Returns `applicable: false` when there is only one
+ * attempt or no failing/passing pair exists. Shared by the REST endpoint and
+ * the demo mirror. Never 404s: "not applicable" is a valid answer.
  */
 export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<AttemptDiffResult> {
   const [current] = await db.select().from(testRunsCases).where(eq(testRunsCases.id, id));
   if (!current) return { applicable: false, reason: 'not-found', differences: [] };
 
-  const siblings = await db
+  const siblingRows = await db
     .select()
     .from(testRunsCases)
     .where(
@@ -755,45 +768,52 @@ export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<Attempt
           : sql`${testRunsCases.browserName} IS NULL`,
       ),
     );
-  siblings.sort((a: any, b: any) => (a.retries ?? 0) - (b.retries ?? 0));
+  const rowByRetry = new Map<number, (typeof siblingRows)[number]>(siblingRows.map((r: any) => [r.retries ?? 0, r]));
 
-  if (siblings.length < 2) return { applicable: false, reason: 'single-attempt', differences: [] };
+  // The recorded attempt outcomes; every attempt row carries the full sequence.
+  const attemptsMeta: AttemptMeta[] = (Array.isArray(current.attempts) ? (current.attempts as AttemptMeta[]) : [])
+    .slice()
+    .sort((a, b) => (a.retry ?? 0) - (b.retry ?? 0));
+
+  if (attemptsMeta.length < 2)
+    return { applicable: false, reason: 'single-attempt', differences: [], currentExecutionId: id };
 
   const currentRetry = current.retries ?? 0;
-  let failingRow: (typeof siblings)[number] | undefined;
-  let passingRow: (typeof siblings)[number] | undefined;
+  let failing: AttemptMeta | undefined;
+  let passing: AttemptMeta | undefined;
 
   if (isFailingStatus(current.status)) {
-    failingRow = current;
-    // The first later attempt that passed.
-    passingRow = siblings.find((s: any) => (s.retries ?? 0) > currentRetry && s.status === 'passed');
+    failing = attemptsMeta.find((a) => a.retry === currentRetry) ?? { retry: currentRetry, status: current.status };
+    passing = attemptsMeta.find((a) => a.retry > currentRetry && a.status === 'passed');
   } else if (current.status === 'passed') {
-    passingRow = current;
-    // The last prior attempt that failed.
-    failingRow = [...siblings].reverse().find((s: any) => (s.retries ?? 0) < currentRetry && isFailingStatus(s.status));
+    passing = attemptsMeta.find((a) => a.retry === currentRetry) ?? { retry: currentRetry, status: current.status };
+    failing = [...attemptsMeta].reverse().find((a) => a.retry < currentRetry && isFailingStatus(a.status));
   }
 
-  if (!failingRow || !passingRow)
-    return { applicable: false, reason: 'no-pair', differences: [], currentExecutionId: id };
+  if (!failing || !passing) return { applicable: false, reason: 'no-pair', differences: [], currentExecutionId: id };
 
-  const [failingEvidence, passingEvidence] = await Promise.all([
-    loadAttemptEvidence(db, failingRow),
-    loadAttemptEvidence(db, passingRow),
-  ]);
+  const evidenceFor = async (attempt: AttemptMeta): Promise<AttemptEvidence> => {
+    const row = rowByRetry.get(attempt.retry);
+    if (row) return loadAttemptEvidence(db, row);
+    // The attempt was not stored as its own row — only its recorded duration is known.
+    return { error: null, duration: attempt.duration ?? null };
+  };
+
+  const [failingEvidence, passingEvidence] = await Promise.all([evidenceFor(failing), evidenceFor(passing)]);
 
   const differences = diffAttempts(failingEvidence, passingEvidence);
 
-  const summarize = (row: (typeof siblings)[number]): AttemptDiffSummary => ({
-    executionId: row.id,
-    retry: row.retries ?? 0,
-    status: row.status,
-    duration: row.duration ?? null,
+  const summarize = (attempt: AttemptMeta): AttemptDiffSummary => ({
+    executionId: rowByRetry.get(attempt.retry)?.id ?? null,
+    retry: attempt.retry,
+    status: attempt.status,
+    duration: attempt.duration ?? rowByRetry.get(attempt.retry)?.duration ?? null,
   });
 
   return {
     applicable: true,
-    failing: summarize(failingRow),
-    passing: summarize(passingRow),
+    failing: summarize(failing),
+    passing: summarize(passing),
     currentExecutionId: id,
     differences,
   };

--- a/apps/application/shared/handlers/test-cases.ts
+++ b/apps/application/shared/handlers/test-cases.ts
@@ -688,6 +688,8 @@ export interface AttemptDiffResult {
   applicable: boolean;
   /** Why a diff could not be produced. */
   reason?: 'not-found' | 'single-attempt' | 'no-pair';
+  /** Every attempt of this execution, retry-ascending — the strip's source of truth. */
+  attempts: AttemptDiffSummary[];
   /** The failing attempt of the pair. */
   failing?: AttemptDiffSummary;
   /** The passing attempt of the pair. */
@@ -754,7 +756,7 @@ async function loadAttemptEvidence(
  */
 export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<AttemptDiffResult> {
   const [current] = await db.select().from(testRunsCases).where(eq(testRunsCases.id, id));
-  if (!current) return { applicable: false, reason: 'not-found', differences: [] };
+  if (!current) return { applicable: false, reason: 'not-found', attempts: [], differences: [] };
 
   const siblingRows = await db
     .select()
@@ -770,13 +772,37 @@ export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<Attempt
     );
   const rowByRetry = new Map<number, (typeof siblingRows)[number]>(siblingRows.map((r: any) => [r.retries ?? 0, r]));
 
-  // The recorded attempt outcomes; every attempt row carries the full sequence.
-  const attemptsMeta: AttemptMeta[] = (Array.isArray(current.attempts) ? (current.attempts as AttemptMeta[]) : [])
-    .slice()
-    .sort((a, b) => (a.retry ?? 0) - (b.retry ?? 0));
+  // The attempt outcomes, keyed by retry. A real reporter run stores each
+  // attempt as its own row, so the physical rows already list every attempt;
+  // the demo/dev seed collapses retries into the final row, so the full sequence
+  // survives only in the `attempts` JSON — and the reporter fills that JSON in
+  // progressively, so the richest copy (the most entries) sits on the final
+  // attempt. Union both sources: a physical row is authoritative (it carries
+  // evidence), a JSON-only attempt contributes its recorded outcome.
+  const byRetry = new Map<number, AttemptMeta>();
+  for (const r of siblingRows) {
+    byRetry.set(r.retries ?? 0, { retry: r.retries ?? 0, status: r.status, duration: r.duration ?? null });
+  }
+  let richestMeta: AttemptMeta[] = [];
+  for (const r of siblingRows) {
+    const list = Array.isArray(r.attempts) ? (r.attempts as AttemptMeta[]) : [];
+    if (list.length > richestMeta.length) richestMeta = list;
+  }
+  for (const m of richestMeta) {
+    if (!byRetry.has(m.retry)) byRetry.set(m.retry, { retry: m.retry, status: m.status, duration: m.duration ?? null });
+  }
+  const attemptsMeta = [...byRetry.values()].sort((a, b) => (a.retry ?? 0) - (b.retry ?? 0));
+
+  const summarize = (attempt: AttemptMeta): AttemptDiffSummary => ({
+    executionId: rowByRetry.get(attempt.retry)?.id ?? null,
+    retry: attempt.retry,
+    status: attempt.status,
+    duration: attempt.duration ?? rowByRetry.get(attempt.retry)?.duration ?? null,
+  });
+  const attempts = attemptsMeta.map(summarize);
 
   if (attemptsMeta.length < 2)
-    return { applicable: false, reason: 'single-attempt', differences: [], currentExecutionId: id };
+    return { applicable: false, reason: 'single-attempt', attempts, differences: [], currentExecutionId: id };
 
   const currentRetry = current.retries ?? 0;
   let failing: AttemptMeta | undefined;
@@ -790,7 +816,8 @@ export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<Attempt
     failing = [...attemptsMeta].reverse().find((a) => a.retry < currentRetry && isFailingStatus(a.status));
   }
 
-  if (!failing || !passing) return { applicable: false, reason: 'no-pair', differences: [], currentExecutionId: id };
+  if (!failing || !passing)
+    return { applicable: false, reason: 'no-pair', attempts, differences: [], currentExecutionId: id };
 
   const evidenceFor = async (attempt: AttemptMeta): Promise<AttemptEvidence> => {
     const row = rowByRetry.get(attempt.retry);
@@ -803,15 +830,9 @@ export async function getAttemptDiff(db: DrizzleDB, id: number): Promise<Attempt
 
   const differences = diffAttempts(failingEvidence, passingEvidence);
 
-  const summarize = (attempt: AttemptMeta): AttemptDiffSummary => ({
-    executionId: rowByRetry.get(attempt.retry)?.id ?? null,
-    retry: attempt.retry,
-    status: attempt.status,
-    duration: attempt.duration ?? rowByRetry.get(attempt.retry)?.duration ?? null,
-  });
-
   return {
     applicable: true,
+    attempts,
     failing: summarize(failing),
     passing: summarize(passing),
     currentExecutionId: id,

--- a/apps/application/tests/unit/attempt-diff.test.ts
+++ b/apps/application/tests/unit/attempt-diff.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from 'vitest';
+import { diffAttempts, type AttemptEvidence } from '#shared/attempt-diff';
+
+/** A minimal passing attempt: no error, no failed requests, no problem logs. */
+function cleanPass(overrides: Partial<AttemptEvidence> = {}): AttemptEvidence {
+  return {
+    error: null,
+    steps: [],
+    networkRequests: [],
+    consoleLogs: [],
+    pageState: null,
+    ariaSnapshot: null,
+    duration: 1000,
+    ...overrides,
+  };
+}
+
+describe('diffAttempts', () => {
+  test('fail→pass with a 500 that recovered ranks the error first, then the request', () => {
+    const failing: AttemptEvidence = {
+      error: 'Error: expected 200, got 500',
+      networkRequests: [
+        { method: 'GET', url: 'https://app.test/', status: 200, duration: 40 },
+        { method: 'POST', url: 'https://app.test/api/orders?id=7', status: 500, duration: 120 },
+      ],
+      duration: 1200,
+    };
+    const passing = cleanPass({
+      networkRequests: [
+        { method: 'GET', url: 'https://app.test/', status: 200, duration: 40 },
+        { method: 'POST', url: 'https://app.test/api/orders?id=8', status: 201, duration: 90 },
+      ],
+      duration: 1100,
+    });
+
+    const diff = diffAttempts(failing, passing);
+    const kinds = diff.map((d) => d.kind);
+    expect(kinds[0]).toBe('error');
+    expect(kinds).toContain('network');
+    // Error before network in the ordered list.
+    expect(kinds.indexOf('error')).toBeLessThan(kinds.indexOf('network'));
+
+    const net = diff.find((d) => d.kind === 'network')!;
+    expect(net.only).toBe('failing');
+    expect(net.summary).toContain('POST https://app.test/api/orders');
+    expect(net.summary).toContain('500');
+    expect(net.ref).toEqual({ section: 'networkRequests' });
+  });
+
+  test('fail→pass with a console error only on the fail emits a console diff', () => {
+    const failing: AttemptEvidence = {
+      error: 'Error: element not found',
+      consoleLogs: [
+        { type: 'log', text: 'app booted' },
+        { type: 'error', text: 'Uncaught TypeError: cannot read foo of undefined' },
+      ],
+      duration: 1000,
+    };
+    const passing = cleanPass({
+      consoleLogs: [{ type: 'log', text: 'app booted' }],
+    });
+
+    const diff = diffAttempts(failing, passing);
+    const console = diff.filter((d) => d.kind === 'console');
+    expect(console).toHaveLength(1);
+    expect(console[0]!.only).toBe('failing');
+    expect(console[0]!.detail).toContain('Uncaught TypeError');
+    expect(console[0]!.ref).toEqual({ section: 'console' });
+  });
+
+  test('a timing-only difference yields a single duration row', () => {
+    const failing = cleanPass({ error: null, duration: 8000 });
+    const passing = cleanPass({ duration: 1500 });
+
+    const diff = diffAttempts(failing, passing);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]!.kind).toBe('duration');
+    expect(diff[0]!.only).toBeUndefined();
+    expect(diff[0]!.summary).toContain('slower');
+  });
+
+  test('attempts with no fixture data produce an error-only diff and never throw', () => {
+    const failing: AttemptEvidence = { error: 'AssertionError: expected true' };
+    const passing: AttemptEvidence = { error: null };
+
+    const diff = diffAttempts(failing, passing);
+    expect(diff).toHaveLength(1);
+    expect(diff[0]!.kind).toBe('error');
+    expect(diff[0]!.only).toBe('failing');
+    expect(diff[0]!.detail).toBe('AssertionError: expected true');
+    expect(diff[0]!.ref).toEqual({ section: 'executionError' });
+  });
+
+  test('two identical attempts yield no differences', () => {
+    expect(diffAttempts(cleanPass(), cleanPass())).toEqual([]);
+  });
+
+  test('empty inputs never throw', () => {
+    expect(diffAttempts({}, {})).toEqual([]);
+  });
+
+  test('an ARIA structural node present only on the failure is reported', () => {
+    const failing = cleanPass({
+      ariaSnapshot: '- main:\n  - heading "Dashboard" [level=1]\n- dialog "Session expired"',
+    });
+    const passing = cleanPass({
+      ariaSnapshot: '- main:\n  - heading "Dashboard" [level=1]',
+    });
+
+    const diff = diffAttempts(failing, passing);
+    const aria = diff.filter((d) => d.kind === 'aria');
+    expect(aria).toHaveLength(1);
+    expect(aria[0]!.only).toBe('failing');
+    expect(aria[0]!.summary).toContain('dialog "Session expired"');
+  });
+});

--- a/apps/application/tests/unit/flaky-classify.test.ts
+++ b/apps/application/tests/unit/flaky-classify.test.ts
@@ -94,4 +94,32 @@ describe('Flaky root cause classification', () => {
     });
     expect(result).toBe('other');
   });
+
+  test('an attempt-diff network vote makes an otherwise-unclear flake network', async () => {
+    const { classifyFlakyRootCause } = await import('../../server/utils/flaky-classify');
+    const result = classifyFlakyRootCause({
+      errorMessages: ['Something went wrong: undefined is not a function'],
+      stepErrors: [],
+      stepNames: ['submit order'],
+      networkErrorCount: 0,
+      status5xxCount: 0,
+      attemptDiffNetworkVotes: 1,
+      browserDistribution: { chromium: 3 },
+    });
+    expect(result).toBe('network');
+  });
+
+  test('an attempt-diff network vote outweighs a lone assertion keyword', async () => {
+    const { classifyFlakyRootCause } = await import('../../server/utils/flaky-classify');
+    const result = classifyFlakyRootCause({
+      errorMessages: ['expect(received).toBe(expected)'],
+      stepErrors: [],
+      stepNames: [],
+      networkErrorCount: 0,
+      status5xxCount: 0,
+      attemptDiffNetworkVotes: 2,
+      browserDistribution: { chromium: 3 },
+    });
+    expect(result).toBe('network');
+  });
 });

--- a/apps/docs/evidence.md
+++ b/apps/docs/evidence.md
@@ -34,6 +34,7 @@ Below the header the reading order is the same every time: the **headline**, the
 - **Clues** — the strongest [deterministic clue](#clues) in one line right on the headline (*"GET /api/quote returned 504, 1.1 s before the failure"*), with an **Other clues** card below listing the rest, each with a strength chip, its `t-N s` before the failure, and citation chips that switch to the evidence tab it came from and scroll to it.
 - **Evidence** — one card with content-level tabs; each tab shows a count or a dot when it holds data and is dimmed when empty, and a dimmed tab still opens to say why (not captured / nothing happened / not applicable). The card opens on the tab the strongest clue cites, else the **Timeline** when it can place two or more items, else **Screen** — and a clue or diagnosis citation switches tabs for you:
   - **Timeline** — one time axis that places the **steps**, **console** entries, **network** requests and their **backend logs** on the same clock and marks the **moment of failure**, so "console (1) / network (3)" become *what the app was doing when the test gave up*. Below the axis, the same items read as one chronological list — `t-1.1s · GET /api/quote → 504 (1500 ms)`, `t+0 · click getByRole('button', { name: 'Pay' }) failed` — grouped by the method (or `test.step`) they were called from, each file:line opening in your editor; two views, **Around the failure** and **Whole test**, the latter followed by the full **step table** (category, duration, share of the test). Web Vitals and screenshots carry no capture time, so they are listed as not-yet-placed rather than guessed at.
+  - **Attempts** — shown when a test ran more than once (it failed then passed on retry): every attempt with its status and duration, and below them [what differed](#attempts) between the failing attempt and the one that passed.
   - **Screen** — the failure screenshot, the **visual diff** against the last green run, video, the failure-time **ARIA snapshot**, the reconstructed **DOM snapshot** with pick-a-locator, and the trace and attachments.
   - **Source** — the **test source** as a call stack (the line that actually threw plus the callers above it, so a failure inside a helper is visible), deepening [with a trace](#trace-powered-deep-views) into the complete stack with real source.
   - **Network** — the **network requests** with inline [backend logs](./backend-logs) and a [Full trace](#trace-powered-deep-views) network view. **Console** — the console output. **State** — the **app state** at test end and the **environment diff** against the last green run. **Performance** — performance hints, Web Vitals, the slowest step and wasted time.
@@ -58,6 +59,20 @@ A **clue** is a deterministic, rule-based finding correlated from the evidence a
 - **Fixed before** *(weak)* — this cluster recorded a fix that has since regressed.
 
 The card is hidden when no rule fires, and the ranked list is capped at eight clues.
+
+### Attempts
+
+When a test failed and then passed on retry, the **Attempts** tab compares the failing attempt against the one that passed — the flakiness fingerprint, computed from evidence Piwi already stores for each attempt. It lists every attempt (its status and duration, with the one you opened marked), then **what differed**, most-diagnostic first:
+
+- the **error** that was present on the failing attempt and gone on the pass;
+- a **request** that failed (5xx or no response) on one attempt but not the other;
+- a **console** error or warning logged on only one attempt;
+- a **step** that errored, or ran much slower, on one attempt;
+- a **duration** delta between the two attempts;
+- a **page-state or URL** difference — where the page ended, and which storage keys or cookies each attempt held;
+- an **ARIA structural** difference at the landmark/heading level.
+
+Each difference is labeled by the attempt it sits on (*only on the failing attempt* / *only on the passing attempt* / *changed*) and carries a chip that switches to the evidence tab it came from. That same delta feeds the [root-cause classifier](./flaky-tests#root-cause-classification): a request that failed on the failing attempt and recovered on the pass is strong evidence the flakiness is a network problem.
 
 **A passing execution shows the same page** with the evidence card's **Timeline** tab selected; its traces, attachments, console and network are in the same tabs a failing execution uses.
 

--- a/apps/docs/flaky-tests.md
+++ b/apps/docs/flaky-tests.md
@@ -30,15 +30,17 @@ The project's **Failures** tab has a **Flaky** view with a **configurable lookba
 
 ### Root-cause classification
 
-Every flaky test is automatically tagged with one of five categories, using keyword and distribution heuristics over its errors, steps, and browser spread:
+Every flaky test is automatically tagged with one of five categories, using keyword and distribution heuristics over its errors, steps, and browser spread, sharpened by the failed requests actually captured and by the attempt diff:
 
 | Category | Typical signals |
 |----------|-----------------|
 | `timing` | Timeouts, "to be visible", `waitFor`, element-not-found-within |
-| `network` | `net::` / `ERR_` errors, 5xx responses, `ECONNREFUSED`, `waitForResponse` |
+| `network` | `net::` / `ERR_` errors, 5xx responses, `ECONNREFUSED`, `waitForResponse` — plus the count of failed and 5xx requests captured on the failing attempts, and any request that failed on the failing attempt but not the passing one |
 | `assertion` | `expect(...)`, "Expected:", snapshot/screenshot comparison — with no timing/network noise |
 | `environment` | Fails repeatedly on exactly one browser while others pass |
 | `other` | No clear signal |
+
+The classifier no longer reads keywords alone: it counts the requests that failed or returned 5xx across the test's recent failing attempts, and — the sharpest signal — weighs each recent flake whose failing attempt made a request that failed while the passing attempt did not (see the [attempt diff](./evidence#attempts)). Such a request recovering on retry is strong evidence the flakiness is a network problem, so it counts for several keyword matches.
 
 Filter the flaky table by category to triage a class of failures at once.
 


### PR DESCRIPTION
## What & why

When a test failed and then passed on retry, the single most valuable flaky-test signal — *what differed between the failing attempt and the passing one* — was never computed (audit §0 finding 7, §3.4, big bet **E**). Each attempt is already its own execution row with its own error, network, console, page state and ARIA, so the delta is computable from data Piwi already stores. This turns the flaky leaderboard from a ranking into an explanation, and feeds the root-cause classifier (which previously counted keywords over a dead `0`).

### The diff rules (`shared/attempt-diff.ts`)

`diffAttempts(failing, passing)` is a pure, partial-data-tolerant builder that never throws. It emits a structured, ordered list (`{ kind, summary, detail, only?, ref? }`), most-diagnostic first:

1. **error** — present on the failing attempt and gone on the pass
2. **network** — a request that failed (status ≥ 500 or 0) on only one attempt (keyed by method + path, query stripped)
3. **console** — an error/warning logged on only one attempt
4. **step** — a step that errored, or ran much slower, on one attempt
5. **duration** — an overall delta beyond a 1 s threshold
6. **page-state** — a different end URL, or storage/cookie keys held on only one attempt
7. **aria** — a landmark/heading-level structural node present on only one attempt (parsed from the ARIA YAML, never raw HTML)

Each row is labeled *only on the failing attempt* / *only on the passing attempt* / *changed* and cites the evidence section it came from. Unit-tested in `tests/unit/attempt-diff.test.ts` (500-that-recovered, console-only, timing-only, error-only-with-no-fixtures, ARIA, and no-op cases).

### The endpoint

`GET /api/test-run-cases/[id]/attempt-diff` (flat evidence route like `timeline`/`environment-diff`, same `x-required-roles`, mirrored in the demo router). It resolves the execution's sibling attempts (same run, test case, browser), pairs the failing attempt with the passing one — the failing attempt this id belongs to against the first later pass, or, when this id is the passing one, the last prior fail — loads both attempts' evidence through the same helpers the execution detail uses, and returns the diff plus a compact per-attempt summary. It unions the physical attempt rows with the `attempts` JSON, so it works both for real per-attempt-row runs (opened from either side) and for the demo/dev seed that collapses retries into the final row (where only a duration delta is recoverable). Returns `applicable: false` for a single attempt or no pair.

### The Attempts tab

Added to `EvidenceTabs` after Timeline, shown (not dimmed) only when a test has more than one attempt. It lazy-loads the endpoint on first open and shows a strip of every attempt (retry, status, duration, a "this one" marker) above the **what differed** list, whose citation chips switch to the matching evidence tab through the existing section-locator mechanism. A `case.attempts` help topic was added; the layout stays single-column and works at 375 px with no horizontal scroll.

### Classifier signals now made live

`shared/handlers/flaky-classify.ts` previously passed `networkErrorCount` and `status5xxCount` as `0`. Both are now counted from the network rows stored across the test's recent failing attempts, and a new **attempt-diff network vote** fires when a recent flake's failing attempt made a request that failed while the passing attempt did not — a strong `network` root-cause signal (weighted at several keyword matches). `classifyFlakyRootCause` stays pure; `ClassifyInput` gained one optional field, covered in `tests/unit/flaky-classify.test.ts`.

### Follow-ups

- The demo/dev seed stores only the final attempt row (retries collapsed), so the demo shows the attempt strip and a duration diff; the richer error/network/console diff appears on real reporter data, which stores a row per attempt. Seeding a separate failing-attempt row would let the demo showcase the full diff.

## How was it tested?

- `npm run app:typecheck`, `app:lint`, `app:format:check`, `app:check:demo` — all clean
- `npm run app:test:unit` — 1849 passed (new `attempt-diff` suite + extended `flaky-classify`)
- `npm run app:test -- tests/test-run-case-page.spec.ts tests/flaky-tests.spec.ts` — 14 passed
- Manual: opened a passed-on-retry execution (`/test-run-cases/21`), verified the Attempts tab, the attempt strip, the diff row, the citation chip switching to the Timeline tab, and no horizontal scroll at 390 px

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/evidence.md`, `apps/docs/flaky-tests.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017goo69cPFnCiKhbykf6uXE

---
_Generated by [Claude Code](https://claude.ai/code/session_017goo69cPFnCiKhbykf6uXE)_