### PR TITLE
perf(app): compute quarantine streaks in one query

### DIFF
--- a/apps/application/shared/handlers/quarantine.ts
+++ b/apps/application/shared/handlers/quarantine.ts
@@ -10,7 +10,7 @@
  * what makes the exit possible: consecutive passes accumulate, and once a test
  * has earned its way out the dashboard says so instead of waiting to be asked.
  */
-import { and, asc, desc, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, inArray, isNull, lte, or, sql } from 'drizzle-orm';
 import { quarantinedTests, testCases, testRuns, testRunsCases } from '../../server/database/schema';
 import type { DrizzleDB } from './db';
 
@@ -66,6 +66,10 @@ export async function getQuarantinedCaseIds(db: DrizzleDB, projectId: number): P
  * Trailing passing streak for each test, counted over executions recorded after
  * the run the test was quarantined at. Ordered newest first and stopped at the
  * first failure, so a single recent flake resets the count — which is the point.
+ *
+ * One query for the whole list: each test's executions since its own quarantine
+ * run are ranked newest-first with a window function, and only the first
+ * `STREAK_SCAN_LIMIT` of each are read back.
  */
 async function computeStreaks(
   db: DrizzleDB,
@@ -74,27 +78,52 @@ async function computeStreaks(
   const streaks = new Map<number, { passes: number; runs: number }>();
   if (entries.length === 0) return streaks;
 
-  for (const entry of entries) {
-    const rows = await db
-      .select({ status: testRunsCases.status, id: testRunsCases.id })
-      .from(testRunsCases)
-      .where(
-        and(
-          eq(testRunsCases.testCaseId, entry.testCaseId),
-          entry.quarantinedAtRunId != null ? gt(testRunsCases.testRunId, entry.quarantinedAtRunId) : sql`1 = 1`,
-        ),
-      )
-      .orderBy(desc(testRunsCases.id))
-      .limit(STREAK_SCAN_LIMIT);
+  const sinceQuarantine = or(
+    ...entries.map((entry) =>
+      and(
+        eq(testRunsCases.testCaseId, entry.testCaseId),
+        entry.quarantinedAtRunId != null ? gt(testRunsCases.testRunId, entry.quarantinedAtRunId) : sql`1 = 1`,
+      ),
+    ),
+  );
 
+  const ranked = db
+    .select({
+      testCaseId: testRunsCases.testCaseId,
+      status: testRunsCases.status,
+      id: testRunsCases.id,
+      newestRank:
+        sql<number>`row_number() over (partition by ${testRunsCases.testCaseId} order by ${testRunsCases.id} desc)`.as(
+          'newest_rank',
+        ),
+    })
+    .from(testRunsCases)
+    .where(sinceQuarantine)
+    .as('ranked');
+
+  const rows = await db
+    .select({ testCaseId: ranked.testCaseId, status: ranked.status, id: ranked.id })
+    .from(ranked)
+    .where(lte(ranked.newestRank, STREAK_SCAN_LIMIT))
+    .orderBy(desc(ranked.id));
+
+  const byCase = new Map<number, Array<{ status: string }>>();
+  for (const row of rows) {
+    const list = byCase.get(row.testCaseId);
+    if (list) list.push(row);
+    else byCase.set(row.testCaseId, [row]);
+  }
+
+  for (const entry of entries) {
+    const executions = byCase.get(entry.testCaseId) ?? [];
     let passes = 0;
-    for (const row of rows) {
+    for (const row of executions) {
       if (row.status === 'passed') passes++;
       else if (FAIL_STATUSES.includes(row.status)) break;
       // Skipped / didnotrun executions prove nothing either way; ignore them
       // rather than counting or breaking the streak.
     }
-    streaks.set(entry.testCaseId, { passes, runs: rows.length });
+    streaks.set(entry.testCaseId, { passes, runs: executions.length });
   }
 
   return streaks;

--- a/apps/application/tests/unit/quarantine.test.ts
+++ b/apps/application/tests/unit/quarantine.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
@@ -148,6 +148,41 @@ describe('release streaks', () => {
 
     const { entries } = await listQuarantine(db, 1);
     expect(entries[0]!.consecutivePasses).toBe(0);
+  });
+});
+
+describe('streak queries', () => {
+  test('the number of queries does not grow with the quarantine list', async () => {
+    const one = await seedCase('one');
+    await addQuarantine(db, 1, one);
+    await seedExecution(one, 'passed');
+
+    const select = vi.spyOn(db, 'select');
+    await listQuarantine(db, 1);
+    const queriesForOne = select.mock.calls.length;
+
+    for (const title of ['two', 'three', 'four', 'five']) {
+      const caseId = await seedCase(title);
+      await addQuarantine(db, 1, caseId);
+      await seedExecution(caseId, 'passed');
+    }
+
+    select.mockClear();
+    const { entries } = await listQuarantine(db, 1);
+    expect(entries).toHaveLength(5);
+    expect(select.mock.calls.length).toBe(queriesForOne);
+    select.mockRestore();
+  });
+
+  test('scans at most the newest executions of each test', async () => {
+    const caseId = await seedCase('long-history');
+    await addQuarantine(db, 1, caseId);
+    await seedExecution(caseId, 'failed');
+    for (let i = 0; i < 40; i++) await seedExecution(caseId, 'passed');
+
+    const { entries } = await listQuarantine(db, 1);
+    expect(entries[0]!.consecutivePasses).toBe(30);
+    expect(entries[0]!.runsSinceQuarantine).toBe(30);
   });
 });
 


### PR DESCRIPTION
## What & why

`listQuarantine()` computed each quarantined test's passing streak with its own `SELECT` (`computeStreaks`, one query per entry). It is called by the quarantine page and — per project — by `getOpenFailureClusters()` for the failure-cluster inbox (`GET /api/failure-clusters`, the `list_open_clusters` MCP tool). A workspace with a few dozen quarantined tests paid that many round trips on every inbox load.

The streaks now come from **one query**: each test's executions since its own quarantine run are ranked newest-first with `row_number() over (partition by test_case_id order by id desc)`, only the first `STREAK_SCAN_LIMIT` (30) of each are read back, and the streak is counted in memory exactly as before.

Semantics are unchanged: same per-test `quarantinedAtRunId` cutoff (an `OR` of per-entry predicates, so a test quarantined later than another does not see the other's window), same 30-row scan, same newest-first walk stopping at the first failure, skipped/did-not-run ignored. Window functions are available on both dialects (libSQL/SQLite ≥ 3.25, PostgreSQL) and in the demo's sql.js.

This is the first of a few query-in-a-loop sites I found while reading the server; I picked it because it is on a page load rather than a background task and the batched form is a straight substitution. Happy to follow with the others (suite-level `UPDATE` per ingest batch in `persist-run-cases`, per-cluster SCM resolution in fix verification) if this shape is welcome.

## How was it tested?

- Existing `tests/unit/quarantine.test.ts` streak cases (cutoff, threshold, reset on failure, newest-first, timed-out) pass unchanged.
- Two new cases: the `db.select` call count is the same for one quarantined test and for five (pins "no query per entry"), and a test with 40 executions since quarantine reports a streak of 30 (pins the per-test scan limit inside the window).
- `npm run app:lint`, `app:format:check`, `app:typecheck`, `app:test:unit` — green.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [ ] Docs updated if user-facing — no user-facing change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzRsG5Ldc4epPNkc4n3oZB
