### PR TITLE
chore(app): measure detail-page legibility and pin the failure-clue baseline

### DIFF
--- a/.claude/skills/run-app/SKILL.md
+++ b/.claude/skills/run-app/SKILL.md
@@ -60,6 +60,22 @@ node scripts/db-query.mjs "select id, status from test_runs_cases where status='
 
 Authentication is off on a plain dev server, so no key is needed.
 
+## Measure the failure pages' legibility
+
+```bash
+npm run app:measure -- --url http://localhost:3000        # against a running server
+npm run app:measure -- --json                             # boots + seeds its own server
+```
+
+`measure-detail-pages.mjs` reads the execution page (`/test-run-cases/:id`) and the failure
+cluster page (`/failure-clusters/:id`) after hydration and settle, and reports — inside the detail
+panel — the scroll offset of each block (header, headline, clues, evidence, the fix sections, what
+changed, affected tests, history), the panel's total scroll height, the interactive controls and
+help hints above the fold, the open code blocks and their height, the word count, the active
+evidence tab and the clue strengths. Default routes cover #37, #13 and clusters #10, #2, #5, #1;
+`--routes` overrides them, `--width`/`--height` the viewport, `--json` prints one object per route.
+Without `--url` it boots and seeds a throwaway server the same way the screenshot harness does.
+
 ## Seeded entry points
 
 The seed is generated deterministically from `scripts/generate-demo-seed.mjs`, so these ids are stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ From `apps/application/`:
 | `npm run app:check:demo:runtime` | Drive the **built** demo from its real `/demo/` sub-path in a browser (run `app:generate:demo` first) |
 | `npm run app:screens -- <scene>` | Capture a feature screenshot — `app:screens:docs` for every committed docs illustration, `app:screens:check` to verify they all still have a scene |
 | `npm run app:screens -- --route <path> [--expand] [--height N]` | Screenshot any page without registering a scene — boots and seeds its own server; the `run-app` skill (`.claude/skills/run-app/SKILL.md`) is the full recipe for running and driving the app |
+| `npm run app:measure [-- --url <base>] [--routes …] [--json]` | Measure the execution and failure-cluster pages' legibility (block offsets, scroll height, above-the-fold controls and hints, open code, words); boots its own server without `--url` |
 | `npm run app:generate:deploy` | Regenerate the one-click deploy manifests (`render.yaml`, `fly.toml`, `deploy/`) |
 | `node scripts/db-query.mjs "<sql>" [--json]` | Query the local SQLite DB directly |
 

--- a/apps/application/package.json
+++ b/apps/application/package.json
@@ -38,6 +38,7 @@
     "db:studio:pg": "drizzle-kit studio --config=drizzle.config.pg.ts",
     "app:check:demo": "node scripts/check-demo-routes.mjs",
     "app:check:demo:runtime": "node scripts/check-demo-runtime.mjs",
+    "app:measure": "node scripts/measure-detail-pages.mjs",
     "app:screens": "node scripts/take-feature-screenshots.mjs",
     "app:screens:docs": "node scripts/take-feature-screenshots.mjs --tag docs",
     "app:screens:check": "node scripts/take-feature-screenshots.mjs --check",

--- a/apps/application/scripts/lib/dev-server.mjs
+++ b/apps/application/scripts/lib/dev-server.mjs
@@ -1,0 +1,116 @@
+/**
+ * Booting, seeding and tearing down a throwaway dev server, shared by the
+ * scripts that drive the running app with Playwright (the feature-screenshot
+ * harness and the detail-page measurement). Everything here is server/process
+ * plumbing — no browser — so a script that reuses a server it already has
+ * (`--url`) never imports it.
+ */
+import { spawn, execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** The application workspace root (`scripts/lib/` sits two levels below it). */
+export const APP_DIR = join(__dirname, '..', '..');
+
+/** Default port for a booted throwaway server — off 3000 so a dev server can stay up. */
+export const DEFAULT_PORT = 3050;
+
+export function resolveChromium() {
+  // The sandboxed environments provide a Chromium via PLAYWRIGHT_BROWSERS_PATH;
+  // a normal checkout uses Playwright's own download.
+  const provided = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (provided && existsSync(join(provided, 'chromium'))) return join(provided, 'chromium');
+  return undefined;
+}
+
+export function ensureDevDb() {
+  if (existsSync(join(APP_DIR, '.data', 'piwi.db'))) return;
+  console.log('No dev DB — creating and seeding one (first run only)…');
+  if (!existsSync(join(APP_DIR, 'public', 'demo', 'seed.sql'))) {
+    execSync('npm run app:seed:demo', { cwd: APP_DIR, stdio: 'inherit' });
+  }
+  mkdirSync(join(APP_DIR, '.data'), { recursive: true });
+  execSync('npm run db:migrate', { cwd: APP_DIR, stdio: 'inherit' });
+  execSync('npm run app:seed:dev', { cwd: APP_DIR, stdio: 'inherit' });
+}
+
+export async function waitForHealth(base, timeoutMs = 120_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${base}/api/health`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`server at ${base} did not become healthy within ${timeoutMs / 1000}s`);
+}
+
+/**
+ * Wait for a stopped server to release the port. Without this a second server
+ * fails to bind and the run silently drives the first one, which is still
+ * answering.
+ */
+export async function waitForPortFree(base, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${base}/api/health`);
+    } catch {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`server at ${base} did not shut down within ${timeoutMs / 1000}s`);
+}
+
+/**
+ * Boot a dev server in `mode`; returns { base, stop }. The desktop UI is enabled
+ * for `desktop` only — the sidebar's back/forward pair exists in the Tauri shell
+ * alone, and would misrepresent the web app in a full-viewport capture.
+ */
+export async function startServer({ mode = 'web', port = DEFAULT_PORT } = {}) {
+  ensureDevDb();
+  const desktop = mode === 'desktop';
+  const child = spawn('npx', ['nuxt', 'dev', '--port', String(port)], {
+    cwd: APP_DIR,
+    env: { ...process.env, NUXT_IGNORE_LOCK: '1', ...(desktop ? { NUXT_PUBLIC_DESKTOP: 'true' } : {}) },
+    stdio: 'ignore',
+    // Detached puts nuxt in its own process group so stop() can kill the whole
+    // tree; on Windows npx needs a shell and group-kill is unsupported anyway.
+    detached: process.platform !== 'win32',
+    shell: process.platform === 'win32',
+  });
+  const stop = () => {
+    // Negative pid kills the whole nuxt process group where supported. On
+    // Windows child.kill() only terminates the cmd wrapper — the nuxt node
+    // process survives and keeps the port bound, so kill the tree explicitly.
+    try {
+      if (process.platform === 'win32') {
+        execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: 'ignore' });
+      } else {
+        process.kill(-child.pid, 'SIGTERM');
+      }
+    } catch {
+      // already gone
+    }
+  };
+  process.on('SIGINT', () => {
+    stop();
+    process.exit(130);
+  });
+  const base = `http://localhost:${port}`;
+  console.log(`Starting dev server at ${base}${desktop ? ' (desktop UI enabled)' : ''}…`);
+  try {
+    await waitForHealth(base);
+  } catch (err) {
+    stop();
+    throw err;
+  }
+  return { base, stop };
+}

--- a/apps/application/scripts/lib/page-waits.mjs
+++ b/apps/application/scripts/lib/page-waits.mjs
@@ -1,0 +1,41 @@
+/**
+ * The wait strategy the dashboard needs when a script drives it with Playwright.
+ * The run, execution and notification surfaces hold a Server-Sent Events stream
+ * open, so a bare `networkidle` never resolves — these helpers wait for
+ * hydration and a bounded settle instead. Both take a Playwright `page`, so the
+ * caller owns the browser and this module imports nothing.
+ */
+
+/** Wait for the document to load and Nuxt to finish hydrating, with a fallback. */
+export async function waitForHydration(page) {
+  await page.waitForLoadState('load');
+  await page
+    .waitForFunction(() => window.useNuxtApp?.().isHydrating === false, undefined, { timeout: 20000 })
+    .catch(() => page.waitForTimeout(1500));
+}
+
+/**
+ * Wait for the page to stop moving: web fonts resolved, no in-flight requests,
+ * nothing reporting itself busy, and — when the caller asks — chart geometry
+ * actually drawn. Network is given a bounded wait because the SSE stream keeps
+ * it from ever going fully idle. Replaces guessing with a timeout.
+ */
+export async function settlePage(page, { charts = false, timeout = 20_000 } = {}) {
+  await page.waitForLoadState('networkidle', { timeout }).catch(() => {});
+  await page.evaluate(() => document.fonts.ready);
+  await page
+    .waitForFunction(() => !document.querySelector('[aria-busy="true"]'), undefined, { timeout })
+    .catch(() => {});
+  if (charts) {
+    await page.waitForFunction(
+      () => {
+        const svgs = [...document.querySelectorAll('svg')];
+        return svgs.some((svg) => svg.querySelector('path[d], rect[width], circle[r]'));
+      },
+      undefined,
+      { timeout },
+    );
+  }
+  // One frame after the last mutation, so a chart that just mounted has painted.
+  await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
+}

