### PR TITLE
feat(app): export runs and executions as Perfetto traces

### DIFF
--- a/apps/application/app/components/shared/ExportMenu.vue
+++ b/apps/application/app/components/shared/ExportMenu.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 const props = defineProps<{
-  /** API path of the export endpoint, e.g. `/api/failure-clusters/12/export`. */
-  endpoint: string;
+  /**
+   * API path of the offline-report endpoint, e.g. `/api/failure-clusters/12/export`.
+   * Omit it (as on the run page) to offer only the Perfetto trace.
+   */
+  endpoint?: string;
+  /** API path of the Perfetto trace endpoint, e.g. `/api/test-runs/12/perfetto`. */
+  perfettoEndpoint?: string;
   /** Used only for the desktop shell's fallback filename; the server names the file. */
   baseName: string;
 }>();
@@ -30,6 +35,13 @@ async function run(format: 'html' | 'zip' | 'json' | 'md') {
   await download(withBase(`${props.endpoint}?format=${format}`), `${props.baseName}.${format}`, {
     binary: format === 'zip',
   });
+}
+
+/** The Perfetto trace is a JSON file that opens at ui.perfetto.dev. */
+async function runPerfetto() {
+  open.value = false;
+  if (!props.perfettoEndpoint) return;
+  await download(withBase(props.perfettoEndpoint), `${props.baseName}-perfetto.json`, { binary: false });
 }
 
 /**
@@ -80,92 +92,117 @@ function copyReport() {
 
     <template #content>
       <div class="w-64 p-1 space-y-0.5">
-        <div class="flex items-center justify-between px-2 pt-1 pb-1">
-          <p class="text-xs font-medium text-gray-500">Download</p>
-          <HelpHint topic="export.offline" />
-        </div>
+        <template v-if="endpoint">
+          <div class="flex items-center justify-between px-2 pt-1 pb-1">
+            <p class="text-xs font-medium text-gray-500">Download</p>
+            <HelpHint topic="export.offline" />
+          </div>
 
-        <UButton
-          block
-          size="sm"
-          color="neutral"
-          variant="ghost"
-          class="justify-start"
-          icon="i-lucide-file-code"
-          title="One self-contained HTML file with screenshots and video embedded"
-          @click="run('html')"
-        >
-          HTML — single file
-        </UButton>
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-file-code"
+            title="One self-contained HTML file with screenshots and video embedded"
+            @click="run('html')"
+          >
+            HTML — single file
+          </UButton>
 
-        <UButton
-          block
-          size="sm"
-          color="neutral"
-          variant="ghost"
-          class="justify-start"
-          icon="i-lucide-file-archive"
-          title="Report plus the raw artifacts, including trace archives and data.json"
-          @click="run('zip')"
-        >
-          ZIP — with all evidence
-        </UButton>
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-file-archive"
+            title="Report plus the raw artifacts, including trace archives and data.json"
+            @click="run('zip')"
+          >
+            ZIP — with all evidence
+          </UButton>
 
-        <UButton
-          block
-          size="sm"
-          color="neutral"
-          variant="ghost"
-          class="justify-start"
-          icon="i-lucide-printer"
-          title="Opens the report with your browser's print dialog, for Save as PDF"
-          @click="printReport"
-        >
-          PDF — via print
-        </UButton>
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-printer"
+            title="Opens the report with your browser's print dialog, for Save as PDF"
+            @click="printReport"
+          >
+            PDF — via print
+          </UButton>
 
-        <UButton
-          block
-          size="sm"
-          color="neutral"
-          variant="ghost"
-          class="justify-start"
-          icon="i-lucide-file-text"
-          title="The Markdown report as a file"
-          @click="run('md')"
-        >
-          Markdown
-        </UButton>
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-file-text"
+            title="The Markdown report as a file"
+            @click="run('md')"
+          >
+            Markdown
+          </UButton>
 
-        <UButton
-          block
-          size="sm"
-          color="neutral"
-          variant="ghost"
-          class="justify-start"
-          icon="i-lucide-file-json"
-          title="Everything the report contains, machine-readable"
-          @click="run('json')"
-        >
-          JSON
-        </UButton>
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-file-json"
+            title="Everything the report contains, machine-readable"
+            @click="run('json')"
+          >
+            JSON
+          </UButton>
+        </template>
 
-        <USeparator class="my-1" />
-        <p class="text-xs font-medium text-gray-500 px-2 pt-1 pb-1">Copy to clipboard</p>
+        <template v-if="perfettoEndpoint">
+          <USeparator v-if="endpoint" class="my-1" />
+          <p class="text-xs font-medium text-gray-500 px-2 pt-1 pb-1">Timeline</p>
 
-        <UButton
-          block
-          size="sm"
-          color="neutral"
-          variant="ghost"
-          class="justify-start"
-          icon="i-lucide-clipboard-list"
-          :loading="busy === 'Report'"
-          title="The whole investigation as Markdown, for an issue or a chat"
-          @click="copyReport"
-        >
-          Report (Markdown)
-        </UButton>
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-activity"
+            title="A Trace Event Format file — opens at ui.perfetto.dev or chrome://tracing"
+            @click="runPerfetto"
+          >
+            <span class="flex flex-col items-start text-left leading-tight">
+              Perfetto trace
+              <span class="text-xs text-gray-500">Opens at ui.perfetto.dev</span>
+            </span>
+          </UButton>
+        </template>
+
+        <template v-if="endpoint">
+          <USeparator class="my-1" />
+          <p class="text-xs font-medium text-gray-500 px-2 pt-1 pb-1">Copy to clipboard</p>
+
+          <UButton
+            block
+            size="sm"
+            color="neutral"
+            variant="ghost"
+            class="justify-start"
+            icon="i-lucide-clipboard-list"
+            :loading="busy === 'Report'"
+            title="The whole investigation as Markdown, for an issue or a chat"
+            @click="copyReport"
+          >
+            Report (Markdown)
+          </UButton>
+        </template>
       </div>
     </template>
   </UPopover>

--- a/apps/application/app/demo/api/perfetto.ts
+++ b/apps/application/app/demo/api/perfetto.ts
@@ -1,0 +1,45 @@
+/**
+ * Client-side Perfetto (Trace Event Format) export for demo mode.
+ *
+ * Collection and the trace builder are the shared implementation the server
+ * uses; the demo only supplies its own base URL for the execution links.
+ */
+import { buildPerfettoTrace } from '#shared/perfetto/build';
+import { collectExecutionPerfetto, collectRunPerfetto } from '#shared/handlers/perfetto';
+import type { PerfettoRunInput } from '#shared/perfetto/types';
+import { getDemoDb, getDemoDbBaseUrl } from '../db.client';
+
+function respond(input: PerfettoRunInput | null, scope: 'run' | 'execution', fileName: string): Response {
+  if (!input) {
+    return new Response(JSON.stringify({ statusCode: 404, message: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const trace = buildPerfettoTrace(input, {
+    scope,
+    baseUrl: getDemoDbBaseUrl().replace(/\/+$/, ''),
+    piwiVersion: 'demo',
+  });
+
+  return new Response(JSON.stringify(trace), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${fileName}"`,
+      'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function apiPerfettoTestRun(id: number): Promise<Response> {
+  const input = await collectRunPerfetto(await getDemoDb(), id);
+  return respond(input, 'run', `piwi-run-${id}-perfetto.json`);
+}
+
+export async function apiPerfettoTestRunCase(id: number): Promise<Response> {
+  const input = await collectExecutionPerfetto(await getDemoDb(), id);
+  return respond(input, 'execution', `piwi-execution-${id}-perfetto.json`);
+}

--- a/apps/application/app/demo/api/router.ts
+++ b/apps/application/app/demo/api/router.ts
@@ -37,6 +37,7 @@ import { getEnvironmentDiff } from '~~/server/utils/environment-diff';
 import { getPageDiff } from '~~/server/utils/page-diff';
 import { apiGetDemoDomSnapshot } from './dom-snapshot';
 import { apiExportTestRunCase, apiExportFailureCluster } from './export';
+import { apiPerfettoTestRun, apiPerfettoTestRunCase } from './perfetto';
 import {
   apiGetDemoTraceStacks,
   apiGetDemoTraceNetwork,
@@ -632,6 +633,14 @@ const routes: RouteEntry[] = [
       return getTestRunSummary(await getDemoDb(), +m[1]!);
     },
   },
+  {
+    method: 'GET',
+    pattern: /^\/api\/test-runs\/(\d+)\/perfetto$/,
+    handler: async (m, _b, _q, ctx) => {
+      await assertDemoEntityScope(ctx, 'run', +m[1]!);
+      return apiPerfettoTestRun(+m[1]!);
+    },
+  },
 
   // Failure groups
   {
@@ -979,6 +988,14 @@ const routes: RouteEntry[] = [
     handler: async (m, _, q, ctx) => {
       await assertDemoEntityScope(ctx, 'execution', +m[1]!);
       return apiExportTestRunCase(+m[1]!, q as URLSearchParams | undefined);
+    },
+  },
+  {
+    method: 'GET',
+    pattern: /^\/api\/test-run-cases\/(\d+)\/perfetto$/,
+    handler: async (m, _b, _q, ctx) => {
+      await assertDemoEntityScope(ctx, 'execution', +m[1]!);
+      return apiPerfettoTestRunCase(+m[1]!);
     },
   },
   {

--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -562,6 +562,7 @@ provide(clusterSectionLocatorKey, {
             <ExportMenu
               v-if="testCase"
               :endpoint="`/api/test-run-cases/${testCase.id}/export`"
+              :perfetto-endpoint="`/api/test-run-cases/${testCase.id}/perfetto`"
               :base-name="`piwi-execution-${testCase.id}`"
               class="mr-1"
             />

--- a/apps/application/app/pages/test-runs/[id].vue
+++ b/apps/application/app/pages/test-runs/[id].vue
@@ -706,6 +706,11 @@ const moreMenuItems = computed(() => {
         </template>
         <template #right>
           <div class="flex items-center shrink-0 min-w-0">
+            <ExportMenu
+              :perfetto-endpoint="`/api/test-runs/${runId}/perfetto`"
+              :base-name="`piwi-run-${runId}`"
+              class="mr-1"
+            />
             <UDropdownMenu :items="moreMenuItems">
               <UButton
                 size="sm"

--- a/apps/application/server/api/test-run-cases/[id]/perfetto.get.ts
+++ b/apps/application/server/api/test-run-cases/[id]/perfetto.get.ts
@@ -1,0 +1,30 @@
+import { collectExecutionPerfetto } from '#shared/handlers/perfetto';
+import {
+  requireResolvedProjectAccess,
+  requireRouteId,
+  resolveTestRunCaseProjectId,
+} from '../../../utils/project-access';
+import { sendPerfetto } from '../../../utils/perfetto-request';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Run Cases'],
+    summary: 'Export one execution as a Perfetto trace',
+    description:
+      'Downloads a single execution in Trace Event Format: a slice for the execution with its hooks, fixtures and steps nested underneath, and an instant event at the moment it failed. Open the file at ui.perfetto.dev or in Chrome’s chrome://tracing. Attachments are referenced by URL, not embedded.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'test run case ID');
+  const { db } = await requireResolvedProjectAccess(event, id, resolveTestRunCaseProjectId, 'Test run case');
+
+  const input = await collectExecutionPerfetto(db, id);
+  if (!input) {
+    throw apiError({ statusCode: 404, message: 'Test run case not found' });
+  }
+
+  return sendPerfetto(event, input, 'execution', `piwi-execution-${id}-perfetto.json`);
+});

--- a/apps/application/server/api/test-runs/[id]/perfetto.get.ts
+++ b/apps/application/server/api/test-runs/[id]/perfetto.get.ts
@@ -1,0 +1,26 @@
+import { collectRunPerfetto } from '#shared/handlers/perfetto';
+import { requireResolvedProjectAccess, requireRouteId, resolveRunProjectId } from '../../../utils/project-access';
+import { sendPerfetto } from '../../../utils/perfetto-request';
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Test Runs'],
+    summary: 'Export a run as a Perfetto trace',
+    description:
+      'Downloads the whole run in Trace Event Format: one process per shard, one thread per worker, and a slice for every execution with its hooks, fixtures and steps nested underneath. Open the file at ui.perfetto.dev or in Chrome’s chrome://tracing. Attachments are referenced by URL, not embedded.',
+    parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    'x-required-roles': ['administrator', 'reporter', 'user'],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const id = requireRouteId(event, 'id', 'test run ID');
+  const { db } = await requireResolvedProjectAccess(event, id, resolveRunProjectId, 'Test run');
+
+  const input = await collectRunPerfetto(db, id);
+  if (!input) {
+    throw apiError({ statusCode: 404, message: 'Test run not found' });
+  }
+
+  return sendPerfetto(event, input, 'run', `piwi-run-${id}-perfetto.json`);
+});

--- a/apps/application/server/utils/perfetto-request.ts
+++ b/apps/application/server/utils/perfetto-request.ts
@@ -1,0 +1,38 @@
+import type { H3Event } from 'h3';
+import { buildPerfettoTrace } from '#shared/perfetto/build';
+import type { PerfettoRunInput } from '#shared/perfetto/types';
+import { sanitizeFilename } from './sanitize-filename';
+import { resolvePublicBaseUrl } from './oauth-helpers';
+
+/** The dashboard origin recorded in the trace's execution and attachment URLs. */
+export function perfettoBaseUrl(event: H3Event): string {
+  const siteUrl = (useRuntimeConfig(event).public as { siteUrl?: string })?.siteUrl;
+  const url = getRequestURL(event);
+  return resolvePublicBaseUrl(siteUrl, `${url.protocol}//${url.host}`);
+}
+
+function perfettoPiwiVersion(event: H3Event): string | null {
+  return ((useRuntimeConfig(event).public as { appVersion?: string })?.appVersion as string) || null;
+}
+
+/** Build the Trace Event Format document and stream it as a `.json` download. */
+export function sendPerfetto(
+  event: H3Event,
+  input: PerfettoRunInput,
+  scope: 'run' | 'execution',
+  fileName: string,
+): Buffer {
+  const trace = buildPerfettoTrace(input, {
+    scope,
+    baseUrl: perfettoBaseUrl(event),
+    piwiVersion: perfettoPiwiVersion(event),
+  });
+  const bytes = Buffer.from(JSON.stringify(trace), 'utf-8');
+
+  setResponseHeader(event, 'Content-Type', 'application/json; charset=utf-8');
+  setResponseHeader(event, 'Content-Length', bytes.length);
+  setResponseHeader(event, 'Content-Disposition', `attachment; filename="${sanitizeFilename(fileName)}"`);
+  setResponseHeader(event, 'X-Content-Type-Options', 'nosniff');
+  setResponseHeader(event, 'Cache-Control', 'no-store');
+  return bytes;
+}

--- a/apps/application/shared/handlers/perfetto.ts
+++ b/apps/application/shared/handlers/perfetto.ts
@@ -1,0 +1,152 @@
+/**
+ * Assembles the `PerfettoRunInput` the trace builder consumes, from the same
+ * tables the run and execution pages read. Shared by the server routes and the
+ * demo mirror; only the base URL differs.
+ */
+import { eq, sql } from 'drizzle-orm';
+import { testRuns, testCases, testRunsCases, projects, files } from '../../server/database/schema';
+import type { DrizzleDB } from './db';
+import type {
+  PerfettoExecution,
+  PerfettoRunInput,
+  PerfettoSetupStep,
+  PerfettoStep,
+  PerfettoStepEvent,
+} from '../perfetto/types';
+
+/** Columns the trace needs from an execution row. */
+const EXECUTION_COLUMNS = {
+  id: testRunsCases.id,
+  testRunId: testRunsCases.testRunId,
+  testCaseId: testRunsCases.testCaseId,
+  status: testRunsCases.status,
+  duration: testRunsCases.duration,
+  error: testRunsCases.error,
+  retries: testRunsCases.retries,
+  line: testRunsCases.line,
+  column: testRunsCases.column,
+  steps: testRunsCases.steps,
+  stepEvents: testRunsCases.stepEvents,
+  workerIndex: testRunsCases.workerIndex,
+  shardIndex: testRunsCases.shardIndex,
+  startedAt: testRunsCases.startedAt,
+  tags: testRunsCases.tags,
+  locks: testRunsCases.locks,
+  testAnnotations: testRunsCases.testAnnotations,
+  title: testCases.title,
+  filePath: testCases.filePath,
+};
+
+type ExecutionRow = {
+  id: number;
+  testRunId: number;
+  testCaseId: number;
+  status: string;
+  duration: number | null;
+  error: string | null;
+  retries: number | null;
+  line: number | null;
+  column: number | null;
+  steps: unknown;
+  stepEvents: unknown;
+  workerIndex: number | null;
+  shardIndex: number | null;
+  startedAt: number | null;
+  tags: unknown;
+  locks: unknown;
+  testAnnotations: unknown;
+  title: string | null;
+  filePath: string | null;
+};
+
+function toExecution(row: ExecutionRow, attachments?: PerfettoExecution['attachments']): PerfettoExecution {
+  const location = row.line && row.column ? `${row.filePath}:${row.line}:${row.column}` : (row.filePath ?? undefined);
+  return {
+    executionId: row.id,
+    testCaseId: row.testCaseId,
+    title: row.title ?? `Execution ${row.id}`,
+    filePath: row.filePath ?? null,
+    location,
+    status: row.status,
+    workerIndex: row.workerIndex,
+    shardIndex: row.shardIndex,
+    startedAt: row.startedAt,
+    duration: row.duration,
+    retries: row.retries ?? 0,
+    tags: (row.tags as string[] | null) ?? null,
+    locks: (row.locks as string[] | null) ?? null,
+    annotations: (row.testAnnotations as PerfettoExecution['annotations']) ?? null,
+    error: row.error,
+    steps: (row.steps as PerfettoStep[] | null) ?? null,
+    stepEvents: (row.stepEvents as PerfettoStepEvent[] | null) ?? null,
+    attachments: attachments ?? undefined,
+  };
+}
+
+async function loadRun(db: DrizzleDB, runId: number) {
+  const [run] = await db.select().from(testRuns).where(eq(testRuns.id, runId));
+  if (!run) return null;
+  const [project] = await db.select().from(projects).where(eq(projects.id, run.projectId));
+  return {
+    id: run.id,
+    label: run.label ?? null,
+    status: run.status ?? null,
+    startTime: run.startTime instanceof Date ? run.startTime.getTime() : (run.startTime as number | null),
+    duration: run.duration ?? null,
+    playwrightVersion: run.playwrightVersion ?? null,
+    project: project ? { id: project.id, name: project.name, label: project.label ?? null } : null,
+    setupSteps: (run.setupSteps as PerfettoSetupStep[] | null) ?? null,
+  };
+}
+
+/** The whole run: every execution across its shards and workers. */
+export async function collectRunPerfetto(db: DrizzleDB, runId: number): Promise<PerfettoRunInput | null> {
+  const run = await loadRun(db, runId);
+  if (!run) return null;
+
+  const rows = (await db
+    .select(EXECUTION_COLUMNS)
+    .from(testRunsCases)
+    .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
+    .where(eq(testRunsCases.testRunId, runId))) as ExecutionRow[];
+
+  const { setupSteps, ...runMeta } = run;
+  return {
+    run: runMeta,
+    executions: rows.map((row) => toExecution(row)),
+    setupSteps,
+  };
+}
+
+/** One execution, with its attachments, as a single-execution run input. */
+export async function collectExecutionPerfetto(db: DrizzleDB, executionId: number): Promise<PerfettoRunInput | null> {
+  const [row] = (await db
+    .select(EXECUTION_COLUMNS)
+    .from(testRunsCases)
+    .innerJoin(testCases, eq(testRunsCases.testCaseId, testCases.id))
+    .where(eq(testRunsCases.id, executionId))) as ExecutionRow[];
+  if (!row) return null;
+
+  const run = await loadRun(db, row.testRunId);
+  if (!run) return null;
+
+  const attachmentRows = await db
+    .select({ name: files.subtype, contentType: files.label, path: files.path })
+    .from(files)
+    .where(sql`${files.testRunsCaseId} = ${executionId} AND ${files.type} = 'attachment'`);
+
+  const attachments = attachmentRows.map((a) => ({
+    name: a.name ?? a.path ?? 'attachment',
+    path: a.path ?? null,
+    contentType: a.contentType ?? null,
+  }));
+
+  const { setupSteps: _setupSteps, ...runMeta } = run;
+  return {
+    run: runMeta,
+    executions: [toExecution(row, attachments)],
+    // A single execution carries its own hooks; the run's suite-level setup
+    // steps belong to the whole-run export.
+    setupSteps: null,
+  };
+}

--- a/apps/application/shared/perfetto/build.ts
+++ b/apps/application/shared/perfetto/build.ts
@@ -1,0 +1,293 @@
+/**
+ * Turns a run (or one execution) into a Trace Event Format document that opens
+ * in ui.perfetto.dev and Chrome's `chrome://tracing`.
+ *
+ * Pure and node-free, so the demo reuses it. One process per shard, one thread
+ * per worker; each execution is a complete slice whose hooks, fixtures and steps
+ * nest under it by start time, and the moment a failing execution failed is an
+ * instant event on the same thread. Timestamps are microseconds relative to the
+ * earliest event, matching Playwright's own `perfetto` reporter.
+ */
+import type {
+  PerfettoBuildOptions,
+  PerfettoExecution,
+  PerfettoRunInput,
+  PerfettoStep,
+  PerfettoTrace,
+  TraceEvent,
+} from './types';
+
+/** Chrome trace color names keyed by execution/step status. */
+const STATUS_COLORS: Record<string, string> = {
+  passed: 'good',
+  failed: 'bad',
+  timedout: 'terrible',
+  interrupted: 'yellow',
+  skipped: 'grey',
+  didnotrun: 'grey',
+};
+
+/** Statuses that mark an execution as having failed. */
+const FAILED_STATUSES = new Set(['failed', 'timedout', 'interrupted']);
+
+function statusColor(status: string): string | undefined {
+  return STATUS_COLORS[status.toLowerCase()];
+}
+
+function num(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatAnnotation(a: { type: string; description?: string | null }): string {
+  return a.description ? `${a.type}: ${a.description}` : a.type;
+}
+
+/** The process id for a shard: its 1-based index, or 0 for an unsharded run. */
+function pidOf(ex: { shardIndex?: number | null }): number {
+  return ex.shardIndex != null && Number.isFinite(ex.shardIndex) ? ex.shardIndex : 0;
+}
+
+/** The thread id for a worker within its process. */
+function tidOf(ex: { workerIndex?: number | null }): number {
+  return ex.workerIndex != null && Number.isFinite(ex.workerIndex) ? ex.workerIndex : 0;
+}
+
+/** Map the `stepEvents` fallback into the richer step shape used for slices. */
+function stepFromEvent(event: {
+  title: string;
+  subtitle?: string | null;
+  category: string;
+  startedAt: number;
+  duration: number;
+  status?: string | null;
+}): PerfettoStep {
+  const failed = event.status ? FAILED_STATUSES.has(event.status.toLowerCase()) : false;
+  return {
+    title: event.title,
+    subtitle: event.subtitle ?? null,
+    category: event.category,
+    duration: event.duration,
+    startTime: event.startedAt,
+    failed,
+  };
+}
+
+export function buildPerfettoTrace(input: PerfettoRunInput, options: PerfettoBuildOptions): PerfettoTrace {
+  const baseUrl = options.baseUrl ? options.baseUrl.replace(/\/+$/, '') : null;
+  const events: TraceEvent[] = [];
+  /** Distinct (pid, tid) tracks that carry at least one slice. */
+  const tracks = new Set<string>();
+  /** Process id → its shard index (null when unsharded). */
+  const shardByPid = new Map<number, number | null>();
+  /** Worker index → the smallest process id that ran it (for setup steps). */
+  const pidByWorker = new Map<number, number>();
+
+  const registerTrack = (pid: number, tid: number) => {
+    tracks.add(`${pid}:${tid}`);
+  };
+
+  const stepArgs = (step: PerfettoStep): Record<string, unknown> | undefined => {
+    const args: Record<string, unknown> = {};
+    if (step.params && Object.keys(step.params).length) args.params = step.params;
+    if (step.subtitle) args.subtitle = step.subtitle;
+    if (step.category) args.category = step.category;
+    if (step.location) args.location = step.location;
+    if (step.error?.message) args.error = step.error.message;
+    return Object.keys(args).length ? args : undefined;
+  };
+
+  /** Emit a step's slice, clamped inside its execution's span. */
+  const emitStep = (
+    step: PerfettoStep,
+    pid: number,
+    tid: number,
+    boundStart: number,
+    boundEnd: number,
+    cursor: number,
+  ) => {
+    const dur = Math.max(0, num(step.duration, 0));
+    const rawStart = step.startTime != null && Number.isFinite(step.startTime) ? step.startTime : cursor;
+    const start = clamp(rawStart, boundStart, boundEnd);
+    const end = clamp(start + dur, start, boundEnd);
+    events.push({
+      name: step.subtitle ? `${step.title} ${step.subtitle}` : step.title,
+      cat: step.category || 'step',
+      ph: 'X',
+      ts: start,
+      dur: end - start,
+      pid,
+      tid,
+      cname: step.failed || step.error?.message ? 'bad' : undefined,
+      args: stepArgs(step),
+    });
+    return Math.max(cursor, end);
+  };
+
+  const testArgs = (ex: PerfettoExecution): Record<string, unknown> => {
+    const args: Record<string, unknown> = { status: ex.status };
+    if (ex.location) args.location = ex.location;
+    else if (ex.filePath) args.location = ex.filePath;
+    if (ex.testCaseId != null) args.testId = ex.testCaseId;
+    args.executionId = ex.executionId;
+    if (ex.workerIndex != null) args.workerIndex = ex.workerIndex;
+    if (ex.shardIndex != null) args.shardIndex = ex.shardIndex;
+    if (ex.retries) args.retry = ex.retries;
+    if (ex.tags?.length) args.tags = ex.tags.join(' ');
+    if (ex.locks?.length) args.locks = ex.locks;
+    if (ex.annotations?.length) args.annotations = ex.annotations.map(formatAnnotation);
+    if (ex.error) args.error = ex.error;
+    if (baseUrl) args.url = `${baseUrl}/test-run-cases/${ex.executionId}`;
+    if (ex.attachments?.length) {
+      args.attachments = ex.attachments.map((a) => (baseUrl && a.path ? `${baseUrl}/api/files/${a.path}` : a.name));
+    }
+    return args;
+  };
+
+  for (const ex of input.executions) {
+    const pid = pidOf(ex);
+    const tid = tidOf(ex);
+    shardByPid.set(pid, ex.shardIndex ?? null);
+    if (ex.workerIndex != null) {
+      const existing = pidByWorker.get(ex.workerIndex);
+      if (existing == null || pid < existing) pidByWorker.set(ex.workerIndex, pid);
+    }
+    registerTrack(pid, tid);
+
+    const startMs = num(ex.startedAt, num(input.run.startTime, 0));
+    const steps = ex.steps?.length ? ex.steps : (ex.stepEvents ?? []).map(stepFromEvent);
+
+    // The slice must span its steps even when the recorded duration is shorter.
+    let endMs = startMs + Math.max(0, num(ex.duration, 0));
+    for (const step of steps) {
+      if (step.startTime != null && Number.isFinite(step.startTime)) {
+        endMs = Math.max(endMs, step.startTime + Math.max(0, num(step.duration, 0)));
+      }
+    }
+
+    events.push({
+      name: ex.title,
+      cat: 'test',
+      ph: 'X',
+      ts: startMs,
+      dur: endMs - startMs,
+      pid,
+      tid,
+      cname: statusColor(ex.status),
+      args: testArgs(ex),
+    });
+
+    let cursor = startMs;
+    let failStart: number | null = null;
+    for (const step of steps) {
+      const before = cursor;
+      cursor = emitStep(step, pid, tid, startMs, endMs, cursor);
+      if (failStart == null && (step.failed || step.error?.message)) {
+        failStart = clamp(step.startTime != null ? step.startTime : before, startMs, endMs);
+      }
+    }
+
+    if (FAILED_STATUSES.has(ex.status.toLowerCase())) {
+      events.push({
+        name: 'failed',
+        cat: 'error',
+        ph: 'i',
+        s: 't',
+        ts: failStart ?? endMs,
+        pid,
+        tid,
+        cname: 'bad',
+        args: ex.error ? { error: ex.error } : undefined,
+      });
+    }
+  }
+
+  // Suite-level setup steps carry a worker but no shard: place each on the
+  // lowest process id that ran that worker, matching the workers timeline.
+  for (const step of input.setupSteps ?? []) {
+    if (step.workerIndex == null || !Number.isFinite(step.workerIndex)) continue;
+    const tid = step.workerIndex;
+    const pid = pidByWorker.get(step.workerIndex) ?? 0;
+    shardByPid.set(pid, shardByPid.get(pid) ?? null);
+    registerTrack(pid, tid);
+    const start = num(step.startedAt, num(input.run.startTime, 0));
+    const dur = Math.max(0, num(step.duration, 0));
+    const failed = step.status ? FAILED_STATUSES.has(step.status.toLowerCase()) : false;
+    events.push({
+      name: step.subtitle ? `[setup] ${step.title} ${step.subtitle}` : `[setup] ${step.title}`,
+      cat: step.category || 'setup',
+      ph: 'X',
+      ts: start,
+      dur,
+      pid,
+      tid,
+      cname: failed ? 'bad' : undefined,
+      args: step.location ? { location: step.location } : undefined,
+    });
+  }
+
+  // Normalize to microseconds relative to the earliest event.
+  let timeOrigin = Infinity;
+  for (const event of events) timeOrigin = Math.min(timeOrigin, event.ts);
+  if (!Number.isFinite(timeOrigin)) timeOrigin = 0;
+  events.sort((a, b) => a.ts - b.ts);
+  for (const event of events) {
+    event.ts = Math.round((event.ts - timeOrigin) * 1000);
+    if (event.dur !== undefined) event.dur = Math.round(event.dur * 1000);
+  }
+
+  const metadataEvents = buildMetadata(shardByPid, tracks, options.scope);
+
+  const metadata: Record<string, unknown> = {
+    source: 'piwi',
+    scope: options.scope,
+    'run-id': input.run.id,
+    'run-status': input.run.status ?? null,
+    'playwright-version': input.run.playwrightVersion ?? null,
+    'generated-at': options.generatedAt ?? new Date().toISOString(),
+  };
+  if (options.piwiVersion) metadata['piwi-version'] = options.piwiVersion;
+  if (input.run.label) metadata['run-label'] = input.run.label;
+  if (input.run.project) metadata.project = input.run.project.label || input.run.project.name;
+  if (input.run.startTime != null) metadata['start-time'] = new Date(input.run.startTime).toISOString();
+  if (input.run.duration != null) metadata.duration = input.run.duration;
+
+  return { traceEvents: [...metadataEvents, ...events], displayTimeUnit: 'ms', metadata };
+}
+
+/** Process and thread naming metadata, ordered for stable lanes in the viewer. */
+function buildMetadata(
+  shardByPid: Map<number, number | null>,
+  tracks: Set<string>,
+  scope: 'run' | 'execution',
+): TraceEvent[] {
+  const out: TraceEvent[] = [];
+  const tidsByPid = new Map<number, Set<number>>();
+  for (const key of tracks) {
+    const [pidStr, tidStr] = key.split(':');
+    const pid = Number(pidStr);
+    const tid = Number(tidStr);
+    let tids = tidsByPid.get(pid);
+    if (!tids) {
+      tids = new Set();
+      tidsByPid.set(pid, tids);
+    }
+    tids.add(tid);
+  }
+
+  const pids = [...tidsByPid.keys()].sort((a, b) => a - b);
+  for (const pid of pids) {
+    const shard = shardByPid.get(pid) ?? null;
+    const name = shard != null ? `Shard ${shard}` : scope === 'execution' ? 'Execution' : 'Tests';
+    out.push({ name: 'process_name', cat: '__metadata', ph: 'M', ts: 0, pid, tid: 0, args: { name } });
+    out.push({ name: 'process_sort_index', cat: '__metadata', ph: 'M', ts: 0, pid, tid: 0, args: { sort_index: pid } });
+    for (const tid of [...tidsByPid.get(pid)!].sort((a, b) => a - b)) {
+      out.push({ name: 'thread_name', cat: '__metadata', ph: 'M', ts: 0, pid, tid, args: { name: `Worker ${tid}` } });
+      out.push({ name: 'thread_sort_index', cat: '__metadata', ph: 'M', ts: 0, pid, tid, args: { sort_index: tid } });
+    }
+  }
+  return out;
+}

--- a/apps/application/shared/perfetto/types.ts
+++ b/apps/application/shared/perfetto/types.ts
@@ -1,0 +1,132 @@
+/**
+ * The shapes behind the Perfetto (Trace Event Format) export of a run and of a
+ * single execution.
+ *
+ * `PerfettoRunInput` is the node-free input the pure builder consumes — one run,
+ * its executions with their steps and hooks, and the run's suite-level setup
+ * steps. `PerfettoTrace` is the Trace Event Format document the builder emits,
+ * which opens in ui.perfetto.dev and Chrome's `chrome://tracing`.
+ */
+
+/** One flattened step recorded during an execution (the `steps` JSON column). */
+export interface PerfettoStep {
+  title: string;
+  /** The step's target (rendered locator or URL), carried separately by newer Playwright. */
+  subtitle?: string | null;
+  /** Curated per-step arguments (rendered locator, URL, value, `test.step` author values). */
+  params?: Record<string, string | number | boolean> | null;
+  category?: string | null;
+  /** Duration in milliseconds. */
+  duration?: number | null;
+  /** Absolute start time in milliseconds; enables placing the step in time. */
+  startTime?: number | null;
+  /** Source pointer `file:line:col`. */
+  location?: string | null;
+  error?: { message?: string | null } | null;
+  failed?: boolean | null;
+}
+
+/** A hook/fixture/wait step with absolute timing (the `stepEvents` JSON column). */
+export interface PerfettoStepEvent {
+  title: string;
+  subtitle?: string | null;
+  category: string;
+  /** Absolute start time in milliseconds. */
+  startedAt: number;
+  duration: number;
+  status?: string | null;
+  location?: string | null;
+}
+
+/** A suite-level setup step (beforeAll/afterAll) tied to a worker, not a test. */
+export interface PerfettoSetupStep extends PerfettoStepEvent {
+  workerIndex?: number | null;
+}
+
+/** An evidence file attached to an execution. */
+export interface PerfettoAttachment {
+  name: string;
+  /** Storage path, turned into a download URL when a base URL is known. */
+  path?: string | null;
+  contentType?: string | null;
+}
+
+/** One execution (a `test_runs_cases` row) with everything the trace draws. */
+export interface PerfettoExecution {
+  executionId: number;
+  testCaseId?: number | null;
+  title: string;
+  filePath?: string | null;
+  location?: string | null;
+  status: string;
+  workerIndex?: number | null;
+  shardIndex?: number | null;
+  /** Absolute start time in milliseconds. */
+  startedAt?: number | null;
+  /** Duration in milliseconds. */
+  duration?: number | null;
+  /** Retry index of this execution (0 for the first attempt). */
+  retries?: number | null;
+  tags?: string[] | null;
+  locks?: string[] | null;
+  annotations?: Array<{ type: string; description?: string | null }> | null;
+  error?: string | null;
+  steps?: PerfettoStep[] | null;
+  stepEvents?: PerfettoStepEvent[] | null;
+  /** Present on the single-execution export; omitted on the whole-run export. */
+  attachments?: PerfettoAttachment[] | null;
+}
+
+/** The node-free input the builder turns into a Trace Event Format document. */
+export interface PerfettoRunInput {
+  run: {
+    id: number;
+    label?: string | null;
+    status?: string | null;
+    /** Absolute start time in milliseconds. */
+    startTime?: number | null;
+    /** Duration in milliseconds. */
+    duration?: number | null;
+    playwrightVersion?: string | null;
+    project?: { id: number; name: string; label?: string | null } | null;
+  };
+  executions: PerfettoExecution[];
+  setupSteps?: PerfettoSetupStep[] | null;
+}
+
+/** A single Trace Event Format event. */
+export interface TraceEvent {
+  name: string;
+  cat: string;
+  /** Phase: `X` complete, `i` instant, `M` metadata. */
+  ph: 'X' | 'i' | 'M';
+  /** Timestamp in microseconds. */
+  ts: number;
+  /** Duration in microseconds (complete events only). */
+  dur?: number;
+  pid: number;
+  tid: number;
+  /** Scope of an instant event: `g` global, `p` process, `t` thread. */
+  s?: 'g' | 'p' | 't';
+  /** Chrome trace color name (good, bad, terrible, yellow, grey). */
+  cname?: string;
+  args?: Record<string, unknown>;
+}
+
+/** The Trace Event Format document. */
+export interface PerfettoTrace {
+  traceEvents: TraceEvent[];
+  displayTimeUnit: 'ms';
+  metadata: Record<string, unknown>;
+}
+
+export interface PerfettoBuildOptions {
+  /** Whole run or one execution — drives the file name and the metadata. */
+  scope: 'run' | 'execution';
+  /** Dashboard origin used to build execution and attachment URLs. */
+  baseUrl?: string | null;
+  /** ISO timestamp recorded in the metadata. */
+  generatedAt?: string;
+  /** Piwi version recorded in the metadata. */
+  piwiVersion?: string | null;
+}

--- a/apps/application/shared/test-project-names.ts
+++ b/apps/application/shared/test-project-names.ts
@@ -99,6 +99,7 @@ export const PROJECT = {
   NO_METADATA: 'no-metadata-test',
   NO_OVERLAP: 'no-overlap',
   PAGE_DIFF: 'page-diff-test',
+  PERFETTO_EXPORT: 'perfetto-export-test',
   PERF_TEST: 'perf-test-project',
   PG_CONCURRENT: 'pg-concurrent-project',
   PG_TEST: 'pg-test-project',

--- a/apps/application/tests/perfetto-export.spec.ts
+++ b/apps/application/tests/perfetto-export.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Perfetto (Trace Event Format) export of a run and of an execution.
+ *
+ * The point is that the downloaded file opens in ui.perfetto.dev, so these
+ * assert the envelope Perfetto reads (traceEvents + displayTimeUnit + metadata),
+ * that shards map to processes and workers to threads, and that every execution
+ * is a slice carrying its steps.
+ */
+
+import { test, expect, type APIRequestContext } from './fixtures';
+import { PROJECT } from '#shared/test-project-names';
+
+const NOW = Date.now();
+
+async function submitShardedRun(request: APIRequestContext): Promise<number> {
+  const res = await request.post('/api/test-runs/submit', {
+    data: {
+      projectName: PROJECT.PERFETTO_EXPORT,
+      status: 'failed',
+      startTime: new Date(NOW).toISOString(),
+      duration: 4000,
+      totalTests: 2,
+      passedTests: 1,
+      failedTests: 1,
+      skippedTests: 0,
+      testCases: [
+        {
+          title: 'adds an item to the cart',
+          status: 'passed',
+          duration: 2000,
+          location: 'tests/cart.spec.ts:12:5',
+          workerIndex: 0,
+          shardIndex: 1,
+          startedAt: NOW,
+          tags: ['smoke'],
+          steps: [
+            {
+              title: 'Navigate',
+              subtitle: 'https://shop.test/cart',
+              category: 'navigation',
+              duration: 500,
+              startTime: NOW + 10,
+            },
+          ],
+        },
+        {
+          title: 'checks out',
+          status: 'failed',
+          error: 'TimeoutError: locator.click: Timeout 30000ms exceeded.',
+          duration: 1500,
+          location: 'tests/checkout.spec.ts:8:3',
+          workerIndex: 0,
+          shardIndex: 2,
+          startedAt: NOW + 100,
+          steps: [
+            {
+              title: 'Expect',
+              subtitle: "getByText('Thank you')",
+              category: 'expect',
+              duration: 1200,
+              startTime: NOW + 200,
+              failed: true,
+              error: { message: 'Timed out' },
+            },
+          ],
+        },
+      ],
+    },
+  });
+  expect(res.ok()).toBeTruthy();
+  return (await res.json()).runId ?? (await res.json()).id;
+}
+
+test.describe('perfetto export', () => {
+  test('exports the whole run as a Trace Event Format file', async ({ request }) => {
+    const runId = await submitShardedRun(request);
+
+    const res = await request.get(`/api/test-runs/${runId}/perfetto`);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toContain('application/json');
+    expect(res.headers()['content-disposition']).toContain('attachment');
+    expect(res.headers()['content-disposition']).toContain(`piwi-run-${runId}-perfetto.json`);
+
+    const trace = await res.json();
+    expect(trace.displayTimeUnit).toBe('ms');
+    expect(Array.isArray(trace.traceEvents)).toBe(true);
+    expect(trace.metadata.source).toBe('piwi');
+    expect(trace.metadata['run-id']).toBe(runId);
+
+    // Two shards → two processes; each execution is a complete slice.
+    const processNames = trace.traceEvents
+      .filter((e: { name: string }) => e.name === 'process_name')
+      .map((e: { args: { name: string } }) => e.args.name)
+      .sort();
+    expect(processNames).toEqual(['Shard 1', 'Shard 2']);
+
+    const slices = trace.traceEvents.filter((e: { ph: string; cat: string }) => e.ph === 'X' && e.cat === 'test');
+    expect(slices.map((e: { name: string }) => e.name).sort()).toEqual(['adds an item to the cart', 'checks out']);
+
+    // The failing execution contributes an instant "moment of failure" event.
+    const instant = trace.traceEvents.find((e: { ph: string }) => e.ph === 'i');
+    expect(instant?.name).toBe('failed');
+
+    // A step is nested under its execution, named with its subtitle.
+    const nav = trace.traceEvents.find((e: { name: string }) => e.name.startsWith('Navigate'));
+    expect(nav?.name).toBe('Navigate https://shop.test/cart');
+  });
+
+  test('exports one execution as a Trace Event Format file', async ({ request }) => {
+    const runId = await submitShardedRun(request);
+    const detail = await (await request.get(`/api/test-runs/${runId}`)).json();
+    const execution = detail.testCases.find((c: { title: string }) => c.title === 'checks out');
+    expect(execution, 'the run should have the checkout execution').toBeTruthy();
+
+    const res = await request.get(`/api/test-run-cases/${execution.executionId}/perfetto`);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-disposition']).toContain(`piwi-execution-${execution.executionId}-perfetto.json`);
+
+    const trace = await res.json();
+    expect(trace.metadata.scope).toBe('execution');
+    const slice = trace.traceEvents.find((e: { cat: string; ph: string }) => e.cat === 'test' && e.ph === 'X');
+    expect(slice.name).toBe('checks out');
+    expect(slice.args.status).toBe('failed');
+    expect(slice.args.url).toContain(`/test-run-cases/${execution.executionId}`);
+  });
+
+  test('404s for a run that does not exist', async ({ request }) => {
+    const missing = await request.get('/api/test-runs/99999999/perfetto');
+    expect(missing.status()).toBe(404);
+  });
+});

--- a/apps/application/tests/unit/perfetto-build.test.ts
+++ b/apps/application/tests/unit/perfetto-build.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect } from 'vitest';
+import { buildPerfettoTrace } from '../../shared/perfetto/build';
+import type { PerfettoRunInput, TraceEvent } from '../../shared/perfetto/types';
+
+/** A run across two shards, each with one worker, one execution failing. */
+function sampleRun(): PerfettoRunInput {
+  const t0 = 1_000_000_000_000;
+  return {
+    run: {
+      id: 42,
+      label: 'nightly',
+      status: 'failed',
+      startTime: t0,
+      duration: 5000,
+      playwrightVersion: '1.63.0',
+      project: { id: 1, name: 'checkout', label: 'Checkout' },
+    },
+    executions: [
+      {
+        executionId: 100,
+        testCaseId: 10,
+        title: 'adds an item to the cart',
+        filePath: 'tests/cart.spec.ts',
+        location: 'tests/cart.spec.ts:12:3',
+        status: 'passed',
+        workerIndex: 0,
+        shardIndex: 1,
+        startedAt: t0,
+        duration: 2000,
+        retries: 0,
+        tags: ['smoke', 'cart'],
+        locks: ['database'],
+        annotations: [{ type: 'slow', description: 'network heavy' }],
+        steps: [
+          {
+            title: 'Navigate',
+            subtitle: 'https://shop.test/cart',
+            category: 'navigation',
+            startTime: t0 + 10,
+            duration: 500,
+            location: 'tests/cart.spec.ts:13:5',
+            params: { url: 'https://shop.test/cart' },
+          },
+          {
+            title: 'Click',
+            subtitle: "getByRole('button', { name: 'Add' })",
+            category: 'action',
+            startTime: t0 + 520,
+            duration: 300,
+          },
+        ],
+      },
+      {
+        executionId: 101,
+        testCaseId: 11,
+        title: 'checks out',
+        filePath: 'tests/checkout.spec.ts',
+        location: 'tests/checkout.spec.ts:20:3',
+        status: 'failed',
+        workerIndex: 0,
+        shardIndex: 2,
+        startedAt: t0 + 100,
+        duration: 1500,
+        retries: 1,
+        tags: ['checkout'],
+        locks: ['database'],
+        error: 'Timed out waiting for selector',
+        steps: [
+          {
+            title: 'Expect',
+            subtitle: "getByText('Thank you')",
+            category: 'expect',
+            startTime: t0 + 200,
+            duration: 1200,
+            failed: true,
+            error: { message: 'Timed out waiting for selector' },
+          },
+        ],
+        attachments: [{ name: 'screenshot', path: 'proj/1/run/42/shot.png', contentType: 'image/png' }],
+      },
+    ],
+    setupSteps: [
+      {
+        title: 'beforeAll',
+        category: 'hook',
+        startedAt: t0 - 50,
+        duration: 40,
+        status: 'passed',
+        workerIndex: 0,
+        location: 'tests/cart.spec.ts:1:1',
+      },
+    ],
+  };
+}
+
+function byName(events: TraceEvent[], name: string): TraceEvent[] {
+  return events.filter((e) => e.name === name);
+}
+
+describe('buildPerfettoTrace', () => {
+  test('produces a Trace Event Format envelope', () => {
+    const trace = buildPerfettoTrace(sampleRun(), { scope: 'run', generatedAt: '2026-09-06T00:00:00.000Z' });
+    expect(trace.displayTimeUnit).toBe('ms');
+    expect(Array.isArray(trace.traceEvents)).toBe(true);
+    expect(trace.metadata.source).toBe('piwi');
+    expect(trace.metadata['run-id']).toBe(42);
+    expect(trace.metadata['playwright-version']).toBe('1.63.0');
+    expect(trace.metadata.project).toBe('Checkout');
+  });
+
+  test('maps shards to processes and workers to threads', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'run' });
+    const processNames = byName(traceEvents, 'process_name');
+    expect(processNames.map((e) => (e.args as { name: string }).name).sort()).toEqual(['Shard 1', 'Shard 2']);
+    // Each shard is its own process id (its 1-based shard index).
+    const cart = traceEvents.find((e) => e.name === 'adds an item to the cart')!;
+    const checkout = traceEvents.find((e) => e.name === 'checks out')!;
+    expect(cart.pid).toBe(1);
+    expect(checkout.pid).toBe(2);
+    expect(byName(traceEvents, 'thread_name').every((e) => (e.args as { name: string }).name === 'Worker 0')).toBe(
+      true,
+    );
+  });
+
+  test('emits a complete slice per execution with rich args', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'run', baseUrl: 'https://piwi.test/' });
+    const cart = traceEvents.find((e) => e.name === 'adds an item to the cart')!;
+    expect(cart.ph).toBe('X');
+    expect(cart.cname).toBe('good');
+    expect(cart.dur).toBeGreaterThan(0);
+    const args = cart.args as Record<string, unknown>;
+    expect(args.status).toBe('passed');
+    expect(args.location).toBe('tests/cart.spec.ts:12:3');
+    expect(args.tags).toBe('smoke cart');
+    expect(args.locks).toEqual(['database']);
+    expect(args.annotations).toEqual(['slow: network heavy']);
+    expect(args.url).toBe('https://piwi.test/test-run-cases/100');
+  });
+
+  test('nests steps under their execution and names them with the subtitle', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'run' });
+    const nav = traceEvents.find((e) => e.name.startsWith('Navigate'))!;
+    expect(nav.name).toBe('Navigate https://shop.test/cart');
+    expect(nav.cat).toBe('navigation');
+    expect((nav.args as { params?: unknown }).params).toEqual({ url: 'https://shop.test/cart' });
+    // The step sits on its execution's thread and process.
+    expect(nav.pid).toBe(1);
+    expect(nav.tid).toBe(0);
+  });
+
+  test('marks a failing step and emits the moment of failure', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'run' });
+    const failingStep = traceEvents.find((e) => e.name.startsWith('Expect'))!;
+    expect(failingStep.cname).toBe('bad');
+    const instant = traceEvents.find((e) => e.ph === 'i')!;
+    expect(instant.name).toBe('failed');
+    expect(instant.s).toBe('t');
+    expect(instant.pid).toBe(2);
+    expect((instant.args as { error: string }).error).toBe('Timed out waiting for selector');
+  });
+
+  test('turns attachment paths into download URLs', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'execution', baseUrl: 'https://piwi.test' });
+    const checkout = traceEvents.find((e) => e.name === 'checks out')!;
+    expect((checkout.args as { attachments: string[] }).attachments).toEqual([
+      'https://piwi.test/api/files/proj/1/run/42/shot.png',
+    ]);
+  });
+
+  test('places suite-level setup steps on the worker lane', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'run' });
+    const setup = traceEvents.find((e) => e.name.startsWith('[setup]'))!;
+    expect(setup.name).toBe('[setup] beforeAll');
+    expect(setup.tid).toBe(0);
+    expect(setup.ph).toBe('X');
+  });
+
+  test('normalizes timestamps to microseconds from the earliest event', () => {
+    const { traceEvents } = buildPerfettoTrace(sampleRun(), { scope: 'run' });
+    const nonMeta = traceEvents.filter((e) => e.ph !== 'M');
+    // The earliest event (the beforeAll setup step) anchors ts = 0.
+    expect(Math.min(...nonMeta.map((e) => e.ts))).toBe(0);
+    // ms → µs: the cart execution starts 50 ms after the setup step.
+    const cart = traceEvents.find((e) => e.name === 'adds an item to the cart')!;
+    expect(cart.ts).toBe(50_000);
+  });
+
+  test('falls back to stepEvents when no full step list is stored', () => {
+    const input: PerfettoRunInput = {
+      run: { id: 1, startTime: 0 },
+      executions: [
+        {
+          executionId: 5,
+          title: 'legacy',
+          status: 'passed',
+          workerIndex: 0,
+          shardIndex: null,
+          startedAt: 0,
+          duration: 100,
+          stepEvents: [{ title: 'beforeEach', category: 'hook', startedAt: 10, duration: 20, status: 'passed' }],
+        },
+      ],
+    };
+    const { traceEvents } = buildPerfettoTrace(input, { scope: 'run' });
+    const process = traceEvents.find((e) => e.name === 'process_name')!;
+    expect((process.args as { name: string }).name).toBe('Tests');
+    const hook = traceEvents.find((e) => e.name === 'beforeEach')!;
+    expect(hook.cat).toBe('hook');
+  });
+
+  test('handles a run with no timestamps without throwing', () => {
+    const input: PerfettoRunInput = {
+      run: { id: 9 },
+      executions: [{ executionId: 1, title: 't', status: 'passed', workerIndex: 0, shardIndex: 1 }],
+    };
+    const trace = buildPerfettoTrace(input, { scope: 'run' });
+    expect(trace.traceEvents.some((e) => e.name === 't')).toBe(true);
+  });
+});

