### PR TITLE
docs(docs): dedupe the hand-copied env-var tables against the reference

### DIFF
--- a/apps/docs/deployment.md
+++ b/apps/docs/deployment.md
@@ -87,17 +87,15 @@ The `.data` directory contains:
 
 ### Environment variables
 
+The server reads three process-level variables directly:
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `NODE_ENV` | `production` | Set automatically |
 | `HOST` | `0.0.0.0` | Listen on all interfaces |
 | `PORT` | `3000` | Application port |
-| `PIWI_SECRET_KEY` | — | Master key for encrypting secrets in the database (AI API keys, SCM tokens). Recommended in all deployments. Generate with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"` (or `openssl rand -hex 32`). |
-| `PIWI_AUTH_ENABLED` | — | Enable authentication |
-| `PIWI_AUTH_SECRET` | — | Secret for encrypting session cookies (required if auth enabled). Generate with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"` (or `openssl rand -hex 32`). |
-| `PIWI_STORAGE_TYPE` | `local` | Storage backend (`local` or `s3`) |
-| `PIWI_DATABASE_URL` | — | PostgreSQL connection string (e.g. `postgresql://user:pass@host:5432/db`). When set, PostgreSQL is used instead of SQLite. |
-| `PIWI_DATABASE_PATH` | `.data/piwi.db` | SQLite database path (ignored when `PIWI_DATABASE_URL` is set) |
+
+Everything else is a `PIWI_*` variable, documented with its default and whether the Settings UI can override it in the generated [configuration reference](/configuration) — most deployments start with `PIWI_SECRET_KEY`, `PIWI_AUTH_ENABLED`, `PIWI_AUTH_SECRET`, `PIWI_DATABASE_URL` and `PIWI_STORAGE_TYPE`. The [configuration generator](/configuration/generator) turns your choices into a ready-to-paste block from the same registry.
 
 ## One-click deploy
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -39,20 +39,19 @@ npm install @piwitests/server
 
 ## Configuration
 
-All configuration is via environment variables (same as the Docker image). Common ones:
+All configuration is via environment variables (same as the Docker image). `PORT`
+(default `3000`) sets the listen port; everything else is a `PIWI_*` variable
+documented — with its default and whether the Settings UI can override it — in the
+[configuration reference](https://piwitests.dev/configuration). Most deployments set at
+least `PIWI_SECRET_KEY`, the master key for encrypting secrets stored in the database
+(AI API keys, SCM tokens); recommended in any real deployment. Generate one with:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `3000` | Port to listen on |
-| `PIWI_SECRET_KEY` | — | Master key for encrypting secrets stored in the database (AI API keys, SCM tokens). Recommended in any real deployment. Generate with `node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"`. |
-| `PIWI_AUTH_ENABLED` | — | Enable authentication (multi-user) |
-| `PIWI_AUTH_SECRET` | — | Secret for encrypting session cookies (required when auth is enabled) |
-| `PIWI_DATABASE_URL` | — | PostgreSQL connection string (e.g. `postgresql://user:pass@host:5432/db`). When set, PostgreSQL is used instead of SQLite. |
-| `PIWI_DATABASE_PATH` | `.data/piwi.db` | SQLite database path (ignored when `PIWI_DATABASE_URL` is set) |
-| `PIWI_STORAGE_TYPE` | `local` | Storage backend (`local` or `s3`) |
+```bash
+node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
+```
 
-See the [configuration reference](https://piwitests.dev/configuration) for the full
-list.
+Enable multi-user access with `PIWI_AUTH_ENABLED=true` plus `PIWI_AUTH_SECRET`, and
+point at PostgreSQL with `PIWI_DATABASE_URL`.
 
 Set variables the usual way for your shell — for example, on a different port:
 


### PR DESCRIPTION
## What & why

Phase-1 restructure **leftovers, part 2 of 3**. Stacked on #471 (which is on #470) — merge in order.

Two surfaces carried reference-style `Variable | Default | Description` tables that restated the generated configuration reference (built from `apps/application/shared/piwi-env-vars.ts`): the deployment guide and the server npm README. Both are now links to that reference, so defaults and descriptions live in one place.

- **deployment.md** keeps only the three process-level variables that are *not* in the registry (`NODE_ENV`, `HOST`, `PORT`) as a small table — their single home — and links the generated reference for every `PIWI_*` variable.
- **server README** replaces its `PIWI_*` table with a short note + the reference link, keeping the `PIWI_SECRET_KEY` one-liner (its one guarded snippet) in prose.

Deliberately **not** done: folding `PORT`/`HOST`/`NODE_ENV` into the registry. Its stated contract and unit test are `PIWI_*`-only (every non-baseline var must declare a semver `since`), and these three are neither Piwi settings nor new — giving them a single home in deployment.md keeps the registry honest. The storage provider recipes, the notifications SMTP block and the authentication prose are not reference-style duplications and are left for the phase-2 page splits.

## How was it tested?

- `npm run docs:build` — green (the `/configuration` links resolve).
- `npx vitest run tests/unit/docs-drift.test.ts` — 122 passing (the secret-snippet guard still holds on the server README).

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by existing guards)
- [x] Docs updated — docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_