--- a/apps/application/scripts/measure-detail-pages.mjs
+++ b/apps/application/scripts/measure-detail-pages.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Measures how legible the execution page (`/test-run-cases/:id`) and the failure
+ * cluster page (`/failure-clusters/:id`) are, so the clarity plan's "In numbers"
+ * table can be re-measured after each phase and diffed against the baseline.
+ *
+ * For each route it reads, inside the detail panel: the scroll offset of every
+ * named block from the top of the panel, the panel's total scroll height, how
+ * many interactive controls and help hints sit above the fold, the open code
+ * blocks and their summed height, the word count, the active evidence tab and
+ * the clue strength badges in order. It changes nothing on the page — it reads
+ * the DOM after hydration and a bounded settle.
+ *
+ * Usage (from application/):
+ *   node scripts/measure-detail-pages.mjs                       # boot + seed a throwaway server
+ *   node scripts/measure-detail-pages.mjs --url http://localhost:3000
+ *   node scripts/measure-detail-pages.mjs --routes /test-run-cases/37,/failure-clusters/10
+ *   node scripts/measure-detail-pages.mjs --width 1280 --height 800
+ *   node scripts/measure-detail-pages.mjs --json
+ *
+ * Without --url the script boots its own dev server and seeds a missing dev DB,
+ * exactly like `take-feature-screenshots.mjs --route`; with --url it drives the
+ * server you point it at (the common case — reuse a `npm run app:dev:bg` server).
+ */
+import { createRequire } from 'node:module';
+
+import { startServer, resolveChromium, waitForPortFree } from './lib/dev-server.mjs';
+import { waitForHydration, settlePage } from './lib/page-waits.mjs';
+
+const require = createRequire(import.meta.url);
+const { chromium } = require('playwright');
+
+/** The routes §1.5 measures: two executions and four clusters. */
+const DEFAULT_ROUTES = [
+  '/test-run-cases/37',
+  '/test-run-cases/13',
+  '/failure-clusters/10',
+  '/failure-clusters/2',
+  '/failure-clusters/5',
+  '/failure-clusters/1',
+];
+
+function parseArgs(argv) {
+  const flags = { url: null, routes: DEFAULT_ROUTES, width: 1280, height: 800, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--url') flags.url = argv[++i];
+    else if (arg === '--routes')
+      flags.routes = argv[++i]
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean);
+    else if (arg === '--width') flags.width = Number(argv[++i]);
+    else if (arg === '--height') flags.height = Number(argv[++i]);
+    else if (arg === '--json') flags.json = true;
+    else throw new Error(`unknown flag: ${arg}`);
+  }
+  for (const [flag, value] of [
+    ['--width', flags.width],
+    ['--height', flags.height],
+  ]) {
+    if (!(Number.isInteger(value) && value > 0)) throw new Error(`${flag} needs a positive integer`);
+  }
+  for (const route of flags.routes) {
+    if (!route.startsWith('/')) throw new Error(`--routes needs absolute paths, got "${route}"`);
+  }
+  return flags;
+}
+
+/**
+ * The measurement, serialized into the page. Self-contained (no module
+ * closures): everything it needs arrives as its argument. Reads only.
+ */
+function measurePage({ viewportHeight }) {
+  // The detail panel is a `UDashboardPanel`, whose `id` renders prefixed. The
+  // summary is pinned above an independently scrolling tab body; blocks are
+  // measured from the top of the whole panel, and the total is the tab body's
+  // scroll height — the panel's real scrolling descendant.
+  const panel =
+    document.getElementById('dashboard-panel-test-run-case-detail') ||
+    document.getElementById('dashboard-panel-failure-cluster-detail') ||
+    document.getElementById('test-run-case-detail') ||
+    document.getElementById('failure-cluster-detail') ||
+    document.body;
+  const panelTop = panel.getBoundingClientRect().top;
+
+  let scroller = null;
+  for (const el of panel.querySelectorAll('*')) {
+    const style = getComputedStyle(el);
+    if (/auto|scroll/.test(style.overflowY) && el.scrollHeight > el.clientHeight + 1) {
+      if (!scroller || el.scrollHeight > scroller.scrollHeight) scroller = el;
+    }
+  }
+
+  const y = (el) => (el ? Math.round(el.getBoundingClientRect().top - panelTop) : null);
+  const q = (sel) => panel.querySelector(sel);
+  const headingSection = (tag, text) => {
+    const heading = [...panel.querySelectorAll(tag)].find((e) => e.textContent.trim().startsWith(text));
+    return heading ? (heading.closest('section') ?? heading) : null;
+  };
+
+  const positions = {
+    header: y(q('h1')),
+    headline: y(q('[data-shot="failure-headline"]')),
+    clues: y(q('[data-shot="failure-clues"]')),
+    evidence: y(headingSection('h2', 'Evidence')),
+    fix: y(q('[data-shot="fix"]')),
+    fixLocatorFix: y(q('[data-shot="fix-locator-fix"]')),
+    fixFixPlan: y(q('[data-shot="fix-fix-plan"]')),
+    fixDiagnosis: y(q('[data-shot="fix-diagnosis"]')),
+    fixVerify: y(q('[data-shot="fix-verify"]')),
+    fixReproduce: y(q('[data-shot="fix-reproduce"]')),
+    whatChanged: y(headingSection('h3', 'What changed')),
+    affectedTests: y(q('[data-shot="cluster-affected-tests"]')),
+    history: y(q('[data-shot="execution-history"], [data-shot="cluster-history"]')),
+  };
+
+  const totalScrollHeight = scroller ? scroller.scrollHeight : document.documentElement.scrollHeight;
+
+  const aboveFold = (el) => el.getBoundingClientRect().top < viewportHeight;
+  const controlSelector = 'button, a[href], [role="tab"], select, input, textarea, [role="button"], [role="combobox"]';
+  const controls = [...panel.querySelectorAll(controlSelector)].filter((el) => el.getBoundingClientRect().width > 0);
+  const controlsAboveFold = controls.filter(aboveFold).length;
+
+  const helpHints = [...panel.querySelectorAll('button[aria-label^="Help:"]')];
+  const helpAboveFold = helpHints.filter(aboveFold).length;
+
+  const pres = [...panel.querySelectorAll('pre')];
+  const preHeight = Math.round(pres.reduce((sum, pre) => sum + pre.getBoundingClientRect().height, 0));
+
+  const words = panel.innerText.split(/\s+/).filter(Boolean).length;
+  const activeTab = (panel.querySelector('[role="tab"][aria-selected="true"]')?.textContent ?? '').trim() || null;
+
+  // The strength chip each clue carries (Strong / Medium / Weak), in DOM order —
+  // the headline's top clue and the clue list below it.
+  const strengths = new Set(['Strong', 'Medium', 'Weak']);
+  const clueStrengths = [...panel.querySelectorAll('[data-shot="failure-headline"] *, [data-shot="failure-clues"] *')]
+    .filter((el) => el.children.length === 0 && strengths.has(el.textContent.trim()))
+    .map((el) => el.textContent.trim());
+
+  return {
+    positions,
+    totalScrollHeight,
+    controls: controls.length,
+    controlsAboveFold,
+    help: helpHints.length,
+    helpAboveFold,
+    pre: pres.length,
+    preHeight,
+    words,
+    activeTab,
+    clueStrengths,
+  };
+}
+
+async function measureRoute(page, base, route, { height }) {
+  await page.goto(`${base}${route}`, { waitUntil: 'domcontentloaded' });
+  await waitForHydration(page);
+  await settlePage(page);
+  const measured = await page.evaluate(measurePage, { viewportHeight: height });
+  return { route, ...measured };
+}
+
+/** The block offsets printed as a column, in reading order, skipping the absent ones. */
+const POSITION_LABELS = [
+  ['header', 'header (h1)'],
+  ['headline', 'headline'],
+  ['clues', 'clues'],
+  ['evidence', 'evidence'],
+  ['fix', 'fix'],
+  ['fixLocatorFix', '· locator fix'],
+  ['fixFixPlan', '· fix plan'],
+  ['fixDiagnosis', '· diagnosis'],
+  ['fixVerify', '· verify'],
+  ['fixReproduce', '· reproduce'],
+  ['whatChanged', 'what changed'],
+  ['affectedTests', 'affected tests'],
+  ['history', 'history'],
+];
+
+function printTable(results, { width, height }) {
+  for (const result of results) {
+    console.log(`\n${result.route}  (${width}×${height})`);
+    console.log('─'.repeat(60));
+    console.log('  px from top of panel:');
+    for (const [key, label] of POSITION_LABELS) {
+      const value = result.positions[key];
+      if (value != null) console.log(`    ${label.padEnd(18)} ${String(value).padStart(6)}`);
+    }
+    console.log(`  total scroll height ${String(result.totalScrollHeight).padStart(6)}`);
+    console.log(
+      `  controls above the fold ${result.controlsAboveFold} / ${result.controls} · ` +
+        `help hints ${result.helpAboveFold} above / ${result.help} · ` +
+        `code blocks ${result.pre} (${result.preHeight}px) · words ${result.words}`,
+    );
+    console.log(`  active evidence tab: ${result.activeTab ?? '—'}`);
+    console.log(`  clue strengths: ${result.clueStrengths.length ? result.clueStrengths.join(', ') : '—'}`);
+  }
+}
+
+async function main() {
+  const flags = parseArgs(process.argv.slice(2));
+
+  const server = flags.url ? { base: flags.url, stop: () => {} } : await startServer({ mode: 'web' });
+  const browser = await chromium.launch({
+    executablePath: resolveChromium(),
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  const results = [];
+  try {
+    const context = await browser.newContext({ viewport: { width: flags.width, height: flags.height } });
+    const page = await context.newPage();
+    // A dev server compiles routes on first hit — well past the 30s default.
+    page.setDefaultNavigationTimeout(90_000);
+    for (const route of flags.routes) {
+      results.push(await measureRoute(page, server.base, route, { height: flags.height }));
+    }
+    await context.close();
+  } finally {
+    await browser.close();
+    server.stop();
+    if (!flags.url) await waitForPortFree(server.base);
+  }
+
+  if (flags.json) {
+    for (const result of results) console.log(JSON.stringify(result));
+  } else {
+    printTable(results, flags);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -40,12 +40,13 @@
  */
 
 import { createRequire } from 'module';
-import { spawn, execSync } from 'child_process';
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { drawAnnotations, clearAnnotations } from './screenshot-annotations.mjs';
+import { resolveChromium, startServer, waitForPortFree } from './lib/dev-server.mjs';
+import { waitForHydration, settlePage } from './lib/page-waits.mjs';
 
 const require = createRequire(import.meta.url);
 const { chromium } = require('playwright');
@@ -54,7 +55,6 @@ const sharp = require('sharp');
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(__dirname, '..');
 const DOCS_SHOTS_DIR = join(APP_DIR, '..', 'docs', 'public', 'screenshots');
-const PORT = 3050;
 
 /** Where a scene's images land. `screens` is gitignored; `docs` is committed. */
 const OUT_TARGETS = {
@@ -611,6 +611,35 @@ const SCENES = [
     pad: 8,
   },
 
+  // ── Failure page clarity (report artifacts) ───────────────────────────────
+  // The first screen of each detail page in its default state, at wide and phone
+  // width, so the clarity plan's "In numbers" table can be re-read visually after
+  // each phase. Full-viewport, nothing expanded — the baseline these phases diff.
+  {
+    name: 'execution-clarity',
+    description: 'Execution page first screen, default state (1280×800 clarity baseline)',
+    route: '/test-run-cases/37',
+    viewport: { width: 1280, height: 800 },
+  },
+  {
+    name: 'execution-clarity-mobile',
+    description: 'The same execution page first screen at phone width',
+    route: '/test-run-cases/37',
+    viewport: { width: 390, height: 800 },
+  },
+  {
+    name: 'cluster-clarity',
+    description: 'Failure cluster page first screen, default state (1280×800 clarity baseline)',
+    route: '/failure-clusters/10',
+    viewport: { width: 1280, height: 800 },
+  },
+  {
+    name: 'cluster-clarity-mobile',
+    description: 'The same cluster page first screen at phone width',
+    route: '/failure-clusters/10',
+    viewport: { width: 390, height: 800 },
+  },
+
   // ── Desktop shell (report artifacts) ──────────────────────────────────────
   {
     name: 'desktop-nav',
@@ -808,38 +837,6 @@ function bridgeScript(scene) {
   `;
 }
 
-async function waitForHydration(page) {
-  await page.waitForLoadState('load');
-  await page
-    .waitForFunction(() => window.useNuxtApp?.().isHydrating === false, undefined, { timeout: 20000 })
-    .catch(() => page.waitForTimeout(1500));
-}
-
-/**
- * Wait for the page to stop moving: web fonts resolved, no in-flight requests,
- * nothing reporting itself busy, and — when the scene asks — chart geometry
- * actually drawn. Replaces guessing with a timeout.
- */
-async function settlePage(page, { charts = false, timeout = 20_000 } = {}) {
-  await page.waitForLoadState('networkidle', { timeout }).catch(() => {});
-  await page.evaluate(() => document.fonts.ready);
-  await page
-    .waitForFunction(() => !document.querySelector('[aria-busy="true"]'), undefined, { timeout })
-    .catch(() => {});
-  if (charts) {
-    await page.waitForFunction(
-      () => {
-        const svgs = [...document.querySelectorAll('svg')];
-        return svgs.some((svg) => svg.querySelector('path[d], rect[width], circle[r]'));
-      },
-      undefined,
-      { timeout },
-    );
-  }
-  // One frame after the last mutation, so a chart that just mounted has painted.
-  await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
-}
-
 /** Attributes the region capture puts on the page, and takes off again. */
 const REGION_ATTR = 'data-shot-region';
 const KEEP_ATTR = 'data-shot-keep';
@@ -926,103 +923,6 @@ function regionStyle(pad, { gridParent = false } = {}) {
   ]
     .filter(Boolean)
     .join('\n');
-}
-
-function ensureDevDb() {
-  if (existsSync(join(APP_DIR, '.data', 'piwi.db'))) return;
-  console.log('No dev DB — creating and seeding one (first run only)…');
-  if (!existsSync(join(APP_DIR, 'public', 'demo', 'seed.sql'))) {
-    execSync('npm run app:seed:demo', { cwd: APP_DIR, stdio: 'inherit' });
-  }
-  mkdirSync(join(APP_DIR, '.data'), { recursive: true });
-  execSync('npm run db:migrate', { cwd: APP_DIR, stdio: 'inherit' });
-  execSync('npm run app:seed:dev', { cwd: APP_DIR, stdio: 'inherit' });
-}
-
-async function waitForHealth(base, timeoutMs = 120_000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${base}/api/health`);
-      if (res.ok) return;
-    } catch {
-      // not up yet
-    }
-    await new Promise((r) => setTimeout(r, 1000));
-  }
-  throw new Error(`server at ${base} did not become healthy within ${timeoutMs / 1000}s`);
-}
-
-/**
- * Wait for a stopped server to release the port. Without this a second mode's
- * server fails to bind and the run silently captures against the first one,
- * which is still answering.
- */
-async function waitForPortFree(base, timeoutMs = 30_000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      await fetch(`${base}/api/health`);
-    } catch {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  throw new Error(`server at ${base} did not shut down within ${timeoutMs / 1000}s`);
-}
-
-/**
- * Boot a dev server in `mode`; returns { base, stop }. The desktop UI is enabled
- * for `desktop` only — the sidebar's back/forward pair exists in the Tauri shell
- * alone, and would misrepresent the web app in a full-viewport capture.
- */
-async function startServer(mode) {
-  ensureDevDb();
-  const desktop = mode === 'desktop';
-  const child = spawn('npx', ['nuxt', 'dev', '--port', String(PORT)], {
-    cwd: APP_DIR,
-    env: { ...process.env, NUXT_IGNORE_LOCK: '1', ...(desktop ? { NUXT_PUBLIC_DESKTOP: 'true' } : {}) },
-    stdio: 'ignore',
-    // Detached puts nuxt in its own process group so stop() can kill the whole
-    // tree; on Windows npx needs a shell and group-kill is unsupported anyway.
-    detached: process.platform !== 'win32',
-    shell: process.platform === 'win32',
-  });
-  const stop = () => {
-    // Negative pid kills the whole nuxt process group where supported. On
-    // Windows child.kill() only terminates the cmd wrapper — the nuxt node
-    // process survives and keeps the port bound, so kill the tree explicitly.
-    try {
-      if (process.platform === 'win32') {
-        execSync(`taskkill /pid ${child.pid} /T /F`, { stdio: 'ignore' });
-      } else {
-        process.kill(-child.pid, 'SIGTERM');
-      }
-    } catch {
-      // already gone
-    }
-  };
-  process.on('SIGINT', () => {
-    stop();
-    process.exit(130);
-  });
-  const base = `http://localhost:${PORT}`;
-  console.log(`Starting dev server at ${base}${desktop ? ' (desktop UI enabled)' : ''}…`);
-  try {
-    await waitForHealth(base);
-  } catch (err) {
-    stop();
-    throw err;
-  }
-  return { base, stop };
-}
-
-function resolveChromium() {
-  // The sandboxed environments provide a Chromium via PLAYWRIGHT_BROWSERS_PATH;
-  // a normal checkout uses Playwright's own download.
-  const provided = process.env.PLAYWRIGHT_BROWSERS_PATH;
-  if (provided && existsSync(join(provided, 'chromium'))) return join(provided, 'chromium');
-  return undefined;
 }
 
 /** Levenshtein distance, for suggesting what the user meant by an unknown scene. */
@@ -1381,7 +1281,7 @@ async function main() {
   let written = 0;
   try {
     for (const [mode, group] of byMode) {
-      const server = flags.url ? { base: flags.url, stop: () => {} } : await startServer(mode);
+      const server = flags.url ? { base: flags.url, stop: () => {} } : await startServer({ mode });
       try {
         for (const scene of group) {
           try {

--- a/apps/application/shared/handlers/test-cases.ts
+++ b/apps/application/shared/handlers/test-cases.ts
@@ -15,7 +15,7 @@ import { computeWastedMs, DEFAULT_WASTED_WAIT_PATTERNS } from '../utils/wasted-w
 import { inlineCasePayloads } from '../../server/utils/case-payloads';
 import { buildFailureVerdict } from '../failure-verdict';
 import { buildFailureTimeline, type FailureTimeline, type TimelineCallsite } from '../failure-timeline';
-import { buildFailureClues, type FailureClue, type FailureCluePageDiff } from '../failure-clues';
+import { buildFailureClues, type FailureClue, type FailureClueInput, type FailureCluePageDiff } from '../failure-clues';
 import { parsePlaywrightError } from '../error-parse';
 import { failingStepParams } from '../describe-failure';
 import { diffAttempts, type AttemptDiffEntry, type AttemptEvidence } from '../attempt-diff';
@@ -578,19 +578,6 @@ export interface FailureCluesResult {
   failureAt: number | null;
 }
 
-/**
- * The deterministic clues for one failing execution: a rule-based correlation
- * pass over the same rows the execution detail already reads — the parsed
- * error, the timeline, network requests, the ARIA snapshot, locator healing,
- * app state, the environment diff, the run's sibling and same-worker
- * executions, and the cluster's fix history. Loads them once and hands them to
- * the pure `buildFailureClues`; shared by the REST endpoint, the demo mirror,
- * the AI-context builder and the MCP tools. Returns an empty list when the
- * execution does not exist.
- *
- * `slowRequestMs` lets the server pass the configured slow-request threshold;
- * without it the engine uses its 1500 ms default.
- */
 /** Reduce a page-diff result to the change (if any) at the failing locator's node, for the clue engine. */
 function pageDiffLocatorChange(pageDiff: Awaited<ReturnType<typeof getPageDiff>> | null): FailureCluePageDiff | null {
   if (pageDiff?.status !== 'ok') return null;
@@ -599,13 +586,25 @@ function pageDiffLocatorChange(pageDiff: Awaited<ReturnType<typeof getPageDiff>>
   return { locatorChange: { type: hunk.type, role: hunk.role, name: hunk.name, oldName: hunk.oldName ?? null } };
 }
 
-export async function getFailureClues(
+/**
+ * Load everything the clue engine reads for one failing execution — the parsed
+ * error, the timeline, network requests, the ARIA snapshot, locator healing,
+ * app state, the environment diff, the run's sibling and same-worker
+ * executions, and the cluster's fix history — as the pure `FailureClueInput`.
+ * Returns null when the execution does not exist. Separating the loading from
+ * `buildFailureClues` lets a fixture capture the exact input the seeded database
+ * produces, so a unit test can pin the ranking without a database.
+ *
+ * `slowRequestMs` lets the server pass the configured slow-request threshold;
+ * without it the engine uses its 1500 ms default.
+ */
+export async function loadFailureClueInput(
   db: DrizzleDB,
   id: number,
   opts: { slowRequestMs?: number | null } = {},
-): Promise<FailureCluesResult> {
+): Promise<FailureClueInput | null> {
   const [trc] = await db.select().from(testRunsCases).where(eq(testRunsCases.id, id));
-  if (!trc) return { clues: [], failureAt: null };
+  if (!trc) return null;
 
   const evidence = await inlineCasePayloads(db, trc);
 
@@ -717,7 +716,7 @@ export async function getFailureClues(
           ),
     ]);
 
-  const clues = buildFailureClues({
+  return {
     execution: {
       id: trc.id,
       testCaseId: trc.testCaseId,
@@ -767,9 +766,23 @@ export async function getFailureClues(
     cluster: clusterFix,
     timeout: trc.timeout ?? null,
     slowRequestMs: opts.slowRequestMs ?? null,
-  });
+  };
+}
 
-  return { clues, failureAt: timeline.failureAt };
+/**
+ * The ranked deterministic clues for one failing execution, plus the failure
+ * anchor the UI counts back from. Shared by the REST endpoint, the demo mirror,
+ * the AI-context builder and the MCP tools. Returns an empty list when the
+ * execution does not exist.
+ */
+export async function getFailureClues(
+  db: DrizzleDB,
+  id: number,
+  opts: { slowRequestMs?: number | null } = {},
+): Promise<FailureCluesResult> {
+  const input = await loadFailureClueInput(db, id, opts);
+  if (!input) return { clues: [], failureAt: null };
+  return { clues: buildFailureClues(input), failureAt: input.timeline ? input.timeline.failureAt : null };
 }
 
 /** Coerce a stored `startedAt` (epoch ms number or Date) to epoch ms. */

--- a/apps/application/tests/unit/failure-clues-seed-cases.test.ts
+++ b/apps/application/tests/unit/failure-clues-seed-cases.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, test, expect } from 'vitest';
+import { buildFailureClues, type FailureClue, type FailureClueInput } from '#shared/failure-clues';
+
+/**
+ * A frozen baseline of the ordered clue ranking for four seeded executions. The
+ * inputs are captured verbatim from the seeded dev database (`loadFailureClueInput`
+ * on `/api/test-run-cases/:id/clues`) and committed under `fixtures/`, so the
+ * test runs the real `buildFailureClues` against real evidence with no database.
+ * The expected `(rule, strength)` pairs are written out literally: a change to
+ * the ranking rules surfaces here as a readable diff of what each failure now
+ * says on its first screen.
+ */
+
+function loadInput(executionId: number): FailureClueInput {
+  const path = fileURLToPath(new URL(`./fixtures/failure-clues/exec-${executionId}.json`, import.meta.url));
+  return JSON.parse(readFileSync(path, 'utf8')) as FailureClueInput;
+}
+
+/** The ranked clue output reduced to the two fields the baseline pins. */
+function ranking(clues: FailureClue[]): Array<[string, string]> {
+  return clues.map((clue) => [clue.rule, clue.strength]);
+}
+
+describe('buildFailureClues — seeded failure ranking baseline', () => {
+  test('#37 — checkout, Pay click timeout', () => {
+    expect(ranking(buildFailureClues(loadInput(37)))).toEqual([
+      ['page-structure-changed', 'strong'],
+      ['element-present-but-blocked', 'strong'],
+      ['console-mentions-target', 'medium'],
+      ['slow-request-overlapping-failure', 'medium'],
+      ['fixed-before', 'weak'],
+    ]);
+  });
+
+  test('#13 — same cluster, earlier run', () => {
+    expect(ranking(buildFailureClues(loadInput(13)))).toEqual([
+      ['page-structure-changed', 'strong'],
+      ['element-present-but-blocked', 'strong'],
+      ['console-mentions-target', 'medium'],
+      ['slow-request-overlapping-failure', 'medium'],
+      ['environment-changed', 'medium'],
+      ['fixed-before', 'weak'],
+    ]);
+  });
+
+  test("#781 — cluster #10's latest occurrence, toHaveCount on getByRole('row')", () => {
+    expect(ranking(buildFailureClues(loadInput(781)))).toEqual([['environment-changed', 'medium']]);
+  });
+
+  test("#587 — cluster #5's latest occurrence, .modal.is-open timeout", () => {
+    expect(ranking(buildFailureClues(loadInput(587)))).toEqual([]);
+  });
+});

--- a/apps/application/tests/unit/fixtures/failure-clues/exec-13.json
+++ b/apps/application/tests/unit/fixtures/failure-clues/exec-13.json
@@ -1,0 +1,521 @@
+{
+  "execution": {
+    "id": 13,
+    "testCaseId": 1,
+    "status": "failed",
+    "duration": 3633,
+    "browserName": "Chromium",
+    "startedAt": 1788683681000,
+    "locks": ["database"],
+    "shardIndex": null
+  },
+  "parsedError": {
+    "kind": "test-timeout",
+    "errorName": null,
+    "subject": "locator",
+    "action": "click",
+    "assertion": null,
+    "negated": false,
+    "locator": "getByRole('button', { name: 'Pay' })",
+    "leafLocator": "getByRole('button', { name: 'Pay' })",
+    "expected": null,
+    "received": null,
+    "timeoutMs": 30000,
+    "url": null,
+    "networkErrorCode": null,
+    "timeoutPhase": null,
+    "lastState": "not-enabled",
+    "resolvedCount": null,
+    "lastCallLogLine": "waiting 100ms",
+    "lastStateLine": "element is not enabled",
+    "messageHead": "Test timeout of 30000ms exceeded.\n---\nlocator.click: Test timeout of 30000ms exceeded.",
+    "topFrame": "tests/helpers/payment.ts:16",
+    "isNavigationFailure": false,
+    "isLocatorResolutionFailure": false
+  },
+  "timeline": {
+    "origin": 1745537488451,
+    "end": 1788683711029,
+    "failureAt": 43146196183,
+    "failedStep": {
+      "index": 4,
+      "label": "Expect \"toBeVisible\" getByText('Order confirmed')",
+      "at": 43146195653,
+      "duration": 530
+    },
+    "lanes": {
+      "steps": [
+        {
+          "id": "step-0",
+          "lane": "steps",
+          "at": 43146192549,
+          "duration": 681,
+          "label": "Navigate /checkout",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 0
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "/checkout",
+          "params": {
+            "url": "https://shop.example.com/checkout"
+          },
+          "category": "navigation"
+        },
+        {
+          "id": "step-1",
+          "lane": "steps",
+          "at": 43146193230,
+          "duration": 606,
+          "label": "Fill \"ada@example.com\" getByLabel('Email')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 1
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByLabel('Email')",
+          "params": {
+            "locator": "getByLabel('Email')",
+            "value": "ada@example.com"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-2",
+          "lane": "steps",
+          "at": 43146193836,
+          "duration": 833,
+          "label": "Fill \"Ada Lovelace\" getByLabel('Name on card')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 2
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByLabel('Name on card')",
+          "params": {
+            "locator": "getByLabel('Name on card')",
+            "value": "Ada Lovelace"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-3",
+          "lane": "steps",
+          "at": 43146194669,
+          "duration": 984,
+          "label": "Click getByRole('button', { name: 'Place order' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 3
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByRole('button', { name: 'Place order' })",
+          "params": {
+            "locator": "getByRole('button', { name: 'Place order' })"
+          },
+          "category": "action"
+        },
+        {
+          "id": "step-4",
+          "lane": "steps",
+          "at": 43146195653,
+          "duration": 530,
+          "label": "Expect \"toBeVisible\" getByText('Order confirmed')",
+          "status": "failed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 4
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByText('Order confirmed')",
+          "params": {
+            "locator": "getByText('Order confirmed')"
+          },
+          "category": "assertion",
+          "failed": true
+        }
+      ],
+      "console": [
+        {
+          "id": "console-0",
+          "lane": "console",
+          "at": 43146194729,
+          "label": "[checkout] price quote still pending after 20s — Pay stays disabled",
+          "status": "warning",
+          "kind": "console",
+          "ref": {
+            "section": "console",
+            "index": 0
+          }
+        }
+      ],
+      "network": [
+        {
+          "id": "network-0",
+          "lane": "network",
+          "at": 43146192669,
+          "duration": 72,
+          "label": "GET https://shop.example.com/api/cart",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 0
+          }
+        },
+        {
+          "id": "network-1",
+          "lane": "network",
+          "at": 43146192776,
+          "duration": 28400,
+          "label": "POST https://shop.example.com/api/checkout/quote",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 1
+          }
+        },
+        {
+          "id": "network-2",
+          "lane": "network",
+          "at": 43146221691,
+          "duration": 887,
+          "label": "GET https://cdn.pay.example.com/sdk.js",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 2
+          }
+        },
+        {
+          "id": "network-3",
+          "lane": "network",
+          "at": 43146221211,
+          "duration": 445,
+          "label": "POST https://shop.example.com/api/payments/authorize",
+          "status": "201",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 3
+          }
+        }
+      ],
+      "backend": [],
+      "dialogs": [
+        {
+          "id": "dialog-0",
+          "lane": "dialogs",
+          "at": 0,
+          "label": "confirm: Your session is about to expire. Stay signed in?",
+          "status": "confirm",
+          "kind": "dialogs",
+          "ref": {
+            "section": "dialogs",
+            "index": 0
+          }
+        }
+      ]
+    },
+    "unplaced": [],
+    "estimated": false,
+    "window": {
+      "start": 43146185653,
+      "end": 43146198183
+    }
+  },
+  "healing": {
+    "failingLocator": {
+      "method": "getByRole",
+      "args": {
+        "role": "button",
+        "name": "Pay"
+      }
+    },
+    "fromPriorSuccess": null,
+    "fromElementMatch": null,
+    "fromAriaSnapshot": null,
+    "source": "none",
+    "recommendation": null,
+    "capturedAt": null,
+    "applicable": false,
+    "reason": "The locator resolved; this is not a locator problem."
+  },
+  "ariaSnapshot": "- document:\n  - form \"Checkout\":\n    - textbox \"Email address\"\n    - textbox \"Card number\"\n    - textbox \"Expiry date\"\n    - textbox \"CVV\"\n    - button \"Pay now\" [disabled]",
+  "ariaSnapshotJson": null,
+  "appState": {
+    "url": "https://shop.example.com/checkout",
+    "hash": null,
+    "historyState": null,
+    "localStorage": [
+      {
+        "key": "cart",
+        "length": 182
+      },
+      {
+        "key": "theme",
+        "length": 5
+      }
+    ],
+    "sessionStorage": [
+      {
+        "key": "checkout-session",
+        "length": 36
+      }
+    ],
+    "cookies": [
+      {
+        "name": "sid",
+        "domain": ".shop.example.com",
+        "path": "/",
+        "httpOnly": true,
+        "secure": true,
+        "sameSite": "Lax"
+      },
+      {
+        "name": "ab_variant",
+        "domain": ".shop.example.com",
+        "path": "/",
+        "httpOnly": false,
+        "secure": true
+      }
+    ]
+  },
+  "environmentDiff": {
+    "status": "ok",
+    "baseline": {
+      "runId": 6,
+      "executionId": 61,
+      "startTime": 1788563016000,
+      "environment": "staging"
+    },
+    "baselineNote": null,
+    "entries": [
+      {
+        "key": "playwrightVersion",
+        "label": "Playwright version",
+        "failing": "1.52.0",
+        "baseline": "1.51.0"
+      }
+    ]
+  },
+  "pageDiff": {
+    "locatorChange": {
+      "type": "renamed",
+      "role": "button",
+      "name": "Pay now",
+      "oldName": "Pay"
+    }
+  },
+  "networkRequests": [
+    {
+      "method": "GET",
+      "url": "https://shop.example.com/api/cart",
+      "status": 200,
+      "duration": 72,
+      "startTime": 1788683681120,
+      "serverLogs": null
+    },
+    {
+      "method": "POST",
+      "url": "https://shop.example.com/api/checkout/quote",
+      "status": 200,
+      "duration": 28400,
+      "startTime": 1788683681227,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://cdn.pay.example.com/sdk.js",
+      "status": 200,
+      "duration": 887,
+      "startTime": 1788683710142,
+      "serverLogs": null
+    },
+    {
+      "method": "POST",
+      "url": "https://shop.example.com/api/payments/authorize",
+      "status": 201,
+      "duration": 445,
+      "startTime": 1788683709662,
+      "serverLogs": null
+    }
+  ],
+  "consoleLogs": [
+    {
+      "type": "warning",
+      "text": "[checkout] price quote still pending after 20s — Pay stays disabled",
+      "timestamp": 1788683683180,
+      "location": "https://shop.example.com/assets/checkout-D4kXqz.js:1:48211"
+    }
+  ],
+  "dialogs": [
+    {
+      "type": "confirm",
+      "message": "Your session is about to expire. Stay signed in?",
+      "closedAt": 1745537488451
+    }
+  ],
+  "browserPeers": [
+    {
+      "browserName": "Chromium",
+      "status": "failed"
+    }
+  ],
+  "workerExecutions": [
+    {
+      "id": 13,
+      "testCaseId": 1,
+      "title": "should complete checkout with credit card",
+      "status": "failed",
+      "startedAt": 1788683681000
+    },
+    {
+      "id": 17,
+      "testCaseId": 5,
+      "title": "should show error for invalid CVV",
+      "status": "passed",
+      "startedAt": 1788683684833
+    },
+    {
+      "id": 21,
+      "testCaseId": 9,
+      "title": "should apply discount code",
+      "status": "passed",
+      "startedAt": 1788683689314
+    }
+  ],
+  "lockHolders": [
+    {
+      "id": 13,
+      "title": "should complete checkout with credit card",
+      "status": "failed",
+      "startedAt": 1788683681000,
+      "duration": 3633,
+      "shardIndex": null,
+      "locks": ["database"]
+    },
+    {
+      "id": 14,
+      "title": "should complete checkout with PayPal",
+      "status": "failed",
+      "startedAt": 1788683681000,
+      "duration": 4290,
+      "shardIndex": null,
+      "locks": ["database", "external-api"]
+    },
+    {
+      "id": 15,
+      "title": "should complete checkout with Apple Pay",
+      "status": "failed",
+      "startedAt": 1788683681000,
+      "duration": 4444,
+      "shardIndex": null,
+      "locks": ["database", "external-api"]
+    },
+    {
+      "id": 16,
+      "title": "should show error for expired card",
+      "status": "passed",
+      "startedAt": 1788683681000,
+      "duration": 3479,
+      "shardIndex": null,
+      "locks": ["database"]
+    },
+    {
+      "id": 17,
+      "title": "should show error for invalid CVV",
+      "status": "passed",
+      "startedAt": 1788683684833,
+      "duration": 4281,
+      "shardIndex": null,
+      "locks": ["database"]
+    },
+    {
+      "id": 18,
+      "title": "should add item to cart",
+      "status": "passed",
+      "startedAt": 1788683685490,
+      "duration": 4061,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 19,
+      "title": "should remove item from cart",
+      "status": "passed",
+      "startedAt": 1788683685644,
+      "duration": 4462,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 20,
+      "title": "should update item quantity",
+      "status": "passed",
+      "startedAt": 1788683684679,
+      "duration": 4385,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 21,
+      "title": "should apply discount code",
+      "status": "passed",
+      "startedAt": 1788683689314,
+      "duration": 3512,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 22,
+      "title": "should display cart total correctly",
+      "status": "passed",
+      "startedAt": 1788683689751,
+      "duration": 3382,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 23,
+      "title": "should fill and save shipping address",
+      "status": "passed",
+      "startedAt": 1788683690306,
+      "duration": 3831,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 24,
+      "title": "should validate required address fields",
+      "status": "passed",
+      "startedAt": 1788683689264,
+      "duration": 4128,
+      "shardIndex": null,
+      "locks": []
+    }
+  ],
+  "cluster": {
+    "fixCommit": "demo001",
+    "fixLandedRunId": 3,
+    "fixVerification": "regressed"
+  },
+  "timeout": 20000,
+  "slowRequestMs": null
+}

--- a/apps/application/tests/unit/fixtures/failure-clues/exec-37.json
+++ b/apps/application/tests/unit/fixtures/failure-clues/exec-37.json
@@ -1,0 +1,514 @@
+{
+  "execution": {
+    "id": 37,
+    "testCaseId": 1,
+    "status": "failed",
+    "duration": 3654,
+    "browserName": "Chromium",
+    "startedAt": 1788620768000,
+    "locks": ["database"],
+    "shardIndex": null
+  },
+  "parsedError": {
+    "kind": "test-timeout",
+    "errorName": null,
+    "subject": "locator",
+    "action": "click",
+    "assertion": null,
+    "negated": false,
+    "locator": "getByRole('button', { name: 'Pay' })",
+    "leafLocator": "getByRole('button', { name: 'Pay' })",
+    "expected": null,
+    "received": null,
+    "timeoutMs": 30000,
+    "url": null,
+    "networkErrorCode": null,
+    "timeoutPhase": null,
+    "lastState": "not-enabled",
+    "resolvedCount": null,
+    "lastCallLogLine": "waiting 100ms",
+    "lastStateLine": "element is not enabled",
+    "messageHead": "Test timeout of 30000ms exceeded.\n---\nlocator.click: Test timeout of 30000ms exceeded.",
+    "topFrame": "tests/helpers/payment.ts:16",
+    "isNavigationFailure": false,
+    "isLocatorResolutionFailure": false
+  },
+  "timeline": {
+    "origin": 1745474575471,
+    "end": 1788620797740,
+    "failureAt": 43146196183,
+    "failedStep": {
+      "index": 4,
+      "label": "Expect \"toBeVisible\" getByText('Order confirmed')",
+      "at": 43146195650,
+      "duration": 533
+    },
+    "lanes": {
+      "steps": [
+        {
+          "id": "step-0",
+          "lane": "steps",
+          "at": 43146192529,
+          "duration": 685,
+          "label": "Navigate /checkout",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 0
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "/checkout",
+          "params": {
+            "url": "https://shop.example.com/checkout"
+          },
+          "category": "navigation"
+        },
+        {
+          "id": "step-1",
+          "lane": "steps",
+          "at": 43146193214,
+          "duration": 609,
+          "label": "Fill \"ada@example.com\" getByLabel('Email')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 1
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByLabel('Email')",
+          "params": {
+            "locator": "getByLabel('Email')",
+            "value": "ada@example.com"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-2",
+          "lane": "steps",
+          "at": 43146193823,
+          "duration": 837,
+          "label": "Fill \"Ada Lovelace\" getByLabel('Name on card')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 2
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByLabel('Name on card')",
+          "params": {
+            "locator": "getByLabel('Name on card')",
+            "value": "Ada Lovelace"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-3",
+          "lane": "steps",
+          "at": 43146194660,
+          "duration": 990,
+          "label": "Click getByRole('button', { name: 'Place order' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 3
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByRole('button', { name: 'Place order' })",
+          "params": {
+            "locator": "getByRole('button', { name: 'Place order' })"
+          },
+          "category": "action"
+        },
+        {
+          "id": "step-4",
+          "lane": "steps",
+          "at": 43146195650,
+          "duration": 533,
+          "label": "Expect \"toBeVisible\" getByText('Order confirmed')",
+          "status": "failed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 4
+          },
+          "origin": null,
+          "group": null,
+          "subtitle": "getByText('Order confirmed')",
+          "params": {
+            "locator": "getByText('Order confirmed')"
+          },
+          "category": "assertion",
+          "failed": true
+        }
+      ],
+      "console": [
+        {
+          "id": "console-0",
+          "lane": "console",
+          "at": 43146194721,
+          "label": "[checkout] price quote still pending after 20s — Pay stays disabled",
+          "status": "warning",
+          "kind": "console",
+          "ref": {
+            "section": "console",
+            "index": 0
+          }
+        }
+      ],
+      "network": [
+        {
+          "id": "network-0",
+          "lane": "network",
+          "at": 43146192649,
+          "duration": 59,
+          "label": "GET https://shop.example.com/api/cart",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 0
+          }
+        },
+        {
+          "id": "network-1",
+          "lane": "network",
+          "at": 43146192743,
+          "duration": 28400,
+          "label": "POST https://shop.example.com/api/checkout/quote",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 1
+          }
+        },
+        {
+          "id": "network-2",
+          "lane": "network",
+          "at": 43146221522,
+          "duration": 747,
+          "label": "GET https://cdn.pay.example.com/sdk.js",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 2
+          }
+        },
+        {
+          "id": "network-3",
+          "lane": "network",
+          "at": 43146221178,
+          "duration": 309,
+          "label": "POST https://shop.example.com/api/payments/authorize",
+          "status": "201",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 3
+          }
+        }
+      ],
+      "backend": [],
+      "dialogs": [
+        {
+          "id": "dialog-0",
+          "lane": "dialogs",
+          "at": 0,
+          "label": "confirm: Your session is about to expire. Stay signed in?",
+          "status": "confirm",
+          "kind": "dialogs",
+          "ref": {
+            "section": "dialogs",
+            "index": 0
+          }
+        }
+      ]
+    },
+    "unplaced": [],
+    "estimated": false,
+    "window": {
+      "start": 43146185650,
+      "end": 43146198183
+    }
+  },
+  "healing": {
+    "failingLocator": {
+      "method": "getByRole",
+      "args": {
+        "role": "button",
+        "name": "Pay"
+      }
+    },
+    "fromPriorSuccess": null,
+    "fromElementMatch": null,
+    "fromAriaSnapshot": null,
+    "source": "none",
+    "recommendation": null,
+    "capturedAt": null,
+    "applicable": false,
+    "reason": "The locator resolved; this is not a locator problem."
+  },
+  "ariaSnapshot": "- document:\n  - form \"Checkout\":\n    - textbox \"Email address\"\n    - textbox \"Card number\"\n    - textbox \"Expiry date\"\n    - textbox \"CVV\"\n    - button \"Pay now\" [disabled]",
+  "ariaSnapshotJson": null,
+  "appState": {
+    "url": "https://shop.example.com/checkout",
+    "hash": null,
+    "historyState": null,
+    "localStorage": [
+      {
+        "key": "cart",
+        "length": 182
+      },
+      {
+        "key": "theme",
+        "length": 5
+      }
+    ],
+    "sessionStorage": [
+      {
+        "key": "checkout-session",
+        "length": 36
+      }
+    ],
+    "cookies": [
+      {
+        "name": "sid",
+        "domain": ".shop.example.com",
+        "path": "/",
+        "httpOnly": true,
+        "secure": true,
+        "sameSite": "Lax"
+      },
+      {
+        "name": "ab_variant",
+        "domain": ".shop.example.com",
+        "path": "/",
+        "httpOnly": false,
+        "secure": true
+      }
+    ]
+  },
+  "environmentDiff": {
+    "status": "ok",
+    "baseline": {
+      "runId": 8,
+      "executionId": 85,
+      "startTime": 1788490884000,
+      "environment": "development"
+    },
+    "baselineNote": null,
+    "entries": []
+  },
+  "pageDiff": {
+    "locatorChange": {
+      "type": "renamed",
+      "role": "button",
+      "name": "Pay now",
+      "oldName": "Pay"
+    }
+  },
+  "networkRequests": [
+    {
+      "method": "GET",
+      "url": "https://shop.example.com/api/cart",
+      "status": 200,
+      "duration": 59,
+      "startTime": 1788620768120,
+      "serverLogs": null
+    },
+    {
+      "method": "POST",
+      "url": "https://shop.example.com/api/checkout/quote",
+      "status": 200,
+      "duration": 28400,
+      "startTime": 1788620768214,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://cdn.pay.example.com/sdk.js",
+      "status": 200,
+      "duration": 747,
+      "startTime": 1788620796993,
+      "serverLogs": null
+    },
+    {
+      "method": "POST",
+      "url": "https://shop.example.com/api/payments/authorize",
+      "status": 201,
+      "duration": 309,
+      "startTime": 1788620796649,
+      "serverLogs": null
+    }
+  ],
+  "consoleLogs": [
+    {
+      "type": "warning",
+      "text": "[checkout] price quote still pending after 20s — Pay stays disabled",
+      "timestamp": 1788620770192,
+      "location": "https://shop.example.com/assets/checkout-D4kXqz.js:1:48211"
+    }
+  ],
+  "dialogs": [
+    {
+      "type": "confirm",
+      "message": "Your session is about to expire. Stay signed in?",
+      "closedAt": 1745474575471
+    }
+  ],
+  "browserPeers": [
+    {
+      "browserName": "Chromium",
+      "status": "failed"
+    }
+  ],
+  "workerExecutions": [
+    {
+      "id": 37,
+      "testCaseId": 1,
+      "title": "should complete checkout with credit card",
+      "status": "failed",
+      "startedAt": 1788620768000
+    },
+    {
+      "id": 41,
+      "testCaseId": 5,
+      "title": "should show error for invalid CVV",
+      "status": "passed",
+      "startedAt": 1788620771854
+    },
+    {
+      "id": 45,
+      "testCaseId": 9,
+      "title": "should apply discount code",
+      "status": "passed",
+      "startedAt": 1788620775950
+    }
+  ],
+  "lockHolders": [
+    {
+      "id": 37,
+      "title": "should complete checkout with credit card",
+      "status": "failed",
+      "startedAt": 1788620768000,
+      "duration": 3654,
+      "shardIndex": null,
+      "locks": ["database"]
+    },
+    {
+      "id": 38,
+      "title": "should complete checkout with PayPal",
+      "status": "failed",
+      "startedAt": 1788620768000,
+      "duration": 3596,
+      "shardIndex": null,
+      "locks": ["database", "external-api"]
+    },
+    {
+      "id": 39,
+      "title": "should complete checkout with Apple Pay",
+      "status": "failed",
+      "startedAt": 1788620768000,
+      "duration": 4399,
+      "shardIndex": null,
+      "locks": ["database", "external-api"]
+    },
+    {
+      "id": 40,
+      "title": "should show error for expired card",
+      "status": "passed",
+      "startedAt": 1788620768000,
+      "duration": 3709,
+      "shardIndex": null,
+      "locks": ["database"]
+    },
+    {
+      "id": 41,
+      "title": "should show error for invalid CVV",
+      "status": "passed",
+      "startedAt": 1788620771854,
+      "duration": 3896,
+      "shardIndex": null,
+      "locks": ["database"]
+    },
+    {
+      "id": 42,
+      "title": "should add item to cart",
+      "status": "passed",
+      "startedAt": 1788620771796,
+      "duration": 3588,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 43,
+      "title": "should remove item from cart",
+      "status": "passed",
+      "startedAt": 1788620772599,
+      "duration": 4368,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 44,
+      "title": "should update item quantity",
+      "status": "passed",
+      "startedAt": 1788620771909,
+      "duration": 4039,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 45,
+      "title": "should apply discount code",
+      "status": "passed",
+      "startedAt": 1788620775950,
+      "duration": 3620,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 46,
+      "title": "should display cart total correctly",
+      "status": "didnotrun",
+      "startedAt": 1788620775584,
+      "duration": 0,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 47,
+      "title": "should fill and save shipping address",
+      "status": "didnotrun",
+      "startedAt": 1788620777167,
+      "duration": 0,
+      "shardIndex": null,
+      "locks": []
+    },
+    {
+      "id": 48,
+      "title": "should validate required address fields",
+      "status": "didnotrun",
+      "startedAt": 1788620776148,
+      "duration": 0,
+      "shardIndex": null,
+      "locks": []
+    }
+  ],
+  "cluster": {
+    "fixCommit": "demo001",
+    "fixLandedRunId": 3,
+    "fixVerification": "regressed"
+  },
+  "timeout": 20000,
+  "slowRequestMs": null
+}

--- a/apps/application/tests/unit/fixtures/failure-clues/exec-587.json
+++ b/apps/application/tests/unit/fixtures/failure-clues/exec-587.json
@@ -1,0 +1,379 @@
+{
+  "execution": {
+    "id": 587,
+    "testCaseId": 31,
+    "status": "failed",
+    "duration": 9555,
+    "browserName": "Chromium",
+    "startedAt": 1788455793486,
+    "locks": [],
+    "shardIndex": null
+  },
+  "parsedError": {
+    "kind": "action-timeout",
+    "errorName": "TimeoutError",
+    "subject": "page",
+    "action": "waitForSelector",
+    "assertion": null,
+    "negated": false,
+    "locator": "locator('.modal.is-open')",
+    "leafLocator": "locator('.modal.is-open')",
+    "expected": null,
+    "received": null,
+    "timeoutMs": 5000,
+    "url": null,
+    "networkErrorCode": null,
+    "timeoutPhase": null,
+    "lastState": "not-found",
+    "resolvedCount": null,
+    "lastCallLogLine": "waiting for locator('.modal.is-open') to be visible",
+    "lastStateLine": "waiting for locator('.modal.is-open') to be visible",
+    "messageHead": "TimeoutError: page.waitForSelector: Timeout 5000ms exceeded.",
+    "topFrame": "tests/ui/modal.spec.ts:15",
+    "isNavigationFailure": false,
+    "isLocatorResolutionFailure": true
+  },
+  "timeline": {
+    "origin": 1788455793486,
+    "end": 1788455803041,
+    "failureAt": 9555,
+    "failedStep": {
+      "index": 3,
+      "label": "Compare against baseline",
+      "at": 5856,
+      "duration": 3699
+    },
+    "lanes": {
+      "steps": [
+        {
+          "id": "step-0",
+          "lane": "steps",
+          "at": 0,
+          "duration": 1541,
+          "label": "Open component page",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 0
+          },
+          "origin": null,
+          "group": null,
+          "category": "navigation"
+        },
+        {
+          "id": "step-1",
+          "lane": "steps",
+          "at": 1541,
+          "duration": 2466,
+          "label": "Interact with component",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 1
+          },
+          "origin": null,
+          "group": null,
+          "category": "action"
+        },
+        {
+          "id": "step-2",
+          "lane": "steps",
+          "at": 4007,
+          "duration": 1849,
+          "label": "Assert rendered state",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 2
+          },
+          "origin": null,
+          "group": null,
+          "category": "assertion"
+        },
+        {
+          "id": "step-3",
+          "lane": "steps",
+          "at": 5856,
+          "duration": 3699,
+          "label": "Compare against baseline",
+          "status": "failed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 3
+          },
+          "origin": null,
+          "group": null,
+          "category": "assertion",
+          "failed": true
+        }
+      ],
+      "console": [
+        {
+          "id": "console-0",
+          "lane": "console",
+          "at": 5733,
+          "label": "Uncaught TypeError: Cannot read properties of undefined (reading 'activate')\n    at ModalController.open (https://design.example.com/assets/modal-C7hQx2.js:2:1381)",
+          "status": "error",
+          "kind": "console",
+          "ref": {
+            "section": "console",
+            "index": 0
+          }
+        }
+      ],
+      "network": [
+        {
+          "id": "network-0",
+          "lane": "network",
+          "at": 120,
+          "duration": 38,
+          "label": "GET https://design.example.com/components/button",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 0
+          }
+        },
+        {
+          "id": "network-1",
+          "lane": "network",
+          "at": 193,
+          "duration": 14,
+          "label": "GET https://design.example.com/assets/tokens-D2mXq.css",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 1
+          }
+        },
+        {
+          "id": "network-2",
+          "lane": "network",
+          "at": 242,
+          "duration": 63,
+          "label": "GET https://design.example.com/assets/components-Bq7Yz.js",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 2
+          }
+        },
+        {
+          "id": "network-3",
+          "lane": "network",
+          "at": 340,
+          "duration": 28,
+          "label": "GET https://design.example.com/fonts/Inter-Variable.woff2",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 3
+          }
+        }
+      ],
+      "backend": [],
+      "dialogs": []
+    },
+    "unplaced": [],
+    "estimated": false,
+    "window": {
+      "start": 0,
+      "end": 9555
+    }
+  },
+  "healing": {
+    "failingLocator": {
+      "method": "locator",
+      "args": {
+        "selector": ".modal.is-open"
+      }
+    },
+    "fromPriorSuccess": null,
+    "fromElementMatch": null,
+    "fromAriaSnapshot": [
+      {
+        "locator": "getByRole('button', { name: 'Open modal' })",
+        "method": "getByRole",
+        "args": {
+          "role": "button",
+          "name": "Open modal"
+        },
+        "score": 50
+      },
+      {
+        "locator": "getByRole('heading', { name: 'Modal' })",
+        "method": "getByRole",
+        "args": {
+          "role": "heading",
+          "name": "Modal"
+        },
+        "score": 47
+      },
+      {
+        "locator": "getByText('Open modal')",
+        "method": "getByText",
+        "args": {
+          "text": "Open modal"
+        },
+        "score": 45
+      },
+      {
+        "locator": "getByText('Modal')",
+        "method": "getByText",
+        "args": {
+          "text": "Modal"
+        },
+        "score": 42
+      }
+    ],
+    "source": "aria-snapshot",
+    "recommendation": {
+      "recommended": {
+        "locator": "getByRole('button', { name: 'Open modal' })",
+        "method": "getByRole",
+        "args": {
+          "role": "button",
+          "name": "Open modal"
+        },
+        "score": 50
+      },
+      "durable": {
+        "locator": "getByRole('button', { name: 'Open modal' })",
+        "method": "getByRole",
+        "args": {
+          "role": "button",
+          "name": "Open modal"
+        },
+        "score": 50
+      },
+      "preservesConvention": false,
+      "hasDurableAlternative": false,
+      "suggestAddTestId": false
+    },
+    "capturedAt": null,
+    "applicable": true,
+    "reason": null,
+    "narrowingSuggestion": null,
+    "location": "tests/ui/modal.spec.ts:15:16",
+    "sourceLine": {
+      "line": 15,
+      "text": "    await page.waitForSelector('.modal.is-open');"
+    },
+    "edit": null
+  },
+  "ariaSnapshot": "- document:\n  - main:\n    - heading \"Modal\"\n    - button \"Open modal\"",
+  "ariaSnapshotJson": null,
+  "appState": {
+    "url": "https://design.example.com/components/button",
+    "hash": null,
+    "historyState": null,
+    "localStorage": [
+      {
+        "key": "docs-theme",
+        "length": 5
+      }
+    ],
+    "sessionStorage": [],
+    "cookies": []
+  },
+  "environmentDiff": {
+    "status": "ok",
+    "baseline": {
+      "runId": 52,
+      "executionId": 627,
+      "startTime": 1788319993000,
+      "environment": "staging"
+    },
+    "baselineNote": null,
+    "entries": []
+  },
+  "pageDiff": null,
+  "networkRequests": [
+    {
+      "method": "GET",
+      "url": "https://design.example.com/components/button",
+      "status": 200,
+      "duration": 38,
+      "startTime": 1788455793606,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://design.example.com/assets/tokens-D2mXq.css",
+      "status": 200,
+      "duration": 14,
+      "startTime": 1788455793679,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://design.example.com/assets/components-Bq7Yz.js",
+      "status": 200,
+      "duration": 63,
+      "startTime": 1788455793728,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://design.example.com/fonts/Inter-Variable.woff2",
+      "status": 200,
+      "duration": 28,
+      "startTime": 1788455793826,
+      "serverLogs": null
+    }
+  ],
+  "consoleLogs": [
+    {
+      "type": "error",
+      "text": "Uncaught TypeError: Cannot read properties of undefined (reading 'activate')\n    at ModalController.open (https://design.example.com/assets/modal-C7hQx2.js:2:1381)",
+      "timestamp": 1788455799219,
+      "location": "https://design.example.com/assets/modal-C7hQx2.js:2:1381"
+    }
+  ],
+  "dialogs": null,
+  "browserPeers": [
+    {
+      "browserName": "Chromium",
+      "status": "failed"
+    }
+  ],
+  "workerExecutions": [
+    {
+      "id": 583,
+      "testCaseId": 27,
+      "title": "Button primary variant renders correctly",
+      "status": "passed",
+      "startedAt": 1788455785000
+    },
+    {
+      "id": 587,
+      "testCaseId": 31,
+      "title": "Modal with large content scrolls correctly",
+      "status": "failed",
+      "startedAt": 1788455793486
+    },
+    {
+      "id": 591,
+      "testCaseId": 35,
+      "title": "Table pagination works correctly",
+      "status": "passed",
+      "startedAt": 1788455803241
+    }
+  ],
+  "lockHolders": [],
+  "cluster": {
+    "fixCommit": null,
+    "fixLandedRunId": null,
+    "fixVerification": null
+  },
+  "timeout": 20000,
+  "slowRequestMs": null
+}

