### PR TITLE
fix(auth): read Google's verified_email flag when mapping the userinfo payload

### DIFF
--- a/apps/application/server/utils/oauth-helpers.ts
+++ b/apps/application/server/utils/oauth-helpers.ts
@@ -77,6 +77,16 @@ export function isEmailDomainAllowed(email: string, emailVerified: boolean, allo
   return allowedDomains.includes(emailDomainOf(email));
 }
 
+/**
+ * Whether a Google userinfo payload says the address is verified. The
+ * `oauth2/v2/userinfo` endpoint names the flag `verified_email`; the OpenID
+ * Connect `userinfo` shape names it `email_verified`. Both are honored so the
+ * verdict does not depend on which endpoint answered.
+ */
+export function isGoogleEmailVerified(raw: Record<string, unknown>): boolean {
+  return raw.verified_email === true || raw.email_verified === true;
+}
+
 /** Whether the user's org memberships satisfy the org allowlist (empty = no restriction). */
 export function isOrgAllowed(memberOrgs: string[], allowedOrgs: string[]): boolean {
   if (allowedOrgs.length === 0) {

--- a/apps/application/server/utils/oauth.ts
+++ b/apps/application/server/utils/oauth.ts
@@ -15,6 +15,7 @@ import {
   buildRedirectUri,
   parseAllowList,
   isEmailDomainAllowed,
+  isGoogleEmailVerified,
   isOrgAllowed,
   resolveProvisioningAction,
   resolveLinkAction,
@@ -75,7 +76,7 @@ function getProviderConfig(event: H3Event, provider: string): OAuthProviderConfi
         mapUser: (raw) => ({
           id: String(raw.id),
           email: String(raw.email ?? ''),
-          emailVerified: raw.email_verified === true,
+          emailVerified: isGoogleEmailVerified(raw),
           name: String(raw.name ?? raw.email ?? ''),
           avatar: String(raw.picture ?? ''),
         }),

--- a/apps/application/tests/unit/oauth-helpers.test.ts
+++ b/apps/application/tests/unit/oauth-helpers.test.ts
@@ -10,6 +10,7 @@ import {
   parseAllowList,
   emailDomainOf,
   isEmailDomainAllowed,
+  isGoogleEmailVerified,
   isOrgAllowed,
   resolveProvisioningAction,
   resolveLinkAction,
@@ -121,6 +122,16 @@ describe('allowlists', () => {
     expect(isEmailDomainAllowed('alice@example.com', false, allowed)).toBe(false); // unverified
     expect(isEmailDomainAllowed('eve@evil.com', true, allowed)).toBe(false); // wrong domain
     expect(isEmailDomainAllowed('', true, allowed)).toBe(false); // no email
+  });
+
+  test('Google verification is read from either userinfo spelling', () => {
+    // oauth2/v2/userinfo
+    expect(isGoogleEmailVerified({ email: 'a@example.com', verified_email: true })).toBe(true);
+    // OpenID Connect userinfo
+    expect(isGoogleEmailVerified({ email: 'a@example.com', email_verified: true })).toBe(true);
+    expect(isGoogleEmailVerified({ email: 'a@example.com', verified_email: false })).toBe(false);
+    expect(isGoogleEmailVerified({ email: 'a@example.com', verified_email: 'true' })).toBe(false);
+    expect(isGoogleEmailVerified({ email: 'a@example.com' })).toBe(false);
   });
 
   test('org allowlist matches case-insensitively, empty = unrestricted', () => {


### PR DESCRIPTION
## What & why

The Google provider fetches `https://www.googleapis.com/oauth2/v2/userinfo`, whose payload spells the verification flag **`verified_email`**. The mapper in `server/utils/oauth.ts` only read `email_verified` (the OpenID Connect spelling), so every Google profile arrived as unverified.

Two visible effects:

- With `PIWI_OAUTH_ALLOWED_DOMAINS` set — the usual way to limit sign-in to a Google Workspace domain — **every Google sign-in fails** with *"A verified email in an allowed domain is required to sign in."*
- Without the allowlist, a Google account whose address matches an existing local account never links to it, because linking also requires a verified email (`resolveProvisioningAction`).

The check now lives in `oauth-helpers.ts` as a pure `isGoogleEmailVerified(raw)` that accepts either spelling, so it is unit-tested and does not depend on which userinfo endpoint answered. No endpoint or scope change; `id`, `email`, `name`, `picture` are read exactly as before.

Found while deploying `phenx/piwitests-server:0.27.0` on GKE behind a Google load balancer with allowed domains configured. Companion fix from the same deployment: #521 (PIWI_OAUTH_* env mapping for the prebuilt server).

## How was it tested?

- `tests/unit/oauth-helpers.test.ts`: new case covering `verified_email: true`, `email_verified: true`, `false`, the string `"true"` (rejected — Google sends a boolean) and the flag missing.
- `npm run app:lint`, `npm run app:format:check`, `npm run app:typecheck`, `npm run app:test:unit` — green.
- Manually: Google sign-in with `PIWI_OAUTH_ALLOWED_DOMAINS` set succeeds against the patched server.

No docs change: the operator-facing behavior is the documented one (only verified emails in allowed domains may sign in); this makes it true for Google.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README) — not needed, see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzRsG5Ldc4epPNkc4n3oZB
