### PR TITLE
docs(docs): single-source the docker-run quick-start block

### DIFF
--- a/apps/docs/deployment.md
+++ b/apps/docs/deployment.md
@@ -11,16 +11,9 @@ lang: en-US
 
 ::: code-group
 
-```bash [Linux / macOS]
-docker pull phenx/piwitests-server:latest
-mkdir -p .data && chown -R 1001:1001 .data # the container runs as non-root UID 1001
-docker run -p 3000:3000 -v $(pwd)/.data:/app/.data phenx/piwitests-server:latest
-```
+<<< @/snippets/docker-run.sh [Linux / macOS]
 
-```powershell [Windows (PowerShell)]
-docker pull phenx/piwitests-server:latest
-docker run -p 3000:3000 -v ${PWD}/.data:/app/.data phenx/piwitests-server:latest
-```
+<<< @/snippets/docker-run.ps1 [Windows (PowerShell)]
 
 :::
 

--- a/apps/docs/getting-started.md
+++ b/apps/docs/getting-started.md
@@ -57,16 +57,9 @@ The fastest way to get started is with the pre-built container image:
 
 ::: code-group
 
-```bash [Linux / macOS]
-docker pull phenx/piwitests-server:latest
-mkdir -p .data && chown -R 1001:1001 .data # the container runs as non-root UID 1001
-docker run -p 3000:3000 -v $(pwd)/.data:/app/.data phenx/piwitests-server:latest
-```
+<<< @/snippets/docker-run.sh [Linux / macOS]
 
-```powershell [Windows (PowerShell)]
-docker pull phenx/piwitests-server:latest
-docker run -p 3000:3000 -v ${PWD}/.data:/app/.data phenx/piwitests-server:latest
-```
+<<< @/snippets/docker-run.ps1 [Windows (PowerShell)]
 
 :::
 

--- a/apps/docs/snippets/docker-run.ps1
+++ b/apps/docs/snippets/docker-run.ps1
@@ -1,0 +1,2 @@
+docker pull phenx/piwitests-server:latest
+docker run -p 3000:3000 -v ${PWD}/.data:/app/.data phenx/piwitests-server:latest

--- a/apps/docs/snippets/docker-run.sh
+++ b/apps/docs/snippets/docker-run.sh
@@ -1,0 +1,3 @@
+docker pull phenx/piwitests-server:latest
+mkdir -p .data && chown -R 1001:1001 .data # the container runs as non-root UID 1001
+docker run -p 3000:3000 -v $(pwd)/.data:/app/.data phenx/piwitests-server:latest


### PR DESCRIPTION
## What & why

Phase-1 restructure **leftovers, part 1 of 3**. Stacked on #470 — review/merge that first.

The canonical "pull, prepare the volume, run" quick-start block was byte-identical in the getting-started guide and the deployment guide. Move it to `apps/docs/snippets/docker-run.sh` (Linux/macOS) and `docker-run.ps1` (Windows/PowerShell) and pull both in with VitePress code includes inside the existing `code-group` tabs.

Deliberately left alone: the README and Docker Hub page keep their own intentionally different docker variants (no `docker pull`; detached + named), and the `init` command (mostly inline prose) and the reporter config block (each page teaches a legitimately different variant) aren't clean mechanical dedups — those are for the restructure's editorial passes.

## How was it tested?

- `npm run docs:build` (from `apps/docs`) — green; confirmed in the built HTML that both tabs render with their content and `.ps1` maps to powershell highlighting.
- `npx vitest run tests/unit/docs-drift.test.ts` — 122 passing.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by existing docs-drift guard)
- [x] Docs updated — docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_