### PR TITLE
docs(docs): remove contributor material from the user-facing site

### DIFF
--- a/apps/docs/analytics.md
+++ b/apps/docs/analytics.md
@@ -67,13 +67,6 @@ let you record a deploy, a CI-runner migration, or a dependency bump against a p
 as a vertical line across the trend charts — so "the slowdown started the day we switched runners"
 becomes something you can see rather than remember.
 
-## How it's built
-
-Each widget is a registry entry backed by a shared handler and served by one generic endpoint,
-`GET /api/analytics/:widget`. The same handlers back the dashboard, the demo, and the API, so a number
-you read on the page is the number the API returns. Widgets fetch independently, so a slow one never
-blocks the rest of the page.
-
 ## See also
 
 - [Flaky tests](./flaky-tests) — the per-project analysis these widgets aggregate

--- a/apps/docs/deployment.md
+++ b/apps/docs/deployment.md
@@ -207,28 +207,6 @@ and TLS are wired up automatically.
 - **Pin a version.** The templates track `latest`. Pin a tag before you depend on the instance, and read
   [Upgrading](./upgrading) first: migrations are forward-only.
 
-## Building locally
-
-Build from the repository root (the `Dockerfile` lives there):
-
-::: code-group
-
-```bash [Linux / macOS]
-docker build -t piwi-dashboard:local .
-docker run -p 3000:3000 -v $(pwd)/.data:/app/.data piwi-dashboard:local
-```
-
-```powershell [Windows (PowerShell)]
-docker build -t piwi-dashboard:local .
-docker run -p 3000:3000 -v ${PWD}/.data:/app/.data piwi-dashboard:local
-```
-
-:::
-
-Pass `--build-arg PIWI_BUILD_SHA=$(git rev-parse HEAD)` to stamp the image with a commit SHA, shown on
-Settings → About and returned by `GET /api/version`. The published images set it from CI; it's optional
-for a local build.
-
 ## Docker Compose
 
 The repository ships a ready-to-use [`docker-compose.yml`](https://github.com/PiwiTests/platform/blob/main/docker-compose.yml) with commented options (secret key, auth, PostgreSQL). Minimal version:
@@ -380,15 +358,6 @@ $env:PORT='8080'; npx @piwitests/server
 > **Docker remains the recommended path for production** — it ships a pinned Node runtime,
 > runs as a non-root user, and isolates the environment. The npm package is best for a
 > quick local trial or environments where Docker isn't available.
-
-## Production build from source
-
-```bash
-cd apps/application
-npm install
-npm run app:build
-npm run app:preview  # preview the production build locally
-```
 
 ## Health checks
 

--- a/apps/docs/extension.md
+++ b/apps/docs/extension.md
@@ -22,27 +22,6 @@ Edge blocks other stores until you say otherwise: the first Chrome Web Store pag
 shows an **Allow extensions from other stores** banner — click **Allow** once, and **Get** installs
 and auto-updates exactly as it does in Chrome. There's no separate Edge Add-ons listing yet.
 
-### From source
-
-Only needed if you want an unreleased build, or you're changing the extension itself.
-
-```bash
-git clone https://github.com/PiwiTests/platform.git
-cd platform
-npm install
-npm run extension:build --workspace=apps/extension
-```
-
-Then, in Chrome or Edge:
-
-1. Open `chrome://extensions` (`edge://extensions` on Edge).
-2. Turn on **Developer mode**.
-3. **Load unpacked** → select `apps/extension/dist`.
-
-A source build doesn't auto-update — rebuild and reload its card on the extensions page to pick up
-changes. If you already have the store version installed, disable one or the other so two copies of
-the picker don't both bind the keyboard shortcut.
-
 ## What it does
 
 Every action in the toolbar popup has a digit shortcut, shown on its tile and numbered in
@@ -237,9 +216,3 @@ its pattern actually matches whatever page you're looking at.
 - **Function matching is deterministic, not AI-assisted, in this phase.** The catalog matcher
   scores DOM patterns against recorded steps; there's no optional AI pass yet to name things or
   break ties beyond the scoring itself.
-
-## Source
-
-`apps/extension/` in the [monorepo](https://github.com/PiwiTests/platform) — see
-[`apps/extension/AGENTS.md`](https://github.com/PiwiTests/platform/blob/main/apps/extension/AGENTS.md)
-for how it's built and tested.

--- a/apps/docs/mcp.md
+++ b/apps/docs/mcp.md
@@ -290,9 +290,3 @@ npx @piwitests/reporter skills add investigate-failure --dir .cursor/skills   # 
 | `run-the-right-tests` | Pick and run the right [selection](./test-selection) for the task — smoke, recently-broken, a time budget — instead of always running the whole suite. |
 
 The skills are agent-agnostic Markdown — only the destination directory is tool-specific, so `--dir` points the install wherever your agent reads skills from. They pair with this MCP server: each one prefers a connected Piwi MCP tool (`explain_failure`, `get_locator_healing`, `list_flaky_tests`, …) and falls back to the dashboard UI when MCP is not connected.
-
-## Architecture
-
-The MCP server is implemented as a single Nitro route (`server/routes/mcp.post.ts`) that dispatches JSON-RPC methods to tool handlers in `server/utils/mcp/tools.ts`. Handlers call the same shared DB helpers used by the REST API — no self-HTTP-calls, no extra processes.
-
-The `get_cluster_context` tool calls `buildClusterDiagnosisContext()` directly, so agents receive the identical SCM-grounded evidence the built-in diagnosis AI uses: error samples, test steps, console logs, network failures, ARIA snapshots, and the diff of changed files since the last green run.


### PR DESCRIPTION
## What & why

Phase-1 restructure **leftovers, part 3 of 3**. Stacked on #472 (on #471, on #470) — merge in order.

The docs-site guide (`apps/docs/AGENTS.md`) is explicit that build steps, source layout and dev commands belong in `CONTRIBUTING.md` / `AGENTS.md` / `ARCHITECTURE.md`, not on a site for people *using* Piwi. Remove the sections that had leaked in:

- **deployment.md** — "Building locally" (`docker build` from the repo) and "Production build from source" (`npm run app:build`).
- **extension.md** — "From source" (git clone + load-unpacked) and the trailing "Source" pointer to `apps/extension/AGENTS.md`.
- **mcp.md** — "Architecture" (internal Nitro route + util file paths).
- **analytics.md** — "How it's built" (internal widget-registry / endpoint design).

No inbound help links or `<DocLink>`s reference any of these anchors (checked), so no in-app literal changes are needed. The `get_cluster_context` evidence detail the mcp "Architecture" note repeated already lives in that tool's row in the tools table.

## How was it tested?

- `npm run docs:build` — green (no broken anchors/links).
- `npx vitest run tests/unit/docs-drift.test.ts` — 122 passing (MCP tool count and all deep-link anchors intact).

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by existing docs-drift guard)
- [x] Docs updated — docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_