### PR TITLE
fix(auth): map PIWI_OAUTH_* onto the prebuilt server's runtime config

### DIFF
--- a/apps/application/tests/unit/docker-server-env.test.ts
+++ b/apps/application/tests/unit/docker-server-env.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// The shim is preloaded ahead of the bundled server in the Docker image, so it
+// is exercised the same way here: a child Node process imports it and prints
+// the environment it leaves behind.
+const SHIM = fileURLToPath(new URL('../../../../docker-server-env.mjs', import.meta.url));
+
+function envAfterShim(env: Record<string, string>): Record<string, string | undefined> {
+  const output = execFileSync(
+    process.execPath,
+    ['--import', SHIM, '-e', 'process.stdout.write(JSON.stringify(process.env))'],
+    { env: { PATH: process.env.PATH ?? '', ...env }, encoding: 'utf8' },
+  );
+  return JSON.parse(output) as Record<string, string | undefined>;
+}
+
+describe('docker-server-env', () => {
+  test('maps PIWI_AUTH_* onto the NUXT_* overrides', () => {
+    const env = envAfterShim({ PIWI_AUTH_ENABLED: 'true', PIWI_AUTH_SECRET: 's3cret' });
+
+    expect(env.NUXT_AUTH_ENABLED).toBe('true');
+    expect(env.NUXT_PUBLIC_AUTH_ENABLED).toBe('true');
+    expect(env.NUXT_AUTH_SECRET).toBe('s3cret');
+  });
+
+  test('maps every PIWI_OAUTH_* variable and lists the configured providers', () => {
+    const env = envAfterShim({
+      PIWI_OAUTH_GOOGLE_CLIENT_ID: 'g-id',
+      PIWI_OAUTH_GOOGLE_CLIENT_SECRET: 'g-secret',
+      PIWI_OAUTH_GITHUB_CLIENT_ID: 'gh-id',
+      PIWI_OAUTH_GITHUB_CLIENT_SECRET: 'gh-secret',
+      PIWI_OAUTH_ALLOWED_DOMAINS: 'example.com',
+      PIWI_OAUTH_GITHUB_ALLOWED_ORGS: 'acme',
+    });
+
+    expect(env.NUXT_OAUTH_GOOGLE_CLIENT_ID).toBe('g-id');
+    expect(env.NUXT_OAUTH_GOOGLE_CLIENT_SECRET).toBe('g-secret');
+    expect(env.NUXT_OAUTH_GITHUB_CLIENT_ID).toBe('gh-id');
+    expect(env.NUXT_OAUTH_GITHUB_CLIENT_SECRET).toBe('gh-secret');
+    expect(env.NUXT_OAUTH_ALLOWED_DOMAINS).toBe('example.com');
+    expect(env.NUXT_OAUTH_GITHUB_ALLOWED_ORGS).toBe('acme');
+    expect(JSON.parse(env.NUXT_PUBLIC_OAUTH_PROVIDERS ?? '[]')).toEqual(['google', 'github']);
+  });
+
+  test('a provider missing its secret is not listed', () => {
+    const env = envAfterShim({
+      PIWI_OAUTH_GOOGLE_CLIENT_ID: 'g-id',
+      PIWI_OAUTH_GOOGLE_CLIENT_SECRET: 'g-secret',
+      PIWI_OAUTH_GITHUB_CLIENT_ID: 'gh-id',
+    });
+
+    expect(JSON.parse(env.NUXT_PUBLIC_OAUTH_PROVIDERS ?? '[]')).toEqual(['google']);
+  });
+
+  test('a NUXT_* value set by the operator wins over the PIWI_* one', () => {
+    const env = envAfterShim({
+      PIWI_OAUTH_GOOGLE_CLIENT_ID: 'from-piwi',
+      PIWI_OAUTH_GOOGLE_CLIENT_SECRET: 'g-secret',
+      NUXT_OAUTH_GOOGLE_CLIENT_ID: 'from-nuxt',
+      NUXT_PUBLIC_OAUTH_PROVIDERS: '["github"]',
+    });
+
+    expect(env.NUXT_OAUTH_GOOGLE_CLIENT_ID).toBe('from-nuxt');
+    expect(env.NUXT_PUBLIC_OAUTH_PROVIDERS).toBe('["github"]');
+  });
+
+  test('leaves the environment alone when nothing is configured', () => {
+    const env = envAfterShim({});
+
+    const touched = Object.keys(env).filter((key) => key.startsWith('NUXT_'));
+    expect(touched).toEqual([]);
+  });
+});

--- a/apps/docs/operate/authentication.md
+++ b/apps/docs/operate/authentication.md
@@ -120,6 +120,8 @@ The dashboard supports signing in with Google or GitHub as an alternative to use
 
 3. **Restart the application.** The login page now shows **Sign in with Google** and/or **Sign in with GitHub** buttons above the password form.
 
