### PR TITLE
fix(ui): fit the steps table and card actions on phone widths

### DIFF
--- a/apps/application/app/components/shared/CollapsibleSectionCard.vue
+++ b/apps/application/app/components/shared/CollapsibleSectionCard.vue
@@ -46,7 +46,9 @@ defineExpose({ setFolded, reveal });
   <div ref="rootEl" class="scroll-mt-4">
     <UCard :ui="{ header: 'p-2.5 sm:px-4 sm:py-3', body: folded ? 'p-0 sm:p-0' : '' }" :class="folded && 'divide-y-0'">
       <template #header>
-        <div class="flex items-center justify-between gap-2">
+        <!-- Below `sm` the actions drop to their own full-width row under the
+             title so a wide actions group never squeezes the heading on a phone. -->
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <!-- role=button (not <button>) so the nested HelpHint button stays valid HTML -->
           <div
             class="flex items-center gap-2 min-w-0 flex-1 cursor-pointer select-none rounded-sm outline-none focus-visible:outline-2 focus-visible:outline-primary"
@@ -74,7 +76,7 @@ defineExpose({ setFolded, reveal });
               <slot name="folded" />
             </span>
           </div>
-          <div v-if="$slots.actions" class="flex items-center gap-1 shrink-0">
+          <div v-if="$slots.actions" class="flex items-center gap-1 sm:shrink-0">
             <slot name="actions" />
           </div>
         </div>

