### PR TITLE
feat(app): generate a local repro recipe and a git bisect for a failure

### DIFF
--- a/apps/application/app/components/shared/FixCard.vue
+++ b/apps/application/app/components/shared/FixCard.vue
@@ -8,7 +8,7 @@
  */
 import type { HelpTopicKey } from '~/utils/help-content';
 
-export type FixSectionKey = 'locator-fix' | 'fix-plan' | 'diagnosis' | 'verify' | 'blocked';
+export type FixSectionKey = 'locator-fix' | 'fix-plan' | 'diagnosis' | 'verify' | 'reproduce' | 'blocked';
 
 const props = defineProps<{
   /** Which sections have content; the card renders them in its canonical order. */
@@ -21,6 +21,7 @@ const LABELS: Record<FixSectionKey, string> = {
   'fix-plan': 'Fix plan',
   diagnosis: 'Diagnosis',
   verify: 'Verify',
+  reproduce: 'Reproduce',
   blocked: 'Blocked by this failure',
 };
 

--- a/apps/application/app/components/shared/PlatformCodeBlock.vue
+++ b/apps/application/app/components/shared/PlatformCodeBlock.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+/**
+ * A code block with a Linux/macOS ↔ Windows toggle, for commands shown to a
+ * user where the two shells can differ. Each form keeps its own copy button
+ * (the inner CodeBlock), so a reader copies exactly the platform they picked.
+ */
+const props = defineProps<{
+  bash: string;
+  powershell: string;
+  /** Remember the reader's pick across blocks on the page. */
+  storageKey?: string;
+}>();
+
+type Shell = 'bash' | 'powershell';
+const shell = ref<Shell>('bash');
+
+// A per-viewer convenience only; never fails the render when storage is blocked.
+onMounted(() => {
+  if (!props.storageKey) return;
+  try {
+    const saved = localStorage.getItem(props.storageKey);
+    if (saved === 'bash' || saved === 'powershell') shell.value = saved;
+  } catch {
+    // Ignore — private windows and blocked storage both leave the default.
+  }
+});
+
+function pick(next: Shell) {
+  shell.value = next;
+  if (!props.storageKey) return;
+  try {
+    localStorage.setItem(props.storageKey, next);
+  } catch {
+    // Ignore — the choice still applies for this view.
+  }
+}
+
+const code = computed(() => (shell.value === 'bash' ? props.bash : props.powershell));
+const lang = computed(() => (shell.value === 'bash' ? 'bash' : 'powershell'));
+</script>
+
+<template>
+  <div class="space-y-1.5">
+    <div class="flex items-center gap-1" role="tablist" aria-label="Shell">
+      <UButton
+        size="xs"
+        :color="shell === 'bash' ? 'primary' : 'neutral'"
+        :variant="shell === 'bash' ? 'subtle' : 'ghost'"
+        role="tab"
+        :aria-selected="shell === 'bash'"
+        @click="pick('bash')"
+      >
+        Linux / macOS
+      </UButton>
+      <UButton
+        size="xs"
+        :color="shell === 'powershell' ? 'primary' : 'neutral'"
+        :variant="shell === 'powershell' ? 'subtle' : 'ghost'"
+        role="tab"
+        :aria-selected="shell === 'powershell'"
+        @click="pick('powershell')"
+      >
+        Windows (PowerShell)
+      </UButton>
+    </div>
+    <CodeBlock :code="code" :lang="lang" />
+  </div>
+</template>

--- a/apps/application/app/components/shared/ReproduceSection.vue
+++ b/apps/application/app/components/shared/ReproduceSection.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+/**
+ * The Reproduce section of the Fix card: a copy-paste recipe that reproduces the
+ * failure locally (checkout, pinned install, browser, exact test command) and,
+ * when the regression window is known, a generated `git bisect` that finds the
+ * breaking commit. Both are shown in Linux/macOS and Windows forms; a missing
+ * bisect window degrades to a one-line muted note with the reason.
+ */
+import { reproScript, type ReproRecipe, type BisectResult } from '#shared/reproduce';
+
+const props = defineProps<{
+  reproduce: ReproRecipe;
+  bisect: BisectResult;
+}>();
+
+const recipeBash = computed(() => reproScript(props.reproduce, 'bash'));
+const recipePowershell = computed(() => reproScript(props.reproduce, 'powershell'));
+</script>
+
+<template>
+  <div class="space-y-3" data-shot="fix-reproduce-body">
+    <div class="space-y-1.5">
+      <p class="text-xs text-muted">
+        Reproduce the failure on your machine — check out the failing commit, install the run's Playwright version and
+        browser, then run exactly the failing test.
+      </p>
+      <PlatformCodeBlock :bash="recipeBash" :powershell="recipePowershell" storage-key="piwi-repro-shell" />
+      <div v-if="reproduce.env.length" class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
+        <span v-for="e in reproduce.env" :key="e.label">
+          <span class="font-medium">{{ e.label }}:</span> <span class="font-mono">{{ e.value }}</span>
+        </span>
+      </div>
+      <p v-for="note in reproduce.notes" :key="note" class="text-xs text-dimmed">{{ note }}</p>
+    </div>
+
+    <div class="space-y-1.5">
+      <div class="flex items-center gap-1.5">
+        <UIcon name="i-lucide-git-branch" class="size-3.5 shrink-0 text-muted" />
+        <h4 class="text-xs font-medium uppercase tracking-wide text-muted">Find the breaking commit</h4>
+      </div>
+      <template v-if="bisect.available">
+        <PlatformCodeBlock :bash="bisect.bash" :powershell="bisect.powershell" storage-key="piwi-repro-shell" />
+        <p class="text-xs text-muted">{{ bisect.explanation }}</p>
+      </template>
+      <p v-else class="text-xs text-dimmed">{{ bisect.reason }}</p>
+    </div>
+  </div>
+</template>

--- a/apps/application/app/demo/api/router.ts
+++ b/apps/application/app/demo/api/router.ts
@@ -98,6 +98,7 @@ import {
   getFailureTimeline,
   getFailureClues,
 } from '#shared/handlers/test-cases';
+import { buildExecutionReproduce } from '#shared/handlers/reproduce';
 import {
   getFailureCluster,
   getOpenFailureClusters,
@@ -966,6 +967,14 @@ const routes: RouteEntry[] = [
     handler: async (m, _b, _q, ctx) => {
       await assertDemoEntityScope(ctx, 'execution', +m[1]!);
       return getFailureClues(await getDemoDb(), +m[1]!);
+    },
+  },
+  {
+    method: 'GET',
+    pattern: /^\/api\/test-run-cases\/(\d+)\/reproduce$/,
+    handler: async (m, _b, _q, ctx) => {
+      await assertDemoEntityScope(ctx, 'execution', +m[1]!);
+      return buildExecutionReproduce(await getDemoDb(), +m[1]!);
     },
   },
   {

--- a/apps/application/app/pages/failure-clusters/[id].vue
+++ b/apps/application/app/pages/failure-clusters/[id].vue
@@ -239,10 +239,12 @@ function refresh() {
 // Diagnosis first, then the locator fix, the verify command and the fix plan.
 const hasLocatorPanel = computed(() => Boolean(affectedCases.value[0]?.recentTestRunsCaseId));
 const showVerify = computed(() => Boolean(fixPlan.value?.verify?.command));
+const showReproduce = computed(() => Boolean(fixPlan.value?.reproduce?.steps?.length));
 const fixSections = computed<FixSectionKey[]>(() => {
   const s: FixSectionKey[] = ['diagnosis'];
   if (hasLocatorPanel.value) s.push('locator-fix');
   if (showVerify.value) s.push('verify');
+  if (showReproduce.value) s.push('reproduce');
   if (fixPlan.value) s.push('fix-plan');
   return s;
 });
@@ -618,6 +620,14 @@ const breadcrumbItems = computed(() => [
                   </ClientOnly>
                 </div>
               </div>
+            </template>
+
+            <!-- Reproduce — the local recipe and a generated git bisect -->
+            <template v-if="showReproduce" #reproduce-label>
+              <span class="inline-flex items-center gap-1">Reproduce <HelpHint topic="fix.reproduce" /></span>
+            </template>
+            <template v-if="fixPlan && showReproduce" #reproduce>
+              <ReproduceSection :reproduce="fixPlan.reproduce" :bisect="fixPlan.bisect" />
             </template>
 
             <!-- Fix plan — the whole plan assembled for a ticket or an agent -->

--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -9,6 +9,7 @@ import { clusterSectionLocatorKey } from '~/composables/useClusterSectionLocator
 import { EVIDENCE_SECTION_TAB } from '~/utils/evidence-sections';
 import type { FixSectionKey } from '~/components/shared/FixCard.vue';
 import type { BlockedCaseRef } from '~~/types/api';
+import type { ReproRecipe, BisectResult } from '#shared/reproduce';
 
 const route = useRoute();
 const testCaseId = route.params.id;
@@ -111,6 +112,11 @@ const aiIntents = computed<AiStepIntent[] | null>(() => {
 /** Whether the desktop (Tauri) bridge is present — set on mount below. */
 const desktopBridge = ref(false);
 
+// The local reproduction recipe and generated bisect for this execution.
+const { data: reproduceData } = await useFetch<{ reproduce: ReproRecipe; bisect: BisectResult } | null>(
+  `/api/test-run-cases/${testCaseId}/reproduce`,
+);
+
 /** The cluster's stored diagnosis, only when it completed and has a summary. */
 const clusterDiagnosis = computed(() => {
   const d = failureCluster.value?.diagnosis;
@@ -179,6 +185,9 @@ async function triggerRerun() {
 /** The Verify section shows when a CI re-run is configured, or in the desktop shell. */
 const showVerify = computed(() => Boolean(rerunInfo.value?.available) || desktopBridge.value);
 
+/** Reproduce shows for a failing execution once its recipe is available. */
+const showReproduce = computed(() => Boolean(verdict.value) && Boolean(reproduceData.value?.reproduce?.steps?.length));
+
 /** The Fix card's sections, in the order the card renders them. */
 const fixSections = computed<FixSectionKey[]>(() => {
   const s: FixSectionKey[] = [];
@@ -186,6 +195,7 @@ const fixSections = computed<FixSectionKey[]>(() => {
   if (failureCluster.value) s.push('fix-plan');
   s.push('diagnosis');
   if (showVerify.value) s.push('verify');
+  if (showReproduce.value) s.push('reproduce');
   if (blockedTests.value.length) s.push('blocked');
   return s;
 });
@@ -824,6 +834,14 @@ provide(clusterSectionLocatorKey, {
                   </span>
                 </ClientOnly>
               </div>
+            </template>
+
+            <!-- Reproduce locally, then bisect the regression -->
+            <template v-if="showReproduce" #reproduce-label>
+              <span class="inline-flex items-center gap-1">Reproduce <HelpHint topic="fix.reproduce" /></span>
+            </template>
+            <template v-if="showReproduce" #reproduce>
+              <ReproduceSection :reproduce="reproduceData!.reproduce" :bisect="reproduceData!.bisect" />
             </template>
 
             <!-- The downstream tests this failure blocked from running -->

--- a/apps/application/app/utils/help-content.ts
+++ b/apps/application/app/utils/help-content.ts
@@ -273,6 +273,11 @@ export const HELP_TOPICS = {
     text: 'Everything to do about this failure in one place — the locator fix for a broken locator, a pointer to the cluster’s fix plan, the diagnosis, how to verify a fix, and the tests this failure blocked. Each part shows only when it applies.',
     doc: 'ai-diagnosis#fix-plans',
   },
+  'fix.reproduce': {
+    title: 'Reproduce',
+    text: 'A copy-paste recipe that reproduces the failure locally — check out the failing commit, install the run’s Playwright version and browser, and run exactly the failing test — plus a generated git bisect between the last green and the failing commit to find what broke it. Both come in Linux/macOS and Windows forms. The bisect needs a last-green commit and an SCM connection; without them it says so.',
+    doc: 'ai-diagnosis#reproduce-and-bisect',
+  },
   'case.test-source': {
     title: 'Test source',
     text: 'The source around the failing line and the callers above it — captured from the failure’s call stack — so you can read where it broke, and the code that led there, without opening your editor. When the execution has a trace, this deepens into the complete call stack with the real source of every frame, read from the trace’s embedded files.',

--- a/apps/application/server/api/test-run-cases/[id]/reproduce.get.ts
+++ b/apps/application/server/api/test-run-cases/[id]/reproduce.get.ts
@@ -1,0 +1,31 @@
+import { buildExecutionReproduce } from '#shared/handlers/reproduce';
+import {
+  requireResolvedProjectAccess,
+  requireRouteId,
+  resolveTestRunCaseProjectId,
+} from '../../../utils/project-access';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Run Cases'],
+    summary: 'A local reproduction recipe and a generated git bisect for an execution',
+    description:
+      "Turns this failure into a copy-paste way to reproduce it locally — check out the failing commit, install the run's Playwright version and browser, and run exactly this test — and, when the regression window is known, a generated `git bisect` between the last green commit and the failing one. Every command comes in a Linux/macOS and a Windows (PowerShell) form. The bisect degrades to `available: false` with a reason when there is no last-green commit or SCM metadata.",
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'integer' }, description: 'Test run case id' },
+    ],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'test run case ID');
+
+  // Authorize by the execution's own project — the id may be opened from a
+  // cluster page whose run belongs to another project.
+  const { db } = await requireResolvedProjectAccess(event, id, resolveTestRunCaseProjectId, 'Test run case');
+
+  const result = await buildExecutionReproduce(db, id);
+  if (!result) throw apiError({ statusCode: 404, message: 'Test run case not found' });
+  return result;
+});

--- a/apps/application/server/utils/fix-plan.ts
+++ b/apps/application/server/utils/fix-plan.ts
@@ -22,8 +22,10 @@ import { getLocatorHealingBatch } from './locator-healing';
 import { validatePatch, type PatchValidation } from '#shared/patch';
 import { parseCallsiteLocation } from '#shared/callsite-location';
 import { buildRetryCommand } from '#shared/retry-command';
+import { computeReproduceContext } from '#shared/handlers/reproduce';
 import type { FixPlan, FixPlanEdit } from '#shared/fix-plan.types';
 import type { DrizzleDB } from '#shared/handlers/db';
+import type { BrowserConfig } from '#shared/types';
 
 export type { FixPlan, FixPlanEdit } from '#shared/fix-plan.types';
 
@@ -51,6 +53,7 @@ export async function buildFixPlan(db: DrizzleDB, clusterId: number): Promise<Fi
       title: testCases.title,
       filePath: testCases.filePath,
       owner: testCases.owner,
+      browser: testRunsCases.browser,
     })
     .from(testRunsCases)
     .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
@@ -69,7 +72,12 @@ export async function buildFixPlan(db: DrizzleDB, clusterId: number): Promise<Fi
       filePath: row.filePath,
       executionId: row.executionId,
       owner: row.owner,
+      projectName: (row.browser as BrowserConfig | null)?.projectName ?? null,
     }));
+
+  // The browser binary the failures ran on — taken from the newest execution, so
+  // the reproduction installs the right one.
+  const reproBrowser = (caseRows[0]?.browser as BrowserConfig | null)?.browserName ?? null;
 
   const [diagnosisRow] = await db
     .select()
@@ -137,6 +145,23 @@ export async function buildFixPlan(db: DrizzleDB, clusterId: number): Promise<Fi
   );
   const titles = failingTests.slice(0, 5).map((test) => test.title);
   const grep = titles.length ? ` -g ${quote(titles.join('|'))}` : '';
+  const verifyCommand = `${fileCmd || 'npx playwright test'}${grep}`;
+
+  // Reproduce locally and bisect the regression window: the checkout of the
+  // failing commit, a pinned install, the browser and the exact test command,
+  // then a `git bisect` between the last green commit and this one. Computed from
+  // the same last-seen run the "What changed" panel reads, so it degrades in
+  // lockstep — no SCM metadata means no bisect, spelled out in the payload.
+  const { reproduce, bisect } = await computeReproduceContext(db, {
+    runId: cluster.lastSeenRunId,
+    cases: failingTests.map((test) => ({
+      filePath: test.filePath,
+      title: test.title,
+      projectName: test.projectName,
+    })),
+    browserName: reproBrowser,
+    verifyCommand,
+  });
 
   return {
     cluster: {
@@ -150,12 +175,14 @@ export async function buildFixPlan(db: DrizzleDB, clusterId: number): Promise<Fi
     },
     diagnosis,
     edits,
-    failingTests: failingTests.map(({ owner: _owner, ...rest }) => rest),
+    failingTests: failingTests.map(({ owner: _owner, projectName: _projectName, ...rest }) => rest),
     ownership: { owner: declaredOwner, source: declaredOwner ? 'annotation' : null },
     verify: {
-      command: `${fileCmd || 'npx playwright test'}${grep}`,
+      command: verifyCommand,
       expectation:
         'Re-run the affected tests, or the whole suite. When every test in this cluster passes in one run, full or filtered, Piwi records the fix — with the commit and how long the cluster was open — and the cluster stops being reported as open.',
     },
+    reproduce,
+    bisect,
   };
 }

--- a/apps/application/shared/fix-plan-markdown.ts
+++ b/apps/application/shared/fix-plan-markdown.ts
@@ -8,6 +8,7 @@
  * with no diagnosis still renders its failing tests and verification command.
  */
 import type { FixPlan } from '#shared/fix-plan.types';
+import { reproScript } from '#shared/reproduce';
 
 /** Fenced code block, guarding against a body that already ends in a newline. */
 function fence(body: string, lang = ''): string {
@@ -98,6 +99,22 @@ export function fixPlanToMarkdown(plan: FixPlan, opts: { url?: string } = {}): s
 
   // Verify
   lines.push('## Verify', '', fence(verify.command), '', verify.expectation, '');
+
+  // Reproduce locally — the commands are git/npm/npx, identical on every OS.
+  if (plan.reproduce.steps.length) {
+    lines.push('## Reproduce locally', '', fence(reproScript(plan.reproduce, 'bash'), 'bash'), '');
+    for (const e of plan.reproduce.env) lines.push(`- ${e.label}: ${e.value}`);
+    if (plan.reproduce.env.length) lines.push('');
+    for (const note of plan.reproduce.notes) lines.push(`> ${note}`);
+    if (plan.reproduce.notes.length) lines.push('');
+  }
+
+  // Bisect
+  if (plan.bisect.available) {
+    lines.push('## Bisect the regression', '', fence(plan.bisect.bash, 'bash'), '', plan.bisect.explanation, '');
+  } else {
+    lines.push('## Bisect the regression', '', plan.bisect.reason, '');
+  }
 
   if (opts.url) lines.push('---', '', `[Open this cluster in Piwi](${opts.url})`, '');
 

--- a/apps/application/shared/fix-plan.types.ts
+++ b/apps/application/shared/fix-plan.types.ts
@@ -8,6 +8,7 @@
  */
 import type { PatchValidation } from '#shared/patch';
 import type { LocatorEdit } from '#shared/locator-healing.types';
+import type { ReproRecipe, BisectResult } from '#shared/reproduce';
 
 export interface FixPlanEdit {
   filePath: string;
@@ -61,4 +62,8 @@ export interface FixPlan {
     /** What happens on the dashboard when it passes. */
     expectation: string;
   };
+  /** Copy-paste steps to reproduce the failure locally (checkout, install, run). */
+  reproduce: ReproRecipe;
+  /** A generated `git bisect` between the last green and the failing commit, or why it is unavailable. */
+  bisect: BisectResult;
 }

--- a/apps/application/shared/handlers/reproduce.ts
+++ b/apps/application/shared/handlers/reproduce.ts
@@ -10,9 +10,10 @@
  * plain reason, so a demo with no SCM metadata still renders the recipe.
  */
 import { and, desc, eq, lt } from 'drizzle-orm';
-import { testRuns } from '../../server/database/schema';
+import { testCases, testRuns, testRunsCases } from '../../server/database/schema';
 import { buildBisectScript, buildReproRecipe, type BisectResult, type ReproRecipe } from '#shared/reproduce';
-import type { RetryCase } from '#shared/retry-command';
+import { buildRetryCommand, type RetryCase } from '#shared/retry-command';
+import type { BrowserConfig } from '#shared/types';
 import type { DrizzleDB } from './db';
 
 export interface ReproduceContext {
@@ -75,6 +76,39 @@ export async function computeReproduceContext(db: DrizzleDB, input: ReproduceInp
   const bisect = buildBisectScript({ good: lastGreenCommit, bad: commit, verifyCommand: input.verifyCommand });
 
   return { reproduce, bisect };
+}
+
+/**
+ * The reproduction recipe and bisect for a single execution — the version the
+ * execution page's Fix card renders. Returns null when the execution is gone.
+ */
+export async function buildExecutionReproduce(db: DrizzleDB, executionId: number): Promise<ReproduceContext | null> {
+  const [row] = await db
+    .select({
+      testRunId: testRunsCases.testRunId,
+      line: testRunsCases.line,
+      browser: testRunsCases.browser,
+      title: testCases.title,
+      filePath: testCases.filePath,
+    })
+    .from(testRunsCases)
+    .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
+    .where(eq(testRunsCases.id, executionId));
+
+  if (!row) return null;
+
+  const browser = row.browser as BrowserConfig | null;
+  const cases: RetryCase[] = [
+    { filePath: row.filePath, title: row.title, line: row.line, projectName: browser?.projectName ?? null },
+  ];
+  const verifyCommand = buildRetryCommand(cases, { mode: 'file-line' }) || 'npx playwright test';
+
+  return computeReproduceContext(db, {
+    runId: row.testRunId,
+    cases,
+    browserName: browser?.browserName ?? null,
+    verifyCommand,
+  });
 }
 
 /**

--- a/apps/application/shared/handlers/reproduce.ts
+++ b/apps/application/shared/handlers/reproduce.ts
@@ -1,0 +1,109 @@
+/**
+ * Gather what a reproduction needs from a run and its history, then hand it to
+ * the pure generators in `#shared/reproduce`. Lives in `shared/handlers` so the
+ * server (the fix plan, the execution endpoint) and the demo mirror compute it
+ * the same way — the generators stay pure and testable, this does the reads.
+ *
+ * The bisect window's `good` end is the last green run before this one on the
+ * same branch (falling back to any branch), and its `bad` end is the failing
+ * run's own commit. When either commit is missing the bisect degrades to a
+ * plain reason, so a demo with no SCM metadata still renders the recipe.
+ */
+import { and, desc, eq, lt } from 'drizzle-orm';
+import { testRuns } from '../../server/database/schema';
+import { buildBisectScript, buildReproRecipe, type BisectResult, type ReproRecipe } from '#shared/reproduce';
+import type { RetryCase } from '#shared/retry-command';
+import type { DrizzleDB } from './db';
+
+export interface ReproduceContext {
+  reproduce: ReproRecipe;
+  bisect: BisectResult;
+}
+
+export interface ReproduceInput {
+  /** The run whose commit, Playwright version and environment describe the failure. */
+  runId: number;
+  /** The failing tests, for the exact `playwright test` invocation. */
+  cases: RetryCase[];
+  /** Browser binary to install (`chromium` / `firefox` / `webkit`). */
+  browserName: string | null;
+  /** The command that verifies a fix — the `bad`/`good` probe for the bisect. */
+  verifyCommand: string;
+  /** Base URL the run targeted, when known. */
+  baseUrl?: string | null;
+}
+
+/** Minimal view of the metadata JSON this reader needs. */
+type RunScm = { scm?: { commit?: string | null } | null } | null;
+
+/**
+ * Compute the reproduction recipe and the bisect for one run. Always returns a
+ * recipe; the bisect is `available: false` when the window cannot be built.
+ */
+export async function computeReproduceContext(db: DrizzleDB, input: ReproduceInput): Promise<ReproduceContext> {
+  const [run] = await db
+    .select({
+      projectId: testRuns.projectId,
+      startTime: testRuns.startTime,
+      branch: testRuns.branch,
+      environment: testRuns.environment,
+      metadata: testRuns.metadata,
+      playwrightVersion: testRuns.playwrightVersion,
+    })
+    .from(testRuns)
+    .where(eq(testRuns.id, input.runId));
+
+  const commit = (run?.metadata as RunScm)?.scm?.commit ?? null;
+
+  let lastGreenCommit: string | null = null;
+  if (run) {
+    lastGreenCommit = await lastGreenCommitBefore(db, run.projectId, run.startTime, run.branch);
+  }
+
+  const projectName = input.cases.find((c) => c.projectName)?.projectName ?? null;
+
+  const reproduce = buildReproRecipe({
+    commit,
+    playwrightVersion: run?.playwrightVersion ?? null,
+    browserName: input.browserName,
+    projectName,
+    environment: run?.environment ?? null,
+    baseUrl: input.baseUrl ?? null,
+    cases: input.cases,
+  });
+
+  const bisect = buildBisectScript({ good: lastGreenCommit, bad: commit, verifyCommand: input.verifyCommand });
+
+  return { reproduce, bisect };
+}
+
+/**
+ * The commit of the last green run before `before`, preferring the same branch
+ * (a fresh branch's history) and falling back to any branch when it has none.
+ */
+async function lastGreenCommitBefore(
+  db: DrizzleDB,
+  projectId: number,
+  before: Date,
+  branch: string | null,
+): Promise<string | null> {
+  const pick = async (branchFilter: boolean): Promise<string | null> => {
+    const conditions = [
+      eq(testRuns.projectId, projectId),
+      eq(testRuns.status, 'passed'),
+      lt(testRuns.startTime, before),
+    ];
+    if (branchFilter && branch) conditions.push(eq(testRuns.branch, branch));
+    const [green] = await db
+      .select({ metadata: testRuns.metadata })
+      .from(testRuns)
+      .where(and(...conditions))
+      .orderBy(desc(testRuns.startTime))
+      .limit(1);
+    return (green?.metadata as RunScm)?.scm?.commit ?? null;
+  };
+
+  const sameBranch = await pick(true);
+  if (sameBranch) return sameBranch;
+  return branch ? pick(false) : null;
+}

--- a/apps/application/shared/highlight.ts
+++ b/apps/application/shared/highlight.ts
@@ -12,12 +12,13 @@ import css from 'highlight.js/lib/languages/css';
 import diff from 'highlight.js/lib/languages/diff';
 import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
+import powershell from 'highlight.js/lib/languages/powershell';
 import python from 'highlight.js/lib/languages/python';
 import typescript from 'highlight.js/lib/languages/typescript';
 import xml from 'highlight.js/lib/languages/xml';
 import yaml from 'highlight.js/lib/languages/yaml';
 
-const LANGUAGES = { bash, css, diff, javascript, json, python, typescript, xml, yaml } as const;
+const LANGUAGES = { bash, css, diff, javascript, json, powershell, python, typescript, xml, yaml } as const;
 
 for (const [name, language] of Object.entries(LANGUAGES)) {
   if (!hljs.getLanguage(name)) hljs.registerLanguage(name, language);
@@ -28,6 +29,7 @@ if (!hljs.getLanguage('ts')) hljs.registerLanguage('ts', typescript);
 if (!hljs.getLanguage('js')) hljs.registerLanguage('js', javascript);
 if (!hljs.getLanguage('yml')) hljs.registerLanguage('yml', yaml);
 if (!hljs.getLanguage('html')) hljs.registerLanguage('html', xml);
+if (!hljs.getLanguage('pwsh')) hljs.registerLanguage('pwsh', powershell);
 
 /**
  * Auto-detection walks every registered grammar, which is far too slow for a

--- a/apps/application/shared/mcp-tools.ts
+++ b/apps/application/shared/mcp-tools.ts
@@ -171,7 +171,7 @@ export const MCP_TOOL_DEFS = [
   {
     name: 'get_fix_plan',
     description:
-      'Everything needed to fix one failure cluster, in a single answer: the diagnosis and its validated patch, ranked locator replacements each with the exact file and line and a ready-to-apply `edit` (the rewritten line plus a unified diff `git apply` accepts), the failing tests, the owning team, and the command that verifies the work. `verify.expectation` states what the dashboard records once those tests pass, so you can confirm the fix landed rather than guessing. Prefer this over assembling get_cluster + get_cluster_diagnosis + get_locator_healing yourself.',
+      'Everything needed to fix one failure cluster, in a single answer: the diagnosis and its validated patch, ranked locator replacements each with the exact file and line and a ready-to-apply `edit` (the rewritten line plus a unified diff `git apply` accepts), the failing tests, the owning team, the command that verifies the work, a `reproduce` recipe (checkout, pinned install, browser install and the exact test command as `{ bash, powershell }` steps), and a `bisect` script (`git bisect` between the last green and the failing commit, or `available: false` with a reason). `verify.expectation` states what the dashboard records once those tests pass, so you can confirm the fix landed rather than guessing. Prefer this over assembling get_cluster + get_cluster_diagnosis + get_locator_healing yourself.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/apps/application/shared/reproduce.ts
+++ b/apps/application/shared/reproduce.ts
@@ -1,0 +1,207 @@
+/**
+ * Turn a failure into a copy-paste way to reproduce it locally, and a ready-made
+ * `git bisect` that finds the commit that broke it.
+ *
+ * Two pure generators, no I/O: the server gathers the run's commit, Playwright
+ * version, browser and the last-green commit and hands them here, so the same
+ * recipe renders on the cluster page, the execution page, the Markdown export
+ * and the `get_fix_plan` MCP tool without any of them re-deriving it.
+ *
+ * Every command is cross-platform. git, npm and npx behave the same on every
+ * OS, so the bash and PowerShell forms of a step are usually identical; the
+ * pair is always returned so a caller can offer both without special-casing.
+ * Each part degrades on its own: no commit skips the checkout and says so, an
+ * unknown Playwright version drops the pin, and a missing bisect window returns
+ * a plain reason instead of a script.
+ */
+import { buildRetryCommand, type RetryCase } from '#shared/retry-command';
+
+/** One numbered line of the local reproduction, in both shell dialects. */
+export interface ReproStep {
+  /** Human label for the step ("Check out the failing commit"). */
+  step: string;
+  /** The command on Linux / macOS. */
+  bash: string;
+  /** The command on Windows (PowerShell). */
+  powershell: string;
+}
+
+/** A fact the reproduction needs but cannot express as a command. */
+export interface ReproEnv {
+  label: string;
+  value: string;
+}
+
+export interface ReproRecipe {
+  /** The reproduction, in order: checkout, install, browser install, run. */
+  steps: ReproStep[];
+  /** Environment the run declared (environment label, base URL) — informational. */
+  env: ReproEnv[];
+  /** What could not be pinned, one plain sentence each. */
+  notes: string[];
+  /** The failing commit, when the run recorded one. */
+  commit: string | null;
+  /** The run's Playwright version, when recorded. */
+  playwrightVersion: string | null;
+  /** The browser binary to install (`chromium` / `firefox` / `webkit`). */
+  browser: string | null;
+  /** The Playwright project the failing tests ran under, when one was recorded. */
+  project: string | null;
+}
+
+export interface ReproInput {
+  /** SHA of the commit the failing run was on. Null skips the checkout step. */
+  commit: string | null;
+  /** Playwright version the run reported. Null drops the version pin. */
+  playwrightVersion: string | null;
+  /** Browser binary (`chromium` / `firefox` / `webkit`) to install. */
+  browserName: string | null;
+  /** Playwright project the failing tests ran under. */
+  projectName: string | null;
+  /** Environment label the run declared. */
+  environment: string | null;
+  /** Base URL the run targeted, when known. */
+  baseUrl: string | null;
+  /** The failing tests, for the exact `playwright test` invocation. */
+  cases: RetryCase[];
+}
+
+export type BisectResult =
+  | { available: false; reason: string }
+  | {
+      available: true;
+      /** Last green commit — the `good` end of the window. */
+      good: string;
+      /** Failing commit — the `bad` end of the window. */
+      bad: string;
+      goodShort: string;
+      badShort: string;
+      /** The whole `git bisect` on Linux / macOS. */
+      bash: string;
+      /** The whole `git bisect` on Windows (PowerShell). */
+      powershell: string;
+      /** One line saying what the script does. */
+      explanation: string;
+    };
+
+export interface BisectInput {
+  /** Last green commit (the regression window's `fromSha`). */
+  good: string | null;
+  /** Failing commit (the regression window's `toSha`). */
+  bad: string | null;
+  /** The command that proves a commit good (exit 0) or bad (non-zero). */
+  verifyCommand: string;
+}
+
+/**
+ * Build the local reproduction recipe. Always returns a recipe; the parts that
+ * cannot be pinned drop out with a note rather than failing.
+ */
+export function buildReproRecipe(input: ReproInput): ReproRecipe {
+  const steps: ReproStep[] = [];
+  const notes: string[] = [];
+
+  // 1. Check out the exact commit the run failed on. git is portable, so both
+  //    shell forms are the same command.
+  if (input.commit) {
+    const checkout = `git switch --detach ${input.commit}`;
+    steps.push({ step: 'Check out the failing commit', bash: checkout, powershell: checkout });
+  } else {
+    notes.push(
+      'No commit was recorded for this run, so the checkout step is skipped — reproduce against your current tree.',
+    );
+  }
+
+  // 2. Install the project's dependencies from the lockfile at that commit.
+  steps.push({ step: 'Install dependencies', bash: 'npm ci', powershell: 'npm ci' });
+
+  // 3. Pin Playwright to the version the run used, so the browsers and the
+  //    runner match. Without a recorded version the project's own pin is used.
+  if (input.playwrightVersion) {
+    const pin = `npm install -D @playwright/test@${input.playwrightVersion}`;
+    steps.push({ step: "Pin Playwright to the run's version", bash: pin, powershell: pin });
+  } else {
+    notes.push("The run's Playwright version was not recorded, so the version your project resolves is used.");
+  }
+
+  // 4. Install the browser the failure ran on (all browsers when unknown).
+  const install = input.browserName ? `npx playwright install ${input.browserName}` : 'npx playwright install';
+  steps.push({ step: 'Install the browser', bash: install, powershell: install });
+
+  // 5. Run exactly the failing test(s) — file:line specs, scoped to the project.
+  const testCmd = buildRetryCommand(input.cases, { mode: 'file-line' }) || 'npx playwright test';
+  steps.push({ step: 'Run the failing test', bash: testCmd, powershell: testCmd });
+
+  const env: ReproEnv[] = [];
+  if (input.environment) env.push({ label: 'Environment', value: input.environment });
+  if (input.baseUrl) env.push({ label: 'Base URL', value: input.baseUrl });
+
+  return {
+    steps,
+    env,
+    notes,
+    commit: input.commit,
+    playwrightVersion: input.playwrightVersion,
+    browser: input.browserName,
+    project: input.projectName,
+  };
+}
+
+/** Comment prefix — `#` starts a comment in both bash and PowerShell. */
+const COMMENT = '#';
+
+/**
+ * Assemble a recipe into one copy-paste script for the given shell: each step
+ * as a `# label` comment followed by its command.
+ */
+export function reproScript(recipe: ReproRecipe, shell: 'bash' | 'powershell'): string {
+  const lines: string[] = [];
+  for (const s of recipe.steps) {
+    lines.push(`${COMMENT} ${s.step}`);
+    lines.push(shell === 'bash' ? s.bash : s.powershell);
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * Build the `git bisect` that finds the breaking commit between the last green
+ * commit and the failing one, or explain why the window is missing.
+ */
+export function buildBisectScript(input: BisectInput): BisectResult {
+  const { good, bad, verifyCommand } = input;
+
+  if (!good || !bad) {
+    return {
+      available: false,
+      reason:
+        'A git bisect needs a last-green commit and the failing commit. Piwi has no commit for one of them — connect an SCM provider and make sure your runs record their commit.',
+    };
+  }
+  if (good === bad) {
+    return {
+      available: false,
+      reason: 'The last green run and the failing run are the same commit — there is nothing to bisect.',
+    };
+  }
+
+  const command = verifyCommand.trim() || 'npx playwright test';
+  const goodShort = good.slice(0, 7);
+  const badShort = bad.slice(0, 7);
+
+  // git and npx are portable, so the two forms are the same commands. `git
+  // bisect run` re-runs the command at each step: exit 0 marks the commit good,
+  // any non-zero marks it bad — exactly what a failing `playwright test` does.
+  const script = [`git bisect start ${bad} ${good}`, `git bisect run ${command}`, 'git bisect reset'].join('\n');
+
+  return {
+    available: true,
+    good,
+    bad,
+    goodShort,
+    badShort,
+    bash: script,
+    powershell: script,
+    explanation: `Walks the commits between the last green (${goodShort}) and the failing commit (${badShort}), re-running the test at each step until it names the first commit that broke it — a non-zero exit marks a commit bad. \`git bisect reset\` returns you to where you started.`,
+  };
+}

--- a/apps/application/shared/reproduce.ts
+++ b/apps/application/shared/reproduce.ts
@@ -129,7 +129,16 @@ export function buildReproRecipe(input: ReproInput): ReproRecipe {
   steps.push({ step: 'Install the browser', bash: install, powershell: install });
 
   // 5. Run exactly the failing test(s) — file:line specs, scoped to the project.
-  const testCmd = buildRetryCommand(input.cases, { mode: 'file-line' }) || 'npx playwright test';
+  //    Dedupe first: cluster cases carry no line, so several tests in one file
+  //    would otherwise repeat the same spec path.
+  const seenSpec = new Set<string>();
+  const uniqueCases = input.cases.filter((c) => {
+    const key = `${c.filePath}:${c.line ?? ''}:${c.projectName ?? ''}`;
+    if (seenSpec.has(key)) return false;
+    seenSpec.add(key);
+    return true;
+  });
+  const testCmd = buildRetryCommand(uniqueCases, { mode: 'file-line' }) || 'npx playwright test';
   steps.push({ step: 'Run the failing test', bash: testCmd, powershell: testCmd });
 
   const env: ReproEnv[] = [];

--- a/apps/application/tests/unit/fix-plan-markdown.test.ts
+++ b/apps/application/tests/unit/fix-plan-markdown.test.ts
@@ -21,6 +21,36 @@ function makePlan(overrides: Partial<FixPlan> = {}): FixPlan {
       command: 'npx playwright test tests/checkout.spec.ts',
       expectation: 'When these pass, Piwi records the fix.',
     },
+    reproduce: {
+      steps: [
+        {
+          step: 'Check out the failing commit',
+          bash: 'git switch --detach abc123',
+          powershell: 'git switch --detach abc123',
+        },
+        {
+          step: 'Run the failing test',
+          bash: 'npx playwright test tests/checkout.spec.ts',
+          powershell: 'npx playwright test tests/checkout.spec.ts',
+        },
+      ],
+      env: [{ label: 'Environment', value: 'production' }],
+      notes: [],
+      commit: 'abc123',
+      playwrightVersion: '1.50.1',
+      browser: 'chromium',
+      project: 'chromium',
+    },
+    bisect: {
+      available: true,
+      good: 'green01',
+      bad: 'abc123',
+      goodShort: 'green01',
+      badShort: 'abc123',
+      bash: 'git bisect start abc123 green01\ngit bisect run npx playwright test\ngit bisect reset',
+      powershell: 'git bisect start abc123 green01\ngit bisect run npx playwright test\ngit bisect reset',
+      explanation: 'Walks the commits between green01 and abc123.',
+    },
     ...overrides,
   };
 }
@@ -37,6 +67,24 @@ describe('fixPlanToMarkdown', () => {
     expect(md).not.toContain('## Diagnosis');
     expect(md).not.toContain('## Suggested locator edits');
     expect(md).not.toContain('## Owner');
+  });
+
+  it('renders the reproduce recipe and the bisect', () => {
+    const md = fixPlanToMarkdown(makePlan());
+    expect(md).toContain('## Reproduce locally');
+    expect(md).toContain('# Check out the failing commit');
+    expect(md).toContain('git switch --detach abc123');
+    expect(md).toContain('Environment: production');
+    expect(md).toContain('## Bisect the regression');
+    expect(md).toContain('git bisect start abc123 green01');
+  });
+
+  it('renders the bisect reason when the window is unavailable', () => {
+    const md = fixPlanToMarkdown(
+      makePlan({ bisect: { available: false, reason: 'A git bisect needs a last-green commit.' } }),
+    );
+    expect(md).toContain('## Bisect the regression');
+    expect(md).toContain('A git bisect needs a last-green commit.');
   });
 
   it('renders the diagnosis, its patch validation and the patch fence', () => {

--- a/apps/application/tests/unit/reproduce.test.ts
+++ b/apps/application/tests/unit/reproduce.test.ts
@@ -69,6 +69,18 @@ test('recipe — no cases falls back to plain playwright test', () => {
   expect(run!.bash).toBe('npx playwright test');
 });
 
+test('recipe — dedupes repeated specs so a shared file appears once', () => {
+  const recipe = buildReproRecipe({
+    ...baseInput,
+    cases: [
+      { filePath: 'tests/auth.spec.ts', title: 'a', line: null, projectName: 'API' },
+      { filePath: 'tests/auth.spec.ts', title: 'b', line: null, projectName: 'API' },
+    ],
+  });
+  const run = recipe.steps.find((s) => s.step === 'Run the failing test')!;
+  expect(run.bash.match(/tests\/auth\.spec\.ts/g)).toHaveLength(1);
+});
+
 test('reproScript — assembles a copy-paste block with step comments', () => {
   const recipe = buildReproRecipe(baseInput);
   const bash = reproScript(recipe, 'bash');

--- a/apps/application/tests/unit/reproduce.test.ts
+++ b/apps/application/tests/unit/reproduce.test.ts
@@ -1,0 +1,117 @@
+import { test, expect } from 'vitest';
+import { buildReproRecipe, buildBisectScript, reproScript, type ReproInput } from '#shared/reproduce';
+
+const baseInput: ReproInput = {
+  commit: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+  playwrightVersion: '1.50.1',
+  browserName: 'chromium',
+  projectName: 'chromium',
+  environment: 'production',
+  baseUrl: 'https://app.example.com',
+  cases: [{ filePath: 'tests/login.spec.ts', title: 'should login', line: 10, projectName: 'chromium' }],
+};
+
+test('recipe — full checkout, pinned install, browser install and test command in order', () => {
+  const recipe = buildReproRecipe(baseInput);
+  const labels = recipe.steps.map((s) => s.step);
+  expect(labels).toEqual([
+    'Check out the failing commit',
+    'Install dependencies',
+    "Pin Playwright to the run's version",
+    'Install the browser',
+    'Run the failing test',
+  ]);
+  expect(recipe.steps[0]!.bash).toBe(`git switch --detach ${baseInput.commit}`);
+  expect(recipe.steps[2]!.bash).toBe('npm install -D @playwright/test@1.50.1');
+  expect(recipe.steps[3]!.bash).toBe('npx playwright install chromium');
+  expect(recipe.steps[4]!.bash).toContain('tests/login.spec.ts:10');
+  expect(recipe.steps[4]!.bash).toContain('--project="chromium"');
+  expect(recipe.notes).toEqual([]);
+});
+
+test('recipe — every step returns both shell forms', () => {
+  const recipe = buildReproRecipe(baseInput);
+  for (const step of recipe.steps) {
+    expect(step.bash.length).toBeGreaterThan(0);
+    expect(step.powershell.length).toBeGreaterThan(0);
+  }
+});
+
+test('recipe — environment and base URL surface as env facts', () => {
+  const recipe = buildReproRecipe(baseInput);
+  expect(recipe.env).toEqual([
+    { label: 'Environment', value: 'production' },
+    { label: 'Base URL', value: 'https://app.example.com' },
+  ]);
+});
+
+test('recipe — no commit skips the checkout and says so', () => {
+  const recipe = buildReproRecipe({ ...baseInput, commit: null });
+  expect(recipe.steps.map((s) => s.step)).not.toContain('Check out the failing commit');
+  expect(recipe.notes.join(' ')).toContain('No commit');
+});
+
+test('recipe — unknown Playwright version drops the pin', () => {
+  const recipe = buildReproRecipe({ ...baseInput, playwrightVersion: null });
+  expect(recipe.steps.map((s) => s.step)).not.toContain("Pin Playwright to the run's version");
+  expect(recipe.notes.join(' ')).toContain('Playwright version');
+});
+
+test('recipe — unknown browser installs all', () => {
+  const recipe = buildReproRecipe({ ...baseInput, browserName: null });
+  const install = recipe.steps.find((s) => s.step === 'Install the browser');
+  expect(install!.bash).toBe('npx playwright install');
+});
+
+test('recipe — no cases falls back to plain playwright test', () => {
+  const recipe = buildReproRecipe({ ...baseInput, cases: [] });
+  const run = recipe.steps.find((s) => s.step === 'Run the failing test');
+  expect(run!.bash).toBe('npx playwright test');
+});
+
+test('reproScript — assembles a copy-paste block with step comments', () => {
+  const recipe = buildReproRecipe(baseInput);
+  const bash = reproScript(recipe, 'bash');
+  expect(bash).toContain('# Check out the failing commit');
+  expect(bash).toContain(`git switch --detach ${baseInput.commit}`);
+  expect(bash).toContain('# Run the failing test');
+  // No trailing blank line.
+  expect(bash.endsWith('\n')).toBe(false);
+});
+
+test('bisect — window present yields start / run / reset', () => {
+  const result = buildBisectScript({
+    good: 'aaaaaaa000',
+    bad: 'bbbbbbb111',
+    verifyCommand: 'npx playwright test x.spec.ts',
+  });
+  expect(result.available).toBe(true);
+  if (!result.available) throw new Error('expected available');
+  expect(result.bash).toContain('git bisect start bbbbbbb111 aaaaaaa000');
+  expect(result.bash).toContain('git bisect run npx playwright test x.spec.ts');
+  expect(result.bash).toContain('git bisect reset');
+  expect(result.goodShort).toBe('aaaaaaa');
+  expect(result.badShort).toBe('bbbbbbb');
+  expect(result.explanation.length).toBeGreaterThan(0);
+});
+
+test('bisect — missing last-green commit degrades with a reason', () => {
+  const result = buildBisectScript({ good: null, bad: 'bbbbbbb111', verifyCommand: 'npx playwright test' });
+  expect(result.available).toBe(false);
+  if (result.available) throw new Error('expected unavailable');
+  expect(result.reason).toContain('last-green commit');
+});
+
+test('bisect — same commit on both ends has nothing to bisect', () => {
+  const result = buildBisectScript({ good: 'same123', bad: 'same123', verifyCommand: 'npx playwright test' });
+  expect(result.available).toBe(false);
+  if (result.available) throw new Error('expected unavailable');
+  expect(result.reason).toContain('nothing to bisect');
+});
+
+test('bisect — empty verify command falls back to playwright test', () => {
+  const result = buildBisectScript({ good: 'aaa', bad: 'bbb', verifyCommand: '' });
+  expect(result.available).toBe(true);
+  if (!result.available) throw new Error('expected available');
+  expect(result.bash).toContain('git bisect run npx playwright test');
+});

--- a/apps/docs/ai-diagnosis.md
+++ b/apps/docs/ai-diagnosis.md
@@ -286,6 +286,47 @@ suggestions and its verification command, so the plan is useful without an AI pr
 Worth stating plainly: none of this leaves your machine. The dashboard is yours, the model is whichever one you
 configured (including a local one), and the patch was validated against your own source before you saw it.
 
+### Reproduce and bisect
+
+The fix plan also hands back the two things you do next: a copy-paste recipe that reproduces the failure locally, and a
+generated `git bisect` that finds the commit that broke it. Both sit in a **Reproduce** section on the Fix card — on the
+cluster page and on the failing execution's page — and travel with the plan through `?format=markdown` and the
+`get_fix_plan` MCP tool.
+
+The **recipe** is the local reproduction, in order: check out the commit the run failed on (`git switch --detach <sha>`),
+install dependencies, pin Playwright to the version the run used, install the browser it ran on, and run exactly the
+failing test. Each part degrades on its own — no recorded commit skips the checkout and says so, an unknown Playwright
+version drops the pin — and the run's environment (label, base URL) is listed beside it. Every command is `git`, `npm` or
+`npx`, so it is identical on Linux, macOS and Windows; the dashboard still offers a **Linux / macOS** and a
+**Windows (PowerShell)** tab so a reader copies the form they expect.
+
+```bash
+# Check out the failing commit
+git switch --detach 9a8b7c6d5e4f30211203f4e5d6c7b8a99a8b7c6d
+# Install dependencies
+npm ci
+# Pin Playwright to the run's version
+npm install -D @playwright/test@1.52.0
+# Install the browser
+npx playwright install chromium
+# Run the failing test
+npx playwright test "tests/admin/users.spec.ts" --project="Chromium"
+```
+
+The **bisect** walks the commits between the last green run and the failing one, re-running the test at each step — a
+non-zero exit marks a commit bad — until it names the first commit that broke it, then `git bisect reset` returns you to
+where you started.
+
+```bash
+git bisect start <failing-commit> <last-green-commit>
+git bisect run npx playwright test "tests/admin/users.spec.ts" -g "Users table paginates 25 rows per page"
+git bisect reset
+```
+
+The bisect needs a **last-green commit** and an **SCM connection**: when Piwi has no commit for the failing run or for the
+last green run before it, or the two are the same commit, the section says so in one line instead of showing a script.
+The recipe is always there.
+
 ## Diagnosis history
 
 Every re-diagnose snapshots the previous result before overwriting it, so a cluster keeps up to 50 prior versions. The

--- a/apps/docs/mcp.md
+++ b/apps/docs/mcp.md
@@ -70,7 +70,7 @@ The server exposes 45 tools — mostly read-only, plus a few write/triage tools 
 | `list_clusters` | Failure clusters grouped by error fingerprint |
 | `list_open_clusters` | Open clusters across *all* projects, ranked by occurrences — a triage queue |
 | `get_cluster` | Cluster detail with affected tests and diagnosis summary |
-| `get_fix_plan` | **One-call fix plan** for a cluster: diagnosis with its validated patch, ranked locator replacements with the file and line to edit, failing tests, owning team, and the command that verifies the fix |
+| `get_fix_plan` | **One-call fix plan** for a cluster: diagnosis with its validated patch, ranked locator replacements with the file and line to edit, failing tests, owning team, the command that verifies the fix, a `reproduce` recipe (checkout, pinned install and the exact test command, in bash and PowerShell), and a generated `bisect` script between the last green and the failing commit |
 | `get_cluster_diagnosis` | Full AI diagnosis: root cause, evidence, suggested fix |
 | `get_cluster_context` | Full AI evidence context (errors, steps, console logs, SCM diff) — the same data the built-in diagnosis AI receives |
 


### PR DESCRIPTION
## What & why

Big bet **F** of the failing-run data audit: turn a failure into a copy-paste way to reproduce it locally, and a ready-made `git bisect` that finds the commit that broke it. Piwi already knows the failing test, the commit, the browser/project, the Playwright version and the last green commit — this hands those back as commands instead of leaving the developer to assemble them.

**The recipe** (`buildReproRecipe`) is the local reproduction, in order:
1. Check out the failing commit — `git switch --detach <sha>`
2. Install dependencies — `npm ci`
3. Pin Playwright to the run's version — `npm install -D @playwright/test@<version>`
4. Install the browser the failure ran on — `npx playwright install <browser>`
5. Run exactly the failing test — reuses `buildRetryCommand` in `file-line` mode

Each part degrades on its own: no recorded commit skips the checkout and says so; an unknown Playwright version drops the pin. The run's environment (label, base URL) is listed beside it.

**The bisect** (`buildBisectScript`) walks the commits between the last green commit and the failing one — `git bisect start <bad> <good>`, `git bisect run <verify command>` (a non-zero exit marks a commit bad), then `git bisect reset`.

**The bisect window source and its degradation.** The window is computed from the same run the cluster's "What changed" reads: `bad` is the failing run's own commit, `good` is the last green run before it on the same branch (falling back to any branch). When either commit is missing, or the two are the same, the bisect returns `{ available: false, reason }` — a one-line muted note in the UI instead of a script. The recipe is always shown.

**Cross-platform forms.** Every command is `git`, `npm` or `npx`, so the Linux/macOS and Windows (PowerShell) forms are identical; the dashboard still offers both tabs (a new `PlatformCodeBlock`) so a reader copies the form they expect.

**Where it surfaces.**
- A new **Reproduce** section on the Fix card (after Verify), on both the cluster page and the failing execution's page, kept in the single-column layout — no new page, no modal.
- The cluster reads it from the extended fix plan (`reproduce` + `bisect` on `FixPlan`), which flows to the fix-plan endpoint, its `?format=markdown` export, the Markdown renderer and the `get_fix_plan` MCP tool for free.
- The execution page reads a new `GET /api/test-run-cases/:id/reproduce` endpoint, mirrored in the demo router.
- A `fix.reproduce` help topic and a "Reproduce and bisect" docs subsection.

## How was it tested?

- **Unit**: `tests/unit/reproduce.test.ts` (recipe ordering, both shell forms, every degradation, spec dedupe, bisect window/degradation) and updated `fix-plan-markdown.test.ts`. Full unit suite: 1856 passed.
- **E2E**: `tests/failure-clusters.spec.ts` + `tests/test-run-case-page.spec.ts` — 31 passed.
- `app:typecheck`, `app:lint`, `app:format:check`, `app:check:demo` all clean.
- **Screens**: looked at `/failure-clusters/10` and `/test-run-cases/37?tab=diagnosis` — the recipe shows both command tabs and an available bisect; a run with no green commit shows the degraded one-line bisect note with the recipe intact.

## Follow-up

The bisect uses a plain same-branch last-green baseline (demo-safe, one code path across server/demo/MCP) rather than the branch-aware SCM resolution the cluster's "What changed" panel owns; refining it to that selection is a possible follow-up.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01579igCJQiVvzLJMdfGj8ij

---
_Generated by [Claude Code](https://claude.ai/code/session_01579igCJQiVvzLJMdfGj8ij)_