### PR TITLE
refactor(ui): dedupe the two failure pages onto shared building blocks

### DIFF
--- a/apps/application/app/components/cluster/ClusterFactsLine.vue
+++ b/apps/application/app/components/cluster/ClusterFactsLine.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+/**
+ * The facts line under the cluster's situation block: a Details popover (owner
+ * and known-issue editing), the shared "Raw error ▸" disclosure (the sample
+ * error and its fingerprint signature) and Copy summary. `revealRawError()` lets
+ * a citation open the raw error from elsewhere on the page.
+ */
+import type { FailureClusterDetail } from '~~/types/api';
+
+defineProps<{
+  cluster: FailureClusterDetail;
+  canWrite: boolean;
+  signatureLine: string | null;
+}>();
+
+const emit = defineEmits<{ refresh: []; copy: [] }>();
+
+const disclosure = ref<{ reveal: () => void } | null>(null);
+function revealRawError() {
+  disclosure.value?.reveal();
+}
+defineExpose({ revealRawError });
+</script>
+
+<template>
+  <div class="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs text-muted">
+    <UPopover>
+      <UButton
+        size="xs"
+        variant="ghost"
+        color="neutral"
+        trailing-icon="i-lucide-chevron-down"
+        label="Details"
+        class="shrink-0"
+      />
+      <template #content>
+        <div class="p-3 space-y-3 text-sm w-72">
+          <div class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Owner</p>
+            <ClusterOwnerLine :owner="cluster.owner" :project-id="cluster.project?.id ?? null" />
+          </div>
+          <div class="space-y-1">
+            <div class="flex items-center gap-1.5 text-xs">
+              <UIcon name="i-lucide-link" class="size-3.5 shrink-0 text-gray-400" />
+              <span class="text-muted uppercase tracking-wide font-medium">Known issue</span>
+              <HelpHint topic="cluster.known-issue" />
+            </div>
+            <EntityLinks
+              entity-type="failure_cluster"
+              :entity-id="cluster.id"
+              :links="cluster.links"
+              :readonly="!canWrite"
+              @updated="emit('refresh')"
+            />
+          </div>
+        </div>
+      </template>
+    </UPopover>
+
+    <RawErrorDisclosure ref="disclosure" :error="cluster.sampleError" :signature="signatureLine" />
+
+    <UButton size="xs" variant="ghost" color="neutral" label="Copy summary" class="shrink-0" @click="emit('copy')" />
+  </div>
+</template>

--- a/apps/application/app/components/cluster/ClusterStateLine.vue
+++ b/apps/application/app/components/cluster/ClusterStateLine.vue
@@ -63,6 +63,12 @@ async function patchSnooze(option: SnoozeOption | null) {
 
 // ── The one reconcile action ─────────────────────────────────────────────────
 const { releaseOne } = useQuarantine(() => props.cluster.project?.id ?? null);
+// Mark resolved / reopen share the failure pages' triage helper, preserving the
+// existing note through the status PATCH.
+const { setClusterStatus } = useClusterTriage(() => props.cluster.id, {
+  currentNote: () => props.cluster.triageNote,
+  onSaved: () => emit('saved'),
+});
 
 async function runReconcile() {
   if (!props.canWrite || busy.value || !props.state.action) return;
@@ -70,24 +76,23 @@ async function runReconcile() {
   try {
     switch (props.state.action) {
       case 'mark-resolved':
-        await patchStatus('resolved');
-        toast.add({ title: 'Marked resolved', color: 'success' });
+        await setClusterStatus('resolved');
         break;
       case 'reopen':
-        await patchStatus('open');
-        toast.add({ title: 'Cluster reopened', color: 'success' });
+        await setClusterStatus('open');
         break;
       case 'unsnooze':
         await patchSnooze(null);
         toast.add({ title: 'Cluster unsnoozed', color: 'success' });
+        emit('saved');
         break;
       case 'release': {
         const quarantined = (props.cluster.affectedTestCases ?? []).filter((c) => c.quarantined);
         for (const c of quarantined) await releaseOne(c.testCaseId);
+        emit('saved');
         break;
       }
     }
-    emit('saved');
   } catch {
     toast.add({ title: 'Could not update the cluster', color: 'error' });
   } finally {
@@ -175,7 +180,7 @@ const snoozeItems = computed(() => [
         <NuxtLink
           v-if="part.kind === 'run' && part.href"
           :to="part.href"
-          class="underline decoration-dotted underline-offset-2 hover:decoration-solid tabular-nums"
+          :class="[SENTENCE_LINK_CLASS, 'tabular-nums']"
           >{{ part.text }}</NuxtLink
         >
         <template v-else>{{ part.text }}</template>

--- a/apps/application/app/components/cluster/WhatChangedLine.vue
+++ b/apps/application/app/components/cluster/WhatChangedLine.vue
@@ -64,26 +64,14 @@ const summary = computed(() => {
     <!-- A resolved diff: the range in one clause, and the way to the card -->
     <template v-else-if="summary">
       <span>{{ summary }}</span>
-      <button
-        type="button"
-        class="underline decoration-dotted underline-offset-2 hover:decoration-solid"
-        @click="emit('see')"
-      >
-        See the changes
-      </button>
+      <button type="button" :class="SENTENCE_LINK_CLASS" @click="emit('see')">See the changes</button>
     </template>
 
     <!-- A hand-picked range whose diff did not resolve: the card holds the picker -->
     <template v-else-if="hasChangesToShow">
       <span>{{ scmStatus.text }}</span>
       <span v-if="scmStatus.detail" class="text-muted">— {{ scmStatus.detail }}</span>
-      <button
-        type="button"
-        class="underline decoration-dotted underline-offset-2 hover:decoration-solid"
-        @click="emit('see')"
-      >
-        Change the range
-      </button>
+      <button type="button" :class="SENTENCE_LINK_CLASS" @click="emit('see')">Change the range</button>
     </template>
 
     <!-- Nothing to diff: why, and the browser where it can work -->

--- a/apps/application/app/components/shared/RawErrorDisclosure.vue
+++ b/apps/application/app/components/shared/RawErrorDisclosure.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+/**
+ * The "Raw error ▸" disclosure both failure pages carry on their facts line: a
+ * ghost trigger inline with the other facts, and — one click below — the
+ * verbatim ANSI error rendered with its colors. The panel wraps to its own
+ * full-width line at the bottom of the facts row (`order-last basis-full`), so
+ * the trigger keeps its place among the other controls whether open or closed.
+ *
+ * The execution page condenses the error first and offers a copy action (the
+ * `actions` slot); the cluster page shows the fingerprint signature under it
+ * (the `signature` prop). `reveal()` opens and scrolls to the panel so a clue or
+ * diagnosis citation can point at the raw error.
+ */
+import { renderAnsi } from '~/utils';
+import { condenseErrorText } from '#shared/error-fingerprint';
+
+const props = defineProps<{
+  /** The verbatim error; the trigger renders only when there is one. */
+  error?: string | null;
+  /** Condense the error before rendering (the execution page's long stacks). */
+  condense?: boolean;
+  /** The fingerprint signature line shown under the error (the cluster page). */
+  signature?: string | null;
+}>();
+
+const open = ref(false);
+const panelEl = ref<HTMLElement | null>(null);
+
+const rendered = computed(() =>
+  props.error ? renderAnsi(props.condense ? condenseErrorText(props.error) : props.error) : '',
+);
+
+function reveal() {
+  open.value = true;
+  nextTick(() => panelEl.value?.scrollIntoView({ behavior: 'smooth', block: 'start' }));
+}
+
+defineExpose({ reveal });
+</script>
+
+<template>
+  <UButton
+    v-if="error"
+    size="xs"
+    variant="ghost"
+    color="neutral"
+    :trailing-icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+    label="Raw error"
+    class="shrink-0"
+    :aria-expanded="open"
+    @click="open = !open"
+  />
+  <div v-if="open && error" ref="panelEl" class="order-last basis-full mt-2 space-y-2 scroll-mt-4">
+    <div v-if="$slots.actions" class="flex justify-end"><slot name="actions" /></div>
+    <div
+      class="text-xs font-mono whitespace-pre-wrap break-words max-h-96 overflow-y-auto rounded bg-red-50 dark:bg-red-950/20 p-3"
+      v-html="rendered"
+    />
+    <p v-if="signature" class="font-mono text-xs break-all text-muted">{{ signature }}</p>
+  </div>
+</template>

--- a/apps/application/app/components/shared/Toolbox.vue
+++ b/apps/application/app/components/shared/Toolbox.vue
@@ -93,17 +93,29 @@ const vTitleFromText = {
   },
 };
 
+const rootEl = ref<HTMLElement | null>(null);
+
 /** Open a section (a next-step action reveals then scrolls to it). */
 function openSection(key: FixSectionKey) {
   openKey.value = key;
 }
 
-defineExpose({ openSection });
+/** Open a section and scroll it into view — the target of a next-step action. */
+function scrollToSection(key: FixSectionKey) {
+  openSection(key);
+  nextTick(() => {
+    rootEl.value
+      ?.querySelector<HTMLElement>(`[data-shot="fix-${key}"]`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+}
+
+defineExpose({ scrollToSection });
 </script>
 
 <template>
   <SectionCard icon="i-lucide-wrench" icon-class="text-primary" title="More ways to fix" :help="help" data-shot="fix">
-    <div class="divide-y divide-default">
+    <div ref="rootEl" class="divide-y divide-default">
       <section v-for="s in active" :key="s.key" class="first:pt-0 last:pb-0" :data-shot="`fix-${s.key}`">
         <div class="flex items-center justify-between gap-2 py-3">
           <button

--- a/apps/application/app/components/test-case/ExecutionFactsLine.vue
+++ b/apps/application/app/components/test-case/ExecutionFactsLine.vue
@@ -1,0 +1,273 @@
+<script setup lang="ts">
+/**
+ * The facts line under an execution's situation block: the source path (open in
+ * IDE), the run facts that collapse to Details on mobile (browser, duration,
+ * attempts, branch, build, age), the Details popover with everything else, and
+ * the shared "Raw error ▸" disclosure with its Copy failure action.
+ *
+ * The secondary facts render once and are hidden below `sm`; the Details popover
+ * repeats the mobile-critical ones so the phone layout keeps them reachable.
+ * `revealRawError()` opens the raw error from a citation elsewhere on the page.
+ */
+import type { AttemptOutcome, TestCaseHistoryPoint } from '~~/types/api';
+
+const props = defineProps<{
+  /** The fetched execution — every fact reads off this object. */
+  testCase: any;
+  /** Prior executions of this test, for the duration-vs-average note. */
+  history?: TestCaseHistoryPoint[];
+}>();
+
+const emit = defineEmits<{ copyFailure: [] }>();
+
+const metadata = computed(() => props.testCase?.testRun?.metadata as Record<string, unknown> | null | undefined);
+const scmInfo = computed(() => {
+  const m = metadata.value;
+  if (!m?.scm) return null;
+  return m.scm as { commit?: string; branch?: string; author?: string; commitMessage?: string };
+});
+const ciInfo = computed(() => {
+  const m = metadata.value;
+  if (!m?.ci) return null;
+  return m.ci as { provider?: string; buildNumber?: string; buildUrl?: string; workflow?: string; jobName?: string };
+});
+const environment = computed(() => props.testCase?.testRun?.environment);
+const browser = computed(() => props.testCase?.browser ?? null);
+const stepsCount = computed(() => (props.testCase?.steps as unknown[] | null)?.length ?? 0);
+
+// The first captured source frame — the failing line — beats the test()
+// declaration for the "open in IDE" link.
+const ideTarget = computed(() => {
+  const frames = (props.testCase as { testSourceFrames?: Array<{ filePath?: string; line?: number }> | null } | null)
+    ?.testSourceFrames;
+  const frame = frames?.[0];
+  if (!frame?.filePath) return null;
+  return { filePath: frame.filePath, line: frame.line };
+});
+
+const historicalTiming = computed(() => {
+  const history = props.history;
+  if (!history || history.length < 2 || !props.testCase?.duration) return null;
+  const previous = history.filter((h) => h.duration !== null && h.id !== props.testCase?.id);
+  if (previous.length === 0) return null;
+  const avg = previous.reduce((sum, h) => sum + (h.duration || 0), 0) / previous.length;
+  const current = props.testCase.duration;
+  const diff = current - avg;
+  const pct = avg > 0 ? Math.round((diff / avg) * 100) : 0;
+  return { avg: Math.round(avg), current, diff: Math.round(diff), pct };
+});
+
+const attempts = computed(() => props.testCase?.attempts ?? null);
+function attemptColor(status: string): 'success' | 'error' | 'neutral' {
+  if (status === 'passed') return 'success';
+  if (status === 'failed' || status === 'timedout' || status === 'timedOut') return 'error';
+  return 'neutral';
+}
+function attemptTitle(a: AttemptOutcome): string {
+  const when = a.startedAt ? ` at ${new Date(a.startedAt).toLocaleString()}` : '';
+  return `Attempt ${a.retry + 1}: ${a.status} (${Math.round(a.duration)} ms)${when}`;
+}
+function isCurrentAttempt(a: AttemptOutcome): boolean {
+  return a.retry === (props.testCase?.retries ?? 0);
+}
+function attemptLink(a: AttemptOutcome): string | null {
+  return !isCurrentAttempt(a) && a.executionId ? `/test-run-cases/${a.executionId}` : null;
+}
+
+const disclosure = ref<{ reveal: () => void } | null>(null);
+function revealRawError() {
+  disclosure.value?.reveal();
+}
+defineExpose({ revealRawError });
+</script>
+
+<template>
+  <div class="flex items-center gap-x-2 gap-y-1 flex-wrap text-xs text-muted">
+    <OpenInIdeLink
+      v-if="ideTarget?.filePath || testCase?.location"
+      :file-path="ideTarget?.filePath"
+      :line="ideTarget?.line"
+      :location="ideTarget ? undefined : (testCase?.location ?? undefined)"
+      :project-key="testCase?.testRun?.project?.id"
+      :project-name="testCase?.testRun?.project?.name"
+    />
+    <!-- Secondary facts collapse at 390px; they stay in Details below. -->
+    <span class="max-sm:hidden inline-flex items-center gap-x-2 gap-y-1 flex-wrap">
+      <span v-if="browser" class="inline-flex items-center gap-1">
+        <BrowserBadge :browser="{ ...browser, viewport: undefined }" size="sm" />
+        <span v-if="browser.viewport" class="tabular-nums">
+          {{ browser.viewport.width }}×{{ browser.viewport.height }}
+        </span>
+      </span>
+      <span v-if="testCase?.status !== 'didnotrun'" class="inline-flex items-center gap-1 tabular-nums">
+        <DurationValue :ms="testCase?.duration" />
+        <span v-if="historicalTiming">
+          (avg <DurationValue :ms="historicalTiming.avg" />, {{ historicalTiming.diff > 0 ? '+' : ''
+          }}{{ historicalTiming.pct }}%)
+        </span>
+      </span>
+      <span
+        v-if="attempts && attempts.length > 1"
+        class="inline-flex items-center gap-1"
+        role="group"
+        aria-label="Attempts of this test in this run"
+      >
+        <template v-for="a in attempts" :key="a.retry">
+          <NuxtLink
+            v-if="attemptLink(a)"
+            :to="attemptLink(a)!"
+            :title="`${attemptTitle(a)} — open this attempt`"
+            class="inline-flex rounded-md outline-none focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary hover:opacity-80"
+          >
+            <UBadge :color="attemptColor(a.status)" variant="soft" size="sm" class="font-mono">
+              {{ a.retry + 1 }}/{{ attempts.length }}
+              <UIcon :name="a.status === 'passed' ? 'i-lucide-check' : 'i-lucide-x'" class="w-3 h-3" />
+            </UBadge>
+          </NuxtLink>
+          <UBadge
+            v-else
+            :color="attemptColor(a.status)"
+            variant="soft"
+            size="sm"
+            class="font-mono"
+            :class="isCurrentAttempt(a) ? 'ring-2 ring-offset-1 ring-primary' : ''"
+            :title="isCurrentAttempt(a) ? `${attemptTitle(a)} — this execution` : attemptTitle(a)"
+            :aria-current="isCurrentAttempt(a) ? 'true' : undefined"
+          >
+            {{ a.retry + 1 }}/{{ attempts.length }}
+            <UIcon :name="a.status === 'passed' ? 'i-lucide-check' : 'i-lucide-x'" class="w-3 h-3" />
+          </UBadge>
+        </template>
+      </span>
+      <span v-if="scmInfo?.branch">{{ scmInfo.branch }}</span>
+      <a
+        v-if="ciInfo?.buildUrl || ciInfo?.buildNumber"
+        :href="ciInfo?.buildUrl || undefined"
+        :target="ciInfo?.buildUrl ? '_blank' : undefined"
+        :class="ciInfo?.buildUrl ? SENTENCE_LINK_CLASS : ''"
+      >
+        {{ ciInfo?.buildNumber ? `Build #${ciInfo.buildNumber}` : 'View build' }}
+      </a>
+      <ClientOnly>
+        <span v-if="testCase?.startedAt" :title="new Date(testCase.startedAt).toLocaleString()">
+          {{ formatRelativeTime(testCase.startedAt) }}
+        </span>
+      </ClientOnly>
+    </span>
+
+    <UPopover>
+      <UButton
+        size="xs"
+        variant="ghost"
+        color="neutral"
+        trailing-icon="i-lucide-chevron-down"
+        label="Details"
+        class="shrink-0"
+      />
+      <template #content>
+        <div class="p-3 space-y-2 text-sm max-w-sm">
+          <!-- The facts that collapse on mobile, kept reachable here. -->
+          <div class="space-y-1 sm:hidden">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Run</p>
+            <p v-if="testCase?.status !== 'didnotrun'" class="tabular-nums">
+              Duration: <DurationValue :ms="testCase?.duration" />
+            </p>
+            <p v-if="scmInfo?.branch">
+              Branch: <span class="text-highlighted">{{ scmInfo.branch }}</span>
+            </p>
+            <p v-if="ciInfo?.buildNumber">Build #{{ ciInfo.buildNumber }}</p>
+            <ClientOnly>
+              <p v-if="testCase?.startedAt">{{ formatRelativeTime(testCase.startedAt) }}</p>
+            </ClientOnly>
+          </div>
+          <div v-if="environment || ciInfo" class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">CI &amp; environment</p>
+            <p v-if="environment">
+              Environment: <span class="text-highlighted">{{ environment }}</span>
+            </p>
+            <p v-if="ciInfo?.provider">Provider: {{ ciInfo.provider }}</p>
+            <p v-if="ciInfo?.workflow || ciInfo?.jobName">
+              <template v-if="ciInfo?.workflow">{{ ciInfo.workflow }}</template>
+              <template v-if="ciInfo?.workflow && ciInfo?.jobName"> · </template>
+              <template v-if="ciInfo?.jobName">{{ ciInfo.jobName }}</template>
+            </p>
+          </div>
+          <div v-if="testCase?.testRun?.playwrightVersion || testCase?.testRun?.reporterVersion" class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Tooling</p>
+            <p>
+              <template v-if="testCase?.testRun?.playwrightVersion"
+                >Playwright v{{ testCase.testRun.playwrightVersion }}</template
+              >
+              <template v-if="testCase?.testRun?.playwrightVersion && testCase?.testRun?.reporterVersion"> · </template>
+              <template v-if="testCase?.testRun?.reporterVersion"
+                >Piwi v{{ testCase.testRun.reporterVersion }}</template
+              >
+            </p>
+          </div>
+          <div class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Execution</p>
+            <p class="tabular-nums">
+              Worker {{ testCase?.workerIndex ?? '—'
+              }}<template v-if="testCase?.shardIndex != null"> · Shard {{ testCase.shardIndex }}</template> ·
+              {{ stepsCount }} steps
+            </p>
+            <p
+              v-if="testCase?.slowestStep && testCase?.status !== 'didnotrun'"
+              class="truncate"
+              :title="testCase.slowestStep"
+            >
+              Slowest step: {{ testCase.slowestStep }}
+              <span v-if="testCase.slowestStepDuration">(<DurationValue :ms="testCase.slowestStepDuration" />)</span>
+            </p>
+            <p v-if="(testCase?.wastedTimeMs ?? 0) > 0">
+              Wasted in fixed waits: <DurationValue :ms="testCase?.wastedTimeMs" />
+            </p>
+          </div>
+          <div v-if="testCase?.locks?.length" class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Locks</p>
+            <p class="flex flex-wrap items-center gap-1.5">
+              <span
+                v-for="lock in testCase.locks"
+                :key="lock"
+                class="inline-flex items-center gap-1 text-highlighted"
+                title="Only one holder of this lock runs at a time"
+              >
+                <UIcon name="i-lucide-lock" class="size-3 text-warning" />{{ lock }}
+              </span>
+            </p>
+          </div>
+          <div v-if="testCase?.tags?.length || testCase?.testMeta" class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Tags</p>
+            <TestMetaBadges :tags="testCase?.tags" :meta="testCase?.testMeta" />
+          </div>
+          <div v-if="testCase?.executionId" class="space-y-1">
+            <p class="text-xs font-medium text-muted uppercase tracking-wide">Links</p>
+            <EntityLinks
+              entity-type="test_case"
+              :entity-id="testCase.executionId"
+              :links="(testCase as any)?.stableLinks ?? null"
+              readonly
+            />
+          </div>
+        </div>
+      </template>
+    </UPopover>
+
+    <!-- Raw error: the verbatim ANSI output, one click below the block. -->
+    <RawErrorDisclosure ref="disclosure" :error="testCase?.error" condense>
+      <template #actions>
+        <UButton
+          size="xs"
+          variant="ghost"
+          color="neutral"
+          icon="i-lucide-clipboard"
+          aria-label="Copy failure"
+          title="Copy failure"
+          @click="emit('copyFailure')"
+        >
+          Copy failure
+        </UButton>
+      </template>
+    </RawErrorDisclosure>
+  </div>
+</template>

--- a/apps/application/app/composables/useApplyClusterTriage.ts
+++ b/apps/application/app/composables/useApplyClusterTriage.ts
@@ -1,0 +1,42 @@
+import type { FixedBeforeMatch } from '#shared/fix-plan.types';
+
+/**
+ * Copy an earlier resolved cluster's triage note onto the current cluster,
+ * prefixed so the history reads as an intentional reuse. The status is left as
+ * it is — a new cluster is never marked resolved because an old one was. Both
+ * failure pages drive `FixedBeforeMatches` through this one handler.
+ */
+export function useApplyClusterTriage(opts: {
+  clusterId: () => number | null | undefined;
+  status: () => string | null | undefined;
+  currentNote: () => string | null | undefined;
+  onApplied: () => unknown;
+}) {
+  const toast = useToast();
+  const applyingId = ref<number | null>(null);
+
+  async function applyTriage(match: FixedBeforeMatch) {
+    const clusterId = opts.clusterId();
+    const status = opts.status();
+    if (clusterId == null || !status || applyingId.value != null) return;
+    applyingId.value = match.clusterId;
+    const excerpt = (match.triageNote ?? match.diagnosisTitle ?? match.reason)
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 280);
+    const line = `Same as cluster #${match.clusterId}: ${excerpt}`;
+    const existing = opts.currentNote()?.trim();
+    const triageNote = existing ? `${existing}\n${line}` : line;
+    try {
+      await $fetch(`/api/failure-clusters/${clusterId}/status`, { method: 'PATCH', body: { status, triageNote } });
+      toast.add({ title: `Applied triage from cluster #${match.clusterId}`, color: 'success' });
+      await opts.onApplied();
+    } catch {
+      toast.add({ title: 'Could not apply the triage', color: 'error' });
+    } finally {
+      applyingId.value = null;
+    }
+  }
+
+  return { applyingId, applyTriage };
+}

--- a/apps/application/app/composables/useCiRerun.ts
+++ b/apps/application/app/composables/useCiRerun.ts
@@ -1,0 +1,50 @@
+import type { MaybeRefOrGetter } from 'vue';
+
+/** A cluster's CI re-run availability and last dispatch, from `/rerun`. */
+export interface RerunInfo {
+  available: boolean;
+  reason: string | null;
+  provider: string | null;
+  enabled: boolean;
+  hasToken: boolean;
+  lastDispatch: { provider: string; url: string; args: string; at: number; byName: string | null } | null;
+}
+
+/**
+ * Dispatch a CI re-run of a cluster's affected tests. Both failure pages fetch
+ * the `RerunInfo` themselves (their SSR strategies differ) but share this POST
+ * and its toasts; the caller refreshes the info afterwards.
+ */
+export function useCiRerun(clusterId: MaybeRefOrGetter<number | null | undefined>, refreshRerun: () => unknown) {
+  const toast = useToast();
+  const rerunning = ref(false);
+
+  async function triggerRerun() {
+    const id = toValue(clusterId);
+    if (id == null || rerunning.value) return;
+    rerunning.value = true;
+    try {
+      const res = await $fetch<{ ok: boolean; message?: string; dispatch?: { url: string } }>(
+        `/api/failure-clusters/${id}/rerun`,
+        { method: 'POST' },
+      );
+      if (res.ok && res.dispatch) {
+        toast.add({
+          title: 'CI re-run dispatched',
+          description: 'The affected tests are re-running.',
+          color: 'success',
+        });
+        await refreshRerun();
+      } else {
+        toast.add({ title: 'CI re-run not started', description: res.message ?? 'Not available.', color: 'warning' });
+      }
+    } catch (e: unknown) {
+      const message = (e as { data?: { message?: string }; message?: string })?.data?.message ?? 'Dispatch failed.';
+      toast.add({ title: 'CI re-run failed', description: message, color: 'error' });
+    } finally {
+      rerunning.value = false;
+    }
+  }
+
+  return { rerunning, triggerRerun };
+}

--- a/apps/application/app/composables/useClusterTriage.ts
+++ b/apps/application/app/composables/useClusterTriage.ts
@@ -1,0 +1,38 @@
+import type { MaybeRefOrGetter } from 'vue';
+
+/**
+ * The one place a failure cluster is marked resolved or reopened: the status
+ * PATCH, the success / error toast and the caller's refresh. Both failure pages
+ * (through the next-step line) and `ClusterStateLine` (its reconcile action)
+ * share it, so the wording and the request live once.
+ *
+ * `currentNote` is opt-in: pass it to carry the existing triage note through the
+ * PATCH (the status endpoint rewrites the note, so an omitted note clears it);
+ * leave it out where the caller intentionally sends none.
+ */
+export function useClusterTriage(
+  clusterId: MaybeRefOrGetter<number | null | undefined>,
+  opts?: { currentNote?: () => string | null | undefined; onSaved?: () => void | Promise<void> },
+) {
+  const toast = useToast();
+
+  async function setClusterStatus(status: 'open' | 'resolved') {
+    const id = toValue(clusterId);
+    if (id == null) return;
+    try {
+      await $fetch(`/api/failure-clusters/${id}/status`, {
+        method: 'PATCH',
+        body: { status, triageNote: opts?.currentNote ? (opts.currentNote() ?? null) : undefined },
+      });
+      toast.add({
+        title: status === 'resolved' ? 'Cluster marked resolved' : 'Cluster reopened',
+        color: 'success',
+      });
+      await opts?.onSaved?.();
+    } catch {
+      toast.add({ title: 'Could not update the cluster', color: 'error' });
+    }
+  }
+
+  return { setClusterStatus };
+}

--- a/apps/application/app/composables/useEvidenceHint.ts
+++ b/apps/application/app/composables/useEvidenceHint.ts
@@ -1,0 +1,30 @@
+import type { MaybeRefOrGetter, ComputedRef } from 'vue';
+import type { FailureClue, FailureStory, FailureClueStrength } from '#shared/failure-clues';
+
+/** The default evidence tab hint: which cited section leads, and how strong it is. */
+export interface EvidenceHint {
+  section: string | null;
+  strength: FailureClueStrength | null;
+}
+
+/**
+ * The evidence opens on the story. Both failure pages derive the same hint for
+ * `EvidenceTabs`: the first member clue's cited section and the story's strength,
+ * or — when no combination chained the clues — the top clue's section and
+ * strength. One home for that rule.
+ */
+export function useEvidenceHint(
+  clues: MaybeRefOrGetter<FailureClue[]>,
+  story: MaybeRefOrGetter<FailureStory | null>,
+): ComputedRef<EvidenceHint> {
+  return computed(() => {
+    const clueList = toValue(clues);
+    const s = toValue(story);
+    const topClue = clueList[0] ?? null;
+    if (s) {
+      const first = clueList.find((c) => c.id === s.clueIds[0]) ?? topClue;
+      return { section: first?.citations?.[0]?.section ?? null, strength: s.strength };
+    }
+    return { section: topClue?.citations?.[0]?.section ?? null, strength: topClue?.strength ?? null };
+  });
+}

--- a/apps/application/app/composables/useNextStepActions.ts
+++ b/apps/application/app/composables/useNextStepActions.ts
@@ -32,10 +32,12 @@ export interface NextStepActionHandlers {
   reproRecipe: () => ReproRecipe | null | undefined;
   /** The endpoint the AI prompt is copied from (`?format=prompt` is appended). */
   diagnosisContextEndpoint: () => string;
-  /** Reveal / scroll to the Fix card's diagnosis, reproduce and locator sections. */
-  scrollToDiagnosis: () => void;
-  scrollToReproduce: () => void;
-  scrollToLocatorFix: () => void;
+  /**
+   * Reveal and scroll to a toolbox section. The diagnosis, reproduce and
+   * locator-fix actions all route through this one callback, so a page passes it
+   * once rather than three identical scroll callbacks.
+   */
+  scrollToSection: (key: 'diagnosis' | 'reproduce' | 'locator-fix') => void;
   /** Select the Attempts evidence tab. */
   selectAttemptsTab: () => void;
   /** Set the cluster's triage status. */
@@ -44,8 +46,8 @@ export interface NextStepActionHandlers {
   quarantine: (payload?: Record<string, unknown>) => void | Promise<void>;
   /** Re-run the cluster's tests in CI. */
   rerunInCi: () => void | Promise<void>;
-  /** Open the execution the payload names. */
-  openExecution: (executionId: number) => void | Promise<void>;
+  /** Open the execution the payload names; defaults to navigating to its page. */
+  openExecution?: (executionId: number) => void | Promise<void>;
   /** "What changed" — the cluster page scrolls, the execution page navigates. */
   whatChanged: () => void | Promise<void>;
   /** "Re-diagnose" — scroll to the diagnosis and trigger it (page-specific). */
@@ -70,7 +72,9 @@ export function useNextStepActions(handlers: NextStepActionHandlers) {
     switch (action) {
       case 'open-execution': {
         const id = payload?.executionId;
-        if (typeof id === 'number') await handlers.openExecution(id);
+        if (typeof id !== 'number') break;
+        if (handlers.openExecution) await handlers.openExecution(id);
+        else await navigateTo(`/test-run-cases/${id}`);
         break;
       }
       case 'mark-resolved':
@@ -86,11 +90,11 @@ export function useNextStepActions(handlers: NextStepActionHandlers) {
         handlers.locatorPanel()?.copyRecommendedLocator();
         break;
       case 'pick-from-snapshot':
-        handlers.scrollToLocatorFix();
+        handlers.scrollToSection('locator-fix');
         handlers.locatorPanel()?.openPicker();
         break;
       case 'all-alternatives':
-        handlers.scrollToLocatorFix();
+        handlers.scrollToSection('locator-fix');
         handlers.locatorPanel()?.expandAlternatives();
         break;
       case 'copy-git-apply': {
@@ -118,10 +122,10 @@ export function useNextStepActions(handlers: NextStepActionHandlers) {
       }
       case 'read-diagnosis':
       case 'diagnose':
-        handlers.scrollToDiagnosis();
+        handlers.scrollToSection('diagnosis');
         break;
       case 'reproduce':
-        handlers.scrollToReproduce();
+        handlers.scrollToSection('reproduce');
         break;
       case 'attempts-tab':
         handlers.selectAttemptsTab();

--- a/apps/application/app/pages/failure-clusters/[id].vue
+++ b/apps/application/app/pages/failure-clusters/[id].vue
@@ -5,9 +5,10 @@ import { parsePlaywrightError } from '#shared/error-parse';
 import type { FailureCluesResult } from '#shared/handlers/test-cases';
 import type { ComponentPublicInstance } from 'vue';
 import type { FailureClusterDetail, TraceInfo } from '~~/types/api';
-import type { FixPlan, FixedBeforeMatch as FixedBeforeMatchType } from '#shared/fix-plan.types';
+import type { FixPlan } from '#shared/fix-plan.types';
 import { fixPlanToMarkdown } from '#shared/fix-plan-markdown';
 import type { FixSectionKey } from '~/components/shared/Toolbox.vue';
+import type { RerunInfo } from '~/composables/useCiRerun';
 import { renderAnsi } from '~/utils';
 import { stripAnsi } from '~/utils/text-format';
 import { buildRetryCommand } from '~/utils/retry-command';
@@ -105,18 +106,9 @@ const { data: cluesData } = await useAsyncData<FailureCluesResult>(
 const clues = computed(() => cluesData.value?.clues ?? []);
 const story = computed(() => cluesData.value?.story ?? null);
 const cluesFailureAt = computed(() => cluesData.value?.failureAt ?? null);
-const topClue = computed(() => clues.value[0] ?? null);
-const topClueSection = computed(() => topClue.value?.citations?.[0]?.section ?? null);
 // The evidence opens on the story: the first member clue's cited section and the
 // story's strength (or the top clue's, when no combination matched).
-const defaultHint = computed<{ section: string | null; strength: 'strong' | 'medium' | 'weak' | null }>(() => {
-  const s = story.value;
-  if (s) {
-    const first = clues.value.find((c) => c.id === s.clueIds[0]) ?? topClue.value;
-    return { section: first?.citations?.[0]?.section ?? null, strength: s.strength };
-  }
-  return { section: topClueSection.value, strength: topClue.value?.strength ?? null };
-});
+const defaultHint = useEvidenceHint(clues, story);
 const hasTrace = computed(() => (execTraces.value?.length ?? 0) > 0);
 const selectedRunId = computed(() => (execution.value as { testRun?: { id?: number } } | null)?.testRun?.id ?? null);
 
@@ -200,13 +192,9 @@ const occurrenceAria = computed(() =>
 // The newest known-issue link, shown compactly on the facts line.
 const knownIssue = computed(() => cluster.value?.links?.[0] ?? null);
 
-// ── Raw error disclosure ─────────────────────────────────────────────────────
-const rawErrorEl = ref<HTMLElement | null>(null);
-const rawErrorOpen = ref(false);
-function revealRawError() {
-  rawErrorOpen.value = true;
-  nextTick(() => rawErrorEl.value?.scrollIntoView({ behavior: 'smooth', block: 'start' }));
-}
+// The facts line carries the raw-error disclosure; a citation reveals it through
+// the exposed method.
+const factsLine = ref<{ revealRawError: () => void } | null>(null);
 
 // ── Copy summary ─────────────────────────────────────────────────────────────
 const { copyRich } = useCopyRich();
@@ -266,47 +254,10 @@ const affectedRetryCases = computed(() =>
 const retryCommand = computed(() => buildRetryCommand(affectedRetryCases.value));
 const { copy: copyRetry } = useCopy();
 
-interface RerunInfo {
-  available: boolean;
-  reason: string | null;
-  provider: string | null;
-  enabled: boolean;
-  hasToken: boolean;
-  lastDispatch: { provider: string; url: string; args: string; at: number; byName: string | null } | null;
-}
 const { data: rerunInfo, refresh: refreshRerun } = await useFetch<RerunInfo>(
   `/api/failure-clusters/${clusterId}/rerun`,
 );
-const rerunToast = useToast();
-const rerunning = ref(false);
-async function triggerRerun() {
-  rerunning.value = true;
-  try {
-    const res = await $fetch<{ ok: boolean; message?: string; dispatch?: { url: string } }>(
-      `/api/failure-clusters/${clusterId}/rerun`,
-      { method: 'POST' },
-    );
-    if (res.ok && res.dispatch) {
-      rerunToast.add({
-        title: 'CI re-run dispatched',
-        description: 'The affected tests are re-running.',
-        color: 'success',
-      });
-      await refreshRerun();
-    } else {
-      rerunToast.add({
-        title: 'CI re-run not started',
-        description: res.message ?? 'Not available.',
-        color: 'warning',
-      });
-    }
-  } catch (e: unknown) {
-    const message = (e as { data?: { message?: string }; message?: string })?.data?.message ?? 'Dispatch failed.';
-    rerunToast.add({ title: 'CI re-run failed', description: message, color: 'error' });
-  } finally {
-    rerunning.value = false;
-  }
-}
+const { rerunning, triggerRerun } = useCiRerun(clusterId, refreshRerun);
 
 function refresh() {
   refreshCluster();
@@ -334,54 +285,21 @@ const fixSections = computed<FixSectionKey[]>(() => {
 });
 
 // ── Folded one-line summaries for the toolbox sections ───────────────────────
-const diagnosisSummary = computed(() => {
-  const d = cluster.value?.diagnosis;
-  if (d?.status === 'completed' && (d.summary || d.category)) {
-    const title = d.summary ?? d.category ?? 'Diagnosed';
-    return d.confidence ? `${title} · ${d.confidence} confidence` : title;
-  }
-  return aiStatus.value?.configured === false ? 'AI is not configured' : 'Not diagnosed yet';
-});
-const reproduceSummary = computed(() => {
-  const steps = fixPlan.value?.reproduce?.steps?.length ?? 0;
-  const bisect = fixPlan.value?.bisect?.available ? 'bisect available' : 'bisect not available';
-  return `${steps} commands · Linux/macOS or Windows · ${bisect}`;
-});
-const verifySummary = computed(() => {
-  const cmd = fixPlan.value?.verify?.command ?? '';
-  const g = cmd.match(/-g\s+(".*?"|'.*?'|\S+)/)?.[1];
-  const parts = [g ? `-g ${g}` : 'The verify command'];
-  if (rerunInfo.value?.available) parts.push('Re-run in CI');
-  return parts.join(' · ');
-});
+const diagnosisSummary = computed(() => diagnosisSectionSummary(cluster.value?.diagnosis, aiStatus.value?.configured));
+const reproduceSummary = computed(() =>
+  reproduceSectionSummary(fixPlan.value?.reproduce?.steps?.length ?? 0, Boolean(fixPlan.value?.bisect?.available)),
+);
+const verifySummary = computed(() =>
+  verifySectionSummary(fixPlan.value?.verify?.command ?? '', Boolean(rerunInfo.value?.available), 'The verify command'),
+);
 
 // ── Apply the same triage ─────────────────────────────────────────────────────
-// One click copies an earlier resolved cluster's triage note onto this one,
-// prefixed so the history reads as an intentional reuse. The status is left as
-// it is — a new cluster is never marked resolved because an old one was.
-const applyingId = ref<number | null>(null);
-const applyToast = useToast();
-async function applyTriage(match: FixedBeforeMatchType) {
-  if (!cluster.value || applyingId.value != null) return;
-  applyingId.value = match.clusterId;
-  const excerpt = (match.triageNote ?? match.diagnosisTitle ?? match.reason).replace(/\s+/g, ' ').trim().slice(0, 280);
-  const prefix = `Same as cluster #${match.clusterId}: `;
-  const existing = cluster.value.triageNote?.trim();
-  const line = `${prefix}${excerpt}`;
-  const triageNote = existing ? `${existing}\n${line}` : line;
-  try {
-    await $fetch(`/api/failure-clusters/${clusterId}/status`, {
-      method: 'PATCH',
-      body: { status: cluster.value.status, triageNote },
-    });
-    applyToast.add({ title: `Applied triage from cluster #${match.clusterId}`, color: 'success' });
-    refresh();
-  } catch {
-    applyToast.add({ title: 'Could not apply the triage', color: 'error' });
-  } finally {
-    applyingId.value = null;
-  }
-}
+const { applyingId, applyTriage } = useApplyClusterTriage({
+  clusterId: () => clusterId,
+  status: () => cluster.value?.status,
+  currentNote: () => cluster.value?.triageNote,
+  onApplied: () => refresh(),
+});
 
 // The diagnosis panel exposes its context/prompt actions for the page's More menu.
 const diagnosisPanel = ref<{
@@ -443,7 +361,6 @@ const moreMenuItems = computed(() => {
 // ── Section locator ──────────────────────────────────────────────────────────
 // A clue or diagnosis citation reveals the evidence it came from: the evidence
 // tabs handle the tabbed sections, the fix plan and the raw error scroll in place.
-const fixCardEl = ref<HTMLElement | null>(null);
 const scmEl = ref<HTMLElement | null>(null);
 const whatChangedLine = ref<ComponentPublicInstance | null>(null);
 const evidenceTabs = ref<{
@@ -456,19 +373,24 @@ const clusterLocatorPanel = ref<{
   openPicker: () => void;
   expandAlternatives: () => void;
 } | null>(null);
+const toolbox = ref<{ scrollToSection: (k: FixSectionKey) => void } | null>(null);
 
 function scrollToEl(el: HTMLElement | null) {
   el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
+function openFixPlan() {
+  toolbox.value?.scrollToSection('fix-plan');
+}
+const scrollToScm = () => scrollToEl(scmEl.value);
 
 const pageSections: Record<string, () => void> = {
-  fixPlan: () => openFixPlan(),
-  sampleError: revealRawError,
-  executionError: revealRawError,
-  scmInvestigation: () => scmEl.value?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-  selectedCommits: () => scmEl.value?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-  topSuspectedCommit: () => scmEl.value?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-  failingAction: () => scmEl.value?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
+  fixPlan: openFixPlan,
+  sampleError: () => factsLine.value?.revealRawError(),
+  executionError: () => factsLine.value?.revealRawError(),
+  scmInvestigation: scrollToScm,
+  selectedCommits: scrollToScm,
+  topSuspectedCommit: scrollToScm,
+  failingAction: scrollToScm,
 };
 provide(clusterSectionLocatorKey, {
   canLocate: (id: string) => id in pageSections || id in EVIDENCE_SECTION_TAB,
@@ -482,34 +404,8 @@ provide(clusterSectionLocatorKey, {
 // The next-step line stays presentation-only; the page owns the wiring through
 // the shared composable, reusing the same panels the toolbox does. Page-specific
 // targets are callbacks.
-const nextStepToast = useToast();
 const { quarantineOne } = useQuarantine(() => cluster.value?.project?.id ?? null);
-
-/** Open a toolbox section and scroll to it (its body is otherwise folded away). */
-const toolbox = ref<{ openSection: (k: string) => void } | null>(null);
-function scrollToFixSection(key: 'diagnosis' | 'reproduce' | 'locator-fix' | 'fix-plan') {
-  toolbox.value?.openSection(key);
-  nextTick(() => {
-    const el = import.meta.client ? document.querySelector<HTMLElement>(`[data-shot="fix-${key}"]`) : null;
-    scrollToEl(el ?? fixCardEl.value);
-  });
-}
-function openFixPlan() {
-  scrollToFixSection('fix-plan');
-}
-
-async function setClusterStatus(status: 'open' | 'resolved') {
-  try {
-    await $fetch(`/api/failure-clusters/${clusterId}/status`, { method: 'PATCH', body: { status } });
-    nextStepToast.add({
-      title: status === 'resolved' ? 'Cluster marked resolved' : 'Cluster reopened',
-      color: 'success',
-    });
-    refresh();
-  } catch {
-    nextStepToast.add({ title: 'Could not update the cluster', color: 'error' });
-  }
-}
+const { setClusterStatus } = useClusterTriage(clusterId, { onSaved: () => refresh() });
 
 const { handle: handleNextStepAction } = useNextStepActions({
   clusterId: () => clusterId,
@@ -518,9 +414,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
   locatorPanel: () => clusterLocatorPanel.value,
   reproRecipe: () => fixPlan.value?.reproduce ?? null,
   diagnosisContextEndpoint: () => `/api/failure-clusters/${clusterId}/context`,
-  scrollToDiagnosis: () => scrollToFixSection('diagnosis'),
-  scrollToReproduce: () => scrollToFixSection('reproduce'),
-  scrollToLocatorFix: () => scrollToFixSection('locator-fix'),
+  scrollToSection: (k) => toolbox.value?.scrollToSection(k),
   selectAttemptsTab: () => evidenceTabs.value?.selectTab('attempts'),
   setClusterStatus,
   quarantine: async () => {
@@ -530,12 +424,9 @@ const { handle: handleNextStepAction } = useNextStepActions({
     }
   },
   rerunInCi: () => triggerRerun(),
-  openExecution: (id) => {
-    navigateTo(`/test-run-cases/${id}`);
-  },
   whatChanged: () => scrollToEl(scmEl.value ?? whatChangedLine.value?.$el ?? null),
   reDiagnose: () => {
-    scrollToFixSection('diagnosis');
+    toolbox.value?.scrollToSection('diagnosis');
     diagnosisPanel.value?.reDiagnose?.();
   },
 });
@@ -597,10 +488,7 @@ const breadcrumbItems = computed(() => [
               </template>
               <template v-if="cluster.project">
                 <span aria-hidden="true">·</span>
-                <NuxtLink
-                  :to="`/projects/${cluster.project.id}?tab=failure-clusters`"
-                  class="underline decoration-dotted underline-offset-2 hover:decoration-solid"
-                >
+                <NuxtLink :to="`/projects/${cluster.project.id}?tab=failure-clusters`" :class="SENTENCE_LINK_CLASS">
                   {{ cluster.project.label || cluster.project.name }}
                 </NuxtLink>
               </template>
@@ -614,7 +502,7 @@ const breadcrumbItems = computed(() => [
                 :href="knownIssue.url"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="underline decoration-dotted underline-offset-2 hover:decoration-solid"
+                :class="SENTENCE_LINK_CLASS"
                 :title="knownIssue.title ?? knownIssue.url"
               >
                 {{ knownIssue.key || knownIssue.provider }}
@@ -690,69 +578,14 @@ const breadcrumbItems = computed(() => [
 
           <!-- Line 6: the facts line — Details, Raw error, Copy summary -->
           <template #facts>
-            <div class="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs text-muted">
-              <UPopover>
-                <UButton
-                  size="xs"
-                  variant="ghost"
-                  color="neutral"
-                  trailing-icon="i-lucide-chevron-down"
-                  label="Details"
-                  class="shrink-0"
-                />
-                <template #content>
-                  <div class="p-3 space-y-3 text-sm w-72">
-                    <div class="space-y-1">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Owner</p>
-                      <ClusterOwnerLine :owner="cluster.owner" :project-id="cluster.project?.id ?? null" />
-                    </div>
-                    <div class="space-y-1">
-                      <div class="flex items-center gap-1.5 text-xs">
-                        <UIcon name="i-lucide-link" class="size-3.5 shrink-0 text-gray-400" />
-                        <span class="text-muted uppercase tracking-wide font-medium">Known issue</span>
-                        <HelpHint topic="cluster.known-issue" />
-                      </div>
-                      <EntityLinks
-                        entity-type="failure_cluster"
-                        :entity-id="cluster.id"
-                        :links="cluster.links"
-                        :readonly="!canWrite"
-                        @updated="refresh"
-                      />
-                    </div>
-                  </div>
-                </template>
-              </UPopover>
-
-              <UButton
-                size="xs"
-                variant="ghost"
-                color="neutral"
-                :trailing-icon="rawErrorOpen ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
-                label="Raw error"
-                class="shrink-0"
-                :aria-expanded="rawErrorOpen"
-                @click="rawErrorOpen = !rawErrorOpen"
-              />
-
-              <UButton
-                size="xs"
-                variant="ghost"
-                color="neutral"
-                label="Copy summary"
-                class="shrink-0"
-                @click="copyCluster"
-              />
-            </div>
-
-            <div v-if="rawErrorOpen" ref="rawErrorEl" class="mt-2 space-y-2 scroll-mt-4">
-              <div
-                v-if="cluster.sampleError"
-                class="text-xs font-mono whitespace-pre-wrap break-words max-h-96 overflow-y-auto rounded bg-red-50 dark:bg-red-950/20 p-3"
-                v-html="renderAnsi(cluster.sampleError)"
-              />
-              <p v-if="signatureLine" class="font-mono text-xs break-all text-muted">{{ signatureLine }}</p>
-            </div>
+            <ClusterFactsLine
+              ref="factsLine"
+              :cluster="cluster"
+              :can-write="canWrite"
+              :signature-line="signatureLine"
+              @refresh="refresh"
+              @copy="copyCluster"
+            />
           </template>
         </SituationBlock>
 
@@ -789,7 +622,7 @@ const breadcrumbItems = computed(() => [
         </div>
 
         <!-- ── More ways to fix ───────────────────────────────────────── -->
-        <div ref="fixCardEl" class="scroll-mt-4">
+        <div class="scroll-mt-4">
           <Toolbox ref="toolbox" :sections="fixSections" :next-step-kind="nextStep?.kind ?? null" help="fix.toolbox">
             <template #diagnosis-summary>{{ diagnosisSummary }}</template>
             <template #locator-fix-summary>Ranked replacement locators from the failing page</template>

--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AiStepIntent, AttemptOutcome, TestCaseHistoryPoint, TraceInfo } from '~~/types/api';
+import type { AiStepIntent, TestCaseHistoryPoint, TraceInfo } from '~~/types/api';
 import { isPiwiAnnotation } from '@piwitests/core/test-meta';
 import { renderAnsi } from '~/utils';
 import { buildRetryCommand } from '~/utils/retry-command';
@@ -8,13 +8,13 @@ import type { FailureCluesResult } from '#shared/handlers/test-cases';
 import { clusterSectionLocatorKey } from '~/composables/useClusterSectionLocator';
 import { EVIDENCE_SECTION_TAB } from '~/utils/evidence-sections';
 import type { FixSectionKey } from '~/components/shared/Toolbox.vue';
+import type { RerunInfo } from '~/composables/useCiRerun';
 import type { BlockedCaseRef } from '~~/types/api';
 import type { ReproRecipe, BisectResult, ReproduceDesktopContext } from '#shared/reproduce';
 import type { FixedBeforeMatch, FixPlan } from '#shared/fix-plan.types';
 import type { Situation, SituationPart } from '#shared/situation';
 import type { NextStep } from '#shared/next-step';
 import { commitUrl } from '#shared/scm-urls';
-import { condenseErrorText } from '#shared/error-fingerprint';
 
 const route = useRoute();
 const testCaseId = route.params.id;
@@ -43,20 +43,11 @@ const { data: cluesData } = await useFetch<FailureCluesResult>(`/api/test-run-ca
 const clues = computed(() => cluesData.value?.clues ?? []);
 const story = computed(() => cluesData.value?.story ?? null);
 const cluesFailureAt = computed(() => cluesData.value?.failureAt ?? null);
-const topClue = computed(() => clues.value[0] ?? null);
-const topClueSection = computed(() => topClue.value?.citations?.[0]?.section ?? null);
 
 // The evidence opens on the story: the first member clue's cited section and the
 // story's strength (or the top clue's, when no combination matched) tell the tab
 // strip which view leads.
-const defaultHint = computed<{ section: string | null; strength: 'strong' | 'medium' | 'weak' | null }>(() => {
-  const s = story.value;
-  if (s) {
-    const first = clues.value.find((c) => c.id === s.clueIds[0]) ?? topClue.value;
-    return { section: first?.citations?.[0]?.section ?? null, strength: s.strength };
-  }
-  return { section: topClueSection.value, strength: topClue.value?.strength ?? null };
-});
+const defaultHint = useEvidenceHint(clues, story);
 
 const { data: traceData, refresh: refreshTraces } = await useFetch(`/api/test-run-cases/${testCaseId}/traces`, {
   transform: (r: { items: TraceInfo[] }) => r.items,
@@ -77,21 +68,6 @@ const runIsActive = computed(() => {
   const status = testCase.value?.testRun?.status;
   return status === 'running' || status === 'finalizing';
 });
-
-const metadata = computed(() => testCase.value?.testRun?.metadata as Record<string, unknown> | null | undefined);
-const scmInfo = computed(() => {
-  const m = metadata.value;
-  if (!m?.scm) return null;
-  return m.scm as { commit?: string; branch?: string; author?: string; commitMessage?: string };
-});
-const ciInfo = computed(() => {
-  const m = metadata.value;
-  if (!m?.ci) return null;
-  return m.ci as { provider?: string; buildNumber?: string; buildUrl?: string; workflow?: string; jobName?: string };
-});
-const environment = computed(() => testCase.value?.testRun?.environment);
-const browser = computed(() => testCase.value?.browser ?? null);
-const stepsCount = computed(() => (testCase.value?.steps as unknown[] | null)?.length ?? 0);
 
 /** The one-line verdict on a failing execution, built server-side from the stored error and signals. */
 const verdict = computed(() => (testCase.value as { verdict?: FailureVerdict | null } | null)?.verdict ?? null);
@@ -179,14 +155,6 @@ const isLocatorFailure = computed(() =>
 );
 
 // CI re-run for the cluster this failure belongs to, for the Verify section.
-interface RerunInfo {
-  available: boolean;
-  reason: string | null;
-  provider: string | null;
-  enabled: boolean;
-  hasToken: boolean;
-  lastDispatch: { provider: string; url: string; args: string; at: number; byName: string | null } | null;
-}
 const { data: rerunInfo, refresh: refreshRerun } = await useAsyncData<RerunInfo | null>(
   `test-run-case-rerun-${testCaseId}`,
   () => {
@@ -221,63 +189,14 @@ const { data: fixPlanData } = await useAsyncData<FixPlan | null>(
 );
 const fixPlanPatch = computed(() => fixPlanData.value?.diagnosis?.patch ?? null);
 
-const applyingId = ref<number | null>(null);
-const applyToast = useToast();
-async function applyTriage(match: FixedBeforeMatch) {
-  const clusterId = failureCluster.value?.id;
-  const currentStatus = failureCluster.value?.status;
-  if (!clusterId || !currentStatus || applyingId.value != null) return;
-  applyingId.value = match.clusterId;
-  const excerpt = (match.triageNote ?? match.diagnosisTitle ?? match.reason).replace(/\s+/g, ' ').trim().slice(0, 280);
-  const line = `Same as cluster #${match.clusterId}: ${excerpt}`;
-  const existing = (failureCluster.value as { triageNote?: string | null } | null)?.triageNote?.trim();
-  const triageNote = existing ? `${existing}\n${line}` : line;
-  try {
-    await $fetch(`/api/failure-clusters/${clusterId}/status`, {
-      method: 'PATCH',
-      body: { status: currentStatus, triageNote },
-    });
-    applyToast.add({ title: `Applied triage from cluster #${match.clusterId}`, color: 'success' });
-    await Promise.all([refresh(), refreshFixedBefore()]);
-  } catch {
-    applyToast.add({ title: 'Could not apply the triage', color: 'error' });
-  } finally {
-    applyingId.value = null;
-  }
-}
+const { applyingId, applyTriage } = useApplyClusterTriage({
+  clusterId: () => failureCluster.value?.id ?? null,
+  status: () => failureCluster.value?.status,
+  currentNote: () => (failureCluster.value as { triageNote?: string | null } | null)?.triageNote,
+  onApplied: () => Promise.all([refresh(), refreshFixedBefore()]),
+});
 
-const rerunToast = useToast();
-const rerunning = ref(false);
-async function triggerRerun() {
-  const id = failureCluster.value?.id;
-  if (!id || rerunning.value) return;
-  rerunning.value = true;
-  try {
-    const res = await $fetch<{ ok: boolean; message?: string; dispatch?: { url: string } }>(
-      `/api/failure-clusters/${id}/rerun`,
-      { method: 'POST' },
-    );
-    if (res.ok && res.dispatch) {
-      rerunToast.add({
-        title: 'CI re-run dispatched',
-        description: 'The affected tests are re-running.',
-        color: 'success',
-      });
-      await refreshRerun();
-    } else {
-      rerunToast.add({
-        title: 'CI re-run not started',
-        description: res.message ?? 'Not available.',
-        color: 'warning',
-      });
-    }
-  } catch (e: unknown) {
-    const message = (e as { data?: { message?: string } })?.data?.message ?? 'Dispatch failed.';
-    rerunToast.add({ title: 'CI re-run failed', description: message, color: 'error' });
-  } finally {
-    rerunning.value = false;
-  }
-}
+const { rerunning, triggerRerun } = useCiRerun(() => failureCluster.value?.id ?? null, refreshRerun);
 
 /** The Verify section shows when a CI re-run is configured, or in the desktop shell. */
 const showVerify = computed(() => Boolean(rerunInfo.value?.available) || desktopBridge.value);
@@ -303,49 +222,20 @@ const showFix = computed(() => Boolean(verdict.value) || blockedTests.value.leng
 
 // ── Folded one-line summaries for the toolbox sections ───────────────────────
 const { aiStatus } = useAiStatus();
-const diagnosisSummary = computed(() => {
-  const d = failureCluster.value?.diagnosis;
-  if (d?.status === 'completed' && (clusterDiagnosis.value || d.category)) {
-    const title = clusterDiagnosis.value?.summary ?? d.category ?? 'Diagnosed';
-    return d.confidence ? `${title} · ${d.confidence} confidence` : title;
-  }
-  return aiStatus.value?.configured === false ? 'AI is not configured' : 'Not diagnosed yet';
-});
-const reproduceSummary = computed(() => {
-  const steps = reproduceData.value?.reproduce?.steps?.length ?? 0;
-  const bisect = reproduceData.value?.bisect?.available ? 'bisect available' : 'bisect not available';
-  return `${steps} commands · Linux/macOS or Windows · ${bisect}`;
-});
-const verifySummary = computed(() => {
-  const cmd = retryCommand.value ?? '';
-  const g = cmd.match(/-g\s+(".*?"|'.*?'|\S+)/)?.[1];
-  const parts = [g ? `-g ${g}` : 'Re-run the failing test'];
-  if (rerunInfo.value?.available) parts.push('Re-run in CI');
-  return parts.join(' · ');
-});
+const diagnosisSummary = computed(() =>
+  diagnosisSectionSummary(failureCluster.value?.diagnosis, aiStatus.value?.configured),
+);
+const reproduceSummary = computed(() =>
+  reproduceSectionSummary(
+    reproduceData.value?.reproduce?.steps?.length ?? 0,
+    Boolean(reproduceData.value?.bisect?.available),
+  ),
+);
+const verifySummary = computed(() =>
+  verifySectionSummary(retryCommand.value ?? '', Boolean(rerunInfo.value?.available), 'Re-run the failing test'),
+);
 
-const historicalTiming = computed(() => {
-  if (!historyData.value || historyData.value.length < 2 || !testCase.value?.duration) return null;
-  const previous = historyData.value.filter((h) => h.duration !== null && h.id !== testCase.value?.id);
-  if (previous.length === 0) return null;
-  const avg = previous.reduce((sum, h) => sum + (h.duration || 0), 0) / previous.length;
-  const current = testCase.value.duration;
-  const diff = current - avg;
-  const pct = avg > 0 ? Math.round((diff / avg) * 100) : 0;
-  return { avg: Math.round(avg), current, diff: Math.round(diff), pct };
-});
-
-// ── Header: identity, exceptional badges, facts ─────────────────────────────
-// The first captured source frame — the failing line — beats the test()
-// declaration for the header's "open in IDE" link.
-const ideTarget = computed(() => {
-  const frames = (testCase.value as { testSourceFrames?: Array<{ filePath?: string; line?: number }> | null } | null)
-    ?.testSourceFrames;
-  const frame = frames?.[0];
-  if (!frame?.filePath) return null;
-  return { filePath: frame.filePath, line: frame.line };
-});
-
+// ── Header: identity, exceptional badges ─────────────────────────────────────
 // Playwright test marks only — `piwi:` annotations are ownership, not marks.
 const annotations = computed(() =>
   (testCase.value?.testAnnotations ?? []).filter(
@@ -399,24 +289,6 @@ const headerBadges = computed(() => {
     out.push({ label: `@${ann.type}`, color: 'neutral', mono: true, title: ann.description || ann.type });
   return out;
 });
-
-// ── Attempts (facts line) ───────────────────────────────────────────────────
-const attempts = computed(() => testCase.value?.attempts ?? null);
-function attemptColor(status: string): 'success' | 'error' | 'neutral' {
-  if (status === 'passed') return 'success';
-  if (status === 'failed' || status === 'timedout' || status === 'timedOut') return 'error';
-  return 'neutral';
-}
-function attemptTitle(a: AttemptOutcome): string {
-  const when = a.startedAt ? ` at ${new Date(a.startedAt).toLocaleString()}` : '';
-  return `Attempt ${a.retry + 1}: ${a.status} (${Math.round(a.duration)} ms)${when}`;
-}
-function isCurrentAttempt(a: AttemptOutcome): boolean {
-  return a.retry === (testCase.value?.retries ?? 0);
-}
-function attemptLink(a: AttemptOutcome): string | null {
-  return !isCurrentAttempt(a) && a.executionId ? `/test-run-cases/${a.executionId}` : null;
-}
 
 // ── Retry command ────────────────────────────────────────────────────────────
 // The trailing "then" on the next-step line, plus the More menu and the Verify
@@ -577,10 +449,8 @@ onUnmounted(disconnectRunStream);
 // A clue or diagnosis citation reveals the evidence it came from: the evidence
 // tabs handle the tabbed sections (switch tab + scroll), while the raw error and
 // locator-fix blocks scroll in place.
-const rawErrorOpen = ref(false);
-const rawErrorEl = ref<HTMLElement | null>(null);
-const fixCardEl = ref<HTMLElement | null>(null);
 const evidenceEl = ref<HTMLElement | null>(null);
+const factsLine = ref<{ revealRawError: () => void } | null>(null);
 const locatorPanel = ref<{
   copyPatch: () => void;
   copyRecommendedLocator: () => void;
@@ -592,20 +462,17 @@ const evidenceTabs = ref<{
   revealSection: (id: string) => boolean;
   selectTab: (t: string) => void;
 } | null>(null);
+const toolbox = ref<{ scrollToSection: (k: FixSectionKey) => void } | null>(null);
 
 function scrollToEl(el: HTMLElement | null) {
   el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 // The raw error is a disclosure on the facts line; the locator fix lives in the
-// Fix card. A citation reveals or scrolls to the block that holds it.
-function revealRawError() {
-  rawErrorOpen.value = true;
-  nextTick(() => scrollToEl(rawErrorEl.value));
-}
+// toolbox. A citation reveals or scrolls to the block that holds it.
 const pageSections: Record<string, () => void> = {
-  sampleError: revealRawError,
-  executionError: revealRawError,
-  locatorHealing: () => scrollToFixSection('locator-fix'),
+  sampleError: () => factsLine.value?.revealRawError(),
+  executionError: () => factsLine.value?.revealRawError(),
+  locatorHealing: () => toolbox.value?.scrollToSection('locator-fix'),
 };
 provide(clusterSectionLocatorKey, {
   // Answered from static maps so a citation renders as a button at SSR time too,
@@ -621,32 +488,7 @@ provide(clusterSectionLocatorKey, {
 // The next-step line stays presentation-only; the page owns the wiring through
 // the shared composable, reusing the same fetches and panels the toolbox does
 // rather than issuing new requests. Page-specific targets are callbacks.
-const triageToast = useToast();
-
-/** Open a toolbox section and scroll to it (its body is otherwise folded away). */
-const toolbox = ref<{ openSection: (k: string) => void } | null>(null);
-function scrollToFixSection(key: 'diagnosis' | 'reproduce' | 'locator-fix') {
-  toolbox.value?.openSection(key);
-  nextTick(() => {
-    const el = import.meta.client ? document.querySelector<HTMLElement>(`[data-shot="fix-${key}"]`) : null;
-    scrollToEl(el ?? fixCardEl.value);
-  });
-}
-
-async function setClusterStatus(status: 'open' | 'resolved') {
-  const id = failureCluster.value?.id;
-  if (!id) return;
-  try {
-    await $fetch(`/api/failure-clusters/${id}/status`, { method: 'PATCH', body: { status } });
-    triageToast.add({
-      title: status === 'resolved' ? 'Cluster marked resolved' : 'Cluster reopened',
-      color: 'success',
-    });
-    await refresh();
-  } catch {
-    triageToast.add({ title: 'Could not update the cluster', color: 'error' });
-  }
-}
+const { setClusterStatus } = useClusterTriage(() => failureCluster.value?.id ?? null, { onSaved: () => refresh() });
 
 const { handle: handleNextStepAction } = useNextStepActions({
   clusterId: () => failureCluster.value?.id ?? null,
@@ -655,9 +497,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
   locatorPanel: () => locatorPanel.value,
   reproRecipe: () => reproduceData.value?.reproduce ?? null,
   diagnosisContextEndpoint: () => `/api/test-run-cases/${testCaseId}/diagnosis-context`,
-  scrollToDiagnosis: () => scrollToFixSection('diagnosis'),
-  scrollToReproduce: () => scrollToFixSection('reproduce'),
-  scrollToLocatorFix: () => scrollToFixSection('locator-fix'),
+  scrollToSection: (k) => toolbox.value?.scrollToSection(k),
   selectAttemptsTab: () => {
     evidenceTabs.value?.selectTab('attempts');
     nextTick(() => scrollToEl(evidenceEl.value));
@@ -665,9 +505,6 @@ const { handle: handleNextStepAction } = useNextStepActions({
   setClusterStatus,
   quarantine: () => toggleQuarantine(),
   rerunInCi: () => triggerRerun(),
-  openExecution: (id) => {
-    navigateTo(`/test-run-cases/${id}`);
-  },
   whatChanged: () => {
     if (failureCluster.value) navigateTo(`/failure-clusters/${failureCluster.value.id}`);
   },
@@ -794,8 +631,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
                 <NuxtLink
                   v-if="part.href"
                   :to="part.href"
-                  class="underline decoration-dotted underline-offset-2 hover:decoration-solid"
-                  :class="part.kind === 'commit' ? 'font-mono' : ''"
+                  :class="[SENTENCE_LINK_CLASS, part.kind === 'commit' ? 'font-mono' : '']"
                   >{{ part.text }}</NuxtLink
                 >
                 <a
@@ -803,7 +639,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
                   :href="situationCommitHref(part)!"
                   target="_blank"
                   rel="noopener"
-                  class="underline decoration-dotted underline-offset-2 hover:decoration-solid font-mono"
+                  :class="[SENTENCE_LINK_CLASS, 'font-mono']"
                   >{{ part.text }}</a
                 >
                 <span v-else-if="part.kind === 'commit'" class="font-mono">{{ part.text }}</span>
@@ -820,219 +656,12 @@ const { handle: handleNextStepAction } = useNextStepActions({
 
           <!-- Line 6: the facts line, one size smaller, with Details and Raw error -->
           <template #facts>
-            <div class="flex items-center gap-x-2 gap-y-1 flex-wrap text-xs text-muted">
-              <OpenInIdeLink
-                v-if="ideTarget?.filePath || testCase?.location"
-                :file-path="ideTarget?.filePath"
-                :line="ideTarget?.line"
-                :location="ideTarget ? undefined : (testCase?.location ?? undefined)"
-                :project-key="testCase?.testRun?.project?.id"
-                :project-name="testCase?.testRun?.project?.name"
-              />
-              <!-- Secondary facts collapse at 390px; they stay in Details below. -->
-              <span class="max-sm:hidden inline-flex items-center gap-x-2 gap-y-1 flex-wrap">
-                <span v-if="browser" class="inline-flex items-center gap-1">
-                  <BrowserBadge :browser="{ ...browser, viewport: undefined }" size="sm" />
-                  <span v-if="browser.viewport" class="tabular-nums">
-                    {{ browser.viewport.width }}×{{ browser.viewport.height }}
-                  </span>
-                </span>
-                <span v-if="testCase?.status !== 'didnotrun'" class="inline-flex items-center gap-1 tabular-nums">
-                  <DurationValue :ms="testCase?.duration" />
-                  <span v-if="historicalTiming">
-                    (avg <DurationValue :ms="historicalTiming.avg" />, {{ historicalTiming.diff > 0 ? '+' : ''
-                    }}{{ historicalTiming.pct }}%)
-                  </span>
-                </span>
-                <span
-                  v-if="attempts && attempts.length > 1"
-                  class="inline-flex items-center gap-1"
-                  role="group"
-                  aria-label="Attempts of this test in this run"
-                >
-                  <template v-for="a in attempts" :key="a.retry">
-                    <NuxtLink
-                      v-if="attemptLink(a)"
-                      :to="attemptLink(a)!"
-                      :title="`${attemptTitle(a)} — open this attempt`"
-                      class="inline-flex rounded-md outline-none focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-primary hover:opacity-80"
-                    >
-                      <UBadge :color="attemptColor(a.status)" variant="soft" size="sm" class="font-mono">
-                        {{ a.retry + 1 }}/{{ attempts.length }}
-                        <UIcon :name="a.status === 'passed' ? 'i-lucide-check' : 'i-lucide-x'" class="w-3 h-3" />
-                      </UBadge>
-                    </NuxtLink>
-                    <UBadge
-                      v-else
-                      :color="attemptColor(a.status)"
-                      variant="soft"
-                      size="sm"
-                      class="font-mono"
-                      :class="isCurrentAttempt(a) ? 'ring-2 ring-offset-1 ring-primary' : ''"
-                      :title="isCurrentAttempt(a) ? `${attemptTitle(a)} — this execution` : attemptTitle(a)"
-                      :aria-current="isCurrentAttempt(a) ? 'true' : undefined"
-                    >
-                      {{ a.retry + 1 }}/{{ attempts.length }}
-                      <UIcon :name="a.status === 'passed' ? 'i-lucide-check' : 'i-lucide-x'" class="w-3 h-3" />
-                    </UBadge>
-                  </template>
-                </span>
-                <span v-if="scmInfo?.branch">{{ scmInfo.branch }}</span>
-                <a
-                  v-if="ciInfo?.buildUrl || ciInfo?.buildNumber"
-                  :href="ciInfo?.buildUrl || undefined"
-                  :target="ciInfo?.buildUrl ? '_blank' : undefined"
-                  :class="
-                    ciInfo?.buildUrl ? 'underline decoration-dotted underline-offset-2 hover:decoration-solid' : ''
-                  "
-                >
-                  {{ ciInfo?.buildNumber ? `Build #${ciInfo.buildNumber}` : 'View build' }}
-                </a>
-                <ClientOnly>
-                  <span v-if="testCase?.startedAt" :title="new Date(testCase.startedAt).toLocaleString()">
-                    {{ formatRelativeTime(testCase.startedAt) }}
-                  </span>
-                </ClientOnly>
-              </span>
-
-              <UPopover>
-                <UButton
-                  size="xs"
-                  variant="ghost"
-                  color="neutral"
-                  trailing-icon="i-lucide-chevron-down"
-                  label="Details"
-                  class="shrink-0"
-                />
-                <template #content>
-                  <div class="p-3 space-y-2 text-sm max-w-sm">
-                    <!-- The facts that collapse on mobile, kept reachable here. -->
-                    <div class="space-y-1 sm:hidden">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Run</p>
-                      <p v-if="testCase?.status !== 'didnotrun'" class="tabular-nums">
-                        Duration: <DurationValue :ms="testCase?.duration" />
-                      </p>
-                      <p v-if="scmInfo?.branch">
-                        Branch: <span class="text-highlighted">{{ scmInfo.branch }}</span>
-                      </p>
-                      <p v-if="ciInfo?.buildNumber">Build #{{ ciInfo.buildNumber }}</p>
-                      <ClientOnly>
-                        <p v-if="testCase?.startedAt">{{ formatRelativeTime(testCase.startedAt) }}</p>
-                      </ClientOnly>
-                    </div>
-                    <div v-if="environment || ciInfo" class="space-y-1">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">CI &amp; environment</p>
-                      <p v-if="environment">
-                        Environment: <span class="text-highlighted">{{ environment }}</span>
-                      </p>
-                      <p v-if="ciInfo?.provider">Provider: {{ ciInfo.provider }}</p>
-                      <p v-if="ciInfo?.workflow || ciInfo?.jobName">
-                        <template v-if="ciInfo?.workflow">{{ ciInfo.workflow }}</template>
-                        <template v-if="ciInfo?.workflow && ciInfo?.jobName"> · </template>
-                        <template v-if="ciInfo?.jobName">{{ ciInfo.jobName }}</template>
-                      </p>
-                    </div>
-                    <div
-                      v-if="testCase?.testRun?.playwrightVersion || testCase?.testRun?.reporterVersion"
-                      class="space-y-1"
-                    >
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Tooling</p>
-                      <p>
-                        <template v-if="testCase?.testRun?.playwrightVersion"
-                          >Playwright v{{ testCase.testRun.playwrightVersion }}</template
-                        >
-                        <template v-if="testCase?.testRun?.playwrightVersion && testCase?.testRun?.reporterVersion">
-                          ·
-                        </template>
-                        <template v-if="testCase?.testRun?.reporterVersion"
-                          >Piwi v{{ testCase.testRun.reporterVersion }}</template
-                        >
-                      </p>
-                    </div>
-                    <div class="space-y-1">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Execution</p>
-                      <p class="tabular-nums">
-                        Worker {{ testCase?.workerIndex ?? '—'
-                        }}<template v-if="testCase?.shardIndex != null"> · Shard {{ testCase.shardIndex }}</template> ·
-                        {{ stepsCount }} steps
-                      </p>
-                      <p
-                        v-if="testCase?.slowestStep && testCase?.status !== 'didnotrun'"
-                        class="truncate"
-                        :title="testCase.slowestStep"
-                      >
-                        Slowest step: {{ testCase.slowestStep }}
-                        <span v-if="testCase.slowestStepDuration"
-                          >(<DurationValue :ms="testCase.slowestStepDuration" />)</span
-                        >
-                      </p>
-                      <p v-if="(testCase?.wastedTimeMs ?? 0) > 0">
-                        Wasted in fixed waits: <DurationValue :ms="testCase?.wastedTimeMs" />
-                      </p>
-                    </div>
-                    <div v-if="testCase?.locks?.length" class="space-y-1">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Locks</p>
-                      <p class="flex flex-wrap items-center gap-1.5">
-                        <span
-                          v-for="lock in testCase.locks"
-                          :key="lock"
-                          class="inline-flex items-center gap-1 text-highlighted"
-                          title="Only one holder of this lock runs at a time"
-                        >
-                          <UIcon name="i-lucide-lock" class="size-3 text-warning" />{{ lock }}
-                        </span>
-                      </p>
-                    </div>
-                    <div v-if="testCase?.tags?.length || testCase?.testMeta" class="space-y-1">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Tags</p>
-                      <TestMetaBadges :tags="testCase?.tags" :meta="testCase?.testMeta" />
-                    </div>
-                    <div v-if="testCase?.executionId" class="space-y-1">
-                      <p class="text-xs font-medium text-muted uppercase tracking-wide">Links</p>
-                      <EntityLinks
-                        entity-type="test_case"
-                        :entity-id="testCase.executionId"
-                        :links="(testCase as any)?.stableLinks ?? null"
-                        readonly
-                      />
-                    </div>
-                  </div>
-                </template>
-              </UPopover>
-
-              <!-- Raw error: the verbatim ANSI output, one click below the block. -->
-              <UButton
-                v-if="testCase?.error"
-                size="xs"
-                variant="ghost"
-                color="neutral"
-                :trailing-icon="rawErrorOpen ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
-                label="Raw error"
-                class="shrink-0"
-                :aria-expanded="rawErrorOpen"
-                @click="rawErrorOpen = !rawErrorOpen"
-              />
-            </div>
-
-            <div v-if="rawErrorOpen && testCase?.error" ref="rawErrorEl" class="mt-2 space-y-1 scroll-mt-4">
-              <div class="flex justify-end">
-                <UButton
-                  size="xs"
-                  variant="ghost"
-                  color="neutral"
-                  icon="i-lucide-clipboard"
-                  aria-label="Copy failure"
-                  title="Copy failure"
-                  @click="copyFailure"
-                >
-                  Copy failure
-                </UButton>
-              </div>
-              <div
-                class="text-xs font-mono whitespace-pre-wrap break-words max-h-96 overflow-y-auto rounded bg-red-50 dark:bg-red-950/20 p-3"
-                v-html="renderAnsi(condenseErrorText(testCase.error))"
-              />
-            </div>
+            <ExecutionFactsLine
+              ref="factsLine"
+              :test-case="testCase"
+              :history="historyData"
+              @copy-failure="copyFailure"
+            />
           </template>
         </SituationBlock>
 
@@ -1056,7 +685,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
         </div>
 
         <!-- ── More ways to fix ───────────────────────────────────────── -->
-        <div ref="fixCardEl" class="scroll-mt-4">
+        <div class="scroll-mt-4">
           <Toolbox
             v-if="showFix"
             ref="toolbox"

--- a/apps/application/app/utils/index.ts
+++ b/apps/application/app/utils/index.ts
@@ -11,6 +11,47 @@ import {
 import { TEST_PRIORITIES, type TestPriority } from '@piwitests/core/test-meta';
 
 /**
+ * A link that lives inside a sentence keeps the sentence's color and carries a
+ * dotted underline that turns solid on hover — never `text-primary`, which is for
+ * navigation lists and tables. The situation, story, state and what-changed lines
+ * and both failure pages share this one class string.
+ */
+export const SENTENCE_LINK_CLASS = 'underline decoration-dotted underline-offset-2 hover:decoration-solid';
+
+/** The `diagnosis` shape the toolbox's folded summary reads. */
+export interface ToolboxDiagnosisLike {
+  status?: string | null;
+  summary?: string | null;
+  category?: string | null;
+  confidence?: string | null;
+}
+
+/** The Toolbox's one-line Diagnosis summary — the same wording on both failure pages. */
+export function diagnosisSectionSummary(
+  diagnosis: ToolboxDiagnosisLike | null | undefined,
+  aiConfigured: boolean | undefined,
+): string {
+  if (diagnosis?.status === 'completed' && (diagnosis.summary || diagnosis.category)) {
+    const title = diagnosis.summary ?? diagnosis.category ?? 'Diagnosed';
+    return diagnosis.confidence ? `${title} · ${diagnosis.confidence} confidence` : title;
+  }
+  return aiConfigured === false ? 'AI is not configured' : 'Not diagnosed yet';
+}
+
+/** The Toolbox's one-line Reproduce summary. */
+export function reproduceSectionSummary(steps: number, bisectAvailable: boolean): string {
+  return `${steps} commands · Linux/macOS or Windows · ${bisectAvailable ? 'bisect available' : 'bisect not available'}`;
+}
+
+/** The Toolbox's one-line Verify summary — the `-g` grep of the command, then whether CI can re-run. */
+export function verifySectionSummary(command: string, rerunAvailable: boolean, fallbackLabel: string): string {
+  const g = command.match(/-g\s+(".*?"|'.*?'|\S+)/)?.[1];
+  const parts = [g ? `-g ${g}` : fallbackLabel];
+  if (rerunAvailable) parts.push('Re-run in CI');
+  return parts.join(' · ');
+}
+
+/**
  * Narrow a stored priority to the union `TestMetaBadges` takes. The database
  * column is a plain string, so anything unrecognized drops out rather than
  * rendering a badge nobody defined.


### PR DESCRIPTION
## What & why

Phase 7 of the failure-page clarity plan: a **dedupe and simplification pass** over the two failure pages — `app/pages/test-run-cases/[id].vue` (execution) and `app/pages/failure-clusters/[id].vue` (cluster) — with **no behaviour change and no visual change**. Phases 1–6 shipped the situation block, story line, next-step line, cluster-state line, sparkline, toolbox and evidence tabs; the two pages ended up carrying much of that wiring twice. This extracts the shared logic and markup into one home each.

### What moved where

| Duplicated twice | New single home |
|---|---|
| Toolbox one-line summaries (diagnosis / reproduce / verify) | `diagnosisSectionSummary` / `reproduceSectionSummary` / `verifySectionSummary` (`app/utils/index.ts`) |
| Evidence default hint (story → first clue's section + strength, else top clue) | `useEvidenceHint` composable |
| Raw-error disclosure (ghost button + ANSI block) | `RawErrorDisclosure.vue` |
| `scrollToFixSection` | `Toolbox.scrollToSection()` (exposed API) |
| resolve/reopen `setClusterStatus` + toasts | `useClusterTriage` (shared with `ClusterStateLine`) |
| next-step scroll / open-execution handler defaults | folded into `useNextStepActions` (pages pass only what differs, via one `scrollToSection` callback) |
| facts line + Details popover + mobile collapse | `ExecutionFactsLine.vue` / `ClusterFactsLine.vue` |
| sentence-link class string | `SENTENCE_LINK_CLASS` constant |
| CI re-run (`triggerRerun` + `RerunInfo`) | `useCiRerun` |
| "apply the same triage" | `useApplyClusterTriage` |

### Before / after numbers

- **Identical non-trivial lines between the two pages** (≥45 chars, trimmed, set intersection): **75 → 49** (budget ≤ 50).
- **Page sizes**: execution `1237 → 866` (pre-plan main 974); cluster `915 → 748` (pre-plan main 775) — both below their pre-plan sizes.
- **`npm run app:measure --json`** on the eight reference routes (`/test-run-cases/37,13,587,682`, `/failure-clusters/10,2,5,1`): identical before/after, including `distinctTextStyles` (14 on #37, 11 on #10, 12 on #2). Proven at the same wall-clock instant against `origin/main` — the only nominal delta seen across runs was a 1-word change on #1 caused by a relative timestamp advancing between captures, which `origin/main` reproduces identically.
- **Failure-page screenshot scenes** are pixel-identical (verified with a frozen clock against `origin/main` for the cluster scenes, whose "last X ago" line otherwise drifts with real time).

### Item 9 (formatRelativeTime / formatLongDuration): intentionally not applied

The plan asked these to delegate to `shared/relative-time.ts`. They can't without a visible change: `formatRelativeTime` (date-fns "about 1 hour ago", "less than a minute ago") and `relativeTimeAgo` (exact "1 hour ago", "just now"), and `formatLongDuration` (two units) vs `durationApprox` (one unit) produce **different strings**. Delegating changed `app:measure` output (empirically: words 369→367 on #13, 670→669 on #10) — violating the byte-identical-measure requirement — and would alter relative-time rendering across 30+ files, well outside this pass's no-visual-change scope. Left unchanged; noted here for a future dedicated visual change.

## How was it tested?

- `app:typecheck`, `app:lint`, `app:format:check` — clean
- `app:test:unit` — 2247 passed
- Failure-page E2E specs (`test-run-case-page`, `cluster-page-layout`, `fix-plan`, `desktop-reproduce`, `failure-clusters`, `fixed-before`, `fix-verification`, `page-diff`, `quarantine`, `mobile-responsiveness`) — green (one project-cluster-list assertion in `fix-verification` flaked only when 10 mutating specs shared one reused dev DB; it passes 7/7 in isolation and is on a surface this PR does not touch)
- `npm run app:measure --json` (8 routes) and the failure-page screenshot scenes — identical to `origin/main`
- `npx commitlint --from origin/main --to HEAD` — clean

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] Tests added/updated for behavior changes — none needed; behaviour and rendering are unchanged, so existing unit + E2E suites cover it
- [x] Docs updated if user-facing — n/a, nothing user-facing moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fwoFfvov2ycUWdfgb8n68

---
_Generated by [Claude Code](https://claude.ai/code/session_018fwoFfvov2ycUWdfgb8n68)_