### PR TITLE
fix(app): serve seeded demo evidence media from the file endpoint

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -44,6 +44,9 @@ npm run app:dev:bg          # dev server on http://localhost:3000, detached, wai
 
 - Nuxt HMR picks up edits; there is no need to restart per change. Compile errors show up in
   `.data/dev-server.log`, not in the browser.
+- `app:seed:dev` also copies the committed evidence media (`public/demo/{screenshots,traces,videos}`)
+  into the storage directory under the `demo/…` paths the seeded rows reference, so the failure pages
+  serve the real screenshot, trace and video through `/api/files/` instead of a broken image.
 - The Playwright E2E config reuses a server already on port 3000 (`npm run app:test -- <spec>`), so one
   background server serves both your screenshots and the specs.
 - Capture against it with `npm run app:screens -- --route <path> --url http://localhost:3000`.

--- a/apps/application/AGENTS.md
+++ b/apps/application/AGENTS.md
@@ -469,7 +469,10 @@ NUXT_IGNORE_LOCK=1 npx nuxt dev --port 3002      # 4. plain dev server, auth dis
 ```
 
 `app:seed:dev` creates and migrates a missing or empty dev DB itself, so step 2 is only needed when you want a clean
-schema by hand; it is idempotent (`INSERT OR IGNORE`), and to refresh stale rows wipe `.data` and re-run it. Drive the
+schema by hand; it is idempotent (`INSERT OR IGNORE`), and to refresh stale rows wipe `.data` and re-run it. It also
+copies the committed evidence media (`public/demo/{screenshots,traces,videos}`) into the storage directory under the
+`demo/…` paths the seeded rows reference, so the failure pages serve the real screenshot, trace and video through the
+file endpoint rather than a broken image. Drive the
 app with Playwright — `scripts/take-feature-screenshots.mjs` (`--route`, `--url`) is the working harness, and its
 `settlePage` is the wait strategy to copy: the run and execution pages hold an SSE stream open, so a bare
 `networkidle` never resolves, and the page scrolls inside a panel, so `fullPage` captures a single viewport.

--- a/apps/application/scripts/copy-demo-media.mjs
+++ b/apps/application/scripts/copy-demo-media.mjs
@@ -1,0 +1,62 @@
+/**
+ * Copies the committed demo evidence media into the storage directory so a dev
+ * database seeded from the demo serves its screenshots, traces and videos
+ * through the normal file endpoint.
+ *
+ * The seeded `files` rows reference each artifact by the relative path
+ * `demo/{screenshots,traces,videos}/<name>`, which the file endpoint resolves
+ * inside the storage directory. The binaries themselves live under
+ * `public/demo/...` (served statically by the demo SPA), so a plain dev server
+ * finds nothing there until they are copied across.
+ */
+
+import { existsSync, mkdirSync, readdirSync, statSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The `public/demo/` subdirectories holding committed evidence binaries. */
+export const DEMO_MEDIA_SUBDIRS = ['screenshots', 'traces', 'videos'];
+
+/**
+ * Recursively copy one directory tree, writing only files whose destination is
+ * missing or differs in size. Real file copies, never symlinks, so the result
+ * works on Windows and inside Docker bind mounts.
+ *
+ * @returns the number of files written.
+ */
+function copyTree(srcDir, destDir) {
+  let copied = 0;
+  mkdirSync(destDir, { recursive: true });
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = join(srcDir, entry.name);
+    const destPath = join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copied += copyTree(srcPath, destPath);
+    } else if (entry.isFile()) {
+      if (!existsSync(destPath) || statSync(destPath).size !== statSync(srcPath).size) {
+        copyFileSync(srcPath, destPath);
+        copied++;
+      }
+    }
+  }
+  return copied;
+}
+
+/**
+ * Copy `publicDemoDir/{screenshots,traces,videos}` into
+ * `storageDir/demo/{screenshots,traces,videos}`, the paths the seeded `files`
+ * rows reference. Idempotent: a re-run leaves an already-copied file untouched,
+ * and a subdirectory absent from the source is skipped.
+ *
+ * @param {string} publicDemoDir Absolute path to `public/demo`.
+ * @param {string} storageDir Absolute path to the storage root (e.g. `.data/storage`).
+ * @returns {number} the number of files written.
+ */
+export function copyDemoMedia(publicDemoDir, storageDir) {
+  let copied = 0;
+  for (const sub of DEMO_MEDIA_SUBDIRS) {
+    const srcDir = join(publicDemoDir, sub);
+    if (!existsSync(srcDir)) continue;
+    copied += copyTree(srcDir, join(storageDir, 'demo', sub));
+  }
+  return copied;
+}

--- a/apps/application/scripts/seed-dev-from-demo.mjs
+++ b/apps/application/scripts/seed-dev-from-demo.mjs
@@ -13,9 +13,10 @@
 
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
-import { join, dirname } from 'path';
+import { join, dirname, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { copyDemoMedia } from './copy-demo-media.mjs';
 
 const require = createRequire(import.meta.url);
 const { createClient } = require('@libsql/client');
@@ -24,6 +25,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const appDir = join(__dirname, '..');
 const sqlPath = join(appDir, 'public/demo/seed.sql');
 const dbPath = join(appDir, '.data/piwi.db');
+
+// The file endpoint resolves a row's `demo/…` path inside the storage
+// directory, so the seeded evidence binaries must be copied there. Match the
+// server's storage root (`PIWI_STORAGE_PATH`, default `.data/storage`).
+const storageEnv = process.env.PIWI_STORAGE_PATH || '.data/storage';
+const storageDir = isAbsolute(storageEnv) ? storageEnv : join(appDir, storageEnv);
+const publicDemoDir = join(appDir, 'public/demo');
 
 if (!existsSync(sqlPath)) {
   console.log('No demo seed yet — generating public/demo/seed.sql…');
@@ -136,6 +144,13 @@ if (skip > 0) {
   console.error(`Done. ${ok} inserted, ${skip} failed — the dev database is incomplete.`);
   process.exit(1);
 }
+
+// Copy the committed evidence binaries into the storage directory the file
+// endpoint reads from, under the `demo/…` paths the seeded rows reference.
+// Idempotent, so it also heals a storage directory that was wiped after an
+// earlier seed.
+const copied = copyDemoMedia(publicDemoDir, storageDir);
+console.log(`Demo media: ${copied} file(s) copied into ${storageDir}.`);
 
 // The rebase adds a fixed delta to every timestamp, so it may only run over a
 // load that brought in the whole seed. Re-running it against rows that already

--- a/apps/application/tests/unit/copy-demo-media.test.ts
+++ b/apps/application/tests/unit/copy-demo-media.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, statSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// @ts-expect-error — plain-Node script, no type declarations
+import { copyDemoMedia, DEMO_MEDIA_SUBDIRS } from '../../scripts/copy-demo-media.mjs';
+
+let root: string;
+let publicDemoDir: string;
+let storageDir: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'piwi-copy-demo-media-'));
+  publicDemoDir = join(root, 'public', 'demo');
+  storageDir = join(root, 'storage');
+  for (const sub of DEMO_MEDIA_SUBDIRS) mkdirSync(join(publicDemoDir, sub), { recursive: true });
+  writeFileSync(join(publicDemoDir, 'screenshots', 'shot.png'), 'png-bytes');
+  writeFileSync(join(publicDemoDir, 'traces', 'trace.zip'), 'zip-bytes');
+  writeFileSync(join(publicDemoDir, 'videos', 'clip.webm'), 'webm-bytes');
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('copyDemoMedia', () => {
+  test('copies every media file under demo/<sub> in the storage directory', () => {
+    const copied = copyDemoMedia(publicDemoDir, storageDir);
+
+    expect(copied).toBe(3);
+    expect(readFileSync(join(storageDir, 'demo', 'screenshots', 'shot.png'), 'utf8')).toBe('png-bytes');
+    expect(readFileSync(join(storageDir, 'demo', 'traces', 'trace.zip'), 'utf8')).toBe('zip-bytes');
+    expect(readFileSync(join(storageDir, 'demo', 'videos', 'clip.webm'), 'utf8')).toBe('webm-bytes');
+  });
+
+  test('is idempotent — a second run copies nothing and leaves files untouched', () => {
+    copyDemoMedia(publicDemoDir, storageDir);
+    const dest = join(storageDir, 'demo', 'screenshots', 'shot.png');
+    const firstMtime = statSync(dest).mtimeMs;
+
+    const copiedAgain = copyDemoMedia(publicDemoDir, storageDir);
+
+    expect(copiedAgain).toBe(0);
+    expect(statSync(dest).mtimeMs).toBe(firstMtime);
+  });
+
+  test('re-copies a file whose destination size no longer matches the source', () => {
+    copyDemoMedia(publicDemoDir, storageDir);
+    const dest = join(storageDir, 'demo', 'screenshots', 'shot.png');
+    writeFileSync(dest, 'x');
+
+    const copied = copyDemoMedia(publicDemoDir, storageDir);
+
+    expect(copied).toBe(1);
+    expect(readFileSync(dest, 'utf8')).toBe('png-bytes');
+  });
+
+  test('copies nested subdirectories', () => {
+    mkdirSync(join(publicDemoDir, 'traces', 'nested'), { recursive: true });
+    writeFileSync(join(publicDemoDir, 'traces', 'nested', 'inner.zip'), 'inner');
+
+    copyDemoMedia(publicDemoDir, storageDir);
+
+    expect(readFileSync(join(storageDir, 'demo', 'traces', 'nested', 'inner.zip'), 'utf8')).toBe('inner');
+  });
+
+  test('skips a media subdirectory that does not exist in the source', () => {
+    rmSync(join(publicDemoDir, 'videos'), { recursive: true, force: true });
+
+    const copied = copyDemoMedia(publicDemoDir, storageDir);
+
+    expect(copied).toBe(2);
+    expect(existsSync(join(storageDir, 'demo', 'videos'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

On a dev database seeded from the demo data, the failure pages showed a **broken image** where the demo shows the real failure screenshot (and the video and trace rows were served by the same endpoint, so they broke too).

**Cause.** The seeded `files` rows reference their evidence by the relative path `demo/screenshots/…`, `demo/traces/…`, `demo/videos/…`. The file endpoint (`server/api/files/[...path].get.ts`) resolves that path **inside the storage directory** (`.data/storage`, `PIWI_STORAGE_PATH`). The binaries themselves are committed under `apps/application/public/demo/{screenshots,traces,videos}` and served statically by the demo SPA — but nothing ever copied them into the storage directory, so a plain dev server returned `404 application/json`:

```
curl -s -o /dev/null -w "%{http_code} %{content_type}\n" \
  localhost:3000/api/files/demo/screenshots/checkout-error-banner.png
