### PR TITLE
fix(ui): the 390px pass, docs rewrite and vocabulary sweep for the failure pages

### DIFF
--- a/apps/application/app/components/shared/Toolbox.vue
+++ b/apps/application/app/components/shared/Toolbox.vue
@@ -81,6 +81,18 @@ function toggle(key: FixSectionKey) {
   openKey.value = openKey.value === key ? null : key;
 }
 
+// A folded summary truncates to one line; mirror its text into the element's
+// `title` so the clipped tail stays readable on hover. The summaries are slot
+// content, so read the rendered text rather than threading a second prop.
+const vTitleFromText = {
+  mounted: (el: HTMLElement) => {
+    el.title = el.textContent?.trim() ?? '';
+  },
+  updated: (el: HTMLElement) => {
+    el.title = el.textContent?.trim() ?? '';
+  },
+};
+
 /** Open a section (a next-step action reveals then scrolls to it). */
 function openSection(key: FixSectionKey) {
   openKey.value = key;
@@ -105,7 +117,7 @@ defineExpose({ openSection });
               class="size-4 shrink-0 text-gray-400"
             />
             <span class="text-sm font-medium shrink-0">{{ s.label }}</span>
-            <span v-if="openKey !== s.key" class="min-w-0 flex-1 truncate text-sm text-muted">
+            <span v-if="openKey !== s.key" v-title-from-text class="min-w-0 flex-1 truncate text-sm text-muted">
               <slot :name="`${s.key}-summary`" />
             </span>
           </button>

--- a/apps/application/app/pages/failure-clusters/[id].vue
+++ b/apps/application/app/pages/failure-clusters/[id].vue
@@ -197,7 +197,7 @@ const occurrenceAria = computed(() =>
 // The newest known-issue link, shown compactly on the facts line.
 const knownIssue = computed(() => cluster.value?.links?.[0] ?? null);
 
-// ── Show raw error disclosure ────────────────────────────────────────────────
+// ── Raw error disclosure ─────────────────────────────────────────────────────
 const rawErrorEl = ref<HTMLElement | null>(null);
 const rawErrorOpen = ref(false);
 function revealRawError() {
@@ -536,7 +536,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
   },
 });
 
-// Deep link from the execution page's "Open fix plan" — open the fix-plan section.
+// Deep link from the execution page's fix-plan link — open the fix-plan section.
 onMounted(() => {
   if (route.hash === '#fix-plan') nextTick(() => openFixPlan());
 });

--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -1119,7 +1119,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
               />
             </template>
 
-            <!-- A pointer to the cluster's full fix plan -->
+            <!-- A link to the cluster's full fix plan -->
             <template v-if="failureCluster" #fix-plan>
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
                 <template v-if="failureCluster.diagnosis?.status === 'completed'">
@@ -1135,7 +1135,6 @@ const { handle: handleNextStepAction } = useNextStepActions({
                     {{ failureCluster.diagnosis.confidence }} confidence
                   </UBadge>
                 </template>
-                <span v-else class="text-muted">Assembled on the cluster page.</span>
                 <UButton
                   :to="`/failure-clusters/${failureCluster.id}#fix-plan`"
                   size="xs"
@@ -1144,7 +1143,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
                   trailing-icon="i-lucide-arrow-right"
                   class="px-0"
                 >
-                  Open fix plan
+                  Open on the cluster
                 </UButton>
               </div>
             </template>

--- a/apps/application/app/utils/help-content.ts
+++ b/apps/application/app/utils/help-content.ts
@@ -233,11 +233,6 @@ export const HELP_TOPICS = {
     text: 'One block that answers three questions: what broke (the headline, built from the Playwright error itself), what is most likely behind it (the story that chains the deterministic clues, or the diagnosis when one completed), what is going on (since when, on which commit, in how many other tests, who owns it — one sentence), and what to do next (one action chosen by a policy). Every clue, the raw error and the rest of the facts are one click away.',
     doc: 'features/evidence#one-execution-diagnosis-first',
   },
-  'case.fix': {
-    title: 'Fix',
-    text: 'Everything to do about this failure in one place — the locator fix for a broken locator, a pointer to the cluster’s fix plan, the diagnosis, how to verify a fix, and the tests this failure blocked. Each part shows only when it applies.',
-    doc: 'features/fix-plans',
-  },
   'case.evidence': {
     title: 'Evidence',
     text: 'Everything captured for this execution, one tab per view: the failure timeline (steps, network and console on one clock), the screenshot and video with the visual and page diffs, the test source, the network requests, the console output, the app state at the end, and the browser performance. The tab opens on the view the story points at; the raw page structure — the accessibility tree and the failure-time DOM — folds behind Page structure at the bottom of the Screen tab. An empty tab says whether the evidence was never captured, captured with nothing to show, or does not apply.',
@@ -247,11 +242,6 @@ export const HELP_TOPICS = {
     title: 'More ways to fix',
     text: 'Every other way to fix, verify or reproduce this failure, each folded to one line: the diagnosis, the locator fix, the verify command, the local reproduce-and-bisect recipe, the clusters fixed before, the tests this failure blocked, and the whole fix plan as Markdown (the same plan get_fix_plan returns to an AI agent via the MCP server). The section the next step points at opens with the page; open the others as you need them.',
     doc: 'features/fix-plans',
-  },
-  'fix.reproduce': {
-    title: 'Reproduce',
-    text: 'A copy-paste recipe that reproduces the failure locally — check out the failing commit, install the run’s Playwright version and browser, and run exactly the failing test — plus a generated git bisect between the last green and the failing commit to find what broke it. Both come in Linux/macOS and Windows forms. The bisect needs a last-green commit and an SCM connection; without them it says so. In the desktop app, Reproduce here and Find the breaking commit here run the recipe and drive the bisect for you in a throwaway git worktree, without touching your checkout.',
-    doc: 'features/fix-plans#reproduce-and-bisect',
   },
   'case.test-source': {
     title: 'Test source',
@@ -286,11 +276,6 @@ export const HELP_TOPICS = {
     text: 'HTTP requests the page made during the test, with timing and status — useful for spotting failed or slow calls. When the execution has a trace, the Full trace view shows every request (all resource types) with headers, timing phases, a waterfall and capped body previews; sensitive header values are masked. An empty card distinguishes not captured (add the capture fixtures) from captured-but-nothing-happened; with a trace and no fixtures the list is recovered from the trace and marked "derived from the trace".',
     doc: 'features/evidence#trace-powered-deep-views',
   },
-  'case.aria': {
-    title: 'ARIA snapshot',
-    text: 'A snapshot of the accessibility tree at the moment of failure — what assistive tech saw, and useful grounding for AI diagnosis. An empty card says whether it was not captured (add the capture fixtures) or captured with nothing to snapshot; with a trace and no fixtures it is recovered from the trace\'s error context and marked "derived from the trace".',
-    doc: 'features/ai-diagnosis#what-a-diagnosis-contains',
-  },
   'case.attempts': {
     title: 'Attempts',
     text: 'When a test failed then passed on retry, this compares the failing attempt against the passing one and lists what differed — the error that was there then gone, a request that failed on only one attempt, a console error, a slower step, a duration or page-state change. Each difference links to the evidence it came from. That delta is the flakiness fingerprint, and it feeds the root-cause classifier.',
@@ -318,21 +303,6 @@ export const HELP_TOPICS = {
     title: 'Known issue',
     text: 'Pin the Jira ticket, GitHub issue or PR that tracks this cluster. The link’s key travels with the cluster wherever it is listed, so a triaged cluster shows what is already being done about it.',
   },
-  'cluster.fix-plan': {
-    title: 'Fix',
-    text: 'Everything needed to repair this cluster in one place — the AI diagnosis and its validated patch, the recommended locator fix, the command that verifies the fix, and the whole plan as Markdown. Copy it for a ticket, or let an agent fetch the same plan via the get_fix_plan MCP tool.',
-    doc: 'features/fix-plans',
-  },
-  'cluster.fixed-before': {
-    title: 'Fixed before',
-    text: 'Resolved failures that resemble this one — matched on the same error and locator, the same spec or test, and (when embeddings are configured) semantic similarity. Each shows when it was fixed, the resolving commit, how long it stayed open and the triage note, so you can reuse an earlier resolution. "Apply the same triage" copies that note onto this cluster; it never marks a new cluster resolved because an old one was.',
-    doc: 'features/fix-plans#fixed-before',
-  },
-  'cluster.evidence': {
-    title: 'Test evidence',
-    text: 'The concrete artifacts behind this cluster — screenshots, signals and traces from affected tests — gathered for review and AI diagnosis.',
-    doc: 'features/ai-diagnosis#what-a-diagnosis-contains',
-  },
   'cluster.scm': {
     title: 'What changed',
     text: 'Recent commits and diffs around when this failure started, so you can connect the break to the change that caused it.',
@@ -347,11 +317,6 @@ export const HELP_TOPICS = {
     title: 'Commit browser',
     text: 'Browse the repository’s recent commits and inspect each diff to pick a baseline or find the suspect change.',
     doc: 'features/ai-diagnosis#scm-grounded-context',
-  },
-  'cluster.diagnosis': {
-    title: 'AI diagnosis',
-    text: 'Runs the configured AI model over the failure plus its evidence and code changes to propose a root cause and fix.',
-    doc: 'features/ai-diagnosis#enabling-ai-diagnosis',
   },
   'cluster.context-input': {
     title: 'Additional context',
@@ -372,16 +337,6 @@ export const HELP_TOPICS = {
     title: 'AI not configured',
     text: 'Diagnosis needs an AI provider and API key. Configure one in Settings → AI to enable automatic and on-demand analysis.',
     doc: 'features/ai-diagnosis#enabling-ai-diagnosis',
-  },
-  'cluster.confidence': {
-    title: 'Confidence score',
-    text: 'How sure the model is of the top hypothesis (0–100). It is lowered when key evidence is missing or truncated, so treat a low score as “gather more before acting”.',
-    doc: 'features/ai-diagnosis#what-a-diagnosis-contains',
-  },
-  'cluster.hypotheses': {
-    title: 'Other hypotheses',
-    text: 'Alternative root causes the model weighed, ranked by likelihood. Useful when the evidence is ambiguous and the top pick is not conclusive.',
-    doc: 'features/ai-diagnosis#what-a-diagnosis-contains',
   },
   'cluster.coverage': {
     title: 'Data coverage',
@@ -649,12 +604,6 @@ export const HELP_TOPICS = {
   'case.page-diff': {
     title: 'Page diff',
     text: 'Compares the failing page’s ARIA structure against the same test’s last passing (green) sample — same browser, preferring the same environment then branch. Shows what was added, removed, renamed, changed or moved, with unchanged subtrees collapsed and the failing locator’s element highlighted. A green sample is captured about once a day per test, so a baseline appears after the next passing run.',
-  },
-
-  // ── DOM snapshot ─────────────────────────────────────────────────────────
-  'dom-snapshot': {
-    title: 'DOM snapshot',
-    text: 'The page’s HTML around the failing action, rendered from the uploaded Playwright trace — nothing extra is captured. Input values, inline handlers and script bodies are removed; token-shaped strings are masked.',
   },
 
   // ── Page state ───────────────────────────────────────────────────────────

--- a/apps/application/app/utils/index.ts
+++ b/apps/application/app/utils/index.ts
@@ -344,7 +344,7 @@ export function fixVerificationBadge(
   switch (verification) {
     case 'diagnosis-verified':
       return {
-        label: 'Fix verified',
+        label: 'Verified',
         color: 'success',
         icon: 'i-lucide-badge-check',
         hint: 'The tests went green and the change touched the files the diagnosis named.',

--- a/apps/application/tests/mobile-responsiveness.spec.ts
+++ b/apps/application/tests/mobile-responsiveness.spec.ts
@@ -228,7 +228,8 @@ test.describe('Mobile responsiveness', () => {
       });
 
       // Non-baseline screenshot (attached to the report) for a quick visual
-      // sanity check of the two highest-traffic pages at this viewport.
+      // sanity check of the highest-traffic and the two reworked failure pages
+      // at this viewport.
       test('screenshot: home and run detail', async ({ page }, testInfo) => {
         await page.goto('/');
         await waitForHydration(page);
@@ -237,6 +238,24 @@ test.describe('Mobile responsiveness', () => {
         await page.goto(`/test-runs/${runId}`);
         await waitForHydration(page);
         await testInfo.attach(`run-detail-${name}`, { body: await page.screenshot(), contentType: 'image/png' });
+      });
+
+      test('screenshot: the failure pages', async ({ page }, testInfo) => {
+        await page.goto(`/test-run-cases/${testRunCaseId}`);
+        await waitForHydration(page);
+        await expectNoHorizontalOverflow(page, 'execution detail (situation block)');
+        await testInfo.attach(`execution-detail-${name}`, {
+          body: await page.screenshot({ fullPage: true }),
+          contentType: 'image/png',
+        });
+
+        await page.goto(`/failure-clusters/${clusterId}`);
+        await waitForHydration(page);
+        await expectNoHorizontalOverflow(page, 'failure cluster detail (situation block)');
+        await testInfo.attach(`failure-cluster-detail-${name}`, {
+          body: await page.screenshot({ fullPage: true }),
+          contentType: 'image/png',
+        });
       });
     });
   }

--- a/apps/application/tests/unit/app-utils.test.ts
+++ b/apps/application/tests/unit/app-utils.test.ts
@@ -275,7 +275,7 @@ describe('cluster color helpers', () => {
     });
 
     test('only the corroborated verdict claims the fix was verified', () => {
-      expect(fixVerificationBadge('diagnosis-verified')).toMatchObject({ label: 'Fix verified', color: 'success' });
+      expect(fixVerificationBadge('diagnosis-verified')).toMatchObject({ label: 'Verified', color: 'success' });
       // "Stopped failing" must not read as a verified fix — nothing says which
       // change did it.
       expect(fixVerificationBadge('stopped-failing')).toMatchObject({ label: 'Stopped failing', color: 'info' });

--- a/apps/application/tests/unit/ui-vocabulary.test.ts
+++ b/apps/application/tests/unit/ui-vocabulary.test.ts
@@ -75,6 +75,33 @@ const RULES: Rule[] = [
     re: /\b(The one clue|Other clues)\b/,
   },
   {
+    id: 'raw-error',
+    hint: 'the disclosure is "Raw error", not "Show raw error"',
+    re: /Show raw error/i,
+  },
+  {
+    id: 'fix-plan-pointer',
+    hint: 'the pointer sections are gone — the next step leads, and "Fix plan" is only the toolbox export section',
+    re: /Open fix plan|Assembled on the cluster/i,
+  },
+  {
+    id: 'triage-card',
+    hint: 'the state line and its "Triage ▾" menu replaced the Triage card (the menu button and "Triage note" stay)',
+    re: /(?<![-\w])(title|label)\s*[:=]\s*(['"])Triage\2/i,
+  },
+  {
+    id: 'cluster-history-card',
+    hint: 'the occurrence sparkline replaced the cluster History card',
+    re: /(?<![-\w])(title|label)\s*[:=]\s*(['"])History\2/,
+    // The execution page keeps its own recent-executions history block (plan Appendix A).
+    allow: ({ rel }) => rel.includes('test-run-cases/[id].vue'),
+  },
+  {
+    id: 'fix-verified-badge',
+    hint: 'the cluster state sentence carries the verdict; the project badge reads "Verified"',
+    re: /\bFix verified\b/,
+  },
+  {
     id: 'since-last-pass',
     hint: 'the Changes tab replaced "Since last pass"',
     re: /\bSince last pass\b/i,

--- a/apps/docs/features/ai-diagnosis.md
+++ b/apps/docs/features/ai-diagnosis.md
@@ -71,8 +71,9 @@ long the cluster was open. Three verdicts, because they are not the same claim:
 | **Diagnosis verified** | The commits since the last failing run touched a file the [suggested patch](#what-a-diagnosis-contains) named — the change Piwi pointed at is the change that fixed it. |
 | **Regressed** | A fix was recorded, and the cluster is failing again. A fix that didn't hold is worth knowing about. |
 
-The verdict appears on the cluster page, under the signature, with the run the fix landed in, the commit, and how long
-the cluster stayed open. The project's **Failure clusters** tab shows it beside the triage status — deliberately as a
+The verdict rides the cluster page's [state line](./failure-clusters#the-state-line), a sentence naming the run the fix
+landed in, the commit, and how long the cluster stayed open. The project's **Failure clusters** tab shows it beside the
+triage status — deliberately as a
 second badge rather than folded into the first, because the two answer different questions: the status is what a person
 declared, the verdict is what the runs showed. A cluster somebody marked *resolved* that is quietly failing again shows
 both, and that disagreement is the point.
@@ -178,8 +179,8 @@ A diagnosis is grounded in your actual run — it is not a generic "ask AI" butt
 - **Suggested fix** and **prevention tips**
 
 <figure>
-  <img src="/screenshots/ai-diagnosis.png" alt="The AI diagnosis card at the foot of a failure cluster page">
-  <figcaption>The AI diagnosis at the foot of a cluster page — category, confidence, root cause, the evidence it relied on, and a suggested fix — grounded in the same error and evidence the page shows above it.</figcaption>
+  <img src="/screenshots/ai-diagnosis.png" alt="The AI diagnosis in the toolbox of a failure cluster page">
+  <figcaption>The AI diagnosis in a cluster page's toolbox — category, confidence, root cause, the evidence it relied on, and a suggested fix — grounded in the evidence shown above it.</figcaption>
 </figure>
 
 ## Diagnosing one execution

--- a/apps/docs/features/failure-clusters.md
+++ b/apps/docs/features/failure-clusters.md
@@ -73,7 +73,19 @@ falls back to the repository's `CODEOWNERS`. You can override it by **assigning*
 an assignee takes precedence over the derived owner, and the **Mine** queue matches either one against the
 signed-in user (by name or email, best effort).
 
-## The state line
+## The cluster page
+
+Open a cluster and it reads as the same three questions the [execution page](./evidence#one-execution-diagnosis-first) answers, for the failure across every test that shares it:
+
+- **What broke** — the cluster's **name** as the heading (its [AI title](./ai-diagnosis) when one exists, else the deterministic fingerprint name), with the **latest occurrence's headline** as a smaller second line only when it adds a value the name doesn't.
+- **Most likely** — the one explanation: the completed [diagnosis](./ai-diagnosis) when there is one, else the [story or top clue](./evidence#clues) from the latest occurrence.
+- **The occurrence sparkline** — how often the cluster failed across the project's recent runs, oldest to newest, with a summary: *N occurrences in M tests over D · last X ago*.
+- **The state line** — where the cluster stands, in one sentence (below).
+- **Next** — the one [recommended step](./fix-plans#the-next-step) for the cluster.
+
+Below the block, **What changed** answers *why now* — the commits between the last green run and the failing one, and the environment diff — collapsed to one line when there is nothing to show (no SCM connection, no last green run). The **Affected tests** list is the evidence selector: every test in the cluster, sorted by its latest failure; selecting a row switches the evidence below to that test's latest execution and links straight to it. Everything else — the diagnosis and its patch, the locator fix, verify, reproduce — is in the folded [**More ways to fix**](./fix-plans#more-ways-to-fix) toolbox.
+
+### The state line
 
 The cluster page states where a cluster stands in **one sentence with one verb**, next to a coloured dot:
 *still failing*, *fixed and verified — still open*, *stopped failing*, *regressed — the fix did not hold*,
@@ -86,9 +98,6 @@ Two menus sit beside it:
 
 - **Triage** sets the status (open / resolved / ignored), an optional note, and the assignee.
 - **Snooze** hides the cluster from the inbox (see below), or brings a snoozed one back.
-
-The occurrence sparkline above the line shows how often the cluster failed across the project's recent runs,
-oldest to newest, with a summary — *N occurrences in M tests over D · last X ago*.
 
 ## Snoozing
 

--- a/apps/docs/features/fix-plans.md
+++ b/apps/docs/features/fix-plans.md
@@ -13,21 +13,25 @@ A **fix plan** gathers everything Piwi knows about a failure cluster into one an
 
 The same plan is reachable three ways:
 
-- **On the cluster page** — the recommended action leads the page as the **Next** line, the failing tests are the **Affected tests** selector, and the owner is on the identity line. Everything else lives in [**More ways to fix**](#more-ways-to-fix), the folded toolbox below the evidence: the diagnosis and its patch, the locator fix, the verify command, the reproduce recipe, and a **Copy as Markdown** action for a ticket.
+- **On the cluster page** — the recommended action leads as the **Next** line and the failing tests are the **Affected tests** selector; everything else lives in [**More ways to fix**](#more-ways-to-fix), the folded toolbox below the evidence: the diagnosis and its patch, the locator fix, the verify command, the reproduce recipe, and a **Copy as Markdown** action for a ticket.
 - **As Markdown** — `GET /api/failure-clusters/:id/fix-plan?format=markdown` returns the same rendering as plain text, so an export or a script can drop it straight into an issue.
 - **For agents** — the `get_fix_plan` [MCP tool](/features/mcp) returns the structured plan, so a coding agent gets in one call what a person reads on the card.
 
-The last part is what makes it a loop rather than a lookup: the plan states which Playwright command runs exactly the affected tests, and that Piwi will record the fix once they pass — so an agent (or a person) can confirm the work instead of leaving someone to decide whether it landed. Nothing leaves your machine: the dashboard is yours, the model is whichever one you configured (including a local one), and the patch was validated against your own source before you saw it.
+The last part makes it a loop, not a lookup: the plan names the Playwright command that runs exactly the affected tests, and Piwi records the fix once they pass — so the work is confirmed, not guessed at. Nothing leaves your machine: your dashboard, your model, and a patch validated against your own source.
+
+## The next step
+
+Both the cluster and the [execution](./evidence#one-execution-diagnosis-first) page lead with a single **Next** line — one action chosen for you, with a word on why, not a row of equal buttons. A policy picks it from what the page knows, first match wins: open a **blocking** failure, **mark resolved** a verified-but-open cluster, **replace the locator** when [healing](./locator-healing) has one, **apply the diagnosed patch** (or follow the diagnosis when it is stale), **see what changed** when a fix regressed, **compare attempts** on a retry pass, **re-run in CI** for a crash, **diagnose with AI**, else **reproduce locally**. Where the fix is a code change, **Copy retry command** trails it; every other action lives in the toolbox below.
 
 ## More ways to fix
 
-The cluster and [execution](./evidence#one-execution-diagnosis-first) pages end in one **More ways to fix** toolbox — the block that replaced the old Fix card. Each way to fix, verify or reproduce is a section folded to one line (a label and a summary from the page's own data), so no code block opens by default. The section the **Next** step points at opens with the page — a diagnosed fix opens **Diagnosis**, a locator failure opens **Locator fix** — and you unfold the rest as needed.
+Both pages end in one **More ways to fix** toolbox — the block that replaced the old Fix card. Each way to fix, verify or reproduce is a section folded to one line (a label and a one-line summary), so no code block opens by default; the section the next step points at opens with the page, and you unfold the rest as needed.
 
 ## Reproduce and bisect
 
 The fix plan also hands back the two things you do next: a copy-paste recipe that reproduces the failure locally, and a generated `git bisect` that finds the commit that broke it. Both sit in the toolbox's **Reproduce and bisect** section, and travel with the plan through `?format=markdown` and the `get_fix_plan` MCP tool. The exact test command leads; **Show the full recipe ▸** unfolds the checkout, install and bisect.
 
-The **recipe** is the local reproduction, in order: check out the commit the run failed on (`git switch --detach <sha>`), install dependencies, pin Playwright to the version the run used, install the browser it ran on, and run exactly the failing test. Each part degrades on its own — no recorded commit skips the checkout and says so, an unknown Playwright version drops the pin — and the run's environment (label, base URL) is listed beside it. Every command is `git`, `npm` or `npx`, so it is identical on Linux, macOS and Windows; the dashboard still offers a **Linux / macOS** and a **Windows (PowerShell)** tab so a reader copies the form they expect.
+The **recipe** is the local reproduction, in order: check out the commit the run failed on (`git switch --detach <sha>`), install dependencies, pin Playwright to the run's version, install the browser it ran on, and run exactly the failing test. Each part degrades on its own — no recorded commit skips the checkout and says so, an unknown version drops the pin — and the run's environment is listed beside it. Every command is `git`, `npm` or `npx`, identical on Linux, macOS and Windows; the dashboard still offers **Linux / macOS** and **Windows (PowerShell)** tabs.
 
 ```bash
 # Check out the failing commit
@@ -52,11 +56,11 @@ git bisect reset
 
 The bisect needs a **last-green commit** and an **SCM connection**: when Piwi has no commit for the failing run or for the last green run before it, or the two are the same commit, the section says so in one line instead of showing a script. The recipe is always there.
 
-In the [desktop app](/features/desktop#reproducing-a-failure-and-finding-the-breaking-commit) the same section can also do the work for you: **Reproduce here** runs the recipe against the linked folder in a throwaway `git worktree` — your checkout is never touched — and **Find the breaking commit here** drives the whole bisect step by step, with live progress and a stop that stops, then records the first bad commit on the cluster so it shows here and in the fix plan afterwards.
+In the [desktop app](/features/desktop#reproducing-a-failure-and-finding-the-breaking-commit) the same section can do the work for you: **Reproduce here** runs the recipe against the linked folder in a throwaway `git worktree` (your checkout is never touched), and **Find the breaking commit here** drives the whole bisect with live progress, then records the first bad commit on the cluster.
 
 ## Fixed before
 
-An open cluster often isn't new — the same failure, or one close to it, was fixed weeks ago. The fix plan looks back over the project's **resolved** clusters (resolved, or with a verified fix that held) and, when one resembles the open cluster closely enough, shows it in the **Fixed before** section of the toolbox — on the cluster page and on the failing execution's page, and in the `?format=markdown` export and the `get_fix_plan` MCP tool.
+An open cluster often isn't new — the same failure, or one close to it, was fixed weeks ago. The fix plan looks back over the project's **resolved** clusters (resolved, or with a verified fix that held) and, when one resembles the open cluster closely enough, shows it in the **Fixed before** section of the toolbox — on both pages, and in the `?format=markdown` export and the `get_fix_plan` MCP tool.
 
 A match is scored deterministically first — the same fingerprint family (error kind, masked message, masked locator), the same failing locator, the same spec file or test — and then, when an [embedding model](./ai-diagnosis#model-roles) is configured, by semantic similarity of the stored cluster vectors. The top three matches are shown, each with **when** it was resolved, the **commit** that fixed it (linked when the repository host is known), **how long** it stayed open, the triage note, the owner, the earlier diagnosis and its thumbs feedback, and one short reason it matched ("same error and locator", "same spec, similar message (0.91)"). Nothing matches → the section renders nothing, no empty-state noise.
 

--- a/apps/docs/features/ui-overview.md
+++ b/apps/docs/features/ui-overview.md
@@ -132,20 +132,19 @@ them: an **execution** (`/test-run-cases/:id`) answers *"why did this attempt fa
 case** (`/test-cases/:id`) answers *"how has this test behaved over time?"*. Most links from a run land
 on an execution; the test's title links to the test case above it.
 
-A failing execution reads top to bottom in one column: a **header** (status, title, the exceptional
-badges, the failing file and line, and Copy retry command, with a Details popover for the rest), the
-one-line **headline** (with the raw **error** one click away behind *Show raw error*), the **other
-clues**, then one **evidence** card whose content-level tabs — Timeline, Screen, Source, Network,
-Console, State, Performance — hold everything captured, deeper still when a trace is attached. A
-Playwright 1.63 trace with [aria and screen snapshots](./evidence#aria-and-screen-snapshots) adds a
-filmstrip of the page before each step to the Timeline tab, and the before/at-failure screenshots plus
-an in-execution page diff to the Screen tab. Below the
-evidence, the **Fix** card gathers what to do (the locator fix, a fix-plan pointer, the diagnosis, how
-to verify, and the tests this failure blocked) and a **history** block strips this test's recent
-executions with its failing streak. All of it, plus the bundled trace viewer, is described in
-[Failure evidence](./evidence). The header's facts line shows the **attempts** as linked chips when a
-test retried, so "how did this execution get here" is answerable at a glance; every attempt is its own
-execution, and each chip links to that attempt's page while the one you are viewing is ringed.
+A failing execution reads top to bottom in one column, and leads with one **situation block** that
+answers three questions in stacked lines: an **identity** kicker (status, title, marks), the **headline**
+(what broke), **Most likely** (the [story](/guide/concepts#story) or top clue, every clue folded under
+*more*), the **situation** sentence (what's going on), the **Next** step (what to do), and a **facts**
+line — the failing file and line, browser, duration, attempts as linked chips, branch and CI build, with
+a **Details** popover and the verbatim **Raw error** one click away. Below it, one **evidence** card whose
+content-level tabs — Timeline, Screen, Source, Network, Console, State, Performance — hold everything
+captured, opening on the tab the story cites and going deeper when a trace is attached. A Playwright 1.63
+trace with [aria and screen snapshots](./evidence#aria-and-screen-snapshots) adds a filmstrip of the page
+before each step to the Timeline tab, and the before/at-failure screenshots plus an in-execution page diff
+to the Screen tab. After the evidence, the folded **More ways to fix** toolbox holds every other way to
+fix, verify or reproduce, and a **history** block strips this test's recent executions with its failing
+streak. All of it, plus the bundled trace viewer, is described in [Failure evidence](./evidence).
 
 The **test history** page (`/test-cases/:id`) opens on a single facts line under the title — how many
 runs, the pass rate, how many failed, the average duration, the flaky-run count and when it last ran —
@@ -156,9 +155,9 @@ opens the execution, and the **failure clusters** the test belongs to and its **
 
 ## Failure cluster detail
 
-Each cluster (`/failure-clusters/:id`) reads top to bottom in one column. The **header** states the cluster name and one facts line — error kind, occurrences, affected tests, the first- and last-seen runs, the owner and the known-issue link — with **Re-run in CI** (or Copy retry command) as its one action and the rest in a More menu (quarantine all affected tests, show diagnosis context, copy prompt, copy summary). Under it sits the **triage control**: a segmented *Open / Resolved / Ignored* that saves on click, a note, and — once a fix has landed — the **fix verification** badge with its one sentence (which verdict the runs support, the run and commit it landed in, how long the cluster stayed open) and, when triage and fix verification disagree, a one-click reconcile action. See [Did the fix work?](./ai-diagnosis#did-the-fix-work).
+Each cluster (`/failure-clusters/:id`) reads top to bottom in one column and leads with the same **situation block** the execution page uses, plus the cluster-only lines. The **identity** kicker names the cluster, error kind, project, owner and known issue; the **headline** is the cluster's name (its AI title when one exists), with the latest occurrence's headline a smaller second line only when it adds a value. **Most likely** leads with the completed [diagnosis](./ai-diagnosis) when there is one, else the [story or top clue](./evidence#clues). An **occurrence sparkline** shows how often it failed across recent runs (*N occurrences in M tests over D · last X ago*). The **state line** says where the cluster stands in one sentence with one verb next to a coloured dot, offers the one reconcile action when the human status and machine verdict disagree, and carries the **Triage** and **Snooze** menus (see [Did the fix work?](./ai-diagnosis#did-the-fix-work)). The **Next** step and a **facts** line (Details, Raw error, Copy summary) close the block.
 
-Below the header the failure reads as a one-line **headline** built from the cluster's latest occurrence (falling back to its stored sample error), with a **Show raw error** disclosure for the verbatim error and signature, then the deterministic **clues**. The **evidence** is one card whose content-level tabs — Timeline, Screen, Source, Network, Console, State, Performance — hold everything captured for the affected execution you select from the *from:* row on top; **Open execution** links through to that test-run case. Then one **More ways to fix** toolbox folds together what to do about the cluster, each section a single line until you open it (or until the next step opens it for you): the **AI diagnosis** (an SCM-grounded LLM analysis whose cited evidence links back to the matching evidence tab, with a **History** control for its previous versions and a staleness banner that fires only while the failure is still live) — its stored result stays visible even with no provider configured — the **locator fix** for a broken locator (recommendation, provenance and alternatives, shown once), the **verify** command, and the whole **fix plan** as Markdown for a ticket or an agent (see [Fix plans, reproduce & bisect](./fix-plans)). Below the toolbox come **what changed** (the SCM diff since the last green run, with a baseline-commit picker and commit browser), the **affected tests** (a selectable list whose bulk bar moves tests to a new cluster or quarantines them; each row links to its latest execution), and a **history** block with the cluster's occurrences, diagnosis-version count and fix-verification date. Full detail: [AI diagnosis & clustering](./ai-diagnosis).
+Below it, **What changed** (the SCM diff since the last green run, collapsed to one line when there is none) sits above the evidence, and the **Affected tests** list is the evidence selector — selecting a test switches the evidence below to its latest execution and links through with **Open execution**. The **evidence** is one card whose content-level tabs — Timeline, Screen, Source, Network, Console, State, Performance — hold everything captured for the selected execution. After the evidence, the folded **More ways to fix** toolbox holds the **AI diagnosis** and its patch (its stored result stays visible even with no provider configured, with a versions control and a staleness banner that fires only while the failure is still live), the **locator fix**, the **verify** command, **reproduce and bisect**, **fixed before**, and the whole **fix plan** as Markdown for a ticket or an agent. Full detail: [AI diagnosis & clustering](./ai-diagnosis) and [Failure clusters & the inbox](./failure-clusters).
 
 ## Offline export
 

--- a/apps/docs/guide/concepts.md
+++ b/apps/docs/guide/concepts.md
@@ -87,6 +87,36 @@ Fingerprints deliberately **ignore the failing stack frame**, so the same root c
 different spec files stays one cluster. Full detail:
 [Failure clustering & AI diagnosis](/features/ai-diagnosis).
 
+## Story
+
+The **one explanation** a failure page leads with. When several [clues](/features/evidence#clues)
+(deterministic, rule-based findings) form a known combination, Piwi chains them into a single sentence —
+*"the Pay button stayed disabled because POST /api/checkout/quote was still in flight"* — at the strongest
+member's strength, with every clue folded under it. When no combination matches, the story is the strongest
+clue alone; when a cluster has a completed [AI diagnosis](/features/ai-diagnosis), that leads instead.
+
+## Situation
+
+The **one sentence of context** under the explanation: since when the failure has been happening (and on
+which commit and author), how many other tests share the cause and the cluster they join, whether an earlier
+fix regressed, and who owns it. An exceptional case — a new regression, a pass on retry, an infrastructure
+blip — leads it as a badge. It reads on the execution page and, condensed, in [alerts](/features/notifications).
+
+## Next step
+
+The **one recommended action** a failure page leads with, chosen by a policy rather than offered as a menu —
+apply a diagnosed patch, replace a broken locator, reproduce locally, re-run in CI, mark a cluster resolved.
+The page shows the step, one line on why, and the button to do it; every other action lives in the toolbox.
+The policy and its ordering are on [Fix plans](/features/fix-plans#the-next-step).
+
+## Cluster state
+
+Where a **failure cluster** stands, said in one sentence with one verb next to a coloured dot: *still
+failing*, *fixed and verified — still open*, *stopped failing*, *regressed — the fix did not hold*, *resolved*,
+*ignored*, *snoozed* or *all tests quarantined*. It reconciles the human triage status with the
+machine-observed verdict; when they disagree the state line offers the one action that closes the gap. See
+[Failure clusters](/features/failure-clusters#the-state-line).
+
 ## Baseline (last green run)
 
 Several views answer "what changed?" — run insights, the regression signals on a test, the environment

--- a/apps/docs/guide/first-failure.md
+++ b/apps/docs/guide/first-failure.md
@@ -5,7 +5,7 @@ lang: en-US
 
 # Your first failure, explained
 
-You've landed your first run ([Getting started](./getting-started)) and one test is red. This page walks through reading it. Piwi lays a failing execution out **diagnosis-first** — one column, top to bottom: *what* broke, *why*, the evidence, then what to *do* — so you're not scrolling a trace hoping to spot the problem.
+You've landed your first run ([Getting started](./getting-started)) and one test is red. This page walks through reading it. Piwi lays a failing execution out **diagnosis-first** — one column, top to bottom: *what* broke, *why*, *what to do next*, then the evidence and more ways to fix — so you're not scrolling a trace hoping to spot the problem.
 
 Open the failing test from the run page (click its row) to reach its **execution page**.
 
@@ -28,9 +28,17 @@ Under the headline, the **Most likely** line gives you the one explanation, not 
 
 > *"the Pay button stayed disabled because POST /api/checkout/quote was still in flight (28 s); the console said so 1.5 s before the click gave up"*
 
-It carries a strength chip and how many clues **agree**; a **more** disclosure lists every clue, each with a **citation** to the evidence it came from — click it and the page jumps to the proof. Below that, the **situation** sentence says since when, on which commit, how many other tests share the cause, and who owns it, and the **Next** line names the one thing to do — apply the diagnosed patch, replace the locator, or reproduce locally — with the button to do it.
+It carries a strength chip and how many clues **agree**; a **more** disclosure lists every clue, each with a **citation** to the evidence it came from — click it and the page jumps to the proof.
 
-## 3. The evidence — see it
+## 3. The situation — what's going on
+
+Below the explanation, the **situation** sentence puts the failure in context in one line: since when it's been failing (and on which commit), how many other tests share the same cause and the [cluster](/features/failure-clusters) they join, whether an earlier fix regressed, and who owns it. An exceptional case — a new regression, a pass on retry, an infrastructure blip — leads the sentence as its one badge.
+
+## 4. Next — what to do
+
+The **Next** line names the one thing to do, chosen for you rather than offered as a menu: apply the diagnosed patch, replace the [broken locator](/features/locator-healing), reproduce it locally, re-run in CI, or mark the cluster resolved — with the button to do it, and a word on why it's the step. Where the work is a code change, the exact command to re-run this test trails it as **Copy retry command**. The full policy is on the [fix-plans page](/features/fix-plans#the-next-step).
+
+## 5. The evidence — see it
 
 One **evidence card** with tabs — **Timeline, Screen, Source, Network, Console, State, Performance** — opens on the tab the strongest clue points at. The one to know first is **Timeline**: it places the test's steps, console entries, network requests and backend logs on a single clock and marks the **moment of failure**, so "console (1) / network (3)" becomes *what the app was doing when the test gave up*. **Screen** holds the failure screenshot, the visual diff against the last green run, and the failure-time page state; **Source** shows the test source as a real call stack, so a failure inside a helper shows the helper.
 
@@ -38,13 +46,13 @@ One **evidence card** with tabs — **Timeline, Screen, Source, Network, Console
 The error, trace, headline and clustering work with the reporter alone. The console, network, Web Vitals, failure-time snapshot and locator healing come from the [capture fixtures](./capture-fixtures) — one file in your test setup. If a tab is dimmed, that's usually why; it opens to say so.
 :::
 
-## 4. The fix — what to do
+## 6. More ways to fix
 
-At the bottom, the **Fix** card gathers what to do about it, each part shown only when it applies:
+You've already got the one recommended step above. Below the evidence, **More ways to fix** is the folded toolbox holding every *other* way to fix, verify or reproduce — each a section collapsed to one line, so no wall of code opens by default. The section the **Next** step points at is already open; unfold the rest as you need them:
 
 - a **[replacement locator](/features/locator-healing)** when a locator broke, ranked by stability and in your suite's own style;
-- the **[AI diagnosis](/features/ai-diagnosis)** summary, when you've configured a model (optional, and grounded in your real diff);
-- **verify** — re-run in CI, or run it locally — and the tests this failure blocked.
+- the **[AI diagnosis](/features/ai-diagnosis)** and its validated patch, when you've configured a model (optional, and grounded in your real diff);
+- **verify** — re-run in CI or run it locally — **reproduce and bisect**, whether this failure was **fixed before**, the tests it **blocked**, and the **[fix plan](/features/fix-plans)** as Markdown.
 
 The point is to leave with something to do, not just something to read.
 


### PR DESCRIPTION
## What & why

Phase 5 — the last phase of the [failure-page clarity plan](https://github.com/PiwiTests/platform/blob/claude/test-failure-page-clarity-fl18c5/proposals/failure-page-clarity.md) (§7, §2, §3, §9 "Delete", §10 "Phase 5", Appendix B). The 390 px pass, the docs rewritten to the three questions, the help topics pruned, the vocabulary sweep, and the final re-measure.

**Stacked PR.** Built on Phase 4 (#509 · `claude/clarity-phase-4`), which builds on Phase 3 (#508), Phase 2 (#507) and Phase 1 (#506). Its base is `claude/clarity-phase-4`; move the base as those merge. `origin/claude/clarity-phase-4` is merged in, so Phase 4's E2E fix (`0d42099`, the bisect-visible and open-folded-section spec changes) is included and the 12 previously-red jobs are covered.

### 1. The 390 px pass (§7)

The situation blocks from phases 2–4 already hold at 390 px — the facts line collapses to the path + *Details ▾* + *Raw error ▸*, the cluster state line and its Triage/Snooze menus wrap without overflow, the occurrence sparkline drops to the last 12 runs below `sm`, and the evidence tab strip wraps in place. Verified on `/test-run-cases/37`, `/test-run-cases/587`, `/failure-clusters/10` and `/failure-clusters/2` at 390 × 844: `document.scrollWidth === clientWidth` on all four, no element scrolls the page horizontally.

- **`fix(ui)`** — the toolbox's folded summaries now mirror their (truncated) text into a `title`, so the clipped tail is readable on hover; this is what clips first at 390 px.
- Both failure pages were already in the "core pages have no horizontal overflow" list in `mobile-responsiveness.spec.ts`; **added a mobile screenshot of each** (execution + cluster), guarded by the no-overflow check, at both the phone and tablet viewports.
- Captured `execution-clarity-mobile`, `cluster-clarity-mobile` and `failure-headline-mobile` after the fixes — **sent in the working session** (see below).

### 2. Docs rewritten to the three questions (§2)

- **`features/fix-plans.md`** — a *The next step* section spelling the policy out in plain words (first match wins), the *More ways to fix* toolbox and what each folded section holds; the fix plan itself only as the Markdown export and `get_fix_plan`.
- **`features/failure-clusters.md`** — a *The cluster page* section: the name and latest headline, the occurrence sparkline, the one-verb state sentence with its action and the Triage/Snooze menus, affected tests as the evidence selector, What changed.
- **`guide/first-failure.md`** — the walkthrough now follows the new top: headline → *Most likely* → situation → next step → evidence → toolbox.
- **`guide/concepts.md`** — new vocabulary: *story*, *situation*, *next step*, *cluster state*.
- **`features/ui-overview.md`** — the execution and cluster page sections rewritten to the situation block, the evidence selector and the toolbox.
- **`features/ai-diagnosis.md`** — the fix verdict now rides the cluster state line; the diagnosis figure sits in the toolbox. **`features/evidence.md`** already read as the three questions from phases 2/4 (unchanged). **`features/locator-healing.md`** already described the *Locator fix* panel in the toolbox (unchanged).
- Trimmed to keep `fix-plans.md` and `ai-diagnosis.md` within the docs word budget. `app:screens:check` green (the `gather-evidence` and `locator-healing` illustrations are unchanged by this PR — the toolbox `title` and the fix-plan-pointer edits fall outside their framed regions).

### 3. Help topics pruned (§9)

Deleted the ten `HELP_TOPICS` entries no component renders any more — `case.fix`, `fix.reproduce`, `case.aria`, `cluster.fix-plan`, `cluster.evidence`, `cluster.diagnosis`, `cluster.fixed-before`, `cluster.confidence`, `cluster.hypotheses` (folded into `case.evidence` / `fix.toolbox` / `cluster.state`, or removed with the diagnosis-result and fixed-before hints), and `dom-snapshot` (its card was deleted in Phase 4). Every key was verified unreferenced across `app/`, `shared/` and `server/`; **no `HELP_TOPICS` key is left without a renderer** (100 keys, 0 orphans). `docs-drift` stays green.

### 4. Vocabulary sweep (§9, Appendix B)

Extended `tests/unit/ui-vocabulary.test.ts` with rules retiring, on screen and in the top-level docs: *Show raw error* (now *Raw error*), *Open fix plan* and *Assembled on the cluster page* (the pointer sections are gone — the execution page's fix-plan section now links "Open on the cluster"), *Triage* as a card title/label (the state line and its Triage ▾ menu replaced the Triage card — the menu button and *Triage note* stay), *History* as a cluster card title (the sparkline replaced it; the execution page keeps its own history block), and *Fix verified* as a badge label (renamed to *Verified*; the cluster state sentence carries the verdict). *Fix plan* stays allowed as the toolbox export section and in the MCP docs.

## How was it tested?

`app:typecheck`, `app:lint`, `app:format:check`, `app:test:unit` (2247) and `app:screens:check` all green; `docs-drift`, `ui-vocabulary` green; `npx commitlint --from origin/claude/clarity-phase-4 --to HEAD` clean. New inline docs anchor links all resolve.

Updated/affected specs pass against a seeded dev server: `mobile-responsiveness.spec.ts` (both failure pages in the overflow list + the new mobile screenshots), `test-run-case-page.spec.ts`, `fix-plan.spec.ts`, `cluster-page-layout.spec.ts`, and the previously-red `desktop-reproduce.spec.ts`, `fixed-before.spec.ts`, `performance-ui.spec.ts` (green after the Phase 4 merge).

### Mobile captures

`execution-clarity-mobile`, `cluster-clarity-mobile` and `failure-headline-mobile` were captured after the fixes and **sent in the working session** — each shows the situation block, facts line, state line and evidence strip at 390 px with no clipped or overflowing block.

### Final numbers (§1.5)

**1280 × 800** (default):

| route | px to evidence | total scroll | controls AF | help AF | open code px | active tab | words |
|---|---|---|---|---|---|---|---|
| /test-run-cases/37 | 554 | 1837 | 32 | 2 | 0 | Timeline | 387 |
| /test-run-cases/13 | 554 | 1829 | 32 | 2 | 0 | Timeline | 386 |
| /test-run-cases/587 | 410 | 2160 | 30 | 2 | 0 | Timeline | 398 |
| /test-run-cases/682 | 449 | 1813 | 31 | 2 | 183 | Timeline | 358 |
| /failure-clusters/10 | 801 | 3182 | 36 | 1 | 145 | Timeline | 683 |
| /failure-clusters/2 | 803 | 2989 | 35 | 1 | 0 | Timeline | 574 |
| /failure-clusters/5 | 826 | 2467 | 40 | 1 | 0 | Timeline | 456 |
| /failure-clusters/1 | 866 | 2832 | 35 | 1 | 0 | Timeline | 657 |

**390 × 844** (phone):

| route | px to evidence | total scroll | controls AF | help AF | open code px | active tab | words |
|---|---|---|---|---|---|---|---|
| /test-run-cases/37 | 783 | 2655 | 21 | 2 | 0 | Timeline | 363 |
| /test-run-cases/13 | 783 | 2635 | 22 | 2 | 0 | Timeline | 361 |
| /test-run-cases/587 | 555 | 2929 | 27 | 2 | 0 | Timeline | 374 |
| /test-run-cases/682 | 583 | 2367 | 28 | 2 | 183 | Timeline | 334 |
| /failure-clusters/10 | 1075 | 5013 | 27 | 1 | 145 | Timeline | 669 |
| /failure-clusters/2 | 1051 | 3944 | 26 | 1 | 0 | Timeline | 563 |
| /failure-clusters/5 | 1096 | 3336 | 26 | 1 | 0 | Timeline | 445 |
| /failure-clusters/1 | 1131 | 4111 | 21 | 1 | 184 | Timeline | 647 |

`helpAboveFold ≤ 2` everywhere (≤ 1 on the cluster pages); `activeTab === Timeline` and open code ≤ 250 px on every route, as in Phase 4. `controlsAboveFold` stays ~21–40 — the structural floor reported in #509 (the fixed navbar plus the evidence tab strip); nothing in Phase 5's scope removes either. `proposals/failure-page-clarity.md` is intentionally left untouched (the proposal is updated separately).

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated (`apps/docs/features/{fix-plans,failure-clusters,ui-overview,ai-diagnosis}.md`, `guide/{first-failure,concepts}.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7raz249dk7r95NFnzFhQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7raz249dk7r95NFnzFhQi)_