--- a/apps/application/tests/unit/fixtures/failure-clues/exec-781.json
+++ b/apps/application/tests/unit/fixtures/failure-clues/exec-781.json
@@ -1,0 +1,496 @@
+{
+  "execution": {
+    "id": 781,
+    "testCaseId": 46,
+    "status": "failed",
+    "duration": 5324,
+    "browserName": "Chromium",
+    "startedAt": 1788462176000,
+    "locks": [],
+    "shardIndex": null
+  },
+  "parsedError": {
+    "kind": "assertion-timeout",
+    "errorName": "Error",
+    "subject": null,
+    "action": null,
+    "assertion": "toHaveCount",
+    "negated": false,
+    "locator": "getByRole('row')",
+    "leafLocator": "getByRole('row')",
+    "expected": "26",
+    "received": "51",
+    "timeoutMs": 5000,
+    "url": null,
+    "networkErrorCode": null,
+    "timeoutPhase": null,
+    "lastState": "resolved-count",
+    "resolvedCount": 51,
+    "lastCallLogLine": "unexpected value \"51\"",
+    "lastStateLine": "unexpected value \"51\"",
+    "messageHead": "Error: expect(locator).toHaveCount(expected) failed\nLocator:  getByRole('row')\nExpected: 26\nReceived: 51\nTimeout:  5000ms",
+    "topFrame": "tests/admin/users.spec.ts:7",
+    "isNavigationFailure": false,
+    "isLocatorResolutionFailure": false
+  },
+  "timeline": {
+    "origin": 1788462176000,
+    "end": 1788462181324,
+    "failureAt": 5324,
+    "failedStep": {
+      "index": 13,
+      "label": "Expect \"toBeVisible\" getByText('Saved')",
+      "at": 4825,
+      "duration": 499
+    },
+    "lanes": {
+      "steps": [
+        {
+          "id": "step-0",
+          "lane": "steps",
+          "at": 0,
+          "duration": 1497,
+          "label": "Sign in",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 0
+          },
+          "origin": null,
+          "group": "Sign in",
+          "category": "test.step"
+        },
+        {
+          "id": "step-1",
+          "lane": "steps",
+          "at": 0,
+          "duration": 333,
+          "label": "Fill \"admin@example.com\" getByLabel('Email')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 1
+          },
+          "origin": null,
+          "group": "Sign in",
+          "subtitle": "getByLabel('Email')",
+          "params": {
+            "locator": "getByLabel('Email')",
+            "value": "admin@example.com"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-2",
+          "lane": "steps",
+          "at": 333,
+          "duration": 333,
+          "label": "Fill \"********\" getByLabel('Password')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 2
+          },
+          "origin": null,
+          "group": "Sign in",
+          "subtitle": "getByLabel('Password')",
+          "params": {
+            "locator": "getByLabel('Password')"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-3",
+          "lane": "steps",
+          "at": 666,
+          "duration": 831,
+          "label": "Click getByRole('button', { name: 'Sign in' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 3
+          },
+          "origin": null,
+          "group": "Sign in",
+          "subtitle": "getByRole('button', { name: 'Sign in' })",
+          "params": {
+            "locator": "getByRole('button', { name: 'Sign in' })"
+          },
+          "category": "action"
+        },
+        {
+          "id": "step-4",
+          "lane": "steps",
+          "at": 1497,
+          "duration": 998,
+          "label": "Navigate to section",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 4
+          },
+          "origin": null,
+          "group": "Navigate to section",
+          "category": "test.step"
+        },
+        {
+          "id": "step-5",
+          "lane": "steps",
+          "at": 1497,
+          "duration": 499,
+          "label": "Click getByRole('link', { name: 'Users' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 5
+          },
+          "origin": null,
+          "group": "Navigate to section",
+          "subtitle": "getByRole('link', { name: 'Users' })",
+          "params": {
+            "locator": "getByRole('link', { name: 'Users' })"
+          },
+          "category": "action"
+        },
+        {
+          "id": "step-6",
+          "lane": "steps",
+          "at": 1996,
+          "duration": 499,
+          "label": "Wait for load state",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 6
+          },
+          "origin": null,
+          "group": "Navigate to section",
+          "category": "wait"
+        },
+        {
+          "id": "step-7",
+          "lane": "steps",
+          "at": 2495,
+          "duration": 1664,
+          "label": "Perform admin action",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 7
+          },
+          "origin": null,
+          "group": "Perform admin action",
+          "category": "test.step"
+        },
+        {
+          "id": "step-8",
+          "lane": "steps",
+          "at": 2495,
+          "duration": 666,
+          "label": "Click getByRole('row', { name: 'Ada Lovelace' }).getByRole('button', { name: 'Edit' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 8
+          },
+          "origin": null,
+          "group": "Perform admin action",
+          "subtitle": "getByRole('row', { name: 'Ada Lovelace' }).getByRole('button', { name: 'Edit' })",
+          "params": {
+            "locator": "getByRole('row', { name: 'Ada Lovelace' })"
+          },
+          "category": "action"
+        },
+        {
+          "id": "step-9",
+          "lane": "steps",
+          "at": 3161,
+          "duration": 499,
+          "label": "Fill \"Editor\" getByLabel('Role')",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 9
+          },
+          "origin": null,
+          "group": "Perform admin action",
+          "subtitle": "getByLabel('Role')",
+          "params": {
+            "locator": "getByLabel('Role')",
+            "value": "Editor"
+          },
+          "category": "input"
+        },
+        {
+          "id": "step-10",
+          "lane": "steps",
+          "at": 3660,
+          "duration": 499,
+          "label": "Click getByRole('button', { name: 'Save' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 10
+          },
+          "origin": null,
+          "group": "Perform admin action",
+          "subtitle": "getByRole('button', { name: 'Save' })",
+          "params": {
+            "locator": "getByRole('button', { name: 'Save' })"
+          },
+          "category": "action"
+        },
+        {
+          "id": "step-11",
+          "lane": "steps",
+          "at": 4159,
+          "duration": 1165,
+          "label": "Assert table state",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 11
+          },
+          "origin": null,
+          "group": "Assert table state",
+          "category": "test.step"
+        },
+        {
+          "id": "step-12",
+          "lane": "steps",
+          "at": 4159,
+          "duration": 666,
+          "label": "Expect \"toHaveText\" getByRole('cell', { name: 'Editor' })",
+          "status": "passed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 12
+          },
+          "origin": null,
+          "group": "Assert table state",
+          "subtitle": "getByRole('cell', { name: 'Editor' })",
+          "params": {
+            "locator": "getByRole('cell', { name: 'Editor' })"
+          },
+          "category": "assertion"
+        },
+        {
+          "id": "step-13",
+          "lane": "steps",
+          "at": 4825,
+          "duration": 499,
+          "label": "Expect \"toBeVisible\" getByText('Saved')",
+          "status": "failed",
+          "kind": "step",
+          "ref": {
+            "section": "steps",
+            "index": 13
+          },
+          "origin": null,
+          "group": "Assert table state",
+          "subtitle": "getByText('Saved')",
+          "params": {
+            "locator": "getByText('Saved')"
+          },
+          "category": "assertion",
+          "failed": true
+        }
+      ],
+      "console": [],
+      "network": [
+        {
+          "id": "network-0",
+          "lane": "network",
+          "at": 120,
+          "duration": 220,
+          "label": "GET https://admin.example.com/api/metrics?range=30d",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 0
+          }
+        },
+        {
+          "id": "network-1",
+          "lane": "network",
+          "at": 375,
+          "duration": 340,
+          "label": "GET https://admin.example.com/api/users?page=1",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 1
+          }
+        },
+        {
+          "id": "network-2",
+          "lane": "network",
+          "at": 750,
+          "duration": 57,
+          "label": "GET https://admin.example.com/api/orgs/current",
+          "status": "200",
+          "kind": "network",
+          "ref": {
+            "section": "networkRequests",
+            "index": 2
+          }
+        }
+      ],
+      "backend": [],
+      "dialogs": []
+    },
+    "unplaced": [],
+    "estimated": false,
+    "window": {
+      "start": 0,
+      "end": 5324
+    }
+  },
+  "healing": {
+    "failingLocator": {
+      "method": "getByRole",
+      "args": {
+        "role": "row"
+      }
+    },
+    "fromPriorSuccess": null,
+    "fromElementMatch": null,
+    "fromAriaSnapshot": null,
+    "source": "none",
+    "recommendation": null,
+    "capturedAt": null,
+    "applicable": false,
+    "reason": "The locator resolved; this is not a locator problem."
+  },
+  "ariaSnapshot": "- document:\n  - main:\n    - heading \"Users\"\n    - table \"Users\":\n      - row \"Name Email Role\"\n      - row \"Ada Lovelace ada@example.com admin\"",
+  "ariaSnapshotJson": null,
+  "appState": {
+    "url": "https://admin.example.com/dashboard",
+    "hash": null,
+    "historyState": null,
+    "localStorage": [
+      {
+        "key": "sidebar-collapsed",
+        "length": 4
+      },
+      {
+        "key": "table-density",
+        "length": 7
+      }
+    ],
+    "sessionStorage": [
+      {
+        "key": "csrf",
+        "length": 32
+      }
+    ],
+    "cookies": [
+      {
+        "name": "admin_session",
+        "domain": "admin.example.com",
+        "path": "/",
+        "httpOnly": true,
+        "secure": true,
+        "sameSite": "Strict"
+      }
+    ]
+  },
+  "environmentDiff": {
+    "status": "ok",
+    "baseline": {
+      "runId": 62,
+      "executionId": 701,
+      "startTime": 1788715996000,
+      "environment": "production"
+    },
+    "baselineNote": null,
+    "entries": [
+      {
+        "key": "playwrightVersion",
+        "label": "Playwright version",
+        "failing": "1.51.0",
+        "baseline": "1.52.0"
+      },
+      {
+        "key": "colorScheme",
+        "label": "Color scheme",
+        "failing": "light",
+        "baseline": "dark"
+      }
+    ]
+  },
+  "pageDiff": null,
+  "networkRequests": [
+    {
+      "method": "GET",
+      "url": "https://admin.example.com/api/metrics?range=30d",
+      "status": 200,
+      "duration": 220,
+      "startTime": 1788462176120,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://admin.example.com/api/users?page=1",
+      "status": 200,
+      "duration": 340,
+      "startTime": 1788462176375,
+      "serverLogs": null
+    },
+    {
+      "method": "GET",
+      "url": "https://admin.example.com/api/orgs/current",
+      "status": 200,
+      "duration": 57,
+      "startTime": 1788462176750,
+      "serverLogs": null
+    }
+  ],
+  "consoleLogs": [],
+  "dialogs": null,
+  "browserPeers": [
+    {
+      "browserName": "Chromium",
+      "status": "failed"
+    }
+  ],
+  "workerExecutions": [
+    {
+      "id": 781,
+      "testCaseId": 46,
+      "title": "Users table paginates 25 rows per page",
+      "status": "failed",
+      "startedAt": 1788462176000
+    },
+    {
+      "id": 785,
+      "testCaseId": 50,
+      "title": "exports the monthly report as CSV",
+      "status": "passed",
+      "startedAt": 1788462181524
+    }
+  ],
+  "lockHolders": [],
+  "cluster": {
+    "fixCommit": "demo010",
+    "fixLandedRunId": 62,
+    "fixVerification": "diagnosis-verified"
+  },
+  "timeout": 20000,
+  "slowRequestMs": null
+}


