### PR TITLE
fix(demo): add cache busting to shell and seed fetches

### DIFF
--- a/apps/application/app/demo/db.client.ts
+++ b/apps/application/app/demo/db.client.ts
@@ -194,7 +194,11 @@ async function fetchCurrentSeedVersion(base: string): Promise<string | null> {
  * IndexedDB, and record the build version it was seeded from.
  */
 async function seedFreshDatabase(SQL: SqlJsStatic, base: string, version: string | null): Promise<void> {
-  const resp = await fetch(`${base}/demo/seed.sql`);
+  // Fetched with `cache: 'no-cache'` so the SQL matches the freshly-deployed
+  // seed the version marker was compared against — a reseed triggered by a new
+  // marker must not pull a stale HTTP-cached dump, or it would record the new
+  // version against old data and never reseed again.
+  const resp = await fetch(`${base}/demo/seed.sql`, { cache: 'no-cache' });
   if (!resp.ok) {
     throw new Error(`[Demo] Failed to load seed.sql: ${resp.status} ${resp.statusText}`);
   }

--- a/apps/application/app/service-worker/demo-sw.ts
+++ b/apps/application/app/service-worker/demo-sw.ts
@@ -91,7 +91,12 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       (async () => {
         try {
-          const shell = await fetch(APP_SHELL_URL, { credentials: 'same-origin' });
+          // Revalidate the shell on every navigation. GitHub Pages serves
+          // index.html with a short max-age and allows no cache-control
+          // override, so `no-cache` forces a conditional request (304 when
+          // unchanged) that always resolves to the current deploy's shell and
+          // the content-hashed bundles it references.
+          const shell = await fetch(APP_SHELL_URL, { credentials: 'same-origin', cache: 'no-cache' });
           if (shell.ok) return shell;
         } catch {
           // Offline or fetch failure — fall back to the original request below.


### PR DESCRIPTION
## What & why

Adds `cache: 'no-cache'` to two critical fetch requests in the demo application:

1. **Service Worker shell fetch** (`demo-sw.ts`): Forces revalidation of `index.html` on every navigation. GitHub Pages serves the shell with a short max-age and doesn't allow cache-control overrides, so `no-cache` ensures conditional requests (304 when unchanged) that always resolve to the current deploy's shell and its content-hashed bundles.

2. **Database seed fetch** (`db.client.ts`): Ensures the SQL seed matches the freshly-deployed version. When a reseed is triggered by a new version marker, we must not pull a stale HTTP-cached dump, or the new version would be recorded against old data and never reseed again.

Both changes prevent stale cached assets from being served after deployments, which could cause version mismatches and data inconsistencies in the demo.

## How was it tested?

No testing needed — these are cache control directives that affect HTTP behavior. The changes are straightforward additions of the `cache: 'no-cache'` option to existing fetch calls, with detailed comments explaining the rationale for each.

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] No tests needed for cache control directives
- [x] No user-facing docs changes required

https://claude.ai/code/session_019TyoH9pXqDiTUbEtcD73L4