### PR TITLE
fix(desktop): stabilize shell e2e test startup timing

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -19,8 +19,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * dev` can boot the sidecar and load the dashboard.
  */
 export const { test, expect } = createTauriTest({
-  // Required by the type, but only used by browser-only mode, which we don't run.
-  devUrl: 'http://127.0.0.1:3000',
+  // Deliberately empty. The type requires a string, but a *truthy* `devUrl` is
+  // not just browser-only: in tauri mode the fixture navigates the webview to it
+  // (`window.location.href = devUrl`) the instant the control socket answers a
+  // ping — before the shell has driven its own token bootstrap, and often before
+  // the native `main` window even exists. The plugin only retries window
+  // resolution for ~2s per command, so on a loaded CI runner that premature
+  // `eval` loses the race and fails the run with
+  // `window 'main' not found after retries (available windows: [])`. An empty
+  // (falsy) value skips that navigation entirely and lets the shell load itself.
+  devUrl: '',
   tauriCommand: 'npx tauri dev',
   tauriFeatures: ['e2e-testing'],
   tauriCwd: resolve(__dirname, '..'),

--- a/apps/desktop/e2e/tests/shell.spec.ts
+++ b/apps/desktop/e2e/tests/shell.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures';
+import type { TauriPage } from '@srsholmes/tauri-playwright';
 
 /**
  * Smoke test for the shell integration, driving the real webview.
@@ -18,7 +19,21 @@ import { test, expect } from '../fixtures';
  * `evaluate()` runs its argument as `await (<script>)`, so each script must be a
  * single expression; the plugin awaits it and hands back the resolved value.
  */
-test('the dashboard can reach the shell IPC commands', async ({ tauriPage }) => {
+test('the dashboard can reach the shell IPC commands', async ({ tauriPage: fixturePage }) => {
+  // Only the real-app ("tauri") project runs (see fixtures.ts), so the fixture is
+  // always a TauriPage. Narrow the declared `TauriPage | BrowserPageAdapter` union
+  // so the window helper below is reachable; the rest of the test uses it through
+  // the same `tauriPage` name.
+  const tauriPage = fixturePage as TauriPage;
+
+  // The control socket accepts commands as soon as the plugin binds it, which can
+  // be a beat before the shell's `main` window is created (the heavy startup work
+  // — picking a port, spawning the Node sidecar, building the tray — runs on the
+  // main thread first). Every eval-based command only retries window resolution
+  // for ~2s, so gate on the window's existence up front (`list_windows` tolerates
+  // an empty list) instead of letting the first probe race that budget.
+  await tauriPage.waitForWindow((w) => w.label === 'main', { timeout: 60_000 });
+
   // The shell boots the sidecar server then navigates the window to it; wait for
   // the app shell to render before probing.
   await tauriPage.waitForSelector('#__nuxt, [data-nuxt-root], body *', 60_000);


### PR DESCRIPTION
## What & why

The shell e2e test was flaking due to a race condition during startup. The test fixture was navigating the webview to `devUrl` immediately when the control socket became available, which could happen before:
1. The native `main` window was created
2. The shell had completed its own token bootstrap

This premature navigation caused subsequent `eval` commands to fail with "window 'main' not found" because the plugin only retries window resolution for ~2s per command.

**Changes:**
- Set `devUrl` to an empty string in fixtures to skip the premature navigation and let the shell load itself naturally
- Add an explicit `waitForWindow` call in the test to gate on the `main` window's existence before running any eval-based commands
- Add type narrowing to access the `TauriPage` window helper (the fixture union includes a browser adapter, but only Tauri mode runs in this project)
- Document the timing constraints and why this approach is necessary

## How was it tested

The changes address the root cause of the flaky startup sequence. The explicit window wait ensures the shell is ready before probing, and removing the premature `devUrl` navigation eliminates the race entirely. Existing e2e test infrastructure validates the fix.

## Checklist

- [x] PR title follows Conventional Commits (`fix(desktop): ...`)
- [x] Changes are minimal and focused on test stability
- [x] Comments explain the non-obvious timing constraints

https://claude.ai/code/session_014WYDA22kbjattqRw2D2eaR