### PR DESCRIPTION
## What & why

Phase 0 of the failure-page clarity plan: nothing changes the product UI — this gives the later phases a way to **measure** the execution page (`/test-run-cases/:id`) and the failure-cluster page (`/failure-clusters/:id`), and a **baseline to diff against**.

**1. `npm run app:measure` (`scripts/measure-detail-pages.mjs`)** — reads each page after hydration and a bounded settle (never a bare `networkidle`; the pages hold an SSE stream open) and reports, inside the detail panel: each block's scroll offset from the top of the panel, the panel's total scroll height, the interactive controls and help hints above the fold, the open code blocks and their height, the word count, the active evidence tab and the clue strengths in order. `--url` drives a running server; without it the script boots and seeds a throwaway server the same way `take-feature-screenshots.mjs --route` does.

The prototype's one defect (total scroll height came back `0`) had a single root cause: it looked for the panel by an id that never matched (`#test-run-case-detail`; the `UDashboardPanel` renders `#dashboard-panel-test-run-case-detail`), so `panel` fell back to `document.body` and the scroll container was never found. The fix finds the panel by its real id and the tab body's real scrolling descendant. Positions, code-block height, help hints and the active tab reproduce §1.5 exactly; the control/word counts are now correctly **scoped to the detail panel** (excluding the global sidebar/nav), which is why they sit a little below the prototype's whole-page figures and match the plan's own panel-scoped `≤ 15` target.

The shared server-boot and page-wait helpers are extracted into `scripts/lib/` (`dev-server.mjs`, `page-waits.mjs`) and used by both this script and the screenshot harness rather than copy-pasted; the harness's behaviour is unchanged.

**2. Four screenshot scenes** — `execution-clarity`, `execution-clarity-mobile`, `cluster-clarity`, `cluster-clarity-mobile` (`/test-run-cases/37` and `/failure-clusters/10`, at 1280×800 and 390px, default state), writing to `.screens/` (gitignored report artifacts). The four captures were shared in the session; they show the baseline the plan describes — two tops of equal weight, "The one clue"/"Other clues (4)", and on the cluster the four contradicting status signals with the default evidence tab on *State*.

**3. A baseline test for today's clue ranking** — `tests/unit/failure-clues-seed-cases.test.ts` runs the real `buildFailureClues` over inputs captured verbatim from the seeded dev database and pins the ordered `(rule, strength)` output for #37, #13, #781 and #587, so Phase 1's ranking change shows as a readable diff. To capture those inputs honestly, `getFailureClues` is split into a reusable `loadFailureClueInput` (same signature and result). The test is in its own file so the parallel Phase 1 branch never edits it.

### `npm run app:measure -- --json` (dev seed, 1280×800)

```
{"route":"/test-run-cases/37","positions":{"header":32,"headline":214,"clues":488,"evidence":999,"fix":2514,"fixLocatorFix":null,"fixFixPlan":2591,"fixDiagnosis":2652,"fixVerify":null,"fixReproduce":2752,"whatChanged":null,"affectedTests":null,"history":3492},"totalScrollHeight":3631,"controls":75,"controlsAboveFold":21,"help":8,"helpAboveFold":3,"pre":4,"preHeight":2125,"words":669,"activeTab":"Screen","clueStrengths":["Strong","Medium","Medium","Weak"]}
{"route":"/test-run-cases/13","positions":{"header":32,"headline":214,"clues":488,"evidence":1101,"fix":2243,"fixLocatorFix":null,"fixFixPlan":2320,"fixDiagnosis":2381,"fixVerify":null,"fixReproduce":2481,"whatChanged":null,"affectedTests":null,"history":3221},"totalScrollHeight":3360,"controls":72,"controlsAboveFold":22,"help":7,"helpAboveFold":3,"pre":4,"preHeight":2125,"words":692,"activeTab":"Screen","clueStrengths":["Strong","Medium","Medium","Medium","Weak"]}
{"route":"/failure-clusters/10","positions":{"header":32,"headline":280,"clues":null,"evidence":551,"fix":1106,"fixLocatorFix":null,"fixFixPlan":2982,"fixDiagnosis":1183,"fixVerify":2108,"fixReproduce":2269,"whatChanged":3094,"affectedTests":3274,"history":3458},"totalScrollHeight":3583,"controls":77,"controlsAboveFold":34,"help":13,"helpAboveFold":4,"pre":4,"preHeight":692,"words":744,"activeTab":"State","clueStrengths":[]}
{"route":"/failure-clusters/2","positions":{"header":32,"headline":248,"clues":487,"evidence":724,"fix":1576,"fixLocatorFix":1790,"fixFixPlan":3771,"fixDiagnosis":1653,"fixVerify":2897,"fixReproduce":3058,"whatChanged":3883,"affectedTests":4063,"history":4248},"totalScrollHeight":4353,"controls":79,"controlsAboveFold":32,"help":9,"helpAboveFold":3,"pre":3,"preHeight":548,"words":841,"activeTab":"Timeline","clueStrengths":["Medium"]}
{"route":"/failure-clusters/5","positions":{"header":32,"headline":248,"clues":null,"evidence":555,"fix":1033,"fixLocatorFix":1247,"fixFixPlan":2534,"fixDiagnosis":1110,"fixVerify":1826,"fixReproduce":1988,"whatChanged":2646,"affectedTests":2826,"history":3076},"totalScrollHeight":3181,"controls":70,"controlsAboveFold":33,"help":9,"helpAboveFold":3,"pre":2,"preHeight":433,"words":559,"activeTab":"State","clueStrengths":[]}
{"route":"/failure-clusters/1","positions":{"header":32,"headline":248,"clues":515,"evidence":1164,"fix":2306,"fixLocatorFix":null,"fixFixPlan":4219,"fixDiagnosis":2383,"fixVerify":3344,"fixReproduce":3506,"whatChanged":4331,"affectedTests":4511,"history":4760},"totalScrollHeight":4889,"controls":98,"controlsAboveFold":25,"help":15,"helpAboveFold":4,"pre":6,"preHeight":2319,"words":1094,"activeTab":"Screen","clueStrengths":["Strong","Medium","Medium","Medium","Weak"]}
```

`#37` and `#10` match the plan's §1.5 reference (header 32, headline 214/280, evidence 999/551, fix 2514/1106, diagnosis 2652/1183, history 3492/3458; help 8·3 / 13·4; code blocks 4·2125px / 4·692px; active tab *Screen* / *State*) — with the total scroll height now reported (3631 / 3583) instead of 0.

## How was it tested?

- `npm run app:typecheck` — clean.
- `npm run app:lint` — clean; `npm run app:format:check` — clean.
- `npm run app:test:unit` — 2180 passed (157 files), including the new baseline test. The pinned arrays were confirmed against the live `/api/test-run-cases/:id/clues` endpoint on a seeded dev server before pinning.
- `npm run app:measure -- --json` and the four scenes were run against a seeded server (output above; captures shared in the session).
- `npx commitlint --from origin/main --to HEAD` — clean.

The dev seed's broken screenshot thumbnail in the Screen tab is a known, separate defect being fixed on another branch — not introduced here.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated (`AGENTS.md` commands table + the `run-app` skill document `app:measure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTczTkTMJ9Na8PzByZ1mFF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTczTkTMJ9Na8PzByZ1mFF)_