### PR TITLE
fix(reporter): fail a request when the connection closes before the body completes

### DIFF
--- a/packages/reporter/src/internal/transport/http-client.ts
+++ b/packages/reporter/src/internal/transport/http-client.ts
@@ -235,6 +235,14 @@ export class HttpClient {
           res.on('end', () => {
             resolve({ status: res.statusCode ?? 0, text: data, headers: res.headers });
           });
+          // A connection dropped after the headers closes the response without
+          // `end`; an incomplete body is a failed request, not a pending one.
+          res.on('error', reject);
+          res.on('close', () => {
+            if (!res.complete) {
+              reject(new Error(`Connection to ${pathname} closed before the response completed`));
+            }
+          });
         },
       );
 

--- a/packages/reporter/tests/http-client.spec.ts
+++ b/packages/reporter/tests/http-client.spec.ts
@@ -214,6 +214,26 @@ describe('HttpClient (against fake http.Server)', () => {
     });
   });
 
+  describe('connection dropped mid-response', () => {
+    it('rejects when the socket closes after the headers but before the body completes', async () => {
+      const { server, url } = await startServer((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.write('{"partial":');
+        setTimeout(() => res.socket?.destroy(), 20);
+      });
+      try {
+        const client = new HttpClient(url, new Logger(false), 5000);
+        await expect(client.postJSON('/api/cut', {}, null)).rejects.toThrow(
+          /closed before the response completed|aborted|ECONNRESET|socket hang up/,
+        );
+      } finally {
+        (server as any).closeAllConnections?.();
+        server.close();
+        await new Promise<void>((r) => server.on('close', () => r()));
+      }
+    });
+  });
+
   describe('insecure transport warning', () => {
     function warningsFor(url: string): string[] {
       const logger = new Logger(false);


### PR DESCRIPTION
## What & why

`HttpClient.request()` listens for `data` and `end` on the response and for `error` on the request only. When the connection drops **after the headers have arrived** — a proxy reset, a dashboard restart or redeploy during `/upload`, a load balancer idle cutoff mid-body — Node ends the response without `end`, and with no `error` listener on the response it emits nothing at all. The socket is gone, so `req.setTimeout` (inactivity) never fires either. The promise behind `postJSON` / `postFormData` never settles, and `onEnd` hangs until the CI job is killed — with no log line pointing at the dashboard.

The response now rejects on `error`, and on `close` when `res.complete` is `false`. The rejection reaches the submit fallback ladder (streaming → upload → submit) like any other transport failure, so a dropped upload gets its retry instead of a hung run.

## How was it tested?

- New case in `tests/http-client.spec.ts`: a fake server writes `200` + a partial JSON body, then destroys the socket. **Without the change the test times out at 5 s** (the promise never settles); with it `postJSON` rejects within milliseconds.
- `npm run reporter:test`, `reporter:lint`, `reporter:typecheck`, `reporter:format:check` — green.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing — no user-facing surface changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzRsG5Ldc4epPNkc4n3oZB
