### PR TITLE
docs(docs): add the Branches feature page

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -116,6 +116,7 @@ export default defineConfig({
           { text: 'Failure clusters & the inbox', link: '/failure-clusters' },
           { text: 'AI diagnosis & clustering', link: '/ai-diagnosis' },
           { text: 'Flaky tests', link: '/flaky-tests' },
+          { text: 'Branches', link: '/branches' },
           { text: 'Analytics', link: '/analytics' },
           { text: 'Timeline markers', link: '/timeline-markers' },
           { text: 'Notifications & alerts', link: '/notifications' },

--- a/apps/docs/branches.md
+++ b/apps/docs/branches.md
@@ -1,0 +1,59 @@
+---
+title: Branches
+lang: en-US
+---
+
+# Branches
+
+Every run Piwi stores is tagged with the git **branch** it came from, and that branch is a real, queryable dimension — not a string buried in metadata. Filter any view to one branch, compare like with like, and let baselines and flakiness scoring stop mixing your feature branches together. This is the headline of 0.26: branch-aware runs and baselines.
+
+**Needs:** the reporter only — the branch is collected automatically with the rest of the git metadata (`collectScmInfo`, on by default). Nothing to install or switch on.
+
+## How the branch is recorded
+
+On CI, git alone is unreliable: a pull-request checkout is usually a detached `HEAD`, so `git rev-parse` reports the literal string `HEAD` instead of a branch. The reporter resolves the real branch through a fallback chain instead:
+
+1. **`PIWI_BRANCH`** — an explicit operator override, when you want to name the branch yourself.
+2. **The CI provider's branch variables** — `GITHUB_HEAD_REF` / `GITHUB_REF_NAME` on GitHub Actions, the merge-request and commit refs on GitLab, and the equivalents for CircleCI, Travis, Azure, Jenkins and Bitbucket. On a pull-request build the **source** branch wins over the plain ref, so the run records the branch under test.
+3. **`git rev-parse --abbrev-ref HEAD`** — the local answer, used only when it is a real branch. A detached `HEAD` is discarded rather than recorded.
+
+When the provider exposes it, the reporter also captures the **pull-request number**, so [pull-request feedback](./ci#pull-request-feedback) can look the PR up exactly instead of guessing from the branch name. Branch and PR detection happen automatically as part of CI collection — see [CI & sharding → What gets detected](./ci#what-gets-detected).
+
+## The default branch
+
+Each project has a **Default branch** setting on its **Settings** tab (placeholder `e.g. main`). Leave it blank and Piwi resolves it from your SCM provider. The default branch is the reference point for the rest of this page: baselines fall back to it, and "already flaky on the default branch" is measured against it.
+
+## Filtering by branch
+
+On a project page, the filter bar carries a **branch** multi-select (the git-branch icon, "All branches") next to the environment filter. It appears once the project has runs from more than one branch, and it scopes the **runs list** and the **flaky leaderboard** to the branches you pick. [Analytics](./analytics) has its own branch scope control, so a pass-rate trend or slow-test table can be read for one branch at a time.
+
+Because the branch is an indexed column, these filters are served by the database rather than by fetching a wide batch and sifting metadata in memory. Runs reported before the column existed fall back to the branch recorded in their metadata, so old history still filters.
+
+## Branch-aware baselines
+
+The bigger change is invisible until you look for it: **baselines are chosen within a branch.**
+
+- **Regression signals** — the *new regression* and *new flaky* badges on an execution compare against the most recent passing run on the **same branch**, then fall back to the default branch. Two feature branches reporting interleaved runs no longer become each other's baseline.
+- **The visual-diff baseline** ([What changed in a run](./flaky-tests#changes)) prefers the same branch the same way, so a screenshot diff compares against a run that shares your branch's state.
+- **Pull-request feedback** builds its "new failures vs. pre-existing" split from those same branch-aware signals, and **exonerates** a test that is already flaky on the default branch — a failure the PR did not introduce is reported as pre-existing rather than blamed on the change. The `max-new-regressions` [CI gate](./ci#blocking-a-merge) then counts the right number.
+
+## From an agent (MCP)
+
+The MCP tools take a branch filter too: `list_runs` and the flaky tools accept a `branch` argument, so an agent can ask "what is failing on `main`" or "is this test flaky on my branch" without pulling every run. See the [MCP server](./mcp).
+
+## Notifications
+
+Notification subscriptions can filter by branch and alert only on the default branch, so a noisy work-in-progress branch does not page you. See [Notifications & alerts](./notifications).
+
+## Limits
+
+- **Branch scoping is opt-in per view, not yet the default.** Flakiness scores and trends aggregate across every branch until you apply the filter; scoping them to the default branch *by default* is on the roadmap.
+- **Branches are a run dimension, not yet entities.** There is no per-branch merge-readiness verdict, branch-class gate policy, or retention by branch class yet — those are the "branches as entities" work still under *Exploring* in the [roadmap](https://github.com/PiwiTests/platform/blob/main/ROADMAP.md).
+- **A run needs a resolvable branch.** A purely local run with no CI variables, a detached `HEAD`, and no `PIWI_BRANCH` records no branch at all, so it will not appear under any branch filter.
+
+## Related
+
+- [CI & sharding](./ci) — how the branch and PR number are detected on each provider
+- [Flaky tests](./flaky-tests) — the leaderboard and regression signals the branch filter scopes
+- [Analytics](./analytics) — trends you can read one branch at a time
+- [Core concepts](./concepts) — where branch sits among run, execution and baseline


### PR DESCRIPTION
## What & why

**Starts phase 2** of the documentation restructure — the first of the plan's "create the new pages from moved text." Branch-aware runs and baselines are the headline of 0.26, yet the audit found the word "branch" appears in **no heading anywhere on the site**; the only prose lived in `ROADMAP.md` and `proposals/first-class-branches.md`.

Adds `apps/docs/branches.md`, written to the `auto-heal.md` feature-page skeleton (what it does · where it is · how to use it · limits · related) and covering only what has actually **shipped** (Tiers 1–2), verified against the reporter and app code:

- how the branch is recorded — `PIWI_BRANCH` → CI provider vars → git, with a detached `HEAD` rejected — and the PR number captured (`metadata-collector.ts`);
- the per-project **Default branch** setting (`ProjectFormFields.vue`);
- the **branch filter** on the project page — runs list + flaky leaderboard (`FilterBar.vue`) — and the analytics branch scope;
- **branch-aware baselines** for regression signals and the visual diff, and the "already flaky on the default branch" exoneration in PR feedback;
- the MCP `branch` filter and branch-scoped notifications.

The **Limits** section states honestly what has *not* shipped (default-branch-by-default scoping; branches as entities). 829 words (budget ≤1,200). Adds a "Branches" entry to the "Reading the results" sidebar group.

This is **purely additive** — a new page and one sidebar line. No existing page URL or heading anchor changes, so it needs no redirect stubs or in-app link updates, and it's independent of the phase-1 PRs (#470–#473), so it can merge in any order.

## How was it tested?

- `npm run docs:build` (from `apps/docs`) — green; the dead-link check validates every cross-link (`./ci#pull-request-feedback`, `./flaky-tests#changes`, `./ci#blocking-a-merge`, …).
- `npx vitest run tests/unit/docs-drift.test.ts` — 118 passing.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by docs-drift + build dead-link check)
- [x] Docs updated — this *is* the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_