+> **Docker image and `npx @piwitests/server`:** the prebuilt server reads these settings from its runtime config, which only honors `NUXT_*` names, so the launcher maps each `PIWI_OAUTH_*` variable onto its `NUXT_OAUTH_*` counterpart at start and lists the configured providers in `NUXT_PUBLIC_OAUTH_PROVIDERS` for the login page. A `NUXT_*` value you set yourself is left untouched.
+
 > **Behind a reverse proxy:** set `PIWI_SITE_URL` to your public URL (e.g. `https://piwi.example.com`). The OAuth `redirect_uri` is built from it, so it stays consistent with the value you registered even when the proxy rewrites the request host. Without it the redirect URI is inferred from the incoming request.
 
 ### Restricting who can sign in (allowlists)

--- a/docker-server-env.mjs
+++ b/docker-server-env.mjs
@@ -5,11 +5,37 @@
 // variables onto those overrides so enabling authentication at run time takes
 // effect on both the server and the browser (public) config. Existing NUXT_*
 // values win, and PIWI_SECRET_KEY / PIWI_AUTH_ENABLED are still read directly by
-// the server, so this only reconciles the pieces baked into the client bundle.
+// the server, so this only reconciles the pieces baked into the bundle.
 if (process.env.PIWI_AUTH_ENABLED === 'true') {
   process.env.NUXT_AUTH_ENABLED ??= 'true';
   process.env.NUXT_PUBLIC_AUTH_ENABLED ??= 'true';
 }
 if (process.env.PIWI_AUTH_SECRET) {
   process.env.NUXT_AUTH_SECRET ??= process.env.PIWI_AUTH_SECRET;
+}
+
+// OAuth settings live in the baked runtime config as well, so each PIWI_OAUTH_*
+// value is mirrored onto the NUXT_* override the server actually reads. An
+// operator who set the NUXT_* name directly keeps that value.
+const OAUTH_ENV = {
+  PIWI_OAUTH_GOOGLE_CLIENT_ID: 'NUXT_OAUTH_GOOGLE_CLIENT_ID',
+  PIWI_OAUTH_GOOGLE_CLIENT_SECRET: 'NUXT_OAUTH_GOOGLE_CLIENT_SECRET',
+  PIWI_OAUTH_GITHUB_CLIENT_ID: 'NUXT_OAUTH_GITHUB_CLIENT_ID',
+  PIWI_OAUTH_GITHUB_CLIENT_SECRET: 'NUXT_OAUTH_GITHUB_CLIENT_SECRET',
+  PIWI_OAUTH_ALLOWED_DOMAINS: 'NUXT_OAUTH_ALLOWED_DOMAINS',
+  PIWI_OAUTH_GITHUB_ALLOWED_ORGS: 'NUXT_OAUTH_GITHUB_ALLOWED_ORGS',
+};
+for (const [piwiName, nuxtName] of Object.entries(OAUTH_ENV)) {
+  if (process.env[piwiName]) process.env[nuxtName] ??= process.env[piwiName];
+}
+
+// The login page lists its sign-in buttons from `public.oauthProviders`, baked
+// at build time. Derive it from the providers that have both a client id and a
+// secret, unless the operator set NUXT_PUBLIC_OAUTH_PROVIDERS directly.
+const configuredProviders = ['google', 'github'].filter((provider) => {
+  const key = provider.toUpperCase();
+  return process.env[`NUXT_OAUTH_${key}_CLIENT_ID`] && process.env[`NUXT_OAUTH_${key}_CLIENT_SECRET`];
+});
+if (configuredProviders.length > 0) {
+  process.env.NUXT_PUBLIC_OAUTH_PROVIDERS ??= JSON.stringify(configuredProviders);
 }

--- a/packages/server/bin/piwi-server.mjs
+++ b/packages/server/bin/piwi-server.mjs
@@ -28,6 +28,32 @@ if (process.env.PIWI_AUTH_ENABLED === 'true') {
 }
 if (process.env.PIWI_AUTH_SECRET) process.env.NUXT_AUTH_SECRET ??= process.env.PIWI_AUTH_SECRET
 
+// OAuth settings live in the baked runtime config as well, so each PIWI_OAUTH_*
+// value is mirrored onto the NUXT_* override the server actually reads. An
+// operator who set the NUXT_* name directly keeps that value.
+const OAUTH_ENV = {
+  PIWI_OAUTH_GOOGLE_CLIENT_ID: 'NUXT_OAUTH_GOOGLE_CLIENT_ID',
+  PIWI_OAUTH_GOOGLE_CLIENT_SECRET: 'NUXT_OAUTH_GOOGLE_CLIENT_SECRET',
+  PIWI_OAUTH_GITHUB_CLIENT_ID: 'NUXT_OAUTH_GITHUB_CLIENT_ID',
+  PIWI_OAUTH_GITHUB_CLIENT_SECRET: 'NUXT_OAUTH_GITHUB_CLIENT_SECRET',
+  PIWI_OAUTH_ALLOWED_DOMAINS: 'NUXT_OAUTH_ALLOWED_DOMAINS',
+  PIWI_OAUTH_GITHUB_ALLOWED_ORGS: 'NUXT_OAUTH_GITHUB_ALLOWED_ORGS',
+}
+for (const [piwiName, nuxtName] of Object.entries(OAUTH_ENV)) {
+  if (process.env[piwiName]) process.env[nuxtName] ??= process.env[piwiName]
+}
+
+// The login page lists its sign-in buttons from `public.oauthProviders`, baked
+// at build time. Derive it from the providers that have both a client id and a
+// secret, unless the operator set NUXT_PUBLIC_OAUTH_PROVIDERS directly.
+const configuredProviders = ['google', 'github'].filter((provider) => {
+  const key = provider.toUpperCase()
+  return process.env[`NUXT_OAUTH_${key}_CLIENT_ID`] && process.env[`NUXT_OAUTH_${key}_CLIENT_SECRET`]
+})
+if (configuredProviders.length > 0) {
+  process.env.NUXT_PUBLIC_OAUTH_PROVIDERS ??= JSON.stringify(configuredProviders)
+}
+
 const port = process.env.PORT || process.env.NITRO_PORT || '3000'
 console.log(`Starting Piwi Dashboard on http://localhost:${port}`)
 console.log(`Data (SQLite database + file storage) will be stored in ${resolve(process.cwd(), '.data')}`)


### PR DESCRIPTION
## What & why

The Docker image and `npx @piwitests/server` run a prebuilt bundle whose runtime config is baked at build time and only honors `NUXT_*` overrides. Both launcher shims (`docker-server-env.mjs`, `packages/server/bin/piwi-server.mjs`) already mapped `PIWI_AUTH_ENABLED` and `PIWI_AUTH_SECRET` — but not the six documented `PIWI_OAUTH_*` variables. Two things followed for an operator who set them as the docs say:

1. **`OAuth provider google is not configured`** — the server read `oauth.google.clientId` from the baked config (empty), unless the operator discovered `NUXT_OAUTH_GOOGLE_CLIENT_ID`, `NUXT_OAUTH_GOOGLE_CLIENT_SECRET`, `NUXT_OAUTH_ALLOWED_DOMAINS` (and the GitHub equivalents) by reading the bundle.
2. **No provider buttons on the login page**, even with those set — `login.vue` renders them from `public.oauthProviders`, which `nuxt.config.ts` computes from the `PIWI_*` variables present *at build time* (an empty list in the published image), and nothing derived it at run time. `NUXT_PUBLIC_OAUTH_PROVIDERS='["google"]'` had to be set by hand as well.

This PR makes the documented `PIWI_OAUTH_*` names work in both launchers:

- each `PIWI_OAUTH_*` value is mirrored onto its `NUXT_OAUTH_*` name — `PIWI_OAUTH_GOOGLE_CLIENT_ID` → `NUXT_OAUTH_GOOGLE_CLIENT_ID`, `..._GOOGLE_CLIENT_SECRET`, `..._GITHUB_CLIENT_ID`, `..._GITHUB_CLIENT_SECRET`, `PIWI_OAUTH_ALLOWED_DOMAINS` → `NUXT_OAUTH_ALLOWED_DOMAINS`, `PIWI_OAUTH_GITHUB_ALLOWED_ORGS` → `NUXT_OAUTH_GITHUB_ALLOWED_ORGS`;
- `NUXT_PUBLIC_OAUTH_PROVIDERS` is set from the providers that have both a client id and a secret.

Every assignment uses `??=`, so **an operator who already set the `NUXT_*` names by hand keeps them**, and nothing is written when no provider is configured (the build-time default stays). The two launchers ship in different artifacts (the image copies only the root shim; npm publishes only `bin/`), so both carry the block.

Docs: one callout under *Configuring OAuth* in `operate/authentication.md` saying the prebuilt server maps the names and that a `NUXT_*` value set directly is left untouched.

Found while deploying `phenx/piwitests-server:0.27.0` on GKE behind a Google load balancer. Companion fix from the same deployment: #520 (Google `verified_email` mapping).

## How was it tested?

- New `tests/unit/docker-server-env.test.ts`: preloads the Docker shim into a child `node --import` process and checks the environment it leaves — every `PIWI_OAUTH_*` mapped, providers derived, a provider missing its secret not listed, a hand-set `NUXT_*` value winning, and no `NUXT_*` key written when nothing is configured.
- `node --check` on both shims; `npm run app:lint`, `app:format:check`, `app:typecheck`, `app:test:unit` (incl. `docs-drift`) — green.
- Manually: with only `PIWI_OAUTH_GOOGLE_CLIENT_ID/SECRET` and `PIWI_OAUTH_ALLOWED_DOMAINS` set on the container, the login page shows the Google button and sign-in completes.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, README, or reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzRsG5Ldc4epPNkc4n3oZB
