### PR TITLE
docs(docs): add the "What Piwi does" guide intro page

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -90,6 +90,7 @@ export default defineConfig({
       {
         text: 'Start here',
         items: [
+          { text: 'What Piwi does', link: '/what-piwi-does' },
           { text: 'Getting started', link: '/getting-started' },
           { text: 'Core concepts', link: '/concepts' },
           { text: 'Why Piwi? (comparison & FAQ)', link: '/comparison' },

--- a/apps/docs/what-piwi-does.md
+++ b/apps/docs/what-piwi-does.md
@@ -1,0 +1,60 @@
+---
+title: What Piwi does
+lang: en-US
+---
+
+# What Piwi does
+
+Playwright's HTML report is excellent, and it lasts exactly until the next build. Piwi keeps every run instead — every trace and report — and then does something with them: it groups the failures by root cause, scores the flaky tests by what they cost, and finds the locator you should have used. Self-hosted, MIT, zero telemetry.
+
+Everything in the product is in service of **three jobs, in this order**. It's also the test for whether a feature belongs here at all: one that strengthens none of them is an argument against building it.
+
+## The three jobs
+
+1. **Keep the history.** CI deletes every report it makes. Piwi keeps every run, trace and report, so "has this always been flaky?" and "did my fix hold?" are answerable at all.
+2. **Explain the failures.** Group them by root cause so forty red tests become three problems, score the flaky ones by the CI minutes they actually waste, and — optionally — have an LLM explain a cluster against your real git diff.
+3. **Hand back a fix.** A ranked replacement locator, a validated patch, an owner, and the command that verifies the work. The point is to leave with something to *do*, not just something to read.
+
+Everything else — analytics, notifications, the CI gate, PR feedback, the MCP server, the desktop app — is a delivery route for those three. The dashboard follows the same ranking: it leads with results and failures, and the supporting lenses sit behind them.
+
+## The loop it serves
+
+Explaining a failure is the heart of it, and it's a loop: gather the evidence, group the failures by cause, explain why they broke, hand back a fix, then verify the fix actually held.
+
+<figure>
+  <img src="/diagrams/failure-loop.svg" alt="The failure-explaining loop: gather evidence, group into clusters, diagnose, hand back a fix, and a verification arrow back to the start">
+  <figcaption>The loop the whole product serves — gather, group, explain, hand back, then verify the fix held.</figcaption>
+</figure>
+
+Each step is a page on this site: the [failing execution](./evidence) and its [evidence](./evidence#clues), [failure clusters](./failure-clusters), [AI diagnosis](./ai-diagnosis), [locator healing](./reporter#locator-healing) and [auto-heal PRs](./auto-heal), and the [fix verification](./ai-diagnosis#did-the-fix-work) that closes it.
+
+## Two rules
+
+Two rules run through every feature, and they're worth knowing before you adopt it:
+
+1. **The tool proposes, the developer decides.** Piwi never rewrites a test, never merges a fix, and never applies a patch on its own. It gathers, ranks and suggests; the last step is always yours. Even [auto-heal PRs](./auto-heal) only *open* a pull request for you to review and merge.
+2. **Deterministic first, AI second.** Anything that has to be right every time — clustering, flaky scoring, locator ranking, fix verification — is computed without a model. AI sits on top, where a suggestion is enough, and what it produces is checked against your real source before you see it. AI is off by default and brings your own key.
+
+## The pieces
+
+Piwi is a reporter that uploads from your Playwright run, a server (or the [desktop app](./desktop)) that keeps and analyzes the results, and a set of ways to reach them — the [browser extension](./extension), an [MCP server](./mcp) and [agent skills](./mcp#agent-skills) for coding agents, [SCM providers](./ci#pull-request-feedback) for PR feedback and healing, and [notifications](./notifications).
+
+<figure>
+  <img src="/diagrams/piwi-ecosystem.svg" alt="The Piwi pieces: a Playwright run and instrumented app feed one server or the desktop app, with the browser extension, coding agents, SCM providers and notifications arranged around it">
+  <figcaption>The reporter and your instrumented app feed one server (or the desktop app); the extension, agents, SCM providers and notifications sit around it.</figcaption>
+</figure>
+
+## What it isn't
+
+Trust is the point, so the limits are stated plainly, not buried:
+
+- **Playwright only, by design.** The ingest API, trace handling, step analytics and locator healing are all built around Playwright's model. If you need to aggregate many frameworks (JUnit, pytest, Cypress) into one place, [ReportPortal or Allure](./comparison) fit better.
+- **Pre-1.0.** Patch and minor releases can carry breaking changes, and the database schema moves with them — read [Upgrading](./upgrading) before you bump a tag.
+- **Not an "ask AI" button.** Diagnosis is optional, grounded in your diff, and never in the write path.
+
+## Where to go next
+
+- [Getting started](./getting-started) — pick a path and land your first run
+- [Core concepts](./concepts) — the vocabulary (run, execution, cluster, fingerprint, baseline)
+- [Why Piwi? (comparison & FAQ)](./comparison) — how it compares, and whether it's the right tool for you
+- [Live demo](https://piwitests.dev/demo/) — the real app on seeded data, entirely in your browser


### PR DESCRIPTION
## What & why

Phase-2 restructure — an additive **new page**, and the "what is this, and how does it work" intro the Guide lacked. The three-jobs framing, the two design rules, and the failure-loop and ecosystem diagrams existed only inside the ~5,000-word blog post, which is off the sidebar.

Adds `apps/docs/what-piwi-does.md` (Start here, 754 words):

- **The three jobs** — keep the history, explain the failures, hand back a fix — taken from ROADMAP's canonical "What Piwi is for", with "everything else is a delivery route for those three."
- **The loop it serves**, illustrated with the committed `/diagrams/failure-loop.svg`, each step linking the page that covers it (evidence → clusters → diagnosis → healing/auto-heal → fix verification).
- **The two rules** (the tool proposes / the developer decides; deterministic first, AI second).
- **The pieces**, with `/diagrams/piwi-ecosystem.svg`.
- **A plain "what it isn't"** — Playwright-only by design, pre-1.0, AI optional and never in the write path.
- Where to go next.

Both diagrams are the **same committed assets the blog already uses** (self-contained light panels, legible in either theme — verified they carry their own background). Adds "What Piwi does" as the first "Start here" sidebar entry. **Purely additive** — no existing URL or heading anchor changes.

## How was it tested?

- `npm run docs:build` — green; the dead-link check validates every cross-link (`evidence#clues`, `ai-diagnosis#did-the-fix-work`, `reporter#locator-healing`, `ci#pull-request-feedback`, …) and both diagram paths resolve.
- `npx vitest run tests/unit/docs-drift.test.ts` — 127 passing.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by docs-drift + build dead-link check)
- [x] Docs updated — this *is* the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_