### PR TITLE
feat(ui): show the failing step's screenshot and ARIA on the timeline

### DIFF
--- a/apps/application/app/components/test-case/FailingStepSnapshot.vue
+++ b/apps/application/app/components/test-case/FailingStepSnapshot.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+/**
+ * The page state captured *at the failing step*, surfaced inline on that step in
+ * the failure timeline: the screenshot before the failing action beside the
+ * screenshot at the failure, and the accessibility (ARIA) tree at the failure
+ * folded away below them. Reads this run's own trace 1.63 per-action snapshots
+ * through `useTraceSnapshots` (the same request the filmstrip already made, so
+ * no extra fetch). Renders nothing when the trace carries no snapshot for the
+ * failing step.
+ */
+import { useTraceSnapshots } from '~/composables/useTraceSnapshots';
+
+const props = defineProps<{ testRunsCaseId: number }>();
+
+const { failingStep, failingAriaText, snapshotUrl } = useTraceSnapshots(() => props.testRunsCaseId);
+
+const beforeSrc = computed(() =>
+  failingStep.value?.screen.before ? snapshotUrl(failingStep.value.callId, 'screen', 'before') : null,
+);
+const afterSrc = computed(() =>
+  failingStep.value?.screen.after ? snapshotUrl(failingStep.value.callId, 'screen', 'after') : null,
+);
+
+const hasScreenshot = computed(() => Boolean(beforeSrc.value || afterSrc.value));
+const hasAria = computed(() => Boolean(failingAriaText.value));
+const render = computed(() => hasScreenshot.value || hasAria.value);
+
+const ariaOpen = ref(false);
+</script>
+
+<template>
+  <div v-if="render" class="rounded-lg border border-default bg-elevated/40 p-2.5 space-y-2">
+    <p class="text-xs font-medium text-muted">Page at the failing step</p>
+
+    <div v-if="hasScreenshot" class="grid gap-3" :class="beforeSrc && afterSrc ? 'sm:grid-cols-2' : ''">
+      <figure v-if="beforeSrc" class="min-w-0">
+        <figcaption class="mb-1 text-xs text-muted">Before the failing action</figcaption>
+        <img
+          :src="beforeSrc"
+          alt="Page before the failing action"
+          loading="lazy"
+          class="max-h-64 w-full rounded border border-default bg-default object-contain object-top"
+        />
+      </figure>
+      <figure v-if="afterSrc" class="min-w-0">
+        <figcaption class="mb-1 text-xs text-muted">At the failure</figcaption>
+        <img
+          :src="afterSrc"
+          alt="Page at the failure"
+          loading="lazy"
+          class="max-h-64 w-full rounded border border-default bg-default object-contain object-top"
+        />
+      </figure>
+    </div>
+
+    <div v-if="hasAria">
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 text-xs text-muted hover:text-default outline-none focus-visible:outline-2 focus-visible:outline-primary rounded"
+        :aria-expanded="ariaOpen ? 'true' : 'false'"
+        @click="ariaOpen = !ariaOpen"
+      >
+        <UIcon :name="ariaOpen ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'" class="size-3.5" />
+        Accessibility tree at the failure
+      </button>
+      <div v-show="ariaOpen" class="mt-1.5 max-h-80 overflow-y-auto">
+        <MarkdownPreview :text="'```yaml\n' + failingAriaText + '\n```'" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/application/app/components/test-case/FailureTimelineCard.vue
+++ b/apps/application/app/components/test-case/FailureTimelineCard.vue
@@ -767,6 +767,12 @@ function onViewTrace() {
                   />
                 </div>
               </div>
+              <FailingStepSnapshot
+                v-if="row.failed"
+                data-shot="failing-step-evidence"
+                :test-runs-case-id="testRunsCaseId"
+                class="mt-2.5"
+              />
             </div>
 
             <!-- An interleaved network / console / backend row -->
@@ -826,95 +832,104 @@ function onViewTrace() {
             <tbody>
               <template v-for="row in mergedRows" :key="row.kind === 'step' ? `s-${row.index}` : row.item.id">
                 <!-- A step row -->
-                <tr
-                  v-if="row.kind === 'step'"
-                  class="[&>td]:border-b [&>td]:border-default [&>td]:px-3 [&>td]:py-2 [&>td]:align-top"
-                  :class="row.failed ? 'bg-red-50 dark:bg-red-950/30' : ''"
-                >
-                  <td v-if="showAxis" class="tabular-nums text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
-                    {{ row.item ? formatRel(row.item.at) : '' }}
-                  </td>
-                  <td>
-                    <span
-                      v-if="status === 'didnotrun'"
-                      class="inline-flex items-center justify-center size-5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 text-xs leading-none"
-                      title="Not run"
-                      >–</span
-                    >
-                    <span
-                      v-else-if="row.failed"
-                      class="inline-flex items-center justify-center size-5 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 text-xs leading-none"
-                      title="Step failed"
-                      >✗</span
-                    >
-                    <span
-                      v-else
-                      class="inline-flex items-center justify-center size-5 rounded-full bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 text-xs leading-none"
-                      title="Step passed"
-                      >✓</span
-                    >
-                  </td>
-                  <td>
-                    <UBadge :color="stepCategoryColor[row.step.category] || 'neutral'" variant="soft" size="xs">
-                      {{ row.step.category }}
-                    </UBadge>
-                  </td>
-                  <td>
-                    <div class="flex items-center gap-2">
-                      <span :class="row.failed ? 'text-red-600 dark:text-red-400 font-medium' : ''">
-                        <StepLabel :step="row.step" />
-                      </span>
-                      <UBadge
-                        v-if="row.index === slowestStepIndex"
-                        color="warning"
-                        variant="subtle"
-                        size="xs"
-                        class="shrink-0"
-                        title="Slowest step in this test"
+                <template v-if="row.kind === 'step'">
+                  <tr
+                    class="[&>td]:border-b [&>td]:border-default [&>td]:px-3 [&>td]:py-2 [&>td]:align-top"
+                    :class="row.failed ? 'bg-red-50 dark:bg-red-950/30' : ''"
+                  >
+                    <td v-if="showAxis" class="tabular-nums text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                      {{ row.item ? formatRel(row.item.at) : '' }}
+                    </td>
+                    <td>
+                      <span
+                        v-if="status === 'didnotrun'"
+                        class="inline-flex items-center justify-center size-5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 text-xs leading-none"
+                        title="Not run"
+                        >–</span
                       >
-                        slowest
+                      <span
+                        v-else-if="row.failed"
+                        class="inline-flex items-center justify-center size-5 rounded-full bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 text-xs leading-none"
+                        title="Step failed"
+                        >✗</span
+                      >
+                      <span
+                        v-else
+                        class="inline-flex items-center justify-center size-5 rounded-full bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 text-xs leading-none"
+                        title="Step passed"
+                        >✓</span
+                      >
+                    </td>
+                    <td>
+                      <UBadge :color="stepCategoryColor[row.step.category] || 'neutral'" variant="soft" size="xs">
+                        {{ row.step.category }}
                       </UBadge>
-                    </div>
-                    <StepParamsDisclosure :params="row.step.params" class="mt-1" />
-                    <ErrorText
-                      v-if="row.failed && row.step.error?.message"
-                      mode="block"
-                      :text="row.step.error.message"
-                      class="mt-1"
-                    />
-                    <OpenInIdeLink
-                      v-if="row.step.location"
-                      :location="row.step.location"
-                      :project-key="projectKey ?? undefined"
-                      :project-name="projectName ?? undefined"
-                      class="text-xs text-gray-400 dark:text-gray-500 mt-0.5"
-                    />
-                  </td>
-                  <td>
-                    <div class="min-w-[6rem]">
-                      <div class="flex items-center justify-between gap-2">
-                        <DurationValue
-                          :ms="row.step.duration"
-                          :class="`text-sm ${stepDurationTextClass(row.step.duration)}`"
-                          unit-class="opacity-60"
-                        />
-                        <span
-                          v-if="stepPctOfTest(row.step.duration)"
-                          class="text-xs tabular-nums text-gray-400 dark:text-gray-500"
-                        >
-                          {{ stepPctOfTest(row.step.duration) }}
+                    </td>
+                    <td>
+                      <div class="flex items-center gap-2">
+                        <span :class="row.failed ? 'text-red-600 dark:text-red-400 font-medium' : ''">
+                          <StepLabel :step="row.step" />
                         </span>
+                        <UBadge
+                          v-if="row.index === slowestStepIndex"
+                          color="warning"
+                          variant="subtle"
+                          size="xs"
+                          class="shrink-0"
+                          title="Slowest step in this test"
+                        >
+                          slowest
+                        </UBadge>
                       </div>
-                      <div class="relative mt-1 h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                      <StepParamsDisclosure :params="row.step.params" class="mt-1" />
+                      <ErrorText
+                        v-if="row.failed && row.step.error?.message"
+                        mode="block"
+                        :text="row.step.error.message"
+                        class="mt-1"
+                      />
+                      <OpenInIdeLink
+                        v-if="row.step.location"
+                        :location="row.step.location"
+                        :project-key="projectKey ?? undefined"
+                        :project-name="projectName ?? undefined"
+                        class="text-xs text-gray-400 dark:text-gray-500 mt-0.5"
+                      />
+                    </td>
+                    <td>
+                      <div class="min-w-[6rem]">
+                        <div class="flex items-center justify-between gap-2">
+                          <DurationValue
+                            :ms="row.step.duration"
+                            :class="`text-sm ${stepDurationTextClass(row.step.duration)}`"
+                            unit-class="opacity-60"
+                          />
+                          <span
+                            v-if="stepPctOfTest(row.step.duration)"
+                            class="text-xs tabular-nums text-gray-400 dark:text-gray-500"
+                          >
+                            {{ stepPctOfTest(row.step.duration) }}
+                          </span>
+                        </div>
                         <div
-                          class="absolute inset-y-0 rounded-full"
-                          :class="stepBarColorClass(row.step.duration)"
-                          :style="stepBarStyle(row.step)"
-                        />
+                          class="relative mt-1 h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800"
+                        >
+                          <div
+                            class="absolute inset-y-0 rounded-full"
+                            :class="stepBarColorClass(row.step.duration)"
+                            :style="stepBarStyle(row.step)"
+                          />
+                        </div>
                       </div>
-                    </div>
-                  </td>
-                </tr>
+                    </td>
+                  </tr>
+                  <!-- The page at the failing step: screenshot + ARIA, tied to the step. -->
+                  <tr v-if="row.failed">
+                    <td :colspan="showAxis ? 5 : 4" class="border-b border-default px-3 pb-3 pt-0">
+                      <FailingStepSnapshot :test-runs-case-id="testRunsCaseId" />
+                    </td>
+                  </tr>
+                </template>
 
                 <!-- An interleaved network / console / backend row -->
                 <tr

--- a/apps/application/app/composables/useTraceSnapshots.ts
+++ b/apps/application/app/composables/useTraceSnapshots.ts
@@ -27,6 +27,7 @@ export function useTraceSnapshots(testRunsCaseId: MaybeRefOrGetter<number>) {
   const hasAria = computed(() => response.value?.status === 'ok' && response.value.hasAria);
   const steps = computed(() => (response.value?.status === 'ok' ? response.value.steps : []));
   const failingStep = computed(() => steps.value.find((s) => s.callId === response.value?.failingCallId) ?? null);
+  const failingAriaText = computed(() => response.value?.failingAriaText ?? null);
 
-  return { data: response, pending, error, snapshotUrl, hasScreen, hasAria, steps, failingStep };
+  return { data: response, pending, error, snapshotUrl, hasScreen, hasAria, steps, failingStep, failingAriaText };
 }

--- a/apps/application/scripts/take-feature-screenshots.mjs
+++ b/apps/application/scripts/take-feature-screenshots.mjs
@@ -40,7 +40,8 @@
  */
 
 import { createRequire } from 'module';
-import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { createHash } from 'node:crypto';
 import { join, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -63,6 +64,83 @@ const OUT_TARGETS = {
 };
 
 const DEFAULT_VIEWPORT = { width: 1280, height: 860 };
+
+/**
+ * A real Playwright 1.63 trace recorded with `snapshots: { dom, aria, screen }`,
+ * ingested by the failing-step-evidence scene so the timeline can show the page
+ * captured at the failing step. The seeded demo traces predate 1.63, so this
+ * feature can only be driven from a genuine snapshot-bearing trace.
+ */
+const TRACE_SNAPSHOT_FIXTURE = join(APP_DIR, 'tests', 'fixtures', 'trace-aria-screen-1.63.zip');
+const TRACE_SNAPSHOT_CASE = {
+  title: 'checkout — cancel is gone after paying',
+  location: 'tests/checkout.spec.ts:12:3',
+  retries: 0,
+};
+
+/**
+ * Start a run, push one failing case with a marked failing step, and upload the
+ * 1.63 trace fixture for it. Returns its executionId. Retries the pushes while
+ * the dev server compiles the API routes on first hit.
+ */
+async function ingestTraceSnapshotCase(request, base) {
+  const trace = readFileSync(TRACE_SNAPSHOT_FIXTURE);
+  const traceHash = createHash('sha256').update(trace).digest('hex');
+
+  const post = async (path, options) => {
+    let last;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      if (attempt > 0) await new Promise((r) => setTimeout(r, 3000));
+      try {
+        const res = await request.post(`${base}${path}`, options);
+        if (res.ok()) return res;
+        last = new Error(`${path} → ${res.status()}`);
+      } catch (error) {
+        last = error;
+      }
+    }
+    throw last ?? new Error(`could not POST ${path}`);
+  };
+
+  const started = await (
+    await post('/api/test-runs/start', {
+      data: { projectName: 'trace-snapshots', startTime: new Date().toISOString() },
+    })
+  ).json();
+  const { runId, streamToken } = started;
+
+  await post(`/api/test-runs/${runId}/events`, {
+    data: {
+      streamToken,
+      testCases: [
+        {
+          type: 'complete',
+          ...TRACE_SNAPSHOT_CASE,
+          status: 'failed',
+          duration: 2000,
+          error:
+            "TimeoutError: locator.click: Timeout 1500ms exceeded.\n  - waiting for getByRole('button', { name: 'Cancel' })",
+          steps: [
+            { title: 'Navigate to "data:text/html"', category: 'navigation', duration: 40, startTime: 0 },
+            { title: 'Fill "a@b.test"', category: 'input', duration: 20, startTime: 50 },
+            { title: 'Click "Pay now"', category: 'click', duration: 30, startTime: 80 },
+            { title: 'Click "Cancel"', category: 'click', duration: 1500, startTime: 120, failed: true },
+          ],
+        },
+      ],
+    },
+  });
+
+  const upload = await post(`/api/test-runs/${runId}/case-files`, {
+    multipart: {
+      streamToken,
+      testCase: JSON.stringify(TRACE_SNAPSHOT_CASE),
+      trace_hash: traceHash,
+      trace: { name: 'trace.zip', mimeType: 'application/zip', buffer: trace },
+    },
+  });
+  return (await upload.json()).executionId;
+}
 
 /** Surfaces a scene can be captured against. */
 const MODES = ['web', 'desktop'];
@@ -561,6 +639,52 @@ const SCENES = [
       const toggle = page.getByRole('tablist', { name: 'Screen view' }).getByRole('tab', { name: 'Page diff' });
       await toggle.waitFor({ state: 'visible', timeout: 30_000 });
       await toggle.click();
+      await settle();
+      await shoot();
+    },
+  },
+  {
+    name: 'failing-step-evidence',
+    description: "Timeline tab: the failing step's before/at-failure screenshot and ARIA tree, tied to the step",
+    viewport: { width: 1280, height: 1600 },
+    of: 'table',
+    pad: 12,
+    async prepare({ request, base }) {
+      this.executionId = await ingestTraceSnapshotCase(request, base);
+    },
+    async run({ page, goto, settle, shoot }) {
+      await goto(`/test-run-cases/${this.executionId}`);
+      await page
+        .getByRole('tablist', { name: 'Evidence sections' })
+        .getByRole('tab', { name: 'Timeline', exact: true })
+        .click();
+      // Unfold the accessibility tree so the capture shows both the screenshot
+      // and the ARIA the failing step carries.
+      const aria = page.getByRole('button', { name: 'Accessibility tree at the failure' }).first();
+      await aria.waitFor({ state: 'visible', timeout: 30_000 });
+      await aria.click();
+      await settle();
+      await shoot();
+    },
+  },
+  {
+    name: 'failing-step-evidence-mobile',
+    description: "Failing step's page snapshot on the timeline at phone width",
+    viewport: { width: 390, height: 1800 },
+    of: '[data-shot="failing-step-evidence"]',
+    pad: 12,
+    async prepare({ request, base }) {
+      this.executionId = await ingestTraceSnapshotCase(request, base);
+    },
+    async run({ page, goto, settle, shoot }) {
+      await goto(`/test-run-cases/${this.executionId}`);
+      await page
+        .getByRole('tablist', { name: 'Evidence sections' })
+        .getByRole('tab', { name: 'Timeline', exact: true })
+        .click();
+      const aria = page.getByRole('button', { name: 'Accessibility tree at the failure' }).first();
+      await aria.waitFor({ state: 'visible', timeout: 30_000 });
+      await aria.click();
       await settle();
       await shoot();
     },

--- a/apps/application/server/utils/trace-insights.ts
+++ b/apps/application/server/utils/trace-insights.ts
@@ -604,7 +604,31 @@ export function buildTraceSnapshots(
     hasAria,
     hasScreen,
     pageDiff: pageDiffToFailure(parsed, failingCallId, readAriaText),
+    failingAriaText: failingActionAriaText(parsed, failingCallId, readAriaText),
   };
+}
+
+/** Longest failing-step aria tree kept in the response; a larger one is capped. */
+const FAILING_ARIA_MAX_CHARS = 20_000;
+
+/**
+ * The accessibility tree of the page *at the failing step*, as ARIA text — the
+ * failing action's after-phase snapshot when it recorded one, else its
+ * before-phase. This is the page state the timeline surfaces on the step that
+ * raised the error. Null when the failing step recorded no aria snapshot.
+ */
+function failingActionAriaText(
+  parsed: ParsedTraceData,
+  failingCallId: string | null,
+  readAriaText: (file: string) => string | null,
+): string | null {
+  if (!failingCallId) return null;
+  const action = parsed.actions.find((a) => a.callId === failingCallId);
+  const file = action?.ariaSnapshotAfter ?? action?.ariaSnapshotBefore;
+  if (!file) return null;
+  const text = readAriaText(file);
+  if (text == null) return null;
+  return text.length > FAILING_ARIA_MAX_CHARS ? `${text.slice(0, FAILING_ARIA_MAX_CHARS)}\n# … (truncated)` : text;
 }
 
 /**

--- a/apps/application/tests/trace-snapshots.spec.ts
+++ b/apps/application/tests/trace-snapshots.spec.ts
@@ -116,4 +116,24 @@ test.describe('Trace aria/screen snapshots', () => {
 
     await expect(page.getByRole('region', { name: 'Filmstrip of the page before each step' })).toBeVisible();
   });
+
+  test("the Timeline tab attaches the failing step's screenshot and ARIA to the failing step", async ({ page }) => {
+    await page.goto(`/test-run-cases/${executionId}`);
+    await waitForHydration(page);
+
+    await page
+      .getByRole('tablist', { name: 'Evidence sections' })
+      .getByRole('tab', { name: 'Timeline', exact: true })
+      .click();
+
+    // The page captured at the failing step sits inline on that step. The table
+    // is the desktop layout; the phone card copy carries the same text.
+    await expect(page.locator('table').getByText('Page at the failing step')).toBeVisible();
+
+    // Its accessibility tree unfolds on demand (a role query resolves the visible
+    // desktop toggle, not the display:none phone copy).
+    const ariaToggle = page.getByRole('button', { name: 'Accessibility tree at the failure' });
+    await expect(ariaToggle).toBeVisible();
+    await ariaToggle.click();
+  });
 });

--- a/apps/application/tests/unit/trace-snapshots.test.ts
+++ b/apps/application/tests/unit/trace-snapshots.test.ts
@@ -84,6 +84,9 @@ describe('getTraceSnapshotsFromBlob', () => {
     // The failing action's dialog button flips to disabled between before and after.
     expect(res.pageDiff?.summary.changed).toBe(1);
     expect(res.pageDiff?.hunks[0]).toMatchObject({ role: 'button', name: 'Confirm' });
+
+    // The failing step's aria tree (after phase preferred) — the page at the failure.
+    expect(res.failingAriaText).toBe(['- dialog "Pay"', '  - button "Confirm" [disabled]'].join('\n'));
   });
 
   test('reports no-trace for a missing blob and no-snapshots when nothing was recorded', async () => {
@@ -180,6 +183,9 @@ describe('getTraceSnapshotsFromBlob — assertion failure (mutation on a prior s
 
     // Cancel removed and Pay disabled between the loaded page and the failure.
     expect(res.pageDiff?.summary).toMatchObject({ removed: 1, changed: 1 });
+
+    // The marked step's after-phase aria is the failing-step page structure.
+    expect(res.failingAriaText).toBe(['- dialog "Pay"', '  - button "Pay now" [disabled]'].join('\n'));
   });
 });
 

--- a/apps/application/types/api.ts
+++ b/apps/application/types/api.ts
@@ -700,6 +700,12 @@ export interface TraceSnapshotsResponse {
    * Null when either phase's aria snapshot is missing.
    */
   pageDiff?: { summary: PageDiffSummary; hunks: PageDiffHunk[] } | null;
+  /**
+   * The accessibility tree at the failing step, as ARIA text (the failing
+   * action's after-phase snapshot, else its before-phase). Surfaced on the
+   * failing step in the timeline. Null when the failing step recorded no aria.
+   */
+  failingAriaText?: string | null;
 }
 
 /**

--- a/apps/docs/features/evidence.md
+++ b/apps/docs/features/evidence.md
@@ -105,17 +105,18 @@ The screenshots in **failure evidence** come from Playwright's `screenshot: 'onl
 
 When an execution has an uploaded trace, two evidence blocks go deeper — no configuration beyond recording traces (`trace: 'retain-on-failure'` or `'on-first-retry'` in your Playwright config):
 
-- **Test source → Full stack** — the complete call stack of the failing action from the trace's stacks index, every frame with its real source read from the trace's embedded files (recorded by default with the Playwright test runner), the failing line highlighted, dependency frames folded, and Open-in-IDE links on each in-project frame. A toggle switches back to the reporter-captured frames.
-- **Network → Full trace** — every request the page made (documents, scripts, images — not just fetch/XHR), on a waterfall with the failing action's time window shaded. Click a request for timing phases, request/response headers, and a capped body preview (JSON pretty-printed, images inline). Sensitive header values (`Authorization`, `Cookie`, …) are masked server-side and never leave the dashboard, and token-shaped strings in URLs and bodies are masked too.
+- **Test source → Full stack** — the complete call stack of the failing action from the trace's stacks index, every frame with its real source read from the trace's embedded files, the failing line highlighted, dependency frames folded, and Open-in-IDE links on each in-project frame. A toggle switches back to the reporter-captured frames.
+- **Network → Full trace** — every request the page made (documents, scripts, images — not just fetch/XHR), on a waterfall with the failing action's time window shaded. Click a request for timing phases, request/response headers, and a capped body preview (JSON pretty-printed, images inline). Sensitive header values (`Authorization`, `Cookie`, …) and token-shaped strings in URLs and bodies are masked server-side.
 
-Executions without a trace keep the reporter-captured baseline — the blocks simply hint at what a trace would add. Traces recorded without embedded sources still show the full frame list.
+Executions without a trace keep the reporter-captured baseline. Traces recorded without embedded sources still show the full frame list.
 
 ### Aria and screen snapshots
 
 A Playwright 1.63 trace can record the page's **aria tree** and a **screenshot** before and after every action (`trace: { snapshots: { dom, aria, screen } }`; [`wrapConfig`](/guide/reporter#installing-via-wrapconfig) turns `aria` on by default, `screen` stays [opt-in](/operate/storage#trace-snapshots)). When it did, two more views appear:
 
 - **Screen tab › Before the failing action** — the page as the failing action saw it, before and at the failure, beside the failure screenshot.
-- **Timeline tab › the filmstrip** — a thumbnail of the page *before each step*, in order, the failing step marked. It turns the step list into a visual scrub of how the page looked on the way to the failure, and needs only `screen`.
+- **Timeline tab › the filmstrip** — a thumbnail of the page *before each step*, in order, the failing step marked; a visual scrub of the page on the way to the failure. Needs only `screen`.
+- **Timeline tab › the failing step** — the before and at-failure screenshots and the failure's accessibility tree, inline on the failing step, so the page at the faulty step reads without leaving the timeline.
 
 The [in-execution page diff](#page-diff) reads the same aria snapshots. All three states use the three-state empty copy (*not captured — enable trace snapshots*, with the `/setup` link) when the trace predates 1.63 or was recorded without the kind.
 


### PR DESCRIPTION
## What & why

Implements the "screenshot / DOM at the failing step" evidence feature: in a failing test's **evidence timeline**, the page captured **at the failing step** is now surfaced **inline on that step** — the screenshot before the failing action beside the screenshot at the failure, plus the accessibility (ARIA) tree at the failure folded below them. This is the equivalent of Playwright trace's per-action snapshot, tied to the specific timeline step that raised the error, so the exact page state at the moment of the faulty step reads without leaving the steps table.

Before this, the failing step's screenshot lived only in the separate **Screen** tab (`TraceBeforeActionCard`) and the per-step **filmstrip** thumbnails — disconnected from the step that failed, and the per-action ARIA tree at the failing step was not rendered anywhere.

**The gap was wiring, not parsing.** The trace-snapshot pipeline already parsed Playwright 1.63 per-action aria/screen snapshots, computed the failing step (`failingCallId`) and served each snapshot resource. The change:

- **`server/utils/trace-insights.ts`** — add `failingAriaText` to the trace-snapshots response: the ARIA tree at the failing step (the failing action's after-phase snapshot, else before-phase), capped. Built in the node-free `buildTraceSnapshots`, so the demo mirror (`app/demo/api/trace-insights.ts`) serves it unchanged — no separate demo code. `types/api.ts` + `useTraceSnapshots` follow.
- **`FailingStepSnapshot.vue`** (new) — renders the failing step's before/at-failure screenshot + folded ARIA; renders nothing when the trace carries no failing-step snapshot. It reuses the request the filmstrip already made (shared `useFetch` key), so no extra round-trip.
- **`FailureTimelineCard.vue`** — renders it on the failing step row: a spanning row under the desktop table, and inside the failing step's card on phones.

No new Playwright → DB field is needed — the data rides the existing trace blob — so the "Adding a field to test run data" chain does not apply here.

### Deferred follow-up

Rendering the full failure-time **DOM** (the styled page in an iframe) inline on the timeline step, as the Screen tab's Page structure disclosure does. This PR ships the high-value slice — the screenshot + ARIA at the failing step — and leaves the heavier per-step DOM iframe for a follow-up.

## How was it tested?

- **Unit** (`tests/unit/trace-snapshots.test.ts`): `buildTraceSnapshots` returns the failing step's after-phase ARIA text (and, for an assertion failure whose error is on a snapshot-less step, the marked step's tree).
- **E2E** (`tests/trace-snapshots.spec.ts`): a real 1.63 trace fixture is ingested for a failing case; the Timeline tab shows "Page at the failing step" and the ARIA tree unfolds on demand.
- **Feature screenshots**: new self-contained `failing-step-evidence` scenes (web ~1280px + mobile ~390px) in `scripts/take-feature-screenshots.mjs` — they ingest the 1.63 fixture themselves, since the seeded demo traces predate 1.63. Verified at both widths (no horizontal scroll at 390px).
- Full suite green locally: `app:typecheck`, `app:lint`, `app:format:check`, `app:test:unit` (2275), and the trace-snapshots E2E (4/4). Reporter untouched.

## Checklist

- [x] PR title follows [Conventional Commits](CONTRIBUTING.md) (`type(scope): subject`)
- [x] Tests added/updated for behavior changes
- [x] Docs updated if user-facing (`apps/docs/features/evidence.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcB5Ae3korKdGewGfy8HHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcB5Ae3korKdGewGfy8HHY)_