### PR TITLE
feat(app): lock-aware sharding, split-lock warning, and --add-reporter

### DIFF
--- a/apps/application/server/utils/mcp/tools.ts
+++ b/apps/application/server/utils/mcp/tools.ts
@@ -1567,6 +1567,7 @@ const HANDLERS: Record<McpToolName, McpToolHandler> = {
             totalRoutes: suggestions.smoke.totalRoutes,
             coveredRoutes: suggestions.smoke.coveredRoutes,
             testCaseIds: suggestions.smoke.testCaseIds,
+            splitLocks: suggestions.smoke.splitLocks.length ? suggestions.smoke.splitLocks : null,
             picks: suggestions.smoke.picks.map((p) =>
               dropNulls({
                 testCaseId: p.testCaseId,

--- a/apps/application/server/utils/scm/pr-feedback.ts
+++ b/apps/application/server/utils/scm/pr-feedback.ts
@@ -42,6 +42,7 @@ import type { DbClient } from '../../database';
 import type { FilterDetails } from '#shared/types';
 import { errorExcerpt } from '#shared/notification-events';
 import { caseHeadline } from '#shared/failure-verdict';
+import { locksHeldAcrossShards } from '#shared/lock-overlap';
 
 /** Read the resolved settings, falling back to the (disabled) defaults. */
 export async function getPrFeedbackSettings(db: DbClient): Promise<PrFeedbackSettings> {
@@ -74,6 +75,9 @@ interface CaseRow {
   filePath: string;
   tags: unknown;
   owner: string | null;
+  locks: unknown;
+  shardIndex: number | null;
+  startedAt: number | null;
 }
 
 /**
@@ -169,6 +173,9 @@ export async function buildRunPrSummary(
       filePath: testCases.filePath,
       tags: testCases.tags,
       owner: testCases.owner,
+      locks: testRunsCases.locks,
+      shardIndex: testRunsCases.shardIndex,
+      startedAt: testRunsCases.startedAt,
     })
     .from(testRunsCases)
     .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
@@ -265,6 +272,18 @@ export async function buildRunPrSummary(
     selection: (() => {
       const stamp = (run.filterDetails as FilterDetails | null)?.selection;
       return stamp ? { key: stamp.key, testCount: stamp.resolvedCount } : null;
+    })(),
+    splitLocks: (() => {
+      const held = locksHeldAcrossShards(
+        caseRows.map((row) => ({
+          id: row.id,
+          shardIndex: row.shardIndex,
+          startedAt: row.startedAt,
+          duration: row.duration,
+          locks: Array.isArray(row.locks) ? (row.locks as string[]) : [],
+        })),
+      );
+      return held.length ? held : null;
     })(),
     hasBaseline: insights?.hasBaseline ?? false,
   };

--- a/apps/application/shared/failure-clues.ts
+++ b/apps/application/shared/failure-clues.ts
@@ -22,6 +22,7 @@ import type { FailureTimeline } from '#shared/failure-timeline';
 import { TIMELINE_WINDOW_LEAD_MS } from '#shared/failure-timeline';
 import type { LocatorHealingResult } from '#shared/locator-healing.types';
 import type { PageStateLike } from '#shared/page-state';
+import { intervalsOverlap } from '#shared/lock-overlap';
 
 /** The environment-diff facts the engine reads — the pure subset of the server result. */
 export interface FailureClueEnvironmentDiff {
@@ -569,7 +570,7 @@ export function buildFailureClues(input: FailureClueInput): FailureClue[] {
           if (!isFiniteNumber(h.startedAt) || !isFiniteNumber(h.duration)) return false;
           const hStart = h.startedAt as number;
           const hEnd = hStart + (h.duration as number);
-          return hStart < selfEnd && hEnd > selfStart;
+          return intervalsOverlap(selfStart, selfEnd, hStart, hEnd);
         });
         if (overlap) {
           add({

--- a/apps/application/shared/handlers/selection-suggestions.ts
+++ b/apps/application/shared/handlers/selection-suggestions.ts
@@ -13,6 +13,7 @@ import { and, eq, isNotNull } from 'drizzle-orm';
 import { networkRequests, testCases, testRunsCases } from '../../server/database/schema';
 import type { DrizzleDB } from './db';
 import { loadSelectionCatalog, type CatalogRow } from './selections';
+import { locksSpanningTests } from '../selection';
 
 /** A proposed tag for one test, with the evidence for it. */
 export interface TagSuggestion {
@@ -53,6 +54,12 @@ export interface SmokeMining {
   picks: SmokeCandidate[];
   /** test_case ids of the picks, ready to save as `{ include: [{ ids }] }`. */
   testCaseIds: number[];
+  /**
+   * Lock names held by more than one pick — sharding this suite with Playwright's
+   * own `--shard` could split them across shards; run it with `piwi run --shard`
+   * (lock-aware) instead. Empty when no lock spans two picks.
+   */
+  splitLocks: string[];
 }
 
 export interface SelectionSuggestions {
@@ -235,6 +242,7 @@ function mineSmokeSuite(
     coveredRoutes: covered.size,
     picks,
     testCaseIds: picks.map((p) => p.testCaseId),
+    splitLocks: locksSpanningTests(picks.map((p) => byId.get(p.testCaseId)!)),
   };
 }
 

--- a/apps/application/shared/handlers/selections.ts
+++ b/apps/application/shared/handlers/selections.ts
@@ -18,6 +18,8 @@ import {
   isBuiltinKey,
   materializeSelection,
   MAX_FAILED_IN_LAST_RUNS,
+  partitionTestsIntoShards,
+  locksSpanningTests,
   validateSelectionDefinition,
   validateSelectionKey,
   type MaterializedSelection,
@@ -38,6 +40,7 @@ export interface CatalogRow {
   suitePath: string;
   title: string;
   tags: string[];
+  locks: string[];
   owner: string | null;
   priority: string | null;
   feature: string | null;
@@ -97,6 +100,7 @@ export async function loadSelectionCatalog(
       suitePath: testCases.suitePath,
       title: testCases.title,
       tags: testCases.tags,
+      locks: testCases.locks,
       owner: testCases.owner,
       priority: testCases.priority,
       feature: testCases.feature,
@@ -125,6 +129,7 @@ export async function loadSelectionCatalog(
       suitePath: row.suitePath ?? '',
       title: row.title,
       tags: Array.isArray(row.tags) ? (row.tags as string[]) : [],
+      locks: Array.isArray(row.locks) ? (row.locks as string[]) : [],
       owner: row.owner ?? null,
       priority: row.priority ?? null,
       feature: row.feature ?? null,
@@ -305,6 +310,7 @@ function toResolvedTest(row: CatalogRow): ResolvedTest {
     title: row.title,
     line: row.lastLine,
     avgDurationMs: row.avgDurationMs,
+    locks: row.locks,
   };
 }
 
@@ -340,25 +346,6 @@ export interface ResolveOptions {
    * correctly. Analytics resolves many selections against one shared catalog.
    */
   catalog?: CatalogRow[];
-}
-
-/**
- * Split rows into `total` shards balanced by summed average duration
- * (longest-processing-time first: assign the heaviest test to the lightest
- * shard). Historically informed balancing that Playwright's file-count sharding
- * cannot do.
- */
-function partitionByDuration(rows: CatalogRow[], total: number): CatalogRow[][] {
-  const buckets: CatalogRow[][] = Array.from({ length: total }, () => []);
-  const loads = new Array<number>(total).fill(0);
-  const sorted = [...rows].sort((a, b) => (b.avgDurationMs ?? 0) - (a.avgDurationMs ?? 0) || stableCompare(a, b));
-  for (const row of sorted) {
-    let lightest = 0;
-    for (let i = 1; i < total; i++) if (loads[i]! < loads[lightest]!) lightest = i;
-    buckets[lightest]!.push(row);
-    loads[lightest] = loads[lightest]! + (row.avgDurationMs ?? 0);
-  }
-  return buckets.map((bucket) => bucket.sort(stableCompare));
 }
 
 /**
@@ -425,10 +412,11 @@ export async function resolveSelectionDefinition(
     }
   }
 
-  // shard: keep only this shard's duration-balanced bucket of the final set.
+  // shard: keep only this shard's duration-balanced bucket of the final set,
+  // with every test that shares a lock kept together in one shard.
   const shard = options.shard;
   if (shard && shard.total >= 1 && shard.index >= 1 && shard.index <= shard.total) {
-    ordered = partitionByDuration(ordered, shard.total)[shard.index - 1] ?? [];
+    ordered = partitionTestsIntoShards(ordered, shard.total)[shard.index - 1] ?? [];
   }
 
   // fail-fast: emit worst-first, so the tests most likely to fail start first.
@@ -438,6 +426,14 @@ export async function resolveSelectionDefinition(
     warnings.push({
       code: 'quarantined-included',
       message: 'The selection includes one or more quarantined tests',
+    });
+  }
+
+  const spanningLocks = locksSpanningTests(ordered);
+  if (spanningLocks.length > 0) {
+    warnings.push({
+      code: 'split-lock',
+      message: `Lock(s) ${spanningLocks.join(', ')} are held by more than one test — sharding with Playwright's own "playwright test --shard" could split a lock across shards; run this selection with "piwi run --shard i/n" (lock-aware) to keep each lock in one shard`,
     });
   }
 

--- a/apps/application/shared/lock-overlap.ts
+++ b/apps/application/shared/lock-overlap.ts
@@ -1,0 +1,73 @@
+/**
+ * Cross-shard lock overlap — detecting a lock held on two shards at the same
+ * wall-clock time.
+ *
+ * Playwright serializes lock holders inside one `npx playwright test` process:
+ * the held-lock set lives in that process's dispatcher, so `--shard` runs on
+ * separate processes never coordinate and the same lock can be held on two
+ * shards at once. Playwright cannot see this; it is the classic "passes on one
+ * machine" flake. Both the per-execution failure clue and the run-wide PR
+ * summary read the same overlap here.
+ */
+
+/** A lock-holding execution and the wall-clock window it held its locks. */
+export interface LockHolderInterval {
+  id: number;
+  /** The execution's shard, or null when the run was not sharded. */
+  shardIndex: number | null;
+  /** Epoch ms the execution started, or null when unknown. */
+  startedAt: number | null;
+  /** Execution duration in ms, or null when unknown. */
+  duration: number | null;
+  locks: string[];
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/** Whether the half-open intervals `[aStart, aEnd)` and `[bStart, bEnd)` overlap. */
+export function intervalsOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+/**
+ * Lock names that two holders on different shards held at the same time. A
+ * holder counts only when it carries a shard, a start and a duration. Returns
+ * the lock names sorted, without duplicates.
+ */
+export function locksHeldAcrossShards(holders: LockHolderInterval[]): string[] {
+  const usable = holders.filter(
+    (h) => h.shardIndex != null && isFiniteNumber(h.startedAt) && isFiniteNumber(h.duration),
+  );
+
+  const byLock = new Map<string, LockHolderInterval[]>();
+  for (const holder of usable) {
+    for (const lock of new Set(holder.locks)) {
+      const list = byLock.get(lock);
+      if (list) list.push(holder);
+      else byLock.set(lock, [holder]);
+    }
+  }
+
+  const split: string[] = [];
+  for (const [lock, group] of byLock) {
+    if (groupSpansShards(group)) split.push(lock);
+  }
+  return split.sort();
+}
+
+/** Whether any two holders in one lock's group overlap in time on different shards. */
+function groupSpansShards(group: LockHolderInterval[]): boolean {
+  for (let i = 0; i < group.length; i++) {
+    const a = group[i]!;
+    const aEnd = (a.startedAt as number) + (a.duration as number);
+    for (let j = i + 1; j < group.length; j++) {
+      const b = group[j]!;
+      if (a.shardIndex === b.shardIndex) continue;
+      const bEnd = (b.startedAt as number) + (b.duration as number);
+      if (intervalsOverlap(a.startedAt as number, aEnd, b.startedAt as number, bEnd)) return true;
+    }
+  }
+  return false;
+}

--- a/apps/application/shared/mcp-tools.ts
+++ b/apps/application/shared/mcp-tools.ts
@@ -531,7 +531,7 @@ export const MCP_TOOL_DEFS = [
   {
     name: 'suggest_selections',
     description:
-      'Suggest tags and a smoke suite for a project from observed history (suggest-only, with evidence). Returns `slow` tags for duration outliers, `feature` tags from the route families tests hit, and a mined smoke suite — a budgeted set cover over observed routes, each pick buying fewer new routes than the last. `budgetMs` caps the smoke suite (default 5 min).',
+      'Suggest tags and a smoke suite for a project from observed history (suggest-only, with evidence). Returns `slow` tags for duration outliers, `feature` tags from the route families tests hit, and a mined smoke suite — a budgeted set cover over observed routes, each pick buying fewer new routes than the last. The smoke suite lists any `splitLocks` (locks held by more than one pick), which plain `playwright test --shard` could split across shards — run it with `piwi run --shard` (lock-aware) instead. `budgetMs` caps the smoke suite (default 5 min).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -544,7 +544,7 @@ export const MCP_TOOL_DEFS = [
   {
     name: 'analyze_selections',
     description:
-      'Health and drift for a project\'s selections. For each: what it resolves to now (count, quarantined members, duration, warnings) and whether that differs from what its most recent stamped run recorded — a silent drift a green build can hide. Plus coverage: how many tests are matched by no stored selection (the "unselected" gap), with a sample. Read-only.',
+      'Health and drift for a project\'s selections. For each: what it resolves to now (count, quarantined members, duration, warnings — including a `split-lock` warning when a lock is shared by more than one test, which Playwright\'s own `--shard` could split across shards) and whether that differs from what its most recent stamped run recorded — a silent drift a green build can hide. Plus coverage: how many tests are matched by no stored selection (the "unselected" gap), with a sample. Read-only.',
     inputSchema: {
       type: 'object',
       properties: { projectId: { type: 'number', description: 'Project ID' } },

--- a/apps/application/shared/pr-feedback.ts
+++ b/apps/application/shared/pr-feedback.ts
@@ -114,6 +114,8 @@ export interface PrSummaryInput {
   wastedMinutes: number | null;
   /** The named selection this run resolved from, when it came from `piwi run`. */
   selection?: { key: string; testCount: number } | null;
+  /** Locks held on two shards at once in this run — the guarantee sharding is meant to keep. */
+  splitLocks?: string[] | null;
   /** True when no previous green run existed to compare against. */
   hasBaseline: boolean;
 }
@@ -221,6 +223,14 @@ export function buildPrComment(input: PrSummaryInput): string {
   if (input.selection) {
     const n = input.selection.testCount;
     sections.push(`🎯 Selection **\`${input.selection.key}\`** — ${n} ${n === 1 ? 'test' : 'tests'}`);
+  }
+
+  if (input.splitLocks && input.splitLocks.length > 0) {
+    const names = input.splitLocks.map((lock) => `\`${escapeCell(lock)}\``).join(', ');
+    const plural = input.splitLocks.length === 1 ? 'Lock' : 'Locks';
+    sections.push(
+      `🔓 ${plural} ${names} held on two shards at once — locks serialize only within one \`playwright test\` process, so sharded runs don't coordinate. Shard with \`piwi run --shard\` (lock-aware) to keep each lock in one shard.`,
+    );
   }
 
   if (input.newRegressions.length > 0) {

--- a/apps/application/shared/selection/index.ts
+++ b/apps/application/shared/selection/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './validate';
 export * from './builtins';
 export * from './materialize';
+export * from './shard';

--- a/apps/application/shared/selection/shard.ts
+++ b/apps/application/shared/selection/shard.ts
@@ -1,0 +1,126 @@
+/**
+ * Lock-aware, duration-balanced sharding of a resolved test list.
+ *
+ * Playwright serializes lock holders inside one `npx playwright test` process
+ * only: two `--shard` runs are separate processes with no shared held-lock set,
+ * so a lock declared on tests split across shards can be held on both at once.
+ * Keeping every test that shares a lock in the same shard restores that
+ * guarantee. Tests are first grouped by lock (transitively — a lock shared
+ * between two tests binds them, and a test carrying two locks binds their
+ * groups), then each group is placed whole with longest-processing-time
+ * balancing: the heaviest group goes to the lightest shard. A group heavier than
+ * a shard's fair share still lands on one shard; balance is best effort, the
+ * lock guarantee is not.
+ */
+
+/** The fields the balancer reads from a resolved test. */
+export interface ShardableTest {
+  id: number;
+  filePath: string;
+  suitePath: string;
+  title: string;
+  avgDurationMs: number | null;
+  locks: string[];
+}
+
+/** Deterministic base order — file, then suite, then title, then id. */
+export function stableTestCompare(a: ShardableTest, b: ShardableTest): number {
+  return (
+    a.filePath.localeCompare(b.filePath) ||
+    a.suitePath.localeCompare(b.suitePath) ||
+    a.title.localeCompare(b.title) ||
+    a.id - b.id
+  );
+}
+
+/** The stable-least test of a non-empty group, used as a deterministic tiebreak. */
+function representative<T extends ShardableTest>(tests: T[]): T {
+  return tests.reduce((least, t) => (stableTestCompare(t, least) < 0 ? t : least));
+}
+
+/**
+ * Partition tests into connected components: two tests are in the same component
+ * when they share a lock name, transitively. A test with no locks is its own
+ * singleton component. Uses union-find keyed by array index.
+ */
+function groupByLock<T extends ShardableTest>(rows: T[]): T[][] {
+  const parent = rows.map((_, i) => i);
+  const find = (x: number): number => {
+    let root = x;
+    while (parent[root] !== root) root = parent[root]!;
+    while (parent[x] !== root) {
+      const next = parent[x]!;
+      parent[x] = root;
+      x = next;
+    }
+    return root;
+  };
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[Math.max(ra, rb)] = Math.min(ra, rb);
+  };
+
+  const firstHolder = new Map<string, number>();
+  rows.forEach((row, i) => {
+    for (const lock of row.locks) {
+      const seen = firstHolder.get(lock);
+      if (seen === undefined) firstHolder.set(lock, i);
+      else union(seen, i);
+    }
+  });
+
+  const groups = new Map<number, T[]>();
+  rows.forEach((row, i) => {
+    const root = find(i);
+    const group = groups.get(root);
+    if (group) group.push(row);
+    else groups.set(root, [row]);
+  });
+  return [...groups.values()];
+}
+
+/**
+ * Split rows into `total` shards balanced by summed average duration, keeping
+ * every test that shares a lock in the same shard. Deterministic for the same
+ * input: groups are placed heaviest-first (ties broken by their stable-least
+ * test), each onto the currently lightest shard (ties broken by the lower shard
+ * index), and each shard's tests are returned in stable order.
+ */
+export function partitionTestsIntoShards<T extends ShardableTest>(rows: T[], total: number): T[][] {
+  const buckets: T[][] = Array.from({ length: total }, () => []);
+  if (total < 1) return buckets;
+
+  const groups = groupByLock(rows).map((tests) => ({
+    tests,
+    weight: tests.reduce((sum, t) => sum + (t.avgDurationMs ?? 0), 0),
+    rep: representative(tests),
+  }));
+  groups.sort((a, b) => b.weight - a.weight || stableTestCompare(a.rep, b.rep));
+
+  const loads = new Array<number>(total).fill(0);
+  for (const group of groups) {
+    let lightest = 0;
+    for (let i = 1; i < total; i++) if (loads[i]! < loads[lightest]!) lightest = i;
+    buckets[lightest]!.push(...group.tests);
+    loads[lightest] = loads[lightest]! + group.weight;
+  }
+  return buckets.map((bucket) => bucket.sort(stableTestCompare));
+}
+
+/**
+ * Lock names shared by two or more of these tests — the locks that plain
+ * file-count sharding (Playwright's own `--shard`) could split across shards,
+ * letting the same lock be held on two shards at once. A lock held by a single
+ * test cannot be split, so it is not reported.
+ */
+export function locksSpanningTests(rows: ShardableTest[]): string[] {
+  const holders = new Map<string, number>();
+  for (const row of rows) {
+    for (const lock of new Set(row.locks)) holders.set(lock, (holders.get(lock) ?? 0) + 1);
+  }
+  return [...holders.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([lock]) => lock)
+    .sort();
+}

--- a/apps/application/shared/selection/types.ts
+++ b/apps/application/shared/selection/types.ts
@@ -121,6 +121,8 @@ export interface ResolvedTest {
   title: string;
   line: number | null;
   avgDurationMs: number | null;
+  /** Lock names this test most recently declared, driving lock-aware sharding. */
+  locks: string[];
 }
 
 /** A non-fatal note attached to a resolution. */
@@ -132,7 +134,8 @@ export interface SelectionWarning {
     | 'budget-evicted-pin'
     | 'grep-overselects'
     | 'materialization-truncated'
-    | 'impact-widened';
+    | 'impact-widened'
+    | 'split-lock';
   message: string;
 }
 

--- a/apps/application/tests/unit/lock-overlap.test.ts
+++ b/apps/application/tests/unit/lock-overlap.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from 'vitest';
+import { intervalsOverlap, locksHeldAcrossShards, type LockHolderInterval } from '#shared/lock-overlap';
+
+function holder(overrides: Partial<LockHolderInterval> = {}): LockHolderInterval {
+  return { id: 1, shardIndex: 1, startedAt: 0, duration: 100, locks: ['db'], ...overrides };
+}
+
+describe('intervalsOverlap', () => {
+  test('overlapping windows', () => {
+    expect(intervalsOverlap(0, 100, 50, 150)).toBe(true);
+  });
+  test('touching windows do not overlap (half-open)', () => {
+    expect(intervalsOverlap(0, 100, 100, 200)).toBe(false);
+  });
+  test('disjoint windows', () => {
+    expect(intervalsOverlap(0, 50, 60, 100)).toBe(false);
+  });
+});
+
+describe('locksHeldAcrossShards', () => {
+  test('reports a lock held on two shards at overlapping times', () => {
+    const held = locksHeldAcrossShards([
+      holder({ id: 1, shardIndex: 1, startedAt: 0, duration: 100 }),
+      holder({ id: 2, shardIndex: 2, startedAt: 50, duration: 100 }),
+    ]);
+    expect(held).toEqual(['db']);
+  });
+
+  test('ignores holders on the same shard', () => {
+    const held = locksHeldAcrossShards([
+      holder({ id: 1, shardIndex: 1, startedAt: 0, duration: 100 }),
+      holder({ id: 2, shardIndex: 1, startedAt: 50, duration: 100 }),
+    ]);
+    expect(held).toEqual([]);
+  });
+
+  test('ignores non-overlapping holders on different shards', () => {
+    const held = locksHeldAcrossShards([
+      holder({ id: 1, shardIndex: 1, startedAt: 0, duration: 100 }),
+      holder({ id: 2, shardIndex: 2, startedAt: 200, duration: 100 }),
+    ]);
+    expect(held).toEqual([]);
+  });
+
+  test('ignores holders with no shard index (unsharded run)', () => {
+    const held = locksHeldAcrossShards([
+      holder({ id: 1, shardIndex: null, startedAt: 0, duration: 100 }),
+      holder({ id: 2, shardIndex: null, startedAt: 50, duration: 100 }),
+    ]);
+    expect(held).toEqual([]);
+  });
+
+  test('matches per lock, and returns sorted unique names', () => {
+    const held = locksHeldAcrossShards([
+      holder({ id: 1, shardIndex: 1, startedAt: 0, duration: 100, locks: ['z', 'a'] }),
+      holder({ id: 2, shardIndex: 2, startedAt: 50, duration: 100, locks: ['a', 'z'] }),
+      holder({ id: 3, shardIndex: 3, startedAt: 500, duration: 100, locks: ['solo'] }),
+    ]);
+    expect(held).toEqual(['a', 'z']);
+  });
+});

--- a/apps/application/tests/unit/pr-feedback.test.ts
+++ b/apps/application/tests/unit/pr-feedback.test.ts
@@ -91,6 +91,17 @@ describe('buildPrComment', () => {
     expect(buildPrComment(summary())).not.toContain('Selection');
   });
 
+  test('flags a lock held on two shards at once', () => {
+    const body = buildPrComment(summary({ splitLocks: ['database'] }));
+    expect(body).toContain('`database`');
+    expect(body).toContain('two shards at once');
+    expect(body).toContain('piwi run --shard');
+  });
+
+  test('says nothing about split locks when none crossed shards', () => {
+    expect(buildPrComment(summary())).not.toContain('two shards at once');
+  });
+
   test('separates new failures from pre-existing ones', () => {
     const body = buildPrComment(
       summary({

--- a/apps/application/tests/unit/selection-materialize.test.ts
+++ b/apps/application/tests/unit/selection-materialize.test.ts
@@ -2,9 +2,33 @@ import { describe, test, expect } from 'vitest';
 import { materializeSelection, type ResolvedTest } from '#shared/selection';
 
 const tests: ResolvedTest[] = [
-  { testCaseId: 1, filePath: 'tests/login.spec.ts', suitePath: '', title: 'logs in', line: 10, avgDurationMs: 1200 },
-  { testCaseId: 2, filePath: 'tests/login.spec.ts', suitePath: '', title: 'logs out', line: 24, avgDurationMs: 800 },
-  { testCaseId: 3, filePath: 'tests/cart.spec.ts', suitePath: '', title: 'adds item', line: null, avgDurationMs: null },
+  {
+    testCaseId: 1,
+    filePath: 'tests/login.spec.ts',
+    suitePath: '',
+    title: 'logs in',
+    line: 10,
+    avgDurationMs: 1200,
+    locks: [],
+  },
+  {
+    testCaseId: 2,
+    filePath: 'tests/login.spec.ts',
+    suitePath: '',
+    title: 'logs out',
+    line: 24,
+    avgDurationMs: 800,
+    locks: [],
+  },
+  {
+    testCaseId: 3,
+    filePath: 'tests/cart.spec.ts',
+    suitePath: '',
+    title: 'adds item',
+    line: null,
+    avgDurationMs: null,
+    locks: [],
+  },
 ];
 
 describe('materializeSelection', () => {
@@ -30,7 +54,17 @@ describe('materializeSelection', () => {
 
   test('grep escapes regex metacharacters in titles', () => {
     const m = materializeSelection(
-      [{ testCaseId: 1, filePath: 'a.spec.ts', suitePath: '', title: 'a (b) [c]', line: 1, avgDurationMs: 1 }],
+      [
+        {
+          testCaseId: 1,
+          filePath: 'a.spec.ts',
+          suitePath: '',
+          title: 'a (b) [c]',
+          line: 1,
+          avgDurationMs: 1,
+          locks: [],
+        },
+      ],
       'grep',
     );
     expect(m.args[1]).toBe('a \\(b\\) \\[c\\]');

--- a/apps/application/tests/unit/selection-resolve.test.ts
+++ b/apps/application/tests/unit/selection-resolve.test.ts
@@ -26,6 +26,7 @@ interface CaseOpts {
   filePath?: string;
   suitePath?: string;
   tags?: string[];
+  locks?: string[];
   owner?: string | null;
   priority?: string | null;
   feature?: string | null;
@@ -40,6 +41,7 @@ async function seedCase(title: string, opts: CaseOpts = {}): Promise<number> {
     suitePath: opts.suitePath ?? '',
     title,
     tags: opts.tags ?? null,
+    locks: opts.locks ?? null,
     owner: opts.owner ?? null,
     priority: opts.priority ?? null,
     feature: opts.feature ?? null,
@@ -246,6 +248,57 @@ describe('duration-balanced sharding', () => {
     const a = await resolveSelectionDefinition(db, 1, {}, { shard: { index: 2, total: 3 } });
     const b = await resolveSelectionDefinition(db, 1, {}, { shard: { index: 2, total: 3 } });
     expect(a.tests.map((t) => t.testCaseId)).toEqual(b.tests.map((t) => t.testCaseId));
+  });
+
+  test('keeps every holder of a lock in the same shard', async () => {
+    // Two holders of `db` plus six singletons; a plain duration split would
+    // scatter the holders, but lock-aware sharding keeps them together.
+    const held1 = await seedCase('held-a', { filePath: 'tests/f0.spec.ts', locks: ['db'] });
+    const held2 = await seedCase('held-b', { filePath: 'tests/f7.spec.ts', locks: ['db'] });
+    await seedExecution(held1, 'passed', { duration: 1000 });
+    await seedExecution(held2, 'passed', { duration: 8000 });
+    for (let i = 1; i < 7; i++) {
+      const id = await seedCase(`t${i}`, { filePath: `tests/f${i}.spec.ts` });
+      await seedExecution(id, 'passed', { duration: (i + 1) * 1000 });
+    }
+
+    const shards = await Promise.all(
+      [1, 2, 3, 4].map((index) => resolveSelectionDefinition(db, 1, {}, { shard: { index, total: 4 } })),
+    );
+    const homeOf = (id: number) => shards.findIndex((s) => s.tests.some((t) => t.testCaseId === id));
+    expect(homeOf(held1)).toBe(homeOf(held2));
+    expect(homeOf(held1)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('split-lock warning', () => {
+  test('warns when a lock is shared by more than one test', async () => {
+    const a = await seedCase('a', { locks: ['db'] });
+    const b = await seedCase('b', { locks: ['db'] });
+    await seedExecution(a, 'passed');
+    await seedExecution(b, 'passed');
+
+    const r = await resolveSelectionDefinition(db, 1, {});
+    const warning = r.warnings.find((w) => w.code === 'split-lock');
+    expect(warning).toBeDefined();
+    expect(warning!.message).toContain('db');
+  });
+
+  test('does not warn when each lock is held by a single test', async () => {
+    const a = await seedCase('a', { locks: ['db'] });
+    const b = await seedCase('b', { locks: ['cache'] });
+    await seedExecution(a, 'passed');
+    await seedExecution(b, 'passed');
+
+    const r = await resolveSelectionDefinition(db, 1, {});
+    expect(r.warnings.some((w) => w.code === 'split-lock')).toBe(false);
+  });
+
+  test('surfaces locks on each resolved test', async () => {
+    const a = await seedCase('a', { locks: ['db', 'cache'] });
+    await seedExecution(a, 'passed');
+    const r = await resolveSelectionDefinition(db, 1, {});
+    expect(r.tests[0]!.locks).toEqual(['db', 'cache']);
   });
 });
 

--- a/apps/application/tests/unit/selection-shard.test.ts
+++ b/apps/application/tests/unit/selection-shard.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from 'vitest';
+import { partitionTestsIntoShards, locksSpanningTests, type ShardableTest } from '#shared/selection';
+
+/** Build a shardable test; file path defaults to a per-id spec so ordering is stable. */
+function t(id: number, avgDurationMs: number | null, locks: string[] = [], filePath?: string): ShardableTest {
+  return { id, filePath: filePath ?? `tests/t${id}.spec.ts`, suitePath: '', title: `test ${id}`, avgDurationMs, locks };
+}
+
+/** The set of ids in each shard, for order-independent assertions. */
+function idSets(shards: ShardableTest[][]): Set<number>[] {
+  return shards.map((shard) => new Set(shard.map((row) => row.id)));
+}
+
+/** The shard index a given id landed in. */
+function shardOf(shards: ShardableTest[][], id: number): number {
+  return shards.findIndex((shard) => shard.some((row) => row.id === id));
+}
+
+describe('partitionTestsIntoShards', () => {
+  test('with no locks, balances by duration (longest-processing-time first)', () => {
+    const rows = [t(1, 30), t(2, 20), t(3, 20), t(4, 10)];
+    const shards = partitionTestsIntoShards(rows, 2);
+    // 30→s0, 20→s1, 20→s1, 10→s0 ⇒ both shards sum to 40.
+    expect(idSets(shards)).toEqual([new Set([1, 4]), new Set([2, 3])]);
+  });
+
+  test('with no locks, every test lands in exactly one shard', () => {
+    const rows = [t(1, 5), t(2, 7), t(3, 3), t(4, 9), t(5, 1)];
+    const shards = partitionTestsIntoShards(rows, 3);
+    const all = shards.flatMap((s) => s.map((r) => r.id)).sort((a, b) => a - b);
+    expect(all).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('keeps tests that share a lock in the same shard', () => {
+    const rows = [t(1, 10, ['db']), t(2, 10), t(3, 10, ['db']), t(4, 10)];
+    const shards = partitionTestsIntoShards(rows, 2);
+    expect(shardOf(shards, 1)).toBe(shardOf(shards, 3));
+  });
+
+  test('groups locks transitively — a test carrying two locks joins both groups', () => {
+    const rows = [t(1, 10, ['x']), t(2, 10, ['x', 'y']), t(3, 10, ['y']), t(4, 10), t(5, 10)];
+    const shards = partitionTestsIntoShards(rows, 3);
+    const home = shardOf(shards, 1);
+    expect(shardOf(shards, 2)).toBe(home);
+    expect(shardOf(shards, 3)).toBe(home);
+  });
+
+  test('an oversized lock group still goes to a single shard', () => {
+    const rows = [t(1, 100, ['heavy']), t(2, 100, ['heavy']), t(3, 100, ['heavy']), t(4, 10), t(5, 10), t(6, 10)];
+    const shards = partitionTestsIntoShards(rows, 3);
+    const home = shardOf(shards, 1);
+    // All three heavy holders share one shard even though it dwarfs a fair share.
+    expect(shardOf(shards, 2)).toBe(home);
+    expect(shardOf(shards, 3)).toBe(home);
+  });
+
+  test('is deterministic for the same input', () => {
+    const rows = [t(1, 30, ['a']), t(2, 15), t(3, 15, ['a']), t(4, 40), t(5, 5, ['b']), t(6, 5, ['b'])];
+    const first = partitionTestsIntoShards(rows, 3);
+    const second = partitionTestsIntoShards([...rows].reverse(), 3);
+    expect(first).toEqual(second);
+  });
+
+  test('returns tests within a shard in stable order', () => {
+    const rows = [t(3, 10, [], 'tests/c.spec.ts'), t(1, 10, [], 'tests/a.spec.ts'), t(2, 10, [], 'tests/b.spec.ts')];
+    const shards = partitionTestsIntoShards(rows, 1);
+    expect(shards[0]!.map((r) => r.filePath)).toEqual(['tests/a.spec.ts', 'tests/b.spec.ts', 'tests/c.spec.ts']);
+  });
+
+  test('treats a null duration as zero weight', () => {
+    const rows = [t(1, null, ['db']), t(2, null, ['db']), t(3, 100)];
+    const shards = partitionTestsIntoShards(rows, 2);
+    expect(shardOf(shards, 1)).toBe(shardOf(shards, 2));
+    // The single heavy test lands alone on the other shard.
+    expect(shardOf(shards, 3)).not.toBe(shardOf(shards, 1));
+  });
+
+  test('total below one yields an empty partition', () => {
+    expect(partitionTestsIntoShards([t(1, 10)], 0)).toEqual([]);
+  });
+});
+
+describe('locksSpanningTests', () => {
+  test('reports a lock held by more than one test', () => {
+    const rows = [t(1, 10, ['db']), t(2, 10, ['db']), t(3, 10, ['cache'])];
+    expect(locksSpanningTests(rows)).toEqual(['db']);
+  });
+
+  test('ignores a lock held by a single test', () => {
+    const rows = [t(1, 10, ['db']), t(2, 10, ['cache'])];
+    expect(locksSpanningTests(rows)).toEqual([]);
+  });
+
+  test('counts a lock declared twice on one test only once', () => {
+    const rows = [t(1, 10, ['db', 'db']), t(2, 10)];
+    expect(locksSpanningTests(rows)).toEqual([]);
+  });
+
+  test('returns spanning locks sorted, without duplicates', () => {
+    const rows = [t(1, 10, ['z', 'a']), t(2, 10, ['a', 'z']), t(3, 10, ['a'])];
+    expect(locksSpanningTests(rows)).toEqual(['a', 'z']);
+  });
+});

--- a/apps/docs/cli.md
+++ b/apps/docs/cli.md
@@ -119,7 +119,7 @@ npx @piwitests/reporter run impact --base origin/main
 | `--project <name\|id>` | Project (env `PIWI_PROJECT_NAME`) |
 | `--format <fmt>` | `args` (`file:line`, default) · `grep` · `files` · `json` |
 | `--budget <duration>` | Cap total time, e.g. `5m`, `90s`, `300000` (ms) |
-| `--shard <i/n>` | Keep only shard *i* of *n*, balanced by test duration |
+| `--shard <i/n>` | Keep only shard *i* of *n*, balanced by test duration and lock-aware (a lock's holders stay in one shard) |
 | `--fail-fast` | Order the least-reliable tests first |
 | `--base <ref>` | For `impact`: the ref to diff the working tree against |
 | `--strict` | Fail (exit 2) instead of falling back when unreachable |
@@ -128,6 +128,8 @@ npx @piwitests/reporter run impact --base origin/main
 | `-h`, `--help` | Show help |
 
 Pass extra Playwright arguments after `--`: `piwi run smoke -- --headed --workers=1`.
+
+When `run` spawns Playwright and the target config has **no Piwi reporter**, it appends `--add-reporter @piwitests/reporter` so the run still reaches the dashboard — provided the installed Playwright is **1.63 or later** (the version that added the flag; it appends to the configured reporters rather than replacing them). It logs one line naming what it added. On older Playwright it logs that the reporter is not configured and runs as before. This trial append gives you results, traces and screenshots but not the [capture fixtures](./capture-fixtures) or [`wrapConfig`](./reporter#installing-via-wrapconfig) defaults — wire the reporter into the config (via [`init`](#init)) for the full set. A config that already lists the reporter is left untouched.
 
 ## `ai`
 

--- a/apps/docs/getting-started.md
+++ b/apps/docs/getting-started.md
@@ -106,6 +106,27 @@ Every step is idempotent, so it is safe to re-run. If it finds a config shape it
 
 Prefer to wire it up by hand? The manual steps are below.
 
+### Try it without editing your config
+
+On **Playwright 1.63 or later** you can send one run to a dashboard without editing your config or installing anything. Playwright's `--add-reporter` _appends_ a reporter to the ones your config already lists (unlike `--reporter`, which replaces them), and every reporter option has a `PIWI_*` environment-variable equivalent — so point it at your dashboard with env vars and run:
+
+::: code-group
+
+```bash [Linux / macOS]
+PIWI_DASHBOARD_URL=http://localhost:3000 \
+PIWI_API_KEY=your-api-key \
+PIWI_PROJECT_NAME=my-project \
+npx playwright test --add-reporter @piwitests/reporter
+```
+
+```powershell [Windows (PowerShell)]
+$env:PIWI_DASHBOARD_URL='http://localhost:3000'; $env:PIWI_API_KEY='your-api-key'; $env:PIWI_PROJECT_NAME='my-project'; npx playwright test --add-reporter @piwitests/reporter
+```
+
+:::
+
+This is a trial path, not a full setup. You get the run with its results, traces and screenshots, but **not** the [capture fixtures](#recommended-capture-fixtures) (network timing, Web Vitals, console capture, locator healing) and **not** [`wrapConfig`](./reporter#installing-via-wrapconfig)'s failure-evidence capture defaults — for those, run the [fast path](#fast-path-one-command) or wire the reporter in by hand. On older Playwright (before 1.63) `--add-reporter` does not exist; use the manual setup below. `piwi run` makes the same append for you automatically when your config has no Piwi reporter — see the [CLI reference](./cli#select-run).
+
 ### Manual setup
 
 Install it:

--- a/apps/docs/reporter.md
+++ b/apps/docs/reporter.md
@@ -15,6 +15,27 @@ npm install --save-dev @piwitests/reporter
 
 Or let `npx @piwitests/reporter init` do the install and wiring for you — see the [one-command setup](./getting-started#fast-path-one-command) in Getting started. The rest of this page is the full manual reference.
 
+### Try it without editing your config
+
+On **Playwright 1.63 or later**, `--add-reporter` appends this reporter to whatever your config already uses (unlike `--reporter`, which replaces them), so you can send one run to a dashboard with no install and no config edit. Every reporter option has a `PIWI_*` [environment variable](#environment-variables), so point it at your dashboard that way:
+
+::: code-group
+
+```bash [Linux / macOS]
+PIWI_DASHBOARD_URL=http://localhost:3000 \
+PIWI_API_KEY=your-api-key \
+PIWI_PROJECT_NAME=my-project \
+npx playwright test --add-reporter @piwitests/reporter
+```
+
+```powershell [Windows (PowerShell)]
+$env:PIWI_DASHBOARD_URL='http://localhost:3000'; $env:PIWI_API_KEY='your-api-key'; $env:PIWI_PROJECT_NAME='my-project'; npx playwright test --add-reporter @piwitests/reporter
+```
+
+:::
+
+This is a trial path: you get results, traces and screenshots, but not the [capture fixtures](#capture-fixtures) or [`wrapConfig`](#installing-via-wrapconfig)'s capture defaults. On Playwright before 1.63 the flag does not exist — configure the reporter normally instead. [`piwi run`](./cli#select-run) makes the same append automatically when the config has no Piwi reporter.
+
 ## Basic configuration
 
 Add the reporter to your `playwright.config.ts`:

--- a/apps/docs/test-selection.md
+++ b/apps/docs/test-selection.md
@@ -59,6 +59,15 @@ still covers the whole selection (so a `--require-selection` gate sees all of it
 npx @piwitests/reporter run smoke --shard 2/4 -- --shard=2/4
 ```
 
+The split is **lock-aware**: every test that shares a [lock](./reporter#test-locks) is placed in the same shard, then
+the shards are balanced by duration. Playwright serializes lock holders inside one `npx playwright test` process only —
+two `--shard` runs are separate processes and can hold the same lock at once — so keeping a lock's holders together
+restores the guarantee across shards. A lock group larger than a shard's fair share still goes to one shard (the lock
+guarantee wins over even balancing); grouping is transitive, so a test declaring two locks binds both groups. The
+assignment is deterministic for the same catalog. When a selection's tests share a lock, resolving it (including
+`piwi select --format json`) carries a `split-lock` warning, a reminder to shard with `piwi run --shard` rather than
+Playwright's own `playwright test --shard`, which would split the lock.
+
 ### Fail fast
 
 `--fail-fast` emits the selection worst-first — the least-reliable tests (by pass rate) lead, so a likely failure

--- a/packages/reporter/src/cli/add-reporter.ts
+++ b/packages/reporter/src/cli/add-reporter.ts
@@ -1,0 +1,112 @@
+/**
+ * `--add-reporter` support for `piwi run`: when the target Playwright config has
+ * no Piwi reporter, `run` appends `--add-reporter @piwitests/reporter` so results
+ * still reach the dashboard without editing the config, provided the installed
+ * Playwright is 1.63 or later (the version whose CLI added the flag — it appends
+ * to the configured reporters rather than replacing them like `--reporter`).
+ *
+ * This trades away the wrapped-config defaults: no capture fixtures and none of
+ * `wrapConfig`'s failure-evidence capture defaults. It is the no-edit trial path,
+ * not a substitute for wiring the reporter into the config.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createRequire } from 'node:module';
+import { detectProject } from './detect.js';
+
+export const REPORTER_PACKAGE = '@piwitests/reporter';
+export const ADD_REPORTER_FLAG = '--add-reporter';
+
+/** First Playwright version whose CLI accepts `--add-reporter`. */
+const ADD_REPORTER_MIN = { major: 1, minor: 63 } as const;
+
+/** Whether the installed Playwright version accepts `--add-reporter`. */
+export function playwrightSupportsAddReporter(version: string | null | undefined): boolean {
+  const match = version ? /^(\d+)\.(\d+)/.exec(version) : null;
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major > ADD_REPORTER_MIN.major || (major === ADD_REPORTER_MIN.major && minor >= ADD_REPORTER_MIN.minor);
+}
+
+/** Whether a config's source already wires in the Piwi reporter (import or entry). */
+export function configHasPiwiReporter(source: string): boolean {
+  return new RegExp(REPORTER_PACKAGE.replace(/[/\\]/g, '\\$&')).test(source);
+}
+
+export interface AddReporterDecision {
+  /** Extra Playwright CLI args to prepend — empty when nothing is added. */
+  args: string[];
+  /** One line to log, or null when there is nothing worth saying. */
+  log: string | null;
+}
+
+/**
+ * Decide whether to append `--add-reporter`, from the config's source (null when
+ * no config was found) and the installed Playwright version. Adds the flag only
+ * when a config exists, does not already wire in the reporter, and the installed
+ * Playwright is new enough; on an older Playwright it logs that the reporter is
+ * not configured and adds nothing.
+ */
+export function decideAddReporter(configSource: string | null, playwrightVersion: string | null): AddReporterDecision {
+  if (configSource === null || configHasPiwiReporter(configSource)) return { args: [], log: null };
+  if (playwrightSupportsAddReporter(playwrightVersion)) {
+    return {
+      args: [ADD_REPORTER_FLAG, REPORTER_PACKAGE],
+      log: `piwi run: the Playwright config has no Piwi reporter — appending ${ADD_REPORTER_FLAG} ${REPORTER_PACKAGE}`,
+    };
+  }
+  return {
+    args: [],
+    log: `piwi run: the Playwright config has no Piwi reporter and Playwright ${playwrightVersion ?? 'unknown'} predates ${ADD_REPORTER_FLAG} (1.63) — results will not reach the dashboard`,
+  };
+}
+
+/** Resolve the Playwright config the run will use, honoring `--config` / `-c`. */
+function resolveConfigPath(cwd: string, playwrightArgs: string[]): string | null {
+  for (let i = 0; i < playwrightArgs.length; i++) {
+    const arg = playwrightArgs[i]!;
+    if (arg === '--config' || arg === '-c') {
+      const next = playwrightArgs[i + 1];
+      if (next) return path.resolve(cwd, next);
+    } else if (arg.startsWith('--config=')) {
+      return path.resolve(cwd, arg.slice('--config='.length));
+    }
+  }
+  return detectProject(cwd).configPath;
+}
+
+function readConfigSource(configPath: string | null): string | null {
+  if (!configPath) return null;
+  try {
+    return fs.readFileSync(configPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Read the Playwright version installed in the target project, or null. */
+export function readInstalledPlaywrightVersion(cwd: string): string | null {
+  try {
+    const require = createRequire(path.join(cwd, 'noop.js'));
+    for (const id of ['@playwright/test/package.json', 'playwright/package.json']) {
+      try {
+        return (require(id) as { version?: string }).version ?? null;
+      } catch {
+        // Try the next candidate.
+      }
+    }
+  } catch {
+    // No resolvable Playwright — treat as unknown.
+  }
+  return null;
+}
+
+/**
+ * Compute the `--add-reporter` arguments and log line for a `run` about to spawn
+ * Playwright in `cwd` with `playwrightArgs`.
+ */
+export function computeAddReporterArgs(cwd: string, playwrightArgs: string[]): AddReporterDecision {
+  const source = readConfigSource(resolveConfigPath(cwd, playwrightArgs));
+  return decideAddReporter(source, readInstalledPlaywrightVersion(cwd));
+}

--- a/packages/reporter/src/cli/select.ts
+++ b/packages/reporter/src/cli/select.ts
@@ -24,6 +24,7 @@ import {
   type ImpactResolution,
   type SelectionResolution,
 } from '../internal/support/selection-client.js';
+import { computeAddReporterArgs } from './add-reporter.js';
 
 const EXIT_OK = 0;
 const EXIT_ERROR = 2;
@@ -46,7 +47,7 @@ Connection:
 Selection:
   --format <fmt>        args (file:line, default) | grep | files | json
   --budget <duration>   Cap total time, e.g. 5m, 90s, 300000 (ms)
-  --shard <i/n>         Keep only shard i of n, balanced by test duration
+  --shard <i/n>         Keep only shard i of n, balanced by duration, lock-aware
   --fail-fast           Order the least-reliable tests first (fail-fast)
   --base <ref>          For "impact": the ref to diff the working tree against
 
@@ -347,6 +348,17 @@ function spawnPlaywright(pkgRunner: string, playwrightArgs: string[], env: NodeJ
   });
 }
 
+/**
+ * Spawn Playwright for `run`, prepending `--add-reporter @piwitests/reporter`
+ * when the target config has no Piwi reporter and the installed Playwright is
+ * 1.63 or later. Logs one line naming what was added, or why it was not.
+ */
+function spawnPlaywrightForRun(pkgRunner: string, playwrightArgs: string[], env: NodeJS.ProcessEnv): Promise<number> {
+  const decision = computeAddReporterArgs(process.cwd(), playwrightArgs);
+  if (decision.log) console.error(decision.log);
+  return spawnPlaywright(pkgRunner, [...decision.args, ...playwrightArgs], env);
+}
+
 async function runRunImpact(args: SelectArgs, env: NodeJS.ProcessEnv): Promise<number> {
   let projectId: number;
   try {
@@ -357,7 +369,7 @@ async function runRunImpact(args: SelectArgs, env: NodeJS.ProcessEnv): Promise<n
       return EXIT_ERROR;
     }
     console.error(`piwi run: ${(e as Error).message} — running the full suite`);
-    return spawnPlaywright(args.pkgRunner, args.extra, env);
+    return spawnPlaywrightForRun(args.pkgRunner, args.extra, env);
   }
 
   let impact: ImpactResolution;
@@ -369,7 +381,7 @@ async function runRunImpact(args: SelectArgs, env: NodeJS.ProcessEnv): Promise<n
       return EXIT_ERROR;
     }
     console.error(`piwi run: ${(e as Error).message} — running the full suite`);
-    return spawnPlaywright(args.pkgRunner, args.extra, env);
+    return spawnPlaywrightForRun(args.pkgRunner, args.extra, env);
   }
 
   printWarnings(impact);
@@ -377,7 +389,7 @@ async function runRunImpact(args: SelectArgs, env: NodeJS.ProcessEnv): Promise<n
     console.error(
       `piwi run: impact widened to the full suite (${impact.impact.unmappedSourceFiles.length} unmapped source file(s))`,
     );
-    return spawnPlaywright(args.pkgRunner, args.extra, env);
+    return spawnPlaywrightForRun(args.pkgRunner, args.extra, env);
   }
   if (impact.estimate.count === 0) {
     console.error(`piwi run: no tests impacted by ${impact.impact.changedFiles} changed file(s) — nothing to run`);
@@ -391,7 +403,7 @@ async function runRunImpact(args: SelectArgs, env: NodeJS.ProcessEnv): Promise<n
     PIWI_SELECTION_COUNT: String(impact.estimate.count),
   };
   console.error(`piwi run: impact → ${impact.estimate.count} test(s)`);
-  return spawnPlaywright(args.pkgRunner, [...impact.materialization.args, ...args.extra], runEnv);
+  return spawnPlaywrightForRun(args.pkgRunner, [...impact.materialization.args, ...args.extra], runEnv);
 }
 
 export async function runRun(argv: string[], env: NodeJS.ProcessEnv = process.env): Promise<number> {
@@ -430,7 +442,7 @@ export async function runRun(argv: string[], env: NodeJS.ProcessEnv = process.en
       return EXIT_ERROR;
     }
     console.error(`piwi run: ${(e as Error).message} — running the full suite`);
-    return spawnPlaywright(args.pkgRunner, args.extra, env);
+    return spawnPlaywrightForRun(args.pkgRunner, args.extra, env);
   }
 
   let outcome: { resolution: Resolution; fromCache: boolean } | null;
@@ -443,7 +455,7 @@ export async function runRun(argv: string[], env: NodeJS.ProcessEnv = process.en
 
   if (!outcome) {
     console.error('piwi run: dashboard unreachable and no cached resolution — running the full suite');
-    return spawnPlaywright(args.pkgRunner, args.extra, env);
+    return spawnPlaywrightForRun(args.pkgRunner, args.extra, env);
   }
 
   const { resolution } = outcome;
@@ -463,5 +475,5 @@ export async function runRun(argv: string[], env: NodeJS.ProcessEnv = process.en
   console.error(
     `piwi run: ${args.key} → ${resolution.estimate.count} tests${resolution.materialization.format !== args.format ? ` (materialized as ${resolution.materialization.format})` : ''}`,
   );
-  return spawnPlaywright(args.pkgRunner, [...resolution.materialization.args, ...args.extra], runEnv);
+  return spawnPlaywrightForRun(args.pkgRunner, [...resolution.materialization.args, ...args.extra], runEnv);
 }

--- a/packages/reporter/src/internal/support/selection-client.ts
+++ b/packages/reporter/src/internal/support/selection-client.ts
@@ -8,7 +8,7 @@
 export interface SelectionResolution {
   key: string | null;
   version: number | null;
-  tests: Array<{ testCaseId: number; filePath: string; title: string; line: number | null }>;
+  tests: Array<{ testCaseId: number; filePath: string; title: string; line: number | null; locks?: string[] }>;
   resolvedHash: string;
   estimate: { count: number; totalDurationMs: number | null };
   warnings: Array<{ code: string; message: string }>;

--- a/packages/reporter/tests/add-reporter.spec.ts
+++ b/packages/reporter/tests/add-reporter.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  decideAddReporter,
+  playwrightSupportsAddReporter,
+  configHasPiwiReporter,
+  computeAddReporterArgs,
+  ADD_REPORTER_FLAG,
+  REPORTER_PACKAGE,
+} from '../src/cli/add-reporter.js';
+
+const PLAIN_CONFIG = `import { defineConfig } from '@playwright/test'\nexport default defineConfig({ testDir: './tests' })\n`;
+const WRAPPED_CONFIG = `import { wrapConfig } from '@piwitests/reporter'\nexport default wrapConfig(defineConfig({}), { projectName: 'x' })\n`;
+
+describe('playwrightSupportsAddReporter', () => {
+  it('accepts 1.63 and later', () => {
+    expect(playwrightSupportsAddReporter('1.63.0')).toBe(true);
+    expect(playwrightSupportsAddReporter('1.64.2')).toBe(true);
+    expect(playwrightSupportsAddReporter('2.0.0')).toBe(true);
+  });
+
+  it('rejects earlier versions and unknown input', () => {
+    expect(playwrightSupportsAddReporter('1.61.1')).toBe(false);
+    expect(playwrightSupportsAddReporter('1.62.0')).toBe(false);
+    expect(playwrightSupportsAddReporter(null)).toBe(false);
+    expect(playwrightSupportsAddReporter(undefined)).toBe(false);
+    expect(playwrightSupportsAddReporter('not-a-version')).toBe(false);
+  });
+});
+
+describe('configHasPiwiReporter', () => {
+  it('detects the reporter package in a config', () => {
+    expect(configHasPiwiReporter(WRAPPED_CONFIG)).toBe(true);
+    expect(configHasPiwiReporter(`reporter: [['@piwitests/reporter']]`)).toBe(true);
+  });
+
+  it('is false for a config without it', () => {
+    expect(configHasPiwiReporter(PLAIN_CONFIG)).toBe(false);
+  });
+});
+
+describe('decideAddReporter', () => {
+  it('appends the reporter when the config lacks it and Playwright is 1.63+', () => {
+    const decision = decideAddReporter(PLAIN_CONFIG, '1.63.0');
+    expect(decision.args).toEqual([ADD_REPORTER_FLAG, REPORTER_PACKAGE]);
+    expect(decision.log).toContain(ADD_REPORTER_FLAG);
+  });
+
+  it('adds nothing but logs on an older Playwright', () => {
+    const decision = decideAddReporter(PLAIN_CONFIG, '1.61.1');
+    expect(decision.args).toEqual([]);
+    expect(decision.log).toContain('1.63');
+    expect(decision.log).toContain('will not reach the dashboard');
+  });
+
+  it('does nothing when the config already wires in the reporter', () => {
+    expect(decideAddReporter(WRAPPED_CONFIG, '1.63.0')).toEqual({ args: [], log: null });
+  });
+
+  it('does nothing when no config was found', () => {
+    expect(decideAddReporter(null, '1.63.0')).toEqual({ args: [], log: null });
+  });
+});
+
+describe('computeAddReporterArgs', () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'piwi-addrep-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('adds nothing when the config already has the reporter', () => {
+    fs.writeFileSync(path.join(root, 'playwright.config.ts'), WRAPPED_CONFIG);
+    expect(computeAddReporterArgs(root, []).args).toEqual([]);
+  });
+
+  it('adds nothing when there is no config at all', () => {
+    expect(computeAddReporterArgs(root, [])).toEqual({ args: [], log: null });
+  });
+
+  it('honors an explicit --config path when locating the config', () => {
+    fs.writeFileSync(path.join(root, 'custom.config.ts'), WRAPPED_CONFIG);
+    // The default-named config is absent; only the explicit one wires in the reporter.
+    expect(computeAddReporterArgs(root, ['--config', 'custom.config.ts']).args).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

Item 6 of the Playwright 1.63 projection, building on the test-locks work merged in #484.

**1. Lock-aware sharding.** `piwi run --shard i/n` / `piwi select --shard i/n` now keep every test that shares a [lock](https://github.com/PiwiTests/platform/blob/main/apps/docs/reporter.md) in the same shard, then balance by duration as before. Playwright serializes lock holders inside one `npx playwright test` process only, so plain `--shard` (separate processes) can hold the same lock on two shards at once; grouping a lock's holders together restores that guarantee. Grouping is transitive (a test with two locks binds both groups) and deterministic; an oversized lock group stays whole on one shard (the lock guarantee wins over even balancing). The balancer is a pure module (`shared/selection/shard.ts`) and the resolve response now carries `locks` per test.

**2. Split-lock warning.** Resolving a selection whose tests share a lock adds a `split-lock` warning — surfaced by `analyze_selections` (via its per-selection `warnings`) and `piwi select`/`run`. The mined smoke suite from `suggest_selections` lists its `splitLocks`, and the PR-feedback summary flags any lock a run actually held on two shards at once. The cross-shard interval-overlap check is extracted from the failure-clue engine (`shared/lock-overlap.ts`) and reused by both the clue and the PR summary rather than duplicated.

**3. `--add-reporter`.** `piwi run` appends `--add-reporter @piwitests/reporter` when it spawns Playwright against a config with no Piwi reporter, so results reach the dashboard without editing the config — gated on the installed Playwright being 1.63 or later (the version whose CLI added the flag; it appends rather than replaces). On older Playwright it logs one line that the reporter is not configured and runs as before; an already-wired config is untouched. Docs gain a no-edit "try it without editing your config" path on the getting-started and reporter pages (env-var form with a Linux/macOS + PowerShell code-group), and the CLI reference documents the `run` behavior.

### Assumptions / notes

- The projection named `PIWI_SERVER_URL` / `PIWI_PROJECT` for the trial path, but the reporter's actual env-var options are `PIWI_DASHBOARD_URL`, `PIWI_PROJECT_NAME` and `PIWI_API_KEY` (`packages/reporter/src/internal/config/env.ts`) — there is no `PIWI_SERVER_URL`/`PIWI_PROJECT`. The docs use the working names so the copy-pasteable commands actually work.
- The desktop-shell part of `--add-reporter` is out of scope (owned by the desktop reproduction work).
- The demo mirror reuses the shared resolver / suggestions / analytics handlers, so it picks up `locks`, the warning and `splitLocks` with no separate change; `app:check:demo` stays green.

## How was it tested?

Verified in `apps/application`: `app:typecheck`, `app:lint`, `app:format:check`, `app:test:unit` (2049 passing), `app:check:demo`. In `packages/reporter`: `reporter:build`, `reporter:typecheck`, `reporter:lint`, `reporter:format:check`, `reporter:test` (721 passing). `npx commitlint --from origin/main --to HEAD` passes. `origin/main` merged into the branch.

New/updated unit tests: the balancer (`selection-shard` — groups, transitive grouping, an oversized group, determinism, no-locks-unchanged), cross-shard overlap (`lock-overlap`), the resolver warning and lock-aware shard integration (`selection-resolve`), the PR-feedback line (`pr-feedback`), and the `--add-reporter` decision for both the ≥1.63 and older-Playwright branches (`add-reporter`).

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated (`apps/docs/`: getting-started, reporter, cli, test-selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sc9UVrFEqkqJ2xAff9Bmo9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sc9UVrFEqkqJ2xAff9Bmo9)_