--- a/apps/application/app/components/shared/LocatorHealingPanel.vue
+++ b/apps/application/app/components/shared/LocatorHealingPanel.vue
@@ -60,10 +60,13 @@ const BareCard = defineComponent({
   setup(bareProps, { slots }) {
     return () =>
       h('div', { class: 'space-y-3' }, [
+        // Below `sm` the actions drop to their own full-width row under the
+        // provenance line, so the sentence spans the card width instead of being
+        // squeezed into a one-word-per-line column beside the buttons.
         slots.subtitle || bareProps.subtitle
-          ? h('div', { class: 'flex items-start justify-between gap-2' }, [
+          ? h('div', { class: 'flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between' }, [
               h('p', { class: 'text-xs min-w-0' }, slots.subtitle ? slots.subtitle() : bareProps.subtitle),
-              slots.actions ? h('div', { class: 'shrink-0' }, slots.actions()) : null,
+              slots.actions ? h('div', { class: 'sm:shrink-0' }, slots.actions()) : null,
             ])
           : slots.actions
             ? h('div', { class: 'flex justify-end' }, slots.actions())

--- a/apps/application/app/components/shared/SectionCard.vue
+++ b/apps/application/app/components/shared/SectionCard.vue
@@ -34,8 +34,11 @@ withDefaults(
 
 <template>
   <section v-if="embedded">
-    <div class="flex items-start justify-between flex-wrap gap-x-2 gap-y-1 mb-2">
-      <div class="flex items-center gap-2 min-w-0 basis-56 grow">
+    <!-- Below `sm` the actions drop to their own full-width row under the title
+         and subtitle, so a wide actions group never squeezes the subtitle into a
+         one-word-per-line column on a phone. -->
+    <div class="flex flex-col gap-y-1 sm:flex-row sm:items-start sm:justify-between sm:flex-wrap sm:gap-x-2 mb-2">
+      <div class="flex items-center gap-2 min-w-0 sm:basis-56 sm:grow">
         <UIcon v-if="icon" :name="icon" class="w-5 h-5 shrink-0" :class="iconClass" />
         <div class="min-w-0">
           <h3 class="text-base font-medium inline-flex items-center gap-1">
@@ -47,7 +50,7 @@ withDefaults(
           </p>
         </div>
       </div>
-      <div v-if="$slots.actions" class="flex items-center gap-1 shrink-0">
+      <div v-if="$slots.actions" class="flex items-center gap-1 sm:shrink-0">
         <slot name="actions" />
       </div>
     </div>
@@ -61,10 +64,12 @@ withDefaults(
 
   <UCard v-else>
     <template #header>
-      <!-- Actions wrap under the title rather than squeezing it, so a wide
-           actions group (a chart legend) cannot crush the heading on a phone. -->
-      <div class="flex items-start justify-between flex-wrap gap-x-2 gap-y-1">
-        <div class="flex items-center gap-2 min-w-0 basis-56 grow">
+      <!-- Below `sm` the actions drop to their own full-width row under the title
+           and subtitle; from `sm` up they sit on the right and wrap under the
+           title rather than squeezing it, so a wide actions group (a chart
+           legend, two buttons) never crushes the heading or the subtitle. -->
+      <div class="flex flex-col gap-y-1 sm:flex-row sm:items-start sm:justify-between sm:flex-wrap sm:gap-x-2">
+        <div class="flex items-center gap-2 min-w-0 sm:basis-56 sm:grow">
           <UIcon v-if="icon" :name="icon" class="w-5 h-5 shrink-0" :class="iconClass" />
           <div class="min-w-0">
             <h3 class="text-lg font-medium inline-flex items-center gap-1">
@@ -76,7 +81,7 @@ withDefaults(
             </p>
           </div>
         </div>
-        <div v-if="$slots.actions" class="flex items-center gap-1 shrink-0">
+        <div v-if="$slots.actions" class="flex items-center gap-1 sm:shrink-0">
           <slot name="actions" />
         </div>
       </div>

--- a/apps/application/app/components/test-case/FailureTimelineCard.vue
+++ b/apps/application/app/components/test-case/FailureTimelineCard.vue
@@ -651,10 +651,138 @@ function onViewTrace() {
           </span>
         </div>
 
+        <!-- Phone layout (below `md`): one stacked card per row, so the Step and
+             Duration columns are never cut and the page never scrolls sideways.
+             The `md`-and-up table below carries the same rows unchanged. -->
+        <div class="md:hidden space-y-2">
+          <template v-for="row in mergedRows" :key="row.kind === 'step' ? `m-s-${row.index}` : `m-${row.item.id}`">
+            <!-- A step row -->
+            <div
+              v-if="row.kind === 'step'"
+              class="rounded-lg border border-default p-2.5"
+              :class="row.failed ? 'bg-red-50 dark:bg-red-950/30' : ''"
+            >
+              <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <span
+                  v-if="status === 'didnotrun'"
+                  class="inline-flex items-center justify-center size-5 shrink-0 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 text-xs leading-none"
+                  title="Not run"
+                  >–</span
+                >
+                <span
+                  v-else-if="row.failed"
+                  class="inline-flex items-center justify-center size-5 shrink-0 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 text-xs leading-none"
+                  title="Step failed"
+                  >✗</span
+                >
+                <span
+                  v-else
+                  class="inline-flex items-center justify-center size-5 shrink-0 rounded-full bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 text-xs leading-none"
+                  title="Step passed"
+                  >✓</span
+                >
+                <UBadge :color="stepCategoryColor[row.step.category] || 'neutral'" variant="soft" size="xs">
+                  {{ row.step.category }}
+                </UBadge>
+                <UBadge
+                  v-if="row.index === slowestStepIndex"
+                  color="warning"
+                  variant="subtle"
+                  size="xs"
+                  title="Slowest step in this test"
+                >
+                  slowest
+                </UBadge>
+                <span
+                  v-if="showAxis && row.item"
+                  class="ml-auto tabular-nums text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap"
+                >
+                  {{ formatRel(row.item.at) }}
+                </span>
+              </div>
+              <p
+                class="mt-1.5 text-sm break-words"
+                :class="row.failed ? 'text-red-600 dark:text-red-400 font-medium' : ''"
+              >
+                {{ row.step.title }}
+              </p>
+              <ErrorText
+                v-if="row.failed && row.step.error?.message"
+                mode="block"
+                :text="row.step.error.message"
+                class="mt-1"
+              />
+              <OpenInIdeLink
+                v-if="row.step.location"
+                :location="row.step.location"
+                :project-key="projectKey ?? undefined"
+                :project-name="projectName ?? undefined"
+                class="text-xs text-gray-400 dark:text-gray-500 mt-0.5"
+              />
+              <div class="mt-1.5">
+                <div class="flex items-center justify-between gap-2">
+                  <DurationValue
+                    :ms="row.step.duration"
+                    :class="`text-sm ${stepDurationTextClass(row.step.duration)}`"
+                    unit-class="opacity-60"
+                  />
+                  <span
+                    v-if="stepPctOfTest(row.step.duration)"
+                    class="text-xs tabular-nums text-gray-400 dark:text-gray-500"
+                  >
+                    {{ stepPctOfTest(row.step.duration) }}
+                  </span>
+                </div>
+                <div class="relative mt-1 h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                  <div
+                    class="absolute inset-y-0 rounded-full"
+                    :class="stepBarColorClass(row.step.duration)"
+                    :style="stepBarStyle(row.step)"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <!-- An interleaved network / console / backend row -->
+            <div
+              v-else
+              class="rounded-lg border border-default p-2.5 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/60"
+              :class="row.item.failed ? 'bg-red-50 dark:bg-red-950/30' : ''"
+              @click="revealItem(row.item)"
+            >
+              <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <UIcon :name="eventIcon(row.item)" class="size-4 shrink-0" :class="eventIconClass(row.item)" />
+                <span class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {{ kindTag(row.item) || row.item.kind }}
+                </span>
+                <span
+                  v-if="showAxis"
+                  class="ml-auto tabular-nums text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap"
+                >
+                  {{ formatRel(row.item.at) }}
+                </span>
+              </div>
+              <div class="mt-1 flex items-baseline justify-between gap-2">
+                <span class="font-mono text-xs break-all text-gray-700 dark:text-gray-300">
+                  {{ row.item.label
+                  }}<span v-if="row.item.kind === 'network'" class="text-gray-500"> → {{ row.item.status }}</span>
+                </span>
+                <span
+                  v-if="row.item.duration != null"
+                  class="shrink-0 text-xs tabular-nums text-gray-500 dark:text-gray-400"
+                >
+                  {{ Math.round(row.item.duration) }} ms
+                </span>
+              </div>
+            </div>
+          </template>
+        </div>
+
         <!-- One table: steps, with network / console / backend items interleaved
              in time order. `min-width` keeps the columns readable while the
-             wrapper (not the page) scrolls on a narrow screen. -->
-        <TableScroller min-width="34rem" :bleed="false">
+             wrapper (not the page) scrolls; on a phone the stacked cards above
+             replace it, so the table shows from `md` up. -->
+        <TableScroller min-width="34rem" :bleed="false" class="hidden md:block">
           <table class="w-full min-w-[34rem] border-separate border-spacing-0 text-sm">
             <thead>
               <tr

--- a/apps/application/tests/performance-ui.spec.ts
+++ b/apps/application/tests/performance-ui.spec.ts
@@ -134,8 +134,9 @@ test.describe('Performance UI Tests', () => {
       // timeline" for a failed execution, "Steps" for a passing one.
       await page.getByRole('tab', { name: /^Timeline/ }).click();
       await expect(page.getByRole('heading', { name: /Steps|Failure timeline/ })).toBeVisible();
-      // The slowest step is tagged in the table.
-      await expect(page.getByText('slowest').first()).toBeVisible();
+      // The slowest step is tagged in the table (the `md`-and-up view; the phone
+      // card list below `md` carries its own copy, hidden at this width).
+      await expect(page.getByRole('table').getByText('slowest')).toBeVisible();
     }
   });
 


### PR DESCRIPTION
## What & why

Two visual defects remained at phone widths (390 px) on the execution page (`/test-run-cases/:id`) and the failure cluster page (`/failure-clusters/:id`). This is the last follow-up of the UI simplification plan (`proposals/ui-simplification.md`, §2 rule 11 — phone gutters and full-bleed cards below `sm`).

**Defect 1 — the steps table was cut on phones.** The merged steps table in the failure timeline (`FailureTimelineCard.vue`) is `min-w-[34rem]` (544 px) inside a card that is only ~360 px wide on a 390 px screen, so the **Step** and **Duration** columns (and the *slowest* badge) were cut off past the card edge — the `TableScroller` scrolled them out of view rather than showing an obvious scroller.
- Below `md`, each row now renders as a **stacked card**: status glyph, category badge and time offset on the top line, the wrapping step title, the error text, the source link, then the duration with its share and bar underneath. Interleaved network / console / backend rows reflow the same way.
- The `md`-and-up table is unchanged (now `hidden md:block`); the phone list is `md:hidden`. This is the app's existing dense-table convention (`md:hidden` card list + `hidden md:block` table, as in `ProjectTrendTable`).

**Defect 2 — the Locator fix header was squeezed on phones.** The shared card header laid the `#subtitle` (the provenance sentence) and the `#actions` (the two "Pick from snapshot" / "Pick from trace" buttons) side by side with no wrap, so at 390 px the sentence was crushed into a one-word-per-line column beside the buttons.
- Below `sm`, the actions now drop to their **own full-width row under the title and subtitle**, and the subtitle spans the card width; from `sm` up the header is unchanged.
- Fixed in the shared header renderers so every card with `#actions` benefits — `SectionCard.vue`, `CollapsibleSectionCard.vue`, and the embedded bare-card variant that the Fix card renders the locator panel through (`LocatorHealingPanel.vue`, `chrome=false`), which is the variant actually on the execution and cluster Fix cards. No one-off in the locator panel's own markup.

### Before / after (390 px)

The before/after screenshots at 390 px and 1280 px are attached in the review conversation (they can't be uploaded to the PR programmatically). In words:

| Place | Before (390 px) | After (390 px) |
|---|---|---|
| Timeline steps table (`/failure-clusters/2`, `/test-run-cases/37`) | Step + Duration columns cut off the right edge | Stacked card per step, nothing cut, duration bar visible |
| Locator fix header (`/failure-clusters/2`) | Provenance sentence one word per line beside the buttons | Sentence spans the card; the two buttons on a full-width row below |

At **1280 px** both pages are pixel-identical intent: the full four-column table renders and the Locator fix header keeps the subtitle left / buttons right.

## How was it tested?

From `apps/application`:
- `npm run app:typecheck`, `npm run app:lint`, `npm run app:format:check` — clean.
- `npm run app:test:unit` — 1967 passed.
- Playwright: `test-run-case-page.spec.ts` (7/7), `mobile-responsiveness.spec.ts` (12/12), `ai-diagnosis.spec.ts` (21/21).
- `npm run app:screens:check` — green.
- Verified **no horizontal page scroll at 390 px** on `/failure-clusters/2`, `/test-run-cases/37`, `/test-cases/1`, `/test-runs/63` (document `scrollWidth` == `clientWidth`, with the Timeline tab opened).
- Checked every card using `#actions` (`grep #actions app/components`) still reads correctly at 390 px and 1280 px.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — covered by existing responsive and evidence specs (the change is a responsive layout tweak; no new behavior to assert beyond the no-overflow checks these specs already run)
- [x] Docs updated if user-facing — no doc/scene content changes; the affected scenes still pass `app:screens:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjuW8R4LTDsE8fbMXZ1b5B

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjuW8R4LTDsE8fbMXZ1b5B)_