# before → 404 application/json
```

`scripts/seed-dev-from-demo.mjs` seeded the rows only. The `--route` screenshot harness seeds through the same script, so it had the same hole.

**Fix.** The dev seed now copies `public/demo/{screenshots,traces,videos}` into the storage directory under the `demo/…` paths the rows reference, factored into `copyDemoMedia` (`scripts/copy-demo-media.mjs`):

- **Real file copies, never symlinks** — works on Windows and inside Docker bind mounts.
- **Idempotent** — a file whose destination already matches in size is left untouched, so a re-seed also heals a storage directory that was wiped after an earlier seed.
- **Node `fs` APIs only**, no shell commands.

The production file endpoint is untouched (it still reads only from the storage directory, never from `public/`), and the demo SPA is unchanged.

## How was it tested?

- New unit test `tests/unit/copy-demo-media.test.ts` covers the copy step: every file lands under `demo/<sub>`, idempotent re-run copies nothing, a size mismatch re-copies, nested dirs are copied, a missing source subdir is skipped.
- `tests/unit/demo-seed-consistency.test.ts` stays green.
- Full app suite: `app:typecheck`, `app:lint`, `app:format:check`, `app:test:unit` (2181 tests) all pass.
- Manual, after wiping `.data` and re-seeding — `curl` now returns `200 image/png`, `200 application/zip`, `200 video/webm` for a screenshot, a trace and a video.
- `npm run app:screens -- --route /test-run-cases/37` renders the real screenshot and video in the Evidence › Screen tab, both with `--url` (existing server) and without (harness boots + seeds its own).

### Screenshots

`/test-run-cases/37`, Evidence › Screen tab (before/after captures delivered in the working session):

- **Before** — broken `screenshot` thumbnail, non-loading (black) video.
- **After** — real "Checkout" screenshot and playable video, both served through `/api/files/`.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`.claude/skills/run-app/SKILL.md`, `apps/application/AGENTS.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMe7eFtvAnR2ioD99zv68d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMe7eFtvAnR2ioD99zv68d)_