--- a/apps/docs/offline-export.md
+++ b/apps/docs/offline-export.md
@@ -10,7 +10,8 @@ whole failure cluster to a file that opens with **no network and no Piwi server*
 attachment, a mail to someone without an account, or an archive that outlives your retention window.
 
 The **Export** button sits on a test-case execution (`/test-run-cases/:id`) and on a failure cluster
-(`/failure-clusters/:id`).
+(`/failure-clusters/:id`). A run (`/test-runs/:id`) and an execution also offer a **Perfetto trace**
+(see [below](#perfetto-trace)).
 
 ## Formats
 
@@ -49,6 +50,26 @@ The ZIP carries reconstructed `trace.zip` archives, but reading one still needs 
 viewer — `npx playwright show-trace trace.zip`, or the [bundled viewer](./evidence#trace-viewer) on any
 Piwi instance. Bundling the viewer's assets into the export itself is on the
 [roadmap](https://github.com/PiwiTests/platform/blob/main/ROADMAP.md).
+
+## Perfetto trace
+
+A run and an execution also export as a **Perfetto trace** — a [Trace Event Format](https://perfetto.dev/docs/reference/trace-config-proto) JSON file that opens the run on a timeline in
+[ui.perfetto.dev](https://ui.perfetto.dev) or Chrome's `chrome://tracing`, with no Piwi server needed.
+
+The file lays the run out the way it ran: **one process per shard, one thread per worker**. Each
+execution is a slice on its worker's thread, with its hooks, fixtures and steps nested underneath by
+start time, and a slice colored by outcome (green passed, red failed). A failing execution adds an
+instant marker at the moment it failed. Every slice carries its details in the event arguments —
+source location, step params, tags, locks, annotations, status, error message, and links back to the
+execution and its attachments on the dashboard. Suite-level `beforeAll`/`afterAll` setup steps appear
+on their worker's thread too.
+
+Open it by dragging the downloaded `.json` onto [ui.perfetto.dev](https://ui.perfetto.dev), or use
+**Open trace file** there. Timestamps are relative to the first event, so a run always starts at zero.
+
+The trace **does not embed the attachments themselves** — screenshots, video and trace archives are
+referenced by their dashboard URL, so following those links needs the Piwi instance the run came from.
+For a self-contained snapshot of one failure, use the HTML or ZIP export above.
 
 ## See also
 


### PR DESCRIPTION
## What & why

Playwright 1.63 ships a `perfetto` reporter that writes results in Trace Event Format. Piwi already holds everything that reporter emits — per run and per execution — so this adds the same export from the dashboard, with no new viewer to build: the file opens on a timeline in [ui.perfetto.dev](https://ui.perfetto.dev) or Chrome's `chrome://tracing`.

**What's included**

- **A pure, node-free builder** (`apps/application/shared/perfetto/`) that turns a run into a Trace Event Format document (`{ traceEvents, displayTimeUnit: 'ms', metadata }`):
  - **one process per shard, one thread per worker**;
  - a complete slice (`ph: 'X'`, microsecond `ts`/`dur`) for each execution, with its hooks, fixtures and steps nested underneath by start time (falling back to `stepEvents` when the full step list is absent);
  - an instant event (`ph: 'i'`, thread-scoped) at the moment a failing execution failed;
  - slice `args` carrying the source location, step params, subtitle, category, tags, locks, annotations, status, error message and the dashboard URLs of the execution and its attachments;
  - suite-level `beforeAll`/`afterAll` setup steps placed on their worker's thread;
  - timestamps normalized to microseconds relative to the earliest event, and status-colored slices — mirroring Playwright's own `perfetto` reporter (`pid`/`tid` conventions, `cname` colors, metadata event shapes).
- **Two endpoints** — `GET /api/test-runs/:id/perfetto` (whole run) and `GET /api/test-run-cases/:id/perfetto` (one execution) — that collect the data through a shared handler and stream it as a `.json` download under the same auth rules as the other export endpoints. Both are mirrored in the demo router (`app:check:demo` stays green). The API reference is generated from the route metadata.
- **UI**: a *Perfetto trace* entry in the export menu on the run page and the execution page, with a one-line hint that the file opens at ui.perfetto.dev. On the run page the menu shows only that entry (the offline HTML/ZIP/PDF/Markdown/JSON report formats apply to an execution or a cluster, not a whole run).
- **Docs**: a *Perfetto trace* section in `apps/docs/offline-export.md` — what the file contains, how to open it, and that it does **not** embed the attachments themselves (they are referenced by dashboard URL).

**Assumptions / notes**

- No `.json.gz` variant: the existing offline exports build bytes and set `Content-Length` rather than streaming gzip, so the trace is served as plain `.json` to match.
- Attachment bytes are not embedded — the trace references them by their dashboard `/api/files/...` URL, keeping the run export cheap. For a self-contained snapshot of a single failure, the HTML/ZIP offline export remains the right tool.

## How was it tested?

- **Unit** (`tests/unit/perfetto-build.test.ts`): the envelope shape, shard→process / worker→thread mapping, per-execution slices with their args, step nesting and subtitle naming, the failing-step marker and moment-of-failure instant, attachment URL building, setup-step placement, microsecond normalization, and the `stepEvents` / no-timestamp fallbacks.
- **E2E** (`tests/perfetto-export.spec.ts`): submits a sharded run, downloads the run export and asserts the Trace Event Format shape (two shard processes, a slice per execution, the failure instant, a subtitle-named step), downloads the execution export, and checks the 404 path.
- **Manual**: captured the export menu open on the run page (1280 px, Perfetto-only) and the execution page (1280 px, alongside the offline formats), and the run page at 390 px — all render the *Timeline → Perfetto trace* entry cleanly.
- **Verified green**: `app:typecheck`, `app:lint`, `app:format:check`, `app:test:unit` (2032), `app:check:demo`, and the new E2E spec; `npx commitlint --from origin/main --to HEAD`. Drift guards (`wire-shared-drift`, `docs-drift`, `ui-vocabulary`, `reporter-core-identity`) pass.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/offline-export.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NWGaEZnX6ydjh8XXLsNjn

---
_Generated by [Claude Code](https://claude.ai/code/session_016NWGaEZnX6ydjh8XXLsNjn)_