### PR TITLE
docs(docs): split the test functions catalog out of the extension page

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -158,6 +158,7 @@ export default defineConfig({
           { text: 'Piwi CLI', link: '/cli' },
           { text: 'Desktop app', link: '/desktop' },
           { text: 'Browser extension', link: '/extension' },
+          { text: 'Test functions catalog', link: '/test-functions' },
           { text: 'Open in IDE', link: '/ide-integration' },
           { text: 'MCP server', link: '/mcp' },
           { text: 'Agent skills', link: '/mcp#agent-skills' },

--- a/apps/docs/extension.md
+++ b/apps/docs/extension.md
@@ -169,28 +169,10 @@ that — saving it, running codegen server-side — isn't implemented; if it is 
 opt-in per recording with a payload preview before the first send, matching the standard this
 extension already holds itself to for the API key.
 
-The function catalog itself is managed from a project's **Test functions** page in the
-dashboard — add entries by hand, or paste a page-object method/helper's source code and let AI
-propose the name, parameters, and DOM pattern (a review form you edit before saving). With
-[AI](./ai-diagnosis) configured on the instance, an **Extract** button calls it directly. Without
-one — or if you'd rather use your own — **Copy prompt for your own AI** copies the full
-extraction prompt (rules, JSON schema, and your pasted code) for pasting into any AI chat
-(ChatGPT, Claude.ai, an IDE assistant, …); paste its reply back into the form below it and it's
-validated against the exact same schema, no Piwi AI credits spent either way. An MCP-connected
-coding agent (Claude Code, Cursor, …) can skip the copy-paste entirely and call the
-`create_test_function` [MCP tool](./mcp) directly, using its own model to read the source.
-Registered entries can be edited in place from the same page — the pencil button reopens the
-form with everything filled in.
-
-A parameter can be typed **object** for the options-bag argument most helpers take
-(`selectOption(page, { label }, { value })`), listing the bag's keys; a parameter source then
-targets one key by name, so generated calls pass `{ label: 'Country' }` rather than a bare
-string. Extraction is deliberately conservative: a function that branches on its arguments,
-loops, or calls other helpers whose source isn't visible can't be captured as one fixed
-pattern, so it comes back with low confidence and a note saying what was left out, rather than
-a confident-looking guess.
-
-Once a function is registered, use **Test functions** in the extension popup to check whether
+The catalog the extension matches against is managed in the dashboard, not in the extension:
+registering functions (by hand, by AI extraction, or from an MCP agent), object parameters, and
+what extraction can and can't capture are all covered on the [Test functions catalog](./test-functions)
+page. Once a function is registered, use **Test functions** in the extension popup to check whether
 its pattern actually matches whatever page you're looking at.
 
 ## Current limits

--- a/apps/docs/mcp.md
+++ b/apps/docs/mcp.md
@@ -82,7 +82,7 @@ The server exposes 45 tools — mostly read-only, plus a few write/triage tools 
 | `run_cluster_diagnosis` | Trigger an AI diagnosis and return the result |
 | `set_cluster_base_commit` | Pin the baseline commit for a cluster's SCM-diff context |
 | `submit_diagnosis_feedback` | Thumbs up/down on a diagnosis |
-| `create_test_function` | Register a page-object method or helper in a project's [test-function catalog](./extension#connecting-to-a-piwi-instance) from source you (the calling agent) read yourself — no AI call happens on the server side, this only validates and persists |
+| `create_test_function` | Register a page-object method or helper in a project's [test functions catalog](./test-functions) from source you (the calling agent) read yourself — no AI call happens on the server side, this only validates and persists |
 
 **Source control** *(requires an SCM token — per-project or global)*
 

--- a/apps/docs/test-functions.md
+++ b/apps/docs/test-functions.md
@@ -1,0 +1,42 @@
+---
+title: Test functions catalog
+lang: en-US
+---
+
+# Test functions catalog
+
+The test functions catalog is a **per-project registry of your own page-object methods and helpers**, each stored with the DOM pattern its steps produce. It lets recordings and agents refer to *your* code instead of raw locators: the [browser extension](./extension) collapses matched steps in a recording into a call to your function, and an MCP agent can register the functions it writes. The catalog lives in the dashboard, and the extension and MCP tools read from it.
+
+## Where it lives
+
+A project's **Test functions** page in the dashboard (**Project → Test functions**). Every entry is scoped to that project, and the [browser extension](./extension#connecting-to-a-piwi-instance) caches a mapped project's catalog locally so it can match against it while you record.
+
+## Registering a function
+
+Four ways in, all landing in the same reviewed entry:
+
+- **By hand** — **Add function** and fill in the name, parameters and pattern yourself.
+- **Paste the source, let AI propose it** — paste a page-object method or helper's source and a model proposes the name, parameters, and DOM pattern into a **review form you edit before saving**. With [AI](./ai-diagnosis) configured on the instance, an **Extract** button calls it directly.
+- **Bring your own AI** — no instance AI, or you'd rather not use it? **Copy prompt for your own AI** copies the full extraction prompt (the rules, the JSON schema, and your pasted code) to paste into any AI chat (ChatGPT, Claude.ai, an IDE assistant). Paste the reply back and it is validated against the exact same schema — no Piwi AI credits spent either way.
+- **From a coding agent (MCP)** — an MCP-connected agent (Claude Code, Cursor, …) calls the `create_test_function` [MCP tool](./mcp) directly, reading the source with its own model. No AI call happens on the server side; the tool only validates and persists.
+
+Registered entries are edited in place from the same page — the pencil button reopens the form with everything filled in.
+
+## Object parameters
+
+A parameter can be typed **object**, for the options-bag argument most helpers take — `selectOption(page, { label }, { value })`. You list the bag's keys, and a parameter source then targets one key by name, so a generated call passes `{ label: 'Country' }` rather than a bare string.
+
+## What extraction won't do
+
+Extraction is deliberately conservative. A function that branches on its arguments, loops, or calls other helpers whose source isn't visible can't be captured as one fixed pattern — so it comes back with **low confidence and a note** saying what was left out, rather than a confident-looking guess you'd have to catch later.
+
+## Using the catalog
+
+- **While recording**, the extension live-ranks which catalog function the steps so far look like, and on **Copy as TypeScript** matched steps collapse into a call to your function; anything unmatched stays as plain locators. The matcher only ever *selects among* the functions you registered — it never invents one. See the [browser extension](./extension#what-it-does).
+- **Against the current page**, the popup's **Test functions** checklist scores every function in the active project's catalog: ready to use here, a partial match, or not found on this page.
+
+## Related
+
+- [Browser extension](./extension) — records against the catalog and consumes it
+- [MCP server](./mcp) — the `create_test_function` tool
+- [AI diagnosis](./ai-diagnosis) — the model the **Extract** button uses


### PR DESCRIPTION
## What & why

Phase-2 restructure — **the first split** (re-homing, not additive). The dashboard's **test functions catalog** — a server feature — was documented only inside the browser extension's "Connecting to a Piwi instance" section, and `mcp.md` deep-linked there for it. It had no page of its own.

- **New** `apps/docs/test-functions.md` (Apps & integrations, 552 words): what the catalog is, where it lives (Project → Test functions), the four ways to register a function (by hand, AI **Extract**, **Copy prompt for your own AI**, the `create_test_function` MCP tool), object parameters, what extraction won't capture, and how the extension + popup checklist use it.
- `extension.md` keeps the connection mechanics — **and the `## Connecting to a Piwi instance` heading**, so the `extension#connecting-to-a-piwi-instance` anchor that the app's Test-functions page `<DocLink>` resolves against stays valid — and now points at the new page for catalog management.
- Rewires `mcp.md`'s `create_test_function` link from `extension#connecting-to-a-piwi-instance` to the new `/test-functions` page.
- Adds a "Test functions catalog" entry to the "Apps & integrations" sidebar, after Browser extension.

Because the one in-app anchor is **preserved** (that `<DocLink>` legitimately points at the extension, and the extension still covers how it consumes the catalog), no in-app literal change was needed and no redirect stub applies — `extension.md`'s URL is unchanged.

## How was it tested?

- `npm run docs:build` — green; the dead-link check confirms `extension#connecting-to-a-piwi-instance` still resolves and the new/rewired links (`/test-functions`, `extension#what-it-does`) all resolve.
- `npx vitest run tests/unit/docs-drift.test.ts` — 129 passing (the `create_test_function` tool still appears in `mcp.md`; the extension DocLink anchor still resolves).

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes (n/a — covered by docs-drift + build dead-link check)
- [x] Docs updated — this *is* the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdmqq1BRUPeH5BxSPV5Jj)_