### PR TITLE
fix(app): bound trace-ingestion memory to stop the desktop server OOM

### DIFF
--- a/apps/application/app/pages/test-cases/[id].vue
+++ b/apps/application/app/pages/test-cases/[id].vue
@@ -75,7 +75,7 @@ const passRateClass = computed(() => {
               ...(testCase?.project?.id
                 ? [
                     {
-                      label: testCase.project.name || 'Project',
+                      label: testCase.project.label || testCase.project.name || 'Project',
                       to: `/projects/${testCase.project.id}`,
                     },
                   ]
@@ -105,7 +105,7 @@ const passRateClass = computed(() => {
               class="text-sm text-gray-500"
             />
             <UBadge v-if="testCase?.project" color="neutral" variant="soft" size="xs" class="font-mono">
-              {{ testCase.project.name }}
+              {{ testCase.project.label ?? testCase.project.name }}
             </UBadge>
 
             <TestMetaBadges

--- a/apps/application/app/pages/test-run-cases/[id].vue
+++ b/apps/application/app/pages/test-run-cases/[id].vue
@@ -528,7 +528,7 @@ const { handle: handleNextStepAction } = useNextStepActions({
               ...(testCase?.testRun?.project?.id
                 ? [
                     {
-                      label: testCase.testRun.project.name || 'Project',
+                      label: testCase.testRun.project.label || testCase.testRun.project.name || 'Project',
                       to: `/projects/${testCase.testRun.project.id}`,
                     },
                   ]

--- a/apps/application/package.json
+++ b/apps/application/package.json
@@ -56,6 +56,7 @@
     "@nuxt/ui": "^4.10.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vueuse/nuxt": "^14.1.0",
+    "busboy": "^1.6.0",
     "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.0",
     "fflate": "^0.8.2",
@@ -74,6 +75,7 @@
   "devDependencies": {
     "@iconify-json/simple-icons": "^1.2.93",
     "@playwright/test": "^1.63.0",
+    "@types/busboy": "^1.5.4",
     "@types/nodemailer": "^8.0.1",
     "@types/sql.js": "^1.4.11",
     "cross-env": "^10.1.0",

--- a/apps/application/server/api/test-runs/[id]/case-files.post.ts
+++ b/apps/application/server/api/test-runs/[id]/case-files.post.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { getDatabase } from '../../../database';
 import { testRuns, testCases, testRunsCases, files } from '../../../database/schema';
 import { eq, and, desc } from 'drizzle-orm';
@@ -10,6 +11,9 @@ import { deriveTraceEvidence } from '../../../utils/trace-fallback-evidence';
 import { getStorage } from '../../../storage';
 import { joinSuitePath } from '#shared/utils/suites';
 import { sanitizeFilename } from '../../../utils/sanitize-filename';
+import { streamMultipart } from '../../../utils/multipart-stream';
+import { resolveMaxUploadBytes } from '../../../utils/upload-limits';
+import { formatBytes } from '#shared/utils/format-bytes';
 
 defineRouteMeta({
   openAPI: {
@@ -49,62 +53,63 @@ export default eventHandler(async (event) => {
     });
   }
 
-  const formData = await readMultipartFormData(event);
-
-  if (!formData) {
-    throw apiError({
-      statusCode: 400,
-      message: 'No form data provided',
-    });
+  const maxUploadBytes = resolveMaxUploadBytes();
+  const contentLength = parseInt(getRequestHeader(event, 'content-length') ?? '0', 10);
+  if (contentLength > maxUploadBytes) {
+    throw apiError({ statusCode: 413, message: `Upload too large (max ${formatBytes(maxUploadBytes)})` });
   }
 
-  let streamToken: string | undefined;
-  let caseInfo: { title?: string; location?: string; retries?: number; suitePath?: string[] | null } | undefined;
-  let traceFile: { filename: string; data: Buffer } | undefined;
-  let traceHash: string | undefined;
-  let attachmentMeta: { name: string; contentType: string; originalName: string }[] = [];
-  const attachmentFiles: { originalName: string; data: Buffer }[] = [];
+  // Stream the request to temp files so a large trace never sits in the heap for
+  // the whole transfer; the file parts are read back one at a time below and the
+  // temp directory is removed in the `finally`.
+  const multipart = await streamMultipart(event, { maxTotalBytes: maxUploadBytes });
+  try {
+    return await handleCaseFiles(id, multipart);
+  } finally {
+    await multipart.cleanup();
+  }
+});
 
-  for (const part of formData) {
-    if (part.name === 'streamToken') {
-      streamToken = part.data.toString('utf-8');
-    } else if (part.name === 'testCase') {
-      try {
-        caseInfo = JSON.parse(part.data.toString('utf-8'));
-      } catch {
-        throw apiError({
-          statusCode: 400,
-          message: 'Invalid JSON in testCase field',
-        });
-      }
-    } else if (part.name === 'trace' && part.filename) {
-      traceFile = {
-        filename: sanitizeFilename(part.filename),
-        data: part.data,
-      };
-    } else if (part.name === 'trace_hash') {
-      const hash = part.data.toString('utf-8');
-      if (/^[0-9a-f]{64}$/i.test(hash)) traceHash = hash.toLowerCase();
-    } else if (part.name === 'attach_meta') {
-      try {
-        const parsed = JSON.parse(part.data.toString('utf-8'));
-        if (Array.isArray(parsed)) {
-          attachmentMeta = parsed.map((a: Record<string, unknown>) => ({
-            name: String(a.name || 'attachment'),
-            contentType: String(a.contentType || 'application/octet-stream'),
-            originalName: String(a.originalName || 'attachment'),
-          }));
-        }
-      } catch {
-        // Metadata is optional; ignore parse errors
-      }
-    } else if (part.name === 'attach_file' && part.filename) {
-      attachmentFiles.push({
-        originalName: sanitizeFilename(part.filename),
-        data: part.data,
-      });
+async function handleCaseFiles(
+  id: number,
+  multipart: Awaited<ReturnType<typeof streamMultipart>>,
+): Promise<{ success: boolean; executionId: number; traces: number; attachments: number }> {
+  const { fields } = multipart;
+
+  const streamToken = fields.get('streamToken');
+  let caseInfo: { title?: string; location?: string; retries?: number; suitePath?: string[] | null } | undefined;
+  const rawCase = fields.get('testCase');
+  if (rawCase !== undefined) {
+    try {
+      caseInfo = JSON.parse(rawCase);
+    } catch {
+      throw apiError({ statusCode: 400, message: 'Invalid JSON in testCase field' });
     }
   }
+
+  const rawHash = fields.get('trace_hash');
+  const traceHash = rawHash && /^[0-9a-f]{64}$/i.test(rawHash) ? rawHash.toLowerCase() : undefined;
+
+  let attachmentMeta: { name: string; contentType: string; originalName: string }[] = [];
+  const rawAttachMeta = fields.get('attach_meta');
+  if (rawAttachMeta !== undefined) {
+    try {
+      const parsed = JSON.parse(rawAttachMeta);
+      if (Array.isArray(parsed)) {
+        attachmentMeta = parsed.map((a: Record<string, unknown>) => ({
+          name: String(a.name || 'attachment'),
+          contentType: String(a.contentType || 'application/octet-stream'),
+          originalName: String(a.originalName || 'attachment'),
+        }));
+      }
+    } catch {
+      // Metadata is optional; ignore parse errors
+    }
+  }
+
+  // The trace part (at most one) and the attachment parts, streamed to temp files.
+  const traceStreamed = multipart.files.find((f) => f.field === 'trace');
+  const attachmentStreamed = multipart.files.filter((f) => f.field === 'attach_file');
 
   if (!streamToken) {
     throw apiError({
@@ -198,18 +203,20 @@ export default eventHandler(async (event) => {
   let storedAttachments = 0;
 
   // --- Trace ---
-  if ((traceFile || traceHash) && !hasTrace) {
+  if ((traceStreamed || traceHash) && !hasTrace) {
     try {
       let storagePath: string;
       let blobId: number | null = null;
       let size: number | null = null;
 
-      if (traceHash && traceFile) {
-        const blob = await upsertTraceBlob(testRun.projectId, traceHash, traceFile.data);
+      if (traceHash && traceStreamed) {
+        // Read the streamed trace into memory only now, for the one call that
+        // parses it; the buffer is released as soon as the blob is stored.
+        const blob = await upsertTraceBlob(testRun.projectId, traceHash, await readFile(traceStreamed.path));
         storagePath = blob.path;
         blobId = blob.id;
         size = blob.size;
-      } else if (traceHash && !traceFile) {
+      } else if (traceHash && !traceStreamed) {
         // Reporter said this blob already exists on the server — look it up
         const blob = await findTraceBlob(testRun.projectId, traceHash);
         if (!blob) {
@@ -224,9 +231,9 @@ export default eventHandler(async (event) => {
       } else {
         // No hash metadata — store at the run-specific location
         await storage.mkdir(testRunPath);
-        storagePath = `${testRunPath}/${runCase.id}-${traceFile!.filename}`;
-        await storage.writeFile(storagePath, traceFile!.data);
-        size = traceFile!.data.length;
+        storagePath = `${testRunPath}/${runCase.id}-${sanitizeFilename(traceStreamed!.filename)}`;
+        await storage.writeFile(storagePath, await readFile(traceStreamed!.path));
+        size = traceStreamed!.size;
       }
 
       const normalizedPath = storagePath.replace(/\\/g, '/');
@@ -250,19 +257,20 @@ export default eventHandler(async (event) => {
   }
 
   // --- Attachments ---
-  if (attachmentMeta.length > 0 && attachmentFiles.length > 0) {
+  if (attachmentMeta.length > 0 && attachmentStreamed.length > 0) {
     const attachmentDir = `${testRunPath}/${runCase.id}`;
     await storage.mkdir(attachmentDir);
 
-    for (let fi = 0; fi < Math.min(attachmentMeta.length, attachmentFiles.length); fi++) {
+    for (let fi = 0; fi < Math.min(attachmentMeta.length, attachmentStreamed.length); fi++) {
       const meta = attachmentMeta[fi]!;
-      const fileEntry = attachmentFiles[fi]!;
-      const storagePath = `${attachmentDir}/${fileEntry.originalName}`.replace(/\\/g, '/');
+      const fileEntry = attachmentStreamed[fi]!;
+      const originalName = sanitizeFilename(fileEntry.filename);
+      const storagePath = `${attachmentDir}/${originalName}`.replace(/\\/g, '/');
 
       if (existingPaths.has(storagePath)) continue;
 
       try {
-        await storage.writeFile(storagePath, fileEntry.data);
+        await storage.writeFile(storagePath, await readFile(fileEntry.path));
         await db.insert(files).values({
           testRunsCaseId: runCase.id,
           testRunId: id,
@@ -270,7 +278,7 @@ export default eventHandler(async (event) => {
           subtype: meta.name,
           label: meta.contentType,
           path: storagePath,
-          size: fileEntry.data.length,
+          size: fileEntry.size,
         });
         existingPaths.add(storagePath);
         storedAttachments++;
@@ -315,4 +323,4 @@ export default eventHandler(async (event) => {
     traces: storedTraces,
     attachments: storedAttachments,
   };
-});
+}

--- a/apps/application/server/api/test-runs/upload.post.ts
+++ b/apps/application/server/api/test-runs/upload.post.ts
@@ -324,26 +324,24 @@ export default eventHandler(async (event) => {
     }
   }
 
-  // Store all reports and collect their metadata
+  // Store all reports and collect their metadata. Reports are processed one at a
+  // time — each `.gz` report is inflated fully into memory before being written
+  // to disk, so decompressing them in parallel would stack every report's peak
+  // at once. Each report buffer is dropped from the map as soon as it's stored.
   const storedReports: { type: string; label: string; path: string; size: number }[] = [];
 
-  const reportResults = await Promise.all(
-    [...reportFiles.entries()].map(async ([type, report]) => {
-      try {
-        console.log(`[Upload] Storing ${type} report: ${report.filename}`);
-        const { path: storedPath, size } = await storeReport(type, report);
-        const label = getReportLabel(type, report.label);
-        console.log(`[Upload] Stored ${type} report at ${storedPath} (${size} bytes)`);
-        return { type, label, path: storedPath, size };
-      } catch (error) {
-        console.error(`[Upload] Failed to store ${type} report: ${error}`);
-        return null;
-      }
-    }),
-  );
-
-  for (const r of reportResults) {
-    if (r) storedReports.push(r);
+  for (const [type, report] of [...reportFiles.entries()]) {
+    try {
+      console.log(`[Upload] Storing ${type} report: ${report.filename}`);
+      const { path: storedPath, size } = await storeReport(type, report);
+      const label = getReportLabel(type, report.label);
+      console.log(`[Upload] Stored ${type} report at ${storedPath} (${size} bytes)`);
+      storedReports.push({ type, label, path: storedPath, size });
+    } catch (error) {
+      console.error(`[Upload] Failed to store ${type} report: ${error}`);
+    } finally {
+      reportFiles.delete(type);
+    }
   }
 
   // Create or retrieve the test run
@@ -591,6 +589,10 @@ export default eventHandler(async (event) => {
           tracedCaseIds.push(testRunsCaseId);
         } catch (error) {
           console.error(`[Upload] Failed to store trace for case #${testRunsCaseId}: ${error}`);
+        } finally {
+          // Drop the (large) trace buffer once stored so peak memory holds one
+          // trace at a time rather than every uploaded trace at once.
+          traceFiles.delete(index);
         }
       }
     }

--- a/apps/application/server/utils/multipart-stream.ts
+++ b/apps/application/server/utils/multipart-stream.ts
@@ -1,0 +1,163 @@
+import busboy from 'busboy';
+import type { H3Event } from 'h3';
+import { randomBytes } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+/**
+ * A file part of a multipart request, streamed straight to a temp file on disk
+ * rather than buffered in memory. `path` is an absolute path the caller reads
+ * (or moves) and then discards via {@link StreamedMultipart.cleanup}.
+ */
+export interface StreamedFile {
+  /** Multipart field name (e.g. `trace`, `attach_file`). */
+  field: string;
+  /** Filename as sent by the client — unsanitized; sanitize before using it in a storage path. */
+  filename: string;
+  /** Absolute path of the temp file the part was streamed to. */
+  path: string;
+  /** Bytes written to disk. */
+  size: number;
+  /** Declared MIME type. */
+  mimeType: string;
+}
+
+export interface StreamedMultipart {
+  /** Non-file fields; last value wins for a repeated name. */
+  fields: Map<string, string>;
+  /** File parts streamed to temp files, in arrival order. */
+  files: StreamedFile[];
+  /** Remove the temp directory and every streamed file. Always call it in a `finally`. */
+  cleanup: () => Promise<void>;
+}
+
+export interface StreamMultipartOptions {
+  /** Reject once the bytes written across all file parts exceed this. */
+  maxTotalBytes: number;
+  /** Cap on a single non-file field value (default 1 MiB). */
+  maxFieldBytes?: number;
+  /** Cap on the number of file parts (default 500). */
+  maxFiles?: number;
+}
+
+const DEFAULT_MAX_FIELD_BYTES = 1024 * 1024; // 1 MiB
+const DEFAULT_MAX_FILES = 500;
+
+/**
+ * Parse a `multipart/form-data` request as a stream: file parts are written to
+ * temp files as they arrive and small value fields are kept in memory, so a
+ * large upload (a trace ZIP) never sits in the heap for the whole transfer the
+ * way `readMultipartFormData` — which buffers the entire raw body and then every
+ * parsed part — does. The peak the parser holds is one filesystem chunk, not the
+ * upload; the bytes live on disk until the caller reads them one at a time.
+ *
+ * The per-file size cap is `maxTotalBytes`; a part that exceeds it, a field over
+ * `maxFieldBytes`, or more than `maxFiles` parts rejects the whole request. Temp
+ * files are removed on any failure, and the caller removes them on success via
+ * the returned `cleanup`.
+ */
+export async function streamMultipart(event: H3Event, options: StreamMultipartOptions): Promise<StreamedMultipart> {
+  const req = event.node.req;
+  const contentType = req.headers['content-type'] ?? '';
+  if (!contentType.toLowerCase().includes('multipart/form-data')) {
+    throw apiError({ statusCode: 400, message: 'Expected multipart/form-data' });
+  }
+
+  const maxFieldBytes = options.maxFieldBytes ?? DEFAULT_MAX_FIELD_BYTES;
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+
+  const dir = await mkdtemp(join(tmpdir(), 'piwi-upload-'));
+  const cleanup = () => rm(dir, { recursive: true, force: true });
+
+  const fields = new Map<string, string>();
+  const files: StreamedFile[] = [];
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const fail = (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        req.unpipe(bb);
+        req.resume(); // drain the rest so the socket doesn't hang
+        reject(error);
+      };
+      const succeed = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+
+      let bb: ReturnType<typeof busboy>;
+      try {
+        bb = busboy({
+          headers: req.headers,
+          limits: { fileSize: options.maxTotalBytes, fieldSize: maxFieldBytes, files: maxFiles },
+        });
+      } catch {
+        fail(apiError({ statusCode: 400, message: 'Malformed multipart request' }));
+        return;
+      }
+
+      const fileWrites: Promise<void>[] = [];
+      let totalBytes = 0;
+
+      bb.on('file', (field: string, stream: NodeJS.ReadableStream, info: busboy.FileInfo) => {
+        // A part with no filename is not a file upload — drain it so busboy can proceed.
+        if (!info.filename) {
+          stream.resume();
+          return;
+        }
+        const tmpPath = join(dir, `${randomBytes(8).toString('hex')}`);
+        let truncated = false;
+        stream.on('limit', () => {
+          truncated = true;
+        });
+        const ws = createWriteStream(tmpPath);
+        fileWrites.push(
+          pipeline(stream, ws).then(() => {
+            if (truncated) throw apiError({ statusCode: 413, message: 'A file part exceeded the upload limit' });
+            totalBytes += ws.bytesWritten;
+            if (totalBytes > options.maxTotalBytes) {
+              throw apiError({ statusCode: 413, message: 'Upload exceeded the size limit' });
+            }
+            files.push({
+              field,
+              filename: info.filename,
+              path: tmpPath,
+              size: ws.bytesWritten,
+              mimeType: info.mimeType,
+            });
+          }),
+        );
+      });
+
+      bb.on('field', (name: string, value: string, info: busboy.FieldInfo) => {
+        if (info.valueTruncated) {
+          fail(apiError({ statusCode: 413, message: `Field "${name}" exceeded the size limit` }));
+          return;
+        }
+        fields.set(name, value);
+      });
+
+      bb.on('filesLimit', () => fail(apiError({ statusCode: 413, message: 'Too many file parts' })));
+      bb.on('error', fail);
+      bb.on('close', () => {
+        // busboy has finished parsing; wait for the in-flight file writes to flush.
+        Promise.all(fileWrites).then(succeed, fail);
+      });
+
+      req.on('aborted', () => fail(apiError({ statusCode: 400, message: 'Request aborted' })));
+      req.on('error', fail);
+      req.pipe(bb);
+    });
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+
+  return { fields, files, cleanup };
+}

--- a/apps/application/server/utils/trace-blobs.ts
+++ b/apps/application/server/utils/trace-blobs.ts
@@ -103,7 +103,7 @@ export async function upsertTraceBlob(
       }
 
       // 4. Decompress event entries for the slim ZIP (these are small text-based files)
-      const eventEntries: ZipEntry[] = [];
+      let eventEntries: ZipEntry[] = [];
       for (const meta of eventMetas) {
         try {
           eventEntries.push({ name: meta.name, data: await decompressEntry(data, meta) });
@@ -116,6 +116,9 @@ export async function upsertTraceBlob(
       const resourceNames = names;
 
       const slimZip = buildZip(eventEntries);
+      // Release the decompressed event buffers now that they're fused into the
+      // slim ZIP, so the manifest write and blob write below don't hold both.
+      eventEntries = [];
       const manifestJson = Buffer.from(JSON.stringify({ resources: resourceNames }), 'utf8');
 
       dataToStore = slimZip;

--- a/apps/application/server/utils/trace-evidence.ts
+++ b/apps/application/server/utils/trace-evidence.ts
@@ -9,7 +9,7 @@ import { and, eq } from 'drizzle-orm';
 import { files } from '../database/schema';
 import { getStorage } from '../storage';
 import { ariaJsonToText } from '#shared/aria-json';
-import { parseZip, type ZipEntry } from './trace-zip';
+import { parseZip, parseZipDirectory, decompressEntry, type ZipEntry } from './trace-zip';
 import { parseTraceTexts, traceFileRank, type ParsedTraceData } from './trace-events';
 import {
   buildActionCallsites,
@@ -152,11 +152,45 @@ export interface TraceEvidenceStreams {
  * Load a stored trace and return just its event stream and network snapshots —
  * the two inputs the fallback derivation reads to recover console entries and
  * the request list when the capture fixtures were absent.
+ *
+ * Only the `.trace` and `.network` entries are inflated; decompressing the
+ * blob's inline screenshots and aria snapshots (which this derivation never
+ * reads) would hold every image in memory at once during ingestion.
  */
 export async function loadTraceEvidenceStreams(blobPath: string): Promise<TraceEvidenceStreams | null> {
-  const bundle = await loadTraceBundle(blobPath);
-  if (!bundle) return null;
-  return { parsed: bundle.parsed, network: bundle.network };
+  const storage = getStorage();
+  let data: Buffer;
+  let metas: ReturnType<typeof parseZipDirectory>;
+  try {
+    data = await storage.readFile(blobPath);
+    metas = parseZipDirectory(data);
+  } catch {
+    return null;
+  }
+
+  const traceTexts: string[] = [];
+  for (const meta of metas
+    .filter((m) => m.name.endsWith('.trace'))
+    .sort((a, b) => traceFileRank(a.name) - traceFileRank(b.name))) {
+    try {
+      traceTexts.push((await decompressEntry(data, meta)).toString('utf8'));
+    } catch {
+      // Skip a corrupt entry rather than fail the whole derivation.
+    }
+  }
+
+  const networkTexts: string[] = [];
+  for (const meta of metas.filter((m) => m.name.endsWith('.network'))) {
+    try {
+      networkTexts.push((await decompressEntry(data, meta)).toString('utf8'));
+    } catch {
+      // Skip a corrupt entry.
+    }
+  }
+
+  const parsed = traceTexts.length > 0 ? parseTraceTexts(traceTexts) : null;
+  const network = networkTexts.length > 0 ? parseNetworkTexts(networkTexts) : [];
+  return { parsed, network };
 }
 
 /** Full call stack of the failing action, with embedded source when the trace carries it. */

--- a/apps/application/server/utils/trace-zip.ts
+++ b/apps/application/server/utils/trace-zip.ts
@@ -14,6 +14,16 @@ const inflateRawAsync = promisify(inflateRaw);
  */
 const MAX_ENTRY_BYTES = 512 * 1024 * 1024; // 512 MiB
 
+/**
+ * Upper bound on the total size of a ZIP produced by {@link buildZip}. The
+ * output length is the sum of every entry's decompressed data, so a corrupt or
+ * hostile archive whose entries expand to gigabytes would drive a single
+ * unbounded allocation and OOM-kill the process. 1 GiB comfortably exceeds any
+ * real trace (event streams plus a fully reconstructed resource pool) while
+ * turning a bogus total into a thrown error the caller can recover from.
+ */
+const MAX_ZIP_BYTES = 1024 * 1024 * 1024; // 1 GiB
+
 export interface ZipEntry {
   name: string;
   data: Buffer;
@@ -89,6 +99,7 @@ export function parseZipDirectory(data: Buffer): ZipEntryMeta[] {
 
   const entryCount = data.readUInt16LE(eocdOffset + 10);
   const cdOffset = data.readUInt32LE(eocdOffset + 16);
+  if (cdOffset > data.length) throw new Error('Invalid central directory offset');
 
   const metas: ZipEntryMeta[] = [];
   let pos = cdOffset;
@@ -162,69 +173,92 @@ export async function parseZip(data: Buffer): Promise<ZipEntry[]> {
  * This is appropriate for trace event entries which are small text-based files.
  */
 export function buildZip(entries: ZipEntry[]): Buffer {
-  const localParts: Buffer[] = [];
-  const cdParts: Buffer[] = [];
-  let offset = 0;
+  const nameBuffers = entries.map((entry) => Buffer.from(entry.name, 'utf8'));
 
-  for (const entry of entries) {
-    const nameBytes = Buffer.from(entry.name, 'utf8');
-    const size = entry.data.length;
-    const crc = crc32(entry.data);
-
-    // Local file header (30 bytes + filename)
-    const local = Buffer.alloc(30 + nameBytes.length);
-    local.writeUInt32LE(0x04034b50, 0); // signature
-    local.writeUInt16LE(20, 4); // version needed (2.0)
-    local.writeUInt16LE(0, 6); // flags
-    local.writeUInt16LE(0, 8); // method: stored
-    local.writeUInt16LE(0, 10); // mod time
-    local.writeUInt16LE(0, 12); // mod date
-    local.writeUInt32LE(crc, 14); // crc-32
-    local.writeUInt32LE(size, 18); // compressed size
-    local.writeUInt32LE(size, 22); // uncompressed size
-    local.writeUInt16LE(nameBytes.length, 26); // filename length
-    local.writeUInt16LE(0, 28); // extra field length
-    nameBytes.copy(local, 30);
-
-    // Central directory file header (46 bytes + filename)
-    const cd = Buffer.alloc(46 + nameBytes.length);
-    cd.writeUInt32LE(0x02014b50, 0); // signature
-    cd.writeUInt16LE(20, 4); // version made by
-    cd.writeUInt16LE(20, 6); // version needed
-    cd.writeUInt16LE(0, 8); // flags
-    cd.writeUInt16LE(0, 10); // method: stored
-    cd.writeUInt16LE(0, 12); // mod time
-    cd.writeUInt16LE(0, 14); // mod date
-    cd.writeUInt32LE(crc, 16); // crc-32
-    cd.writeUInt32LE(size, 20); // compressed size
-    cd.writeUInt32LE(size, 24); // uncompressed size
-    cd.writeUInt16LE(nameBytes.length, 28); // filename length
-    cd.writeUInt16LE(0, 30); // extra field length
-    cd.writeUInt16LE(0, 32); // file comment length
-    cd.writeUInt16LE(0, 34); // disk number start
-    cd.writeUInt16LE(0, 36); // internal file attributes
-    cd.writeUInt32LE(0, 38); // external file attributes
-    cd.writeUInt32LE(offset, 42); // relative offset of local header
-    nameBytes.copy(cd, 46);
-
-    localParts.push(local, entry.data);
-    cdParts.push(cd);
-    offset += 30 + nameBytes.length + size;
+  // Size the output in one pass, validating each entry against the cap first, so
+  // a length derived from decompressed data that is negative, non-integer or
+  // beyond the cap fails here rather than driving an unbounded allocation.
+  let total = 22; // EOCD
+  for (let i = 0; i < entries.length; i++) {
+    const size = entries[i]!.data.length;
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new Error(`Invalid entry size for "${entries[i]!.name}"`);
+    }
+    total += 30 + nameBuffers[i]!.length + size + 46 + nameBuffers[i]!.length;
+    if (total > MAX_ZIP_BYTES) throw new Error(`ZIP exceeds ${MAX_ZIP_BYTES} bytes`);
   }
 
-  const cdBuf = Buffer.concat(cdParts);
-  const entryCount16 = Math.min(entries.length, 0xffff);
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0); // signature
-  eocd.writeUInt16LE(0, 4); // disk number
-  eocd.writeUInt16LE(0, 6); // disk with central directory
-  eocd.writeUInt16LE(entryCount16, 8); // entries on this disk
-  eocd.writeUInt16LE(entryCount16, 10); // total entries
-  eocd.writeUInt32LE(cdBuf.length, 12); // central directory size
-  eocd.writeUInt32LE(offset, 16); // central directory offset
-  eocd.writeUInt16LE(0, 20); // comment length
+  const out = Buffer.allocUnsafe(total);
+  const localOffsets: number[] = [];
+  const crcs: number[] = [];
+  let pos = 0;
 
-  return Buffer.concat([...localParts, cdBuf, eocd]);
+  // Local file headers (30 bytes + filename) followed by the stored data.
+  for (let i = 0; i < entries.length; i++) {
+    const nameBytes = nameBuffers[i]!;
+    const data = entries[i]!.data;
+    const size = data.length;
+    const crc = crc32(data);
+    crcs.push(crc);
+    localOffsets.push(pos);
+
+    out.writeUInt32LE(0x04034b50, pos); // signature
+    out.writeUInt16LE(20, pos + 4); // version needed (2.0)
+    out.writeUInt16LE(0, pos + 6); // flags
+    out.writeUInt16LE(0, pos + 8); // method: stored
+    out.writeUInt16LE(0, pos + 10); // mod time
+    out.writeUInt16LE(0, pos + 12); // mod date
+    out.writeUInt32LE(crc, pos + 14); // crc-32
+    out.writeUInt32LE(size, pos + 18); // compressed size
+    out.writeUInt32LE(size, pos + 22); // uncompressed size
+    out.writeUInt16LE(nameBytes.length, pos + 26); // filename length
+    out.writeUInt16LE(0, pos + 28); // extra field length
+    nameBytes.copy(out, pos + 30);
+    pos += 30 + nameBytes.length;
+    data.copy(out, pos);
+    pos += size;
+  }
+
+  // Central directory file headers (46 bytes + filename).
+  const cdStart = pos;
+  for (let i = 0; i < entries.length; i++) {
+    const nameBytes = nameBuffers[i]!;
+    const size = entries[i]!.data.length;
+
+    out.writeUInt32LE(0x02014b50, pos); // signature
+    out.writeUInt16LE(20, pos + 4); // version made by
+    out.writeUInt16LE(20, pos + 6); // version needed
+    out.writeUInt16LE(0, pos + 8); // flags
+    out.writeUInt16LE(0, pos + 10); // method: stored
+    out.writeUInt16LE(0, pos + 12); // mod time
+    out.writeUInt16LE(0, pos + 14); // mod date
+    out.writeUInt32LE(crcs[i]!, pos + 16); // crc-32
+    out.writeUInt32LE(size, pos + 20); // compressed size
+    out.writeUInt32LE(size, pos + 24); // uncompressed size
+    out.writeUInt16LE(nameBytes.length, pos + 28); // filename length
+    out.writeUInt16LE(0, pos + 30); // extra field length
+    out.writeUInt16LE(0, pos + 32); // file comment length
+    out.writeUInt16LE(0, pos + 34); // disk number start
+    out.writeUInt16LE(0, pos + 36); // internal file attributes
+    out.writeUInt32LE(0, pos + 38); // external file attributes
+    out.writeUInt32LE(localOffsets[i]!, pos + 42); // relative offset of local header
+    nameBytes.copy(out, pos + 46);
+    pos += 46 + nameBytes.length;
+  }
+  const cdSize = pos - cdStart;
+
+  // End of central directory record (22 bytes).
+  const entryCount16 = Math.min(entries.length, 0xffff);
+  out.writeUInt32LE(0x06054b50, pos); // signature
+  out.writeUInt16LE(0, pos + 4); // disk number
+  out.writeUInt16LE(0, pos + 6); // disk with central directory
+  out.writeUInt16LE(entryCount16, pos + 8); // entries on this disk
+  out.writeUInt16LE(entryCount16, pos + 10); // total entries
+  out.writeUInt32LE(cdSize, pos + 12); // central directory size
+  out.writeUInt32LE(cdStart, pos + 16); // central directory offset
+  out.writeUInt16LE(0, pos + 20); // comment length
+
+  return out;
 }
 
 /**

--- a/apps/application/tests/unit/multipart-stream.test.ts
+++ b/apps/application/tests/unit/multipart-stream.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeAll, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { readFileSync, existsSync } from 'node:fs';
+import { streamMultipart, type StreamedMultipart } from '../../server/utils/multipart-stream';
+
+// `apiError` is a Nitro auto-import in the running server; the util resolves it
+// from the global scope at call time, so provide an equivalent for the tests.
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).apiError = (input: { statusCode: number; message: string }) =>
+    Object.assign(new Error(input.message), { statusCode: input.statusCode });
+});
+
+const BOUNDARY = 'testboundary1234';
+
+interface Part {
+  name: string;
+  value?: string;
+  filename?: string;
+  data?: Buffer;
+  contentType?: string;
+}
+
+function buildMultipart(parts: Part[]): Buffer {
+  const chunks: Buffer[] = [];
+  for (const p of parts) {
+    let head = `--${BOUNDARY}\r\nContent-Disposition: form-data; name="${p.name}"`;
+    if (p.filename !== undefined) head += `; filename="${p.filename}"`;
+    head += '\r\n';
+    if (p.contentType) head += `Content-Type: ${p.contentType}\r\n`;
+    head += '\r\n';
+    chunks.push(Buffer.from(head, 'utf8'));
+    chunks.push(p.data ?? Buffer.from(p.value ?? '', 'utf8'));
+    chunks.push(Buffer.from('\r\n', 'utf8'));
+  }
+  chunks.push(Buffer.from(`--${BOUNDARY}--\r\n`, 'utf8'));
+  return Buffer.concat(chunks);
+}
+
+function makeEvent(body: Buffer, contentType = `multipart/form-data; boundary=${BOUNDARY}`) {
+  const req = new PassThrough() as PassThrough & { headers: Record<string, string> };
+  req.headers = { 'content-type': contentType };
+  req.end(body);
+  return { node: { req } } as never;
+}
+
+let last: StreamedMultipart | null = null;
+afterEach(async () => {
+  if (last) await last.cleanup();
+  last = null;
+});
+
+describe('streamMultipart', () => {
+  test('streams value fields to memory and file parts to disk', async () => {
+    const traceBytes = Buffer.from(Array.from({ length: 4096 }, (_, i) => i % 256));
+    const body = buildMultipart([
+      { name: 'streamToken', value: 'tok-123' },
+      { name: 'testCase', value: '{"title":"t"}' },
+      { name: 'trace', filename: 'trace.zip', data: traceBytes, contentType: 'application/zip' },
+      { name: 'attach_file', filename: 'shot.png', data: Buffer.from('png-bytes'), contentType: 'image/png' },
+    ]);
+
+    const result = (last = await streamMultipart(makeEvent(body), { maxTotalBytes: 1024 * 1024 }));
+
+    expect(result.fields.get('streamToken')).toBe('tok-123');
+    expect(result.fields.get('testCase')).toBe('{"title":"t"}');
+
+    const trace = result.files.find((f) => f.field === 'trace');
+    expect(trace).toBeDefined();
+    expect(trace!.filename).toBe('trace.zip');
+    expect(trace!.size).toBe(traceBytes.length);
+    expect(readFileSync(trace!.path).equals(traceBytes)).toBe(true);
+
+    const attach = result.files.find((f) => f.field === 'attach_file');
+    expect(attach).toBeDefined();
+    expect(readFileSync(attach!.path).toString()).toBe('png-bytes');
+  });
+
+  test('cleanup removes every streamed temp file', async () => {
+    const body = buildMultipart([{ name: 'trace', filename: 'trace.zip', data: Buffer.from('abc') }]);
+    const result = await streamMultipart(makeEvent(body), { maxTotalBytes: 1024 });
+    const path = result.files[0]!.path;
+    expect(existsSync(path)).toBe(true);
+    await result.cleanup();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test('rejects and cleans up when a file exceeds the total cap', async () => {
+    const body = buildMultipart([{ name: 'trace', filename: 'big.zip', data: Buffer.alloc(2048, 1) }]);
+    await expect(streamMultipart(makeEvent(body), { maxTotalBytes: 512 })).rejects.toMatchObject({
+      statusCode: 413,
+    });
+  });
+
+  test('rejects a non-multipart request', async () => {
+    await expect(
+      streamMultipart(makeEvent(Buffer.from('{}'), 'application/json'), { maxTotalBytes: 1024 }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  test('keeps multiple attachment parts in arrival order', async () => {
+    const body = buildMultipart([
+      { name: 'attach_file', filename: 'a.txt', data: Buffer.from('A') },
+      { name: 'attach_file', filename: 'b.txt', data: Buffer.from('B') },
+    ]);
+    const result = (last = await streamMultipart(makeEvent(body), { maxTotalBytes: 1024 }));
+    const attachments = result.files.filter((f) => f.field === 'attach_file');
+    expect(attachments.map((a) => a.filename)).toEqual(['a.txt', 'b.txt']);
+    expect(readFileSync(attachments[0]!.path).toString()).toBe('A');
+    expect(readFileSync(attachments[1]!.path).toString()).toBe('B');
+  });
+});

--- a/apps/application/tests/unit/trace-zip.test.ts
+++ b/apps/application/tests/unit/trace-zip.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest';
+import { buildZip, parseZipSync, parseZipDirectory } from '../../server/utils/trace-zip';
+
+describe('buildZip / parseZipSync round-trip', () => {
+  test('stores and recovers every entry unchanged', () => {
+    const entries = [
+      { name: 'trace.trace', data: Buffer.from('{"type":"context"}\n') },
+      { name: 'trace.network', data: Buffer.from('{"type":"network"}\n') },
+      { name: 'resources/abc.bin', data: Buffer.from(Array.from({ length: 256 }, (_, i) => i)) },
+    ];
+    const parsed = parseZipSync(buildZip(entries));
+    expect(parsed).toHaveLength(3);
+    for (const orig of entries) {
+      const found = parsed.find((e) => e.name === orig.name);
+      expect(found?.data.equals(orig.data)).toBe(true);
+    }
+  });
+
+  test('round-trips several larger entries', () => {
+    const large = Buffer.alloc(128 * 1024, 0x42);
+    const parsed = parseZipSync(
+      buildZip([
+        { name: 'big1.dat', data: large },
+        { name: 'big2.dat', data: large },
+      ]),
+    );
+    expect(parsed).toHaveLength(2);
+    for (const e of parsed) expect(e.data.equals(large)).toBe(true);
+  });
+
+  test('produces a valid empty archive', () => {
+    expect(parseZipSync(buildZip([]))).toHaveLength(0);
+  });
+});
+
+describe('buildZip bounded allocation', () => {
+  test('rejects an entry whose size exceeds the cap without allocating it', () => {
+    // A length taken from (hostile or corrupt) data that would drive a
+    // multi-gigabyte allocation must be refused before any buffer is built.
+    const oversized = { name: 'huge.bin', data: { length: 2 * 1024 * 1024 * 1024 } as unknown as Buffer };
+    expect(() => buildZip([oversized])).toThrow();
+  });
+
+  test('rejects a negative or non-integer entry size', () => {
+    expect(() => buildZip([{ name: 'bad.bin', data: { length: -1 } as unknown as Buffer }])).toThrow();
+    expect(() => buildZip([{ name: 'bad.bin', data: { length: 1.5 } as unknown as Buffer }])).toThrow();
+  });
+});
+
+describe('parseZip corrupt / oversized fields', () => {
+  test('throws cleanly on data that is not a ZIP', () => {
+    expect(() => parseZipSync(Buffer.from('definitely not a zip'))).toThrow();
+    expect(() => parseZipSync(Buffer.alloc(0))).toThrow();
+  });
+
+  test('throws on a truncated archive rather than reading past the buffer', () => {
+    const zip = buildZip([{ name: 'a.txt', data: Buffer.from('hello world') }]);
+    // Drop the central directory + EOCD so the directory parse cannot complete.
+    const truncated = zip.subarray(0, 20);
+    expect(() => parseZipDirectory(truncated)).toThrow();
+  });
+
+  test('skips an entry whose declared size runs past the buffer, keeping valid entries', () => {
+    const zip = buildZip([
+      { name: 'corrupt.dat', data: Buffer.from('AAAA') },
+      { name: 'good.dat', data: Buffer.from('BBBB') },
+    ]);
+
+    // Overwrite the first central-directory entry's compressed-size field with a
+    // value far larger than the archive. A naive parser would try to slice that
+    // many bytes; the guard must skip the entry instead.
+    const eocdOffset = zip.length - 22;
+    const cdOffset = zip.readUInt32LE(eocdOffset + 16);
+    expect(zip.readUInt32LE(cdOffset)).toBe(0x02014b50); // central-directory signature
+    zip.writeUInt32LE(0xfffffff0, cdOffset + 20); // compressed size
+
+    // The directory still parses (the field is not bounds-checked there)…
+    const metas = parseZipDirectory(zip);
+    expect(metas).toHaveLength(2);
+    expect(metas[0]!.compressedSize).toBe(0xfffffff0);
+
+    // …but decompression skips the corrupt entry and returns only the valid one,
+    // never allocating the bogus length.
+    const parsed = parseZipSync(zip);
+    expect(parsed.map((e) => e.name)).toEqual(['good.dat']);
+    expect(parsed[0]!.data.toString()).toBe('BBBB');
+  });
+});

--- a/apps/docs/guide/reporter.md
+++ b/apps/docs/guide/reporter.md
@@ -63,6 +63,10 @@ The `use` block is Playwright's, not Piwi's: `trace`, `screenshot` and `video` d
 
 When you install via [`wrapConfig`](#installing-via-wrapconfig) (what `init` does), the reporter fills in `screenshot: 'only-on-failure'` and `trace: 'retain-on-failure'` for you whenever the top-level `use` leaves them unset — the trace alone gives the dashboard the DOM snapshot, full call stack, full network with bodies and the visual diff without the capture fixtures. On Playwright 1.63 or later the trace default also turns on the per-action **aria tree** (`snapshots: { dom: true, aria: true }`), which feeds the [Screen tab and the page diff](/features/evidence#aria-and-screen-snapshots) at negligible size. The `screen` snapshot kind — a PNG before and after every action, the trace's biggest cost — stays opt-in; set it yourself with `trace: { mode: 'retain-on-failure', snapshots: { dom: true, aria: true, screen: true } }`. Any value you set yourself (including `'off'`) is kept, per-project `use` blocks are never touched, and the reporter logs one line at the start of the run naming what it defaulted. Opt out with `defaultCapture: false` or `PIWI_DEFAULT_CAPTURE=false` to let Playwright's own defaults stand.
 
+::: tip You don't also need Playwright's `html` reporter
+Piwi rebuilds the run — history, errors, evidence, traces and live streaming — from the data this reporter collects, so the dashboard is complete without Playwright's built-in `html` reporter. Running `html` alongside Piwi only repeats end-of-run work: it regenerates its own static report each run and, run locally, opens a browser on failure by default. Drop it (or set `open: 'never'`) to skip that. If you still want Playwright's standalone report, keep it enabled and Piwi uploads it with the run ([`uploadReport`](#configuration-options)).
+:::
+
 ## Installing via wrapConfig
 
 `wrapConfig` wraps your whole Playwright config in one call: it injects the reporter, chains Piwi's [global setup](#global-setup-phase), and defaults the failure-evidence capture options. It is what `npx @piwitests/reporter init` writes for you.
@@ -558,7 +562,7 @@ Uploaded traces open in the dashboard's **built-in, self-hosted trace viewer** �
 
 ### Reporter not uploading files
 
-- Make sure an HTML reporter is configured: `['html', { outputFolder: 'playwright-report' }]`
+- Playwright's own HTML report uploads only when its `html` reporter is configured (`['html', { outputFolder: 'playwright-report' }]`) — but the dashboard reconstructs the run without it, and traces and screenshots upload either way
 - Make sure traces are enabled: `use: { trace: 'retain-on-failure' }`
 - Make sure screenshots are enabled: `use: { screenshot: 'only-on-failure' }` — Playwright's default is `'off'`, so an unset option means no screenshot to upload
 - Check the dashboard server is running and accessible at `serverUrl`

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@nuxt/ui": "^4.10.0",
         "@vite-pwa/nuxt": "^1.1.1",
         "@vueuse/nuxt": "^14.1.0",
+        "busboy": "^1.6.0",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.45.0",
         "fflate": "^0.8.2",
@@ -64,6 +65,7 @@
       "devDependencies": {
         "@iconify-json/simple-icons": "^1.2.93",
         "@playwright/test": "^1.63.0",
+        "@types/busboy": "^1.5.4",
         "@types/nodemailer": "^8.0.1",
         "@types/sql.js": "^1.4.11",
         "cross-env": "^10.1.0",
@@ -9945,6 +9947,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/busboy": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -11668,6 +11680,17 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/c12": {
@@ -20656,6 +20679,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/streamx": {

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -38,6 +38,8 @@ export default wrapConfig(defineConfig({}), {
 
 Run `npx playwright test` — results are uploaded automatically.
 
+> Piwi rebuilds the run from the data it collects, so you don't also need Playwright's built-in `html` reporter — running it alongside Piwi just repeats the end-of-run report generation. Keep it only if you want Playwright's standalone report uploaded too.
+
 **Recommended: enable the capture fixtures.** One small file unlocks the dashboard's richest features:
 
 ```typescript

--- a/packages/reporter/src/internal/support/run-mode.ts
+++ b/packages/reporter/src/internal/support/run-mode.ts
@@ -28,3 +28,30 @@ export function isUiMode(argv: string[] = process.argv): boolean {
 
   return rest.some((tok) => PW_UI_FLAGS.some((flag) => tok === flag || tok.startsWith(`${flag}=`)));
 }
+
+/**
+ * Detect Playwright's **list mode** (`playwright test --list`), which prints the
+ * planned tests without executing any.
+ *
+ * Why the reporter cares: list mode still drives the reporter through
+ * `onBegin`/`onEnd` and runs `globalSetup`, yet no test runs. Registering a run
+ * would leave an empty phantom run on the dashboard — created, finalized and
+ * uploaded with zero results — for every `--list`. Skipping registration and
+ * submission in list mode avoids those.
+ *
+ * As with `isUiMode`, only the tokens after the `test` subcommand are scanned so
+ * a spec file or value that merely contains "list" can't trigger a false positive.
+ *
+ * `argv` is a parameter (defaulting to `process.argv`) purely so tests can drive
+ * it deterministically.
+ */
+const PW_LIST_FLAGS = ['--list'];
+
+export function isListMode(argv: string[] = process.argv): boolean {
+  // Drop the node executable + script path, then start after the `test` subcommand.
+  const args = argv.slice(2);
+  const testIdx = args.indexOf('test');
+  const rest = testIdx >= 0 ? args.slice(testIdx + 1) : args;
+
+  return rest.some((tok) => PW_LIST_FLAGS.some((flag) => tok === flag || tok.startsWith(`${flag}=`)));
+}

--- a/packages/reporter/src/public/config-wrapper.ts
+++ b/packages/reporter/src/public/config-wrapper.ts
@@ -148,8 +148,10 @@ function resolveSetupModule(): string {
  *
  * The `globalSetup` field is set to a `string` (or `string[]` if the user
  * already has a global setup) referencing the Piwi global setup module,
- * which registers the run on the server. The original setup path(s) are
- * preserved and executed first.
+ * which registers the run on the server. Piwi's module is chained first so the
+ * run registers before the user's own setup, appearing as "initializing" on the
+ * dashboard while that setup runs; the original setup path(s) are preserved and
+ * executed after it.
  *
  * Playwright options required in `globalSetup` are forwarded via `PIWI_*`
  * environment variables (see `applyOptionsToEnv` in `config.ts` for the
@@ -169,12 +171,13 @@ function resolveSetupModule(): string {
 export function wrapConfig<T extends PlaywrightTestConfig>(config: T, piwiOptions?: PiwiDashboardOptions): T {
   if (piwiOptions) applyOptionsToEnv(piwiOptions);
 
-  const globalSetupModules: string[] = [];
+  // Piwi's module runs first so the run is registered before the user's own
+  // globalSetup, showing as "initializing" on the dashboard while that setup runs.
+  const globalSetupModules: string[] = [resolveSetupModule()];
   if (config.globalSetup) {
     const orig = Array.isArray(config.globalSetup) ? config.globalSetup : [config.globalSetup];
     globalSetupModules.push(...orig);
   }
-  globalSetupModules.push(resolveSetupModule());
 
   // Forward Piwi's CI-gate options into Playwright's own config so the run
   // exits non-zero locally, with no server round-trip (Playwright 1.52+).

--- a/packages/reporter/src/public/global-setup.ts
+++ b/packages/reporter/src/public/global-setup.ts
@@ -9,7 +9,7 @@ import { computeInstanceId } from '../internal/support/instance-id.js';
 import { detectCiRunLabel } from '../internal/support/ci.js';
 import { getSetupFilePath } from '../internal/support/setup-file.js';
 import { ariaSampleIdentity, clearAriaSampleFile, writeAriaSampleFile } from '../internal/support/aria-sampling.js';
-import { isUiMode } from '../internal/support/run-mode.js';
+import { isUiMode, isListMode } from '../internal/support/run-mode.js';
 
 /**
  * Create a Playwright `globalSetup` function that registers a test run on the
@@ -63,6 +63,15 @@ export function createGlobalSetup(
     // userSetup so the user's own setup keeps working under the UI.
     if (isUiMode()) {
       logger.debug('UI mode detected — skipping run registration.');
+      if (userSetup) return userSetup(config);
+      return;
+    }
+
+    // `playwright test --list` runs globalSetup but executes no tests, so
+    // registering here would leave an empty phantom run on the dashboard. Skip
+    // registration but still chain userSetup so the user's own setup keeps working.
+    if (isListMode()) {
+      logger.debug('List mode detected — skipping run registration.');
       if (userSetup) return userSetup(config);
       return;
     }

--- a/packages/reporter/src/public/reporter.ts
+++ b/packages/reporter/src/public/reporter.ts
@@ -18,6 +18,7 @@ import { detectCiRunLabel } from '../internal/support/ci.js';
 import { workerIndexOf } from '../internal/support/worker-index.js';
 import { detectCliFileFilters } from '../internal/support/cli-filters.js';
 import { readSelectionStamp } from '../internal/support/selection-env.js';
+import { isListMode } from '../internal/support/run-mode.js';
 import { createGlobalSetup } from './global-setup.js';
 import { wrapConfig } from './config-wrapper.js';
 import { toWireTestCase } from '../internal/submit/serializer.js';
@@ -82,6 +83,12 @@ export class PiwiDashboardReporter {
   private shardInfo: ShardInfo | null = null;
   private metadata: Record<string, any> = {};
   private enabled: boolean;
+  /**
+   * True under `playwright test --list`, where Playwright still constructs this
+   * reporter and fires `onBegin`/`onEnd` but runs no tests. Registering and
+   * finalizing a run would create an empty phantom run and upload an empty report.
+   */
+  private readonly listMode: boolean;
   /** True when the server URL and API key came from the desktop app, not from config. */
   private viaDesktopApp: boolean;
   private isFullRun = true;
@@ -105,6 +112,7 @@ export class PiwiDashboardReporter {
   constructor(rawOptions: Record<string, any> = {}) {
     this.options = resolveOptions(rawOptions);
     this.enabled = this.options.enabled !== false && !!this.options.serverUrl;
+    this.listMode = isListMode();
     this.viaDesktopApp = usedDesktopDiscovery();
     this.runLabel = this.options.runLabel || detectCiRunLabel();
     this.instanceId = computeInstanceId(this.options.projectName!, this.runLabel);
@@ -145,6 +153,10 @@ export class PiwiDashboardReporter {
 
   /** Playwright reporter hook: called once at the start of the test run */
   onBegin(config: FullConfig, suite: Suite): void {
+    if (this.listMode) {
+      this.logger.debug('List mode (--list) detected — no run registered or report uploaded.');
+      return;
+    }
     if (!this.enabled) {
       this.logger.info('Not enabled — set PIWI_DASHBOARD_URL or serverUrl to enable.');
       return;
@@ -498,7 +510,7 @@ export class PiwiDashboardReporter {
 
   /** Playwright reporter hook: called when the full test run finishes */
   async onEnd(result: FullResult): Promise<void> {
-    if (!this.enabled) return;
+    if (this.listMode || !this.enabled) return;
 
     // Tests Playwright never reported were cut off by a run-level condition —
     // the global timeout, the failure budget, or an interruption.

--- a/packages/reporter/tests/config-wrapper.spec.ts
+++ b/packages/reporter/tests/config-wrapper.spec.ts
@@ -47,21 +47,21 @@ describe('wrapConfig', () => {
     expect((config.globalSetup as string).includes('global-setup-module')).toBeTruthy();
   });
 
-  it('keeps original globalSetup string and appends piwi module', () => {
+  it('keeps original globalSetup string and prepends piwi module', () => {
     const config = wrapConfig({ globalSetup: './tests/globalSetup' });
     expect(Array.isArray(config.globalSetup)).toBeTruthy();
     expect((config.globalSetup as string[]).length).toBe(2);
-    expect((config.globalSetup as string[])[0]).toBe('./tests/globalSetup');
-    expect((config.globalSetup as string[])[1].includes('global-setup-module')).toBeTruthy();
+    expect((config.globalSetup as string[])[0].includes('global-setup-module')).toBeTruthy();
+    expect((config.globalSetup as string[])[1]).toBe('./tests/globalSetup');
   });
 
-  it('keeps original globalSetup array and appends piwi module', () => {
+  it('keeps original globalSetup array and prepends piwi module', () => {
     const config = wrapConfig({ globalSetup: ['./tests/cleanup', './tests/bootstrap'] });
     expect(Array.isArray(config.globalSetup)).toBeTruthy();
     expect((config.globalSetup as string[]).length).toBe(3);
-    expect((config.globalSetup as string[])[0]).toBe('./tests/cleanup');
-    expect((config.globalSetup as string[])[1]).toBe('./tests/bootstrap');
-    expect((config.globalSetup as string[])[2].includes('global-setup-module')).toBeTruthy();
+    expect((config.globalSetup as string[])[0].includes('global-setup-module')).toBeTruthy();
+    expect((config.globalSetup as string[])[1]).toBe('./tests/cleanup');
+    expect((config.globalSetup as string[])[2]).toBe('./tests/bootstrap');
   });
 
   it('injects piwi reporter when no reporter is set', () => {

--- a/packages/reporter/tests/global-setup.spec.ts
+++ b/packages/reporter/tests/global-setup.spec.ts
@@ -216,6 +216,29 @@ describe('createGlobalSetup', () => {
     }
   });
 
+  it('does not register when Playwright runs in list mode (still chains userSetup)', async () => {
+    const { server, url, requests } = await startServer((_req, res) =>
+      jsonRes(res, 200, { runId: 1, setupToken: 't' }),
+    );
+    const savedArgv = process.argv;
+    process.argv = ['node', 'playwright', 'test', '--list'];
+    try {
+      let userSetupCalled = false;
+      const setupFn = createGlobalSetup({ serverUrl: url, projectName: 'global-setup-list-mode' }, async () => {
+        userSetupCalled = true;
+        return 'chained-result';
+      });
+      const result = await setupFn({ reporter: [PIWI_REPORTER_ENTRY] });
+      expect(requests).toHaveLength(0);
+      expect(userSetupCalled).toBe(true);
+      expect(result).toBe('chained-result');
+      expect(readSetupInfo('global-setup-list-mode')).toBeNull();
+    } finally {
+      process.argv = savedArgv;
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
   it('extracts serverUrl/projectName from an inline reporter entry when no options are passed', async () => {
     const { server, url, requests } = await startServer((_req, res) =>
       jsonRes(res, 200, { runId: 7, setupToken: 'ttt' }),

--- a/packages/reporter/tests/run-mode.spec.ts
+++ b/packages/reporter/tests/run-mode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isUiMode } from '../src/internal/support/run-mode.js';
+import { isUiMode, isListMode } from '../src/internal/support/run-mode.js';
 
 const NODE = ['/usr/bin/node', '/path/to/playwright'];
 
@@ -29,5 +29,27 @@ describe('isUiMode', () => {
   it('only considers tokens after the `test` subcommand', () => {
     // A `--ui` token sitting before `test` is not part of the test invocation.
     expect(isUiMode([...NODE, '--ui', 'test'])).toBe(false);
+  });
+});
+
+describe('isListMode', () => {
+  it('is false for a plain test run', () => {
+    expect(isListMode([...NODE, 'test'])).toBe(false);
+    expect(isListMode([...NODE, 'test', 'tests/login.spec.ts'])).toBe(false);
+  });
+
+  it('detects the --list flag', () => {
+    expect(isListMode([...NODE, 'test', '--list'])).toBe(true);
+  });
+
+  it('does not confuse a similarly-named token for the list flag', () => {
+    // A positional file filter whose name contains "list" must not trigger list mode.
+    expect(isListMode([...NODE, 'test', 'list.spec.ts'])).toBe(false);
+    expect(isListMode([...NODE, 'test', '--listen'])).toBe(false);
+  });
+
+  it('only considers tokens after the `test` subcommand', () => {
+    // A `--list` token sitting before `test` is not part of the test invocation.
+    expect(isListMode([...NODE, '--list', 'test'])).toBe(false);
   });
 });


### PR DESCRIPTION
## What & why

Fixes from real Piwi Desktop usage on a ~200-test suite with heavy failure traces (`retain-on-first-failure`, ~60–80 MB each). Six commits bundled:

**Server / dashboard**
- **`fix(app)` — stop the server OOM (`invalid array length` / heap out of memory).** Finalizing a run with several large failure traces exhausted the heap (~1.1 GB) and crashed the desktop server (exit 134) — which also caused the intermittent `ECONNREFUSED 127.0.0.1:3000`. Root cause: `buildZip` summed every decompressed entry into one uncapped `Buffer.concat`; evidence derivation re-decompressed every inline screenshot just to read the `.trace`/`.network` streams; and reports were inflated in parallel while every trace buffer stayed resident. Now the slim ZIP is size-checked and capped before a single pre-sized allocation, evidence inflates only the streams it needs, reports are processed sequentially, and buffers are released as soon as they're stored.
- **`fix(app)` — stream per-case uploads to disk.** The streaming case-files endpoint read the whole multipart body with `readMultipartFormData` (buffers the raw body **and** every parsed part in heap for the full transfer). It now parses with `busboy`, streaming each file part to a temp file and keeping only small fields in memory, then reads the trace/attachments back one at a time and cleans up the temp dir.
- **`fix(ui)` — project label display.** The execution and test-case pages showed the immutable config project name in their breadcrumb/badge while the rest of the page showed the renamed label, so a run appeared to revert the project name mid-run. They now fall back `label ?? name` like every other surface. (Persistence was already correct — config `projectName` only creates the project; the server rename `label` always wins.)

**Reporter**
- **`fix(reporter)` — `playwright test --list` no longer creates a phantom run.** List mode ran the reporter hooks but no tests, so it registered/finalized/uploaded an empty run every time. A new `isListMode()` (symmetric to `isUiMode()`) skips registration and submission.
- **`fix(reporter)` — run shows as *initializing* during the user's `globalSetup`.** `wrapConfig` now chains Piwi's setup module **before** the user's, so the "Watch live" link appears during a long `globalSetup` instead of only after it.
- **`docs(reporter)` — recommend against also enabling Playwright's `html` reporter** when Piwi is active (it duplicates end-of-run work), in the integration guide and README.

> Heads up: this bundles several independent fixes. Since the repo squash-merges, they collapse to one changelog entry under the PR title — happy to split into separate PRs if you'd prefer granular changelog lines.

## How was it tested?

- **Reporter**: typecheck, lint, **764** unit tests, build — all green. Added `isListMode` and globalSetup-ordering tests.
- **Dashboard**: typecheck, lint, **2288** unit tests (incl. new `trace-zip` and `multipart-stream` suites), format — all green.
- **E2E**: `tests/case-files-live.spec.ts` (**15** tests) validates the real reporter→server multipart path with the new streaming parser — trace + attachment upload mid-run, blob dedup by hash, 422/404/token paths, idempotent retry, inline attachment serving, and CORS trace download.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/`, reporter README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oyYxTYnisQXpEkEFy3kni

---
_Generated by [Claude Code](https://claude.ai/code/session_014oyYxTYnisQXpEkEFy3kni)_