### PR TITLE
docs(docs): add the "Your first failure, explained" walkthrough

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -93,6 +93,7 @@ export default defineConfig({
           { text: 'What Piwi does', link: '/what-piwi-does' },
           { text: 'Getting started', link: '/getting-started' },
           { text: 'Core concepts', link: '/concepts' },
+          { text: 'Your first failure, explained', link: '/first-failure' },
           { text: 'Why Piwi? (comparison & FAQ)', link: '/comparison' },
           { text: 'Privacy & data flow', link: '/privacy' },
         ],

--- a/apps/docs/first-failure.md
+++ b/apps/docs/first-failure.md
@@ -1,0 +1,62 @@
+---
+title: Your first failure, explained
+lang: en-US
+---
+
+# Your first failure, explained
+
+You've landed your first run ([Getting started](./getting-started)) and one test is red. This page walks through reading it. Piwi lays a failing execution out **diagnosis-first** — one column, top to bottom: *what* broke, *why*, the evidence, then what to *do* — so you're not scrolling a trace hoping to spot the problem.
+
+Open the failing test from the run page (click its row) to reach its **execution page**.
+
+<figure>
+  <img src="/screenshots/gather-evidence.png" alt="A failing execution laid out diagnosis-first: the header, a one-line headline, the other clues, and one evidence card with tabs">
+  <figcaption>One failing execution, read top to bottom: the headline, the clues, the evidence, and the fix.</figcaption>
+</figure>
+
+## 1. The headline — what broke
+
+The first line is a plain-English sentence built from the Playwright error, before you read a word of the raw error itself:
+
+> `getByRole('button', { name: 'Pay' }) never became enabled — click timed out after 30 s`
+
+Under it, one row of facts: **why** (a new regression, or just flaky, or passed on retry), **since when** (the first run this started failing, with the commit and author), how many **other tests in this run** share the same cause, and the **owner**. The verbatim error is one click away under **Show raw error** — Piwi never rewrites it, it only leads with a readable summary. That same headline names the test on the run page, in [alerts](./notifications), in the [pull-request comment](./ci#pull-request-feedback), and in your terminal, so you recognize it everywhere.
+
+## 2. The clues — why
+
+Below the headline is a short list of **[clues](./evidence#clues)**: deterministic, rule-based findings correlated from the evidence — *no model runs*. Things like:
+
+- *"GET /api/quote returned 504, 1.1 s before the failure"*
+- *"Element renamed — healing found it under a new identity"*
+- *"Page ended on /login, not /checkout"*
+
+Each clue carries a strength and a **citation** to the evidence it came from; click it and the page jumps to the proof. This is usually where the answer is.
+
+## 3. The evidence — see it
+
+One **evidence card** with tabs — **Timeline, Screen, Source, Network, Console, State, Performance** — opens on the tab the strongest clue points at. The one to know first is **Timeline**: it places the test's steps, console entries, network requests and backend logs on a single clock and marks the **moment of failure**, so "console (1) / network (3)" becomes *what the app was doing when the test gave up*. **Screen** holds the failure screenshot, the visual diff against the last green run, and the failure-time page state; **Source** shows the test source as a real call stack, so a failure inside a helper shows the helper.
+
+::: tip Most of this needs one file
+The error, trace, headline and clustering work with the reporter alone. The console, network, Web Vitals, failure-time snapshot and locator healing come from the [capture fixtures](./capture-fixtures) — one file in your test setup. If a tab is dimmed, that's usually why; it opens to say so.
+:::
+
+## 4. The fix — what to do
+
+At the bottom, the **Fix** card gathers what to do about it, each part shown only when it applies:
+
+- a **[replacement locator](./reporter#locator-healing)** when a locator broke, ranked by stability and in your suite's own style;
+- the **[AI diagnosis](./ai-diagnosis)** summary, when you've configured a model (optional, and grounded in your real diff);
+- **verify** — re-run in CI, or run it locally — and the tests this failure blocked.
+
+The point is to leave with something to do, not just something to read.
+
+## You're not reading it alone
+
+This execution is one member of a **[failure cluster](./failure-clusters)** — Piwi groups every test that failed for the same reason, so forty red tests become three problems you triage once. From the cluster you get the full [fix plan](./ai-diagnosis), the owner, and — once a later run passes every test it covers — [confirmation the fix held](./ai-diagnosis#did-the-fix-work).
+
+## Where to go next
+
+- [Failure evidence](./evidence) — the full reference for everything on this page
+- [Failure clusters & the inbox](./failure-clusters) — triaging failures as groups
+- [Capture fixtures](./capture-fixtures) — the one file that unlocks the richer evidence
+- [Core concepts](./concepts) — run, execution, cluster, fingerprint, baseline


### PR DESCRIPTION
## What & why

Phase-2 restructure — the last mostly-additive Guide page. Stacked on #478 (both touch the "Start here" sidebar group, so stacking keeps `config.mts` conflict-free); merge #478 first.

A new user who lands their first run has the reference ([`evidence.md`](https://piwitests.dev/evidence)) but no guided read-through. This page is that walkthrough — diagnosis-first and in order — linking the reference pages for depth rather than restating them (per the recipes rule: feature pages stay the source of truth).

Adds `apps/docs/first-failure.md` (Start here, 695 words):

- open the execution page, then read it top to bottom;
- **1.** the headline (plain-English error + the one-line facts, raw error one click away); **2.** the deterministic clues and their citations; **3.** the evidence card and its Timeline tab; **4.** the Fix card;
- an honest tip that the richer evidence (console, network, snapshot, healing) needs the capture fixtures;
- the cluster it belongs to, and where to go next.

Reuses the committed `/screenshots/gather-evidence.png` (the blog's failing-execution shot) — no new screenshot generated. Adds "Your first failure, explained" to the "Start here" sidebar after Core concepts. **Purely additive** — no existing URL or anchor changes.

## How was it tested?

- `npm run docs:build` — green; the dead-link check validates every cross-link (`evidence#clues`, `ai-diagnosis#did-the-fix-work`, `reporter#locator-healing`, `ci#pull-request-feedback`, …) and the screenshot path.
- `npx vitest run tests/unit/docs-drift.test.ts` — 128 passing.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by docs-drift + build dead-link check)
- [x] Docs updated — this *is* the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_