### PR TITLE
fix(application): order latest runs by start_time, not id

### DIFF
--- a/apps/application/shared/handlers/test-runs.ts
+++ b/apps/application/shared/handlers/test-runs.ts
@@ -33,7 +33,11 @@ export async function getProjectLatestRun(db: DrizzleDB, projectId: number) {
     .select({ id: testRuns.id, status: testRuns.status })
     .from(testRuns)
     .where(eq(testRuns.projectId, projectId))
-    .orderBy(desc(testRuns.id))
+    // Rank by start_time (id as a deterministic tiebreaker), not MAX(id), so
+    // "latest" stays correct when rows are ingested out of chronological order —
+    // historical uploads on the server, or the demo seed which inserts runs
+    // newest-first (MAX(id) would be the oldest run). Matches `listProjects`.
+    .orderBy(desc(testRuns.startTime), desc(testRuns.id))
     .limit(1);
   return rows[0] ?? null;
 }
@@ -58,7 +62,9 @@ export async function getTestRun(
     .select({ id: testRuns.id, status: testRuns.status })
     .from(testRuns)
     .where(eq(testRuns.projectId, testRun.projectId))
-    .orderBy(desc(testRuns.id))
+    // Rank by start_time (see getProjectLatestRun) so the "Newer run" pill points
+    // at the chronologically newest run, not MAX(id).
+    .orderBy(desc(testRuns.startTime), desc(testRuns.id))
     .limit(1);
   const latestRunId = latestRunResult[0]?.id ?? null;
   const latestRunStatus = latestRunResult[0]?.status ?? null;

--- a/apps/application/tests/unit/latest-run-ordering.test.ts
+++ b/apps/application/tests/unit/latest-run-ordering.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createClient } from '@libsql/client';
+import * as schema from '../../server/database/schema.sqlite';
+
+// The schema barrel picks the PostgreSQL schema at import time when
+// PIWI_DATABASE_URL is set, so clear it before importing the handlers.
+delete process.env.PIWI_DATABASE_URL;
+const { getProjectLatestRun, getTestRun } = await import('../../shared/handlers/test-runs');
+
+const now = Date.now();
+const at = (minutesAgo: number) => new Date(now - minutesAgo * 60 * 1000);
+
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+beforeAll(async () => {
+  db = drizzle(createClient({ url: ':memory:' }), { schema });
+  const migrationsFolder = fileURLToPath(new URL('../../server/database/migrations', import.meta.url));
+  await migrate(db, { migrationsFolder });
+
+  await db.insert(schema.projects).values([{ id: 1, name: 'Alpha' }]);
+
+  // Insert runs the way the demo seed does: newest-first with an incrementing
+  // id, so the NEWEST run (by start_time) has the SMALLEST id and the OLDEST run
+  // has the LARGEST id. Ordering by MAX(id) would therefore pick the OLDEST run.
+  await db.insert(schema.testRuns).values([
+    { id: 5, projectId: 1, status: 'failed', startTime: at(1), isFullRun: 1 }, // newest
+    { id: 8, projectId: 1, status: 'passed', startTime: at(300), isFullRun: 1 },
+    { id: 12, projectId: 1, status: 'passed', startTime: at(900), isFullRun: 1 }, // oldest
+  ]);
+});
+
+describe('latest-run selection is chronological, not MAX(id)', () => {
+  test('getProjectLatestRun returns the newest run by start_time', async () => {
+    const latest = await getProjectLatestRun(db, 1);
+    expect(latest).toEqual({ id: 5, status: 'failed' });
+  });
+
+  test('getTestRun exposes the chronologically newest run as project.latestRunId', async () => {
+    // Open the OLDEST run (largest id): its "Newer run" pill must still point at
+    // the newest run (id 5), never at itself or at MAX(id).
+    const run: any = await getTestRun(db, 12);
+    expect(run?.project?.latestRunId).toBe(5);
+    expect(run?.project?.latestRunStatus).toBe('failed');
+  });
+});


### PR DESCRIPTION
## What & why

Fixes a bug where the "latest run" for a project was determined by `MAX(id)` instead of chronological order (`start_time`). This caused incorrect behavior when test runs were ingested out of chronological order — such as historical uploads or the demo seed which inserts runs newest-first.

With the old logic, the oldest run (largest id) would be incorrectly identified as the latest. This affected:
- `getProjectLatestRun()` — used to display the latest run status in the project list
- `getTestRun()` — used to show the "Newer run" pill when viewing an older run

The fix changes both queries to order by `start_time DESC` (with `id DESC` as a deterministic tiebreaker), matching the existing behavior in `listProjects`.

## How was it tested?

Added comprehensive unit tests in `latest-run-ordering.test.ts` that:
1. Create an in-memory SQLite database with migrations
2. Insert test runs in the same order as the demo seed (newest-first, so MAX(id) ≠ newest)
3. Verify `getProjectLatestRun()` returns the chronologically newest run
4. Verify `getTestRun()` correctly exposes the latest run via `project.latestRunId`

## Checklist

- [x] PR title follows Conventional Commits (`fix(application): ...`)
- [x] Tests added for behavior changes (new unit test file)
- [x] No user-facing docs changes needed (internal handler fix)

https://claude.ai/code/session_012wUfvw6etCwEF8